### PR TITLE
Update `TagListGenerator` to always use`ReadOnlySpan<byte>` properties

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/Sources.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/Sources.cs
@@ -89,23 +89,11 @@ namespace ");
 
                     sb.Append(
                            @"
-#if NETCOREAPP
         private static ReadOnlySpan<byte> ")
                       .Append(property.PropertyName)
-                      .Append(@"Bytes => new byte[] { ")
+                      .Append(@"Bytes => [")
                       .Append(tagByteArray)
-                      .Append(@" };")
-                      .Append(
-                           @"
-#else
-        private static readonly byte[] ")
-                      .Append(property.PropertyName)
-                      .Append(@"Bytes = new byte[] { ")
-                      .Append(tagByteArray)
-                      .Append(@" };")
-                      .Append(
-                           @"
-#endif");
+                      .AppendLine(@"];");
                 }
             }
 
@@ -125,28 +113,15 @@ namespace ");
 
                     sb.Append(
                            @"
-#if NETCOREAPP
         private static ReadOnlySpan<byte> ")
                       .Append(property.PropertyName)
-                      .Append(@"Bytes => new byte[] { ")
+                      .Append(@"Bytes => [")
                       .Append(tagByteArray)
-                      .Append(@" };")
-                      .Append(
-                           @"
-#else
-        private static readonly byte[] ")
-                      .Append(property.PropertyName)
-                      .Append(@"Bytes = new byte[] { ")
-                      .Append(tagByteArray)
-                      .Append(@" };")
-                      .Append(
-                           @"
-#endif");
+                      .AppendLine(@"];");
                 }
 
                 sb.Append(
                     @"
-
         public override string? GetTag(string key)
         {
             return key switch
@@ -283,11 +258,6 @@ namespace ");
 
             if (tagList.MetricProperties.HasValues())
             {
-                if (tagList.TagProperties.IsDefaultOrEmpty)
-                {
-                    sb.AppendLine();
-                }
-
                 sb.Append(
                     @"
         public override double? GetMetric(string key)

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // KeyBytes = MessagePack.Serialize("aerospike.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121];
+
         // NamespaceBytes = MessagePack.Serialize("aerospike.namespace");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NamespaceBytes => new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#else
-        private static readonly byte[] NamespaceBytes = new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> NamespaceBytes => [179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101];
+
         // SetNameBytes = MessagePack.Serialize("aerospike.setname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SetNameBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] SetNameBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> SetNameBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101];
+
         // UserKeyBytes = MessagePack.Serialize("aerospike.userkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserKeyBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#else
-        private static readonly byte[] UserKeyBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> UserKeyBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreEndpointTags
     {
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreMvcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreControllerBytes = MessagePack.Serialize("aspnet_core.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetCoreControllerBytes = new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => [182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetCoreActionBytes = MessagePack.Serialize("aspnet_core.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreActionBytes => new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetCoreActionBytes = new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreActionBytes => [178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetCoreAreaBytes = MessagePack.Serialize("aspnet_core.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetCoreAreaBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97];
+
         // AspNetCorePageBytes = MessagePack.Serialize("aspnet_core.page");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCorePageBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#else
-        private static readonly byte[] AspNetCorePageBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCorePageBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreSingleSpanTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AspNetTags
     {
         // AspNetRouteBytes = MessagePack.Serialize("aspnet.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetRouteBytes => new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetRouteBytes = new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetRouteBytes => [172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101];
+
         // AspNetControllerBytes = MessagePack.Serialize("aspnet.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetControllerBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetControllerBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetControllerBytes => [177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetActionBytes = MessagePack.Serialize("aspnet.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetActionBytes => new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetActionBytes = new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetActionBytes => [173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetAreaBytes = MessagePack.Serialize("aspnet.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetAreaBytes => new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetAreaBytes = new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetAreaBytes => [171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsDynamoDbTags
     {
         // TableNameBytes = MessagePack.Serialize("tablename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TableNameBytes => new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TableNameBytes = new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TableNameBytes => [169, 116, 97, 98, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsEventBridgeTags
     {
         // RuleNameBytes = MessagePack.Serialize("rulename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuleNameBytes => new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuleNameBytes = new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuleNameBytes => [168, 114, 117, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsKinesisTags
     {
         // StreamNameBytes = MessagePack.Serialize("streamname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StreamNameBytes => new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StreamNameBytes = new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StreamNameBytes => [170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AwsS3Tags
     {
         // BucketNameBytes = MessagePack.Serialize("bucketname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketNameBytes => new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BucketNameBytes = new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BucketNameBytes => [170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101];
+
         // ObjectKeyBytes = MessagePack.Serialize("objectkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ObjectKeyBytes => new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#else
-        private static readonly byte[] ObjectKeyBytes = new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> ObjectKeyBytes => [169, 111, 98, 106, 101, 99, 116, 107, 101, 121];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AwsSdkTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AgentNameBytes = MessagePack.Serialize("aws.agent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AgentNameBytes => new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] AgentNameBytes = new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AgentNameBytes => [169, 97, 119, 115, 46, 97, 103, 101, 110, 116];
+
         // OperationBytes = MessagePack.Serialize("aws.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationBytes => new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] OperationBytes = new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OperationBytes => [173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // AwsRegionBytes = MessagePack.Serialize("aws.region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsRegionBytes => new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] AwsRegionBytes = new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AwsRegionBytes => [170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
+
         // RequestIdBytes = MessagePack.Serialize("aws.requestId");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RequestIdBytes => new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] RequestIdBytes = new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> RequestIdBytes => [173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100];
+
         // AwsServiceBytes = MessagePack.Serialize("aws.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsServiceBytes => new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] AwsServiceBytes = new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsServiceBytes => [171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // ServiceBytes = MessagePack.Serialize("aws_service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceBytes => new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] ServiceBytes = new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceBytes => [171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSnsTags
     {
         // AwsTopicNameBytes = MessagePack.Serialize("aws.topic.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsTopicNameBytes => new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsTopicNameBytes = new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsTopicNameBytes => [174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
+
         // TopicArnBytes = MessagePack.Serialize("aws.topic.arn");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicArnBytes => new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#else
-        private static readonly byte[] TopicArnBytes = new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#endif
+        private static ReadOnlySpan<byte> TopicArnBytes => [173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSqsTags
     {
         // AwsQueueNameBytes = MessagePack.Serialize("aws.queue.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsQueueNameBytes => new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsQueueNameBytes = new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsQueueNameBytes => [174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101];
+
         // QueueNameBytes = MessagePack.Serialize("queuename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueNameBytes => new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] QueueNameBytes = new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueNameBytes => [169, 113, 117, 101, 117, 101, 110, 97, 109, 101];
+
         // QueueUrlBytes = MessagePack.Serialize("aws.queue.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueUrlBytes => new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] QueueUrlBytes = new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> QueueUrlBytes => [173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsStepFunctionsTags
     {
         // StateMachineNameBytes = MessagePack.Serialize("statemachinename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StateMachineNameBytes => new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StateMachineNameBytes = new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StateMachineNameBytes => [176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
+
         // MessagingBatchMessageCountBytes = MessagePack.Serialize("messaging.batch.message_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] MessagingBatchMessageCountBytes = new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => [189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116];
+
         // MessagingMessageIdBytes = MessagePack.Serialize("messaging.message_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingMessageIdBytes => new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] MessagingMessageIdBytes = new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> MessagingMessageIdBytes => [180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AzureFunctionsTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ShortNameBytes = MessagePack.Serialize("aas.function.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ShortNameBytes => new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ShortNameBytes = new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ShortNameBytes => [177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // FullNameBytes = MessagePack.Serialize("aas.function.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FullNameBytes => new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] FullNameBytes = new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> FullNameBytes => [179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100];
+
         // BindingSourceBytes = MessagePack.Serialize("aas.function.binding");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BindingSourceBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#else
-        private static readonly byte[] BindingSourceBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#endif
+        private static ReadOnlySpan<byte> BindingSourceBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103];
+
         // TriggerTypeBytes = MessagePack.Serialize("aas.function.trigger");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TriggerTypeBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#else
-        private static readonly byte[] TriggerTypeBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> TriggerTypeBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
@@ -15,71 +15,37 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
+
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // ContainerIdBytes = MessagePack.Serialize("cosmosdb.container");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ContainerIdBytes => new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#else
-        private static readonly byte[] ContainerIdBytes = new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> ContainerIdBytes => [178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114];
+
         // DatabaseIdBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIdBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DatabaseIdBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIdBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // ResponseStatusCodeBytes = MessagePack.Serialize("db.response.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseStatusCodeBytes = new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => [183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // ResponseSubStatusCodeBytes = MessagePack.Serialize("cosmosdb.response.sub_status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseSubStatusCodeBytes = new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => [217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // UserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] UserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> UserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // ConnectionModeBytes = MessagePack.Serialize("cosmosdb.connection.mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConnectionModeBytes => new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] ConnectionModeBytes = new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ConnectionModeBytes => [184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbV1Tags
     {
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SeedNodesBytes = MessagePack.Serialize("db.couchbase.seed.nodes");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SeedNodesBytes => new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#else
-        private static readonly byte[] SeedNodesBytes = new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> SeedNodesBytes => [183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115];
+
         // OperationCodeBytes = MessagePack.Serialize("couchbase.operation.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationCodeBytes => new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OperationCodeBytes = new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationCodeBytes => [184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101];
+
         // BucketBytes = MessagePack.Serialize("couchbase.operation.bucket");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketBytes => new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#else
-        private static readonly byte[] BucketBytes = new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> BucketBytes => [186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116];
+
         // KeyBytes = MessagePack.Serialize("couchbase.operation.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ActionBytes = MessagePack.Serialize("elasticsearch.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ActionBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] ActionBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> ActionBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110];
+
         // MethodBytes = MessagePack.Serialize("elasticsearch.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100];
+
         // UrlBytes = MessagePack.Serialize("elasticsearch.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UrlBytes => new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] UrlBytes = new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> UrlBytes => [177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
     partial class GraphQLTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SourceBytes = MessagePack.Serialize("graphql.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceBytes => new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] SourceBytes = new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceBytes => [174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101];
+
         // OperationNameBytes = MessagePack.Serialize("graphql.operation.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationNameBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OperationNameBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationNameBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // OperationTypeBytes = MessagePack.Serialize("graphql.operation.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationTypeBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] OperationTypeBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationTypeBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientTags
     {
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PeerHostnameBytes = MessagePack.Serialize("peer.hostname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerHostnameBytes => new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] PeerHostnameBytes = new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerHostnameBytes => [173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class GrpcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodKindBytes = MessagePack.Serialize("grpc.method.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodKindBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] MethodKindBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodKindBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100];
+
         // MethodNameBytes = MessagePack.Serialize("grpc.method.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101];
+
         // MethodPathBytes = MessagePack.Serialize("grpc.method.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPathBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] MethodPathBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> MethodPathBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104];
+
         // MethodPackageBytes = MessagePack.Serialize("grpc.method.package");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPackageBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#else
-        private static readonly byte[] MethodPackageBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodPackageBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101];
+
         // MethodServiceBytes = MessagePack.Serialize("grpc.method.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // StatusCodeBytes = MessagePack.Serialize("grpc.status.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusCodeBytes => new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] StatusCodeBytes = new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> StatusCodeBytes => [176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class HangfireTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // CreatedAtBytes = MessagePack.Serialize("job.CreatedAt");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CreatedAtBytes => new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#else
-        private static readonly byte[] CreatedAtBytes = new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#endif
+        private static ReadOnlySpan<byte> CreatedAtBytes => [173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116];
+
         // JobIdBytes = MessagePack.Serialize("job.ID");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> JobIdBytes => new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#else
-        private static readonly byte[] JobIdBytes = new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#endif
+        private static ReadOnlySpan<byte> JobIdBytes => [166, 106, 111, 98, 46, 73, 68];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class HttpTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpClientHandlerTypeBytes = MessagePack.Serialize("http-client-handler-type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] HttpClientHandlerTypeBytes = new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => [184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class HttpV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Iast
     partial class IastTags
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#else
-        private static readonly byte[] IastJsonBytes = new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> IastJsonBytes => [173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110];
+
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IastEnabledBytes = new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IastEnabledBytes => [176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class IbmMqTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class InferredProxyTags
     {
         // InferredSpanBytes = MessagePack.Serialize("_dd.inferred_span");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InferredSpanBytes => new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#else
-        private static readonly byte[] InferredSpanBytes = new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#endif
+        private static ReadOnlySpan<byte> InferredSpanBytes => [177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // StageBytes = MessagePack.Serialize("stage");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageBytes => new byte[] { 165, 115, 116, 97, 103, 101 };
-#else
-        private static readonly byte[] StageBytes = new byte[] { 165, 115, 116, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageBytes => [165, 115, 116, 97, 103, 101];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class InstrumentationTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
 
         public override double? GetMetric(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class KafkaTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // BootstrapServersBytes = MessagePack.Serialize("messaging.kafka.bootstrap.servers");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BootstrapServersBytes => new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#else
-        private static readonly byte[] BootstrapServersBytes = new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> BootstrapServersBytes => [217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115];
+
         // ClusterIdBytes = MessagePack.Serialize("messaging.kafka.cluster_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ClusterIdBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#else
-        private static readonly byte[] ClusterIdBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ClusterIdBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100];
+
         // TopicBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // PartitionBytes = MessagePack.Serialize("kafka.partition");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] PartitionBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> PartitionBytes => [175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110];
+
         // OffsetBytes = MessagePack.Serialize("kafka.offset");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OffsetBytes => new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#else
-        private static readonly byte[] OffsetBytes = new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> OffsetBytes => [172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116];
+
         // TombstoneBytes = MessagePack.Serialize("kafka.tombstone");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TombstoneBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#else
-        private static readonly byte[] TombstoneBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> TombstoneBytes => [175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101];
+
         // ConsumerGroupBytes = MessagePack.Serialize("kafka.group");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConsumerGroupBytes => new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#else
-        private static readonly byte[] ConsumerGroupBytes = new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#endif
+        private static ReadOnlySpan<byte> ConsumerGroupBytes => [171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class KafkaV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // QueryBytes = MessagePack.Serialize("mongodb.query");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueryBytes => new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#else
-        private static readonly byte[] QueryBytes = new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> QueryBytes => [173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121];
+
         // CollectionBytes = MessagePack.Serialize("mongodb.collection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CollectionBytes => new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CollectionBytes = new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CollectionBytes => [178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class MsmqTags
     {
         // CommandBytes = MessagePack.Serialize("msmq.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PathBytes = MessagePack.Serialize("msmq.queue.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PathBytes => new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] PathBytes = new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> PathBytes => [175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104];
+
         // MessageWithTransactionBytes = MessagePack.Serialize("msmq.message.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageWithTransactionBytes => new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> MessageWithTransactionBytes => [186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
+
         // IsTransactionalQueueBytes = MessagePack.Serialize("msmq.queue.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => [184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class MsmqV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class OpenTelemetryTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // OtelTraceIdBytes = MessagePack.Serialize("otel.trace_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelTraceIdBytes => new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] OtelTraceIdBytes = new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> OtelTraceIdBytes => [173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100];
+
         // OtelLibraryNameBytes = MessagePack.Serialize("otel.library.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryNameBytes => new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OtelLibraryNameBytes = new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryNameBytes => [177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101];
+
         // OtelLibraryVersionBytes = MessagePack.Serialize("otel.library.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OtelLibraryVersionBytes = new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => [180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // OtelStatusCodeBytes = MessagePack.Serialize("otel.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelStatusCodeBytes => new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OtelStatusCodeBytes = new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelStatusCodeBytes => [176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class ProcessCommandStartTags
     {
         // ComponentBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ComponentBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] ComponentBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> ComponentBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // EnvironmentVariablesBytes = MessagePack.Serialize("cmd.environment_variables");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#else
-        private static readonly byte[] EnvironmentVariablesBytes = new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => [185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115];
+
         // CommandExecBytes = MessagePack.Serialize("cmd.exec");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExecBytes => new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#else
-        private static readonly byte[] CommandExecBytes = new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#endif
+        private static ReadOnlySpan<byte> CommandExecBytes => [168, 99, 109, 100, 46, 101, 120, 101, 99];
+
         // CommandShellBytes = MessagePack.Serialize("cmd.shell");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandShellBytes => new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#else
-        private static readonly byte[] CommandShellBytes = new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#endif
+        private static ReadOnlySpan<byte> CommandShellBytes => [169, 99, 109, 100, 46, 115, 104, 101, 108, 108];
+
         // TruncatedBytes = MessagePack.Serialize("cmd.truncated");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TruncatedBytes => new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#else
-        private static readonly byte[] TruncatedBytes = new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TruncatedBytes => [173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("amqp.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // DeliveryModeBytes = MessagePack.Serialize("amqp.delivery_mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DeliveryModeBytes => new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] DeliveryModeBytes = new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> DeliveryModeBytes => [178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101];
+
         // ExchangeBytes = MessagePack.Serialize("amqp.exchange");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ExchangeBytes => new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#else
-        private static readonly byte[] ExchangeBytes = new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> ExchangeBytes => [173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101];
+
         // RoutingKeyBytes = MessagePack.Serialize("amqp.routing_key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RoutingKeyBytes => new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#else
-        private static readonly byte[] RoutingKeyBytes = new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> RoutingKeyBytes => [176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121];
+
         // MessageSizeBytes = MessagePack.Serialize("message.size");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageSizeBytes => new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#else
-        private static readonly byte[] MessageSizeBytes = new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessageSizeBytes => [172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101];
+
         // QueueBytes = MessagePack.Serialize("amqp.queue");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueBytes => new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#else
-        private static readonly byte[] QueueBytes = new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueBytes => [170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisTags
     {
         // DatabaseIndexBytes = MessagePack.Serialize("db.redis.database_index");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIndexBytes => new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#else
-        private static readonly byte[] DatabaseIndexBytes = new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIndexBytes => [183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // RawCommandBytes = MessagePack.Serialize("redis.raw_command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RawCommandBytes => new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] RawCommandBytes = new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> RawCommandBytes => [177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class RemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodNameBytes = MessagePack.Serialize("rpc.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100];
+
         // MethodServiceBytes = MessagePack.Serialize("rpc.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RpcSystemBytes = MessagePack.Serialize("rpc.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RpcSystemBytes => new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] RpcSystemBytes = new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> RpcSystemBytes => [170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // ApplicationIdBytes = MessagePack.Serialize("service-fabric.application-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationIdBytes => new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] ApplicationIdBytes = new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationIdBytes => [189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100];
+
         // ApplicationNameBytes = MessagePack.Serialize("service-fabric.application-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationNameBytes => new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ApplicationNameBytes = new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationNameBytes => [191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101];
+
         // PartitionIdBytes = MessagePack.Serialize("service-fabric.partition-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionIdBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] PartitionIdBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> PartitionIdBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100];
+
         // NodeIdBytes = MessagePack.Serialize("service-fabric.node-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeIdBytes => new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] NodeIdBytes = new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> NodeIdBytes => [182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100];
+
         // NodeNameBytes = MessagePack.Serialize("service-fabric.node-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeNameBytes => new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NodeNameBytes = new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NodeNameBytes => [184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101];
+
         // ServiceNameBytes = MessagePack.Serialize("service-fabric.service-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceNameBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ServiceNameBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceNameBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101];
+
         // RemotingUriBytes = MessagePack.Serialize("service-fabric.service-remoting.uri");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingUriBytes => new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#else
-        private static readonly byte[] RemotingUriBytes = new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#endif
+        private static ReadOnlySpan<byte> RemotingUriBytes => [217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105];
+
         // RemotingServiceNameBytes = MessagePack.Serialize("service-fabric.service-remoting.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingServiceNameBytes => new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] RemotingServiceNameBytes = new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingServiceNameBytes => [217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RemotingMethodNameBytes = MessagePack.Serialize("service-fabric.service-remoting.method-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodNameBytes => new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RemotingMethodNameBytes = new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodNameBytes => [217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101];
+
         // RemotingMethodIdBytes = MessagePack.Serialize("service-fabric.service-remoting.method-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodIdBytes => new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingMethodIdBytes = new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodIdBytes => [217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100];
+
         // RemotingInterfaceIdBytes = MessagePack.Serialize("service-fabric.service-remoting.interface-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInterfaceIdBytes = new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => [217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100];
+
         // RemotingInvocationIdBytes = MessagePack.Serialize("service-fabric.service-remoting.invocation-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInvocationIdBytes = new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => [217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class SqlTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // DbUserBytes = MessagePack.Serialize("db.user");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbUserBytes => new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#else
-        private static readonly byte[] DbUserBytes = new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> DbUserBytes => [167, 100, 98, 46, 117, 115, 101, 114];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // DbmTraceInjectedBytes = MessagePack.Serialize("_dd.dbm_trace_injected");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#else
-        private static readonly byte[] DbmTraceInjectedBytes = new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => [182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100];
+
         // BaseHashBytes = MessagePack.Serialize("_dd.propagated_hash");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BaseHashBytes => new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#else
-        private static readonly byte[] BaseHashBytes = new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#endif
+        private static ReadOnlySpan<byte> BaseHashBytes => [179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class SqlV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
@@ -15,77 +15,40 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestModuleSpanTags
     {
         // IntelligentTestRunnerSkippingCountBytes = MessagePack.Serialize("test.itr.tests_skipping.count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingCountBytes = new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => [189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116];
+
         // TypeBytes = MessagePack.Serialize("test.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TypeBytes => new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] TypeBytes = new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> TypeBytes => [169, 116, 101, 115, 116, 46, 116, 121, 112, 101];
+
         // ModuleBytes = MessagePack.Serialize("test.module");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ModuleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#else
-        private static readonly byte[] ModuleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> ModuleBytes => [171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101];
+
         // BundleBytes = MessagePack.Serialize("test.bundle");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BundleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#else
-        private static readonly byte[] BundleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> BundleBytes => [171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101];
+
         // FrameworkBytes = MessagePack.Serialize("test.framework");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkBytes => new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#else
-        private static readonly byte[] FrameworkBytes = new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkBytes => [174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107];
+
         // FrameworkVersionBytes = MessagePack.Serialize("test.framework_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkVersionBytes => new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] FrameworkVersionBytes = new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkVersionBytes => [182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeNameBytes = MessagePack.Serialize("runtime.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeNameBytes => new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuntimeNameBytes = new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeNameBytes => [172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101];
+
         // RuntimeVersionBytes = MessagePack.Serialize("runtime.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeVersionBytes => new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] RuntimeVersionBytes = new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeVersionBytes => [175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeArchitectureBytes = MessagePack.Serialize("runtime.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] RuntimeArchitectureBytes = new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => [180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSArchitectureBytes = MessagePack.Serialize("os.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSArchitectureBytes => new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] OSArchitectureBytes = new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> OSArchitectureBytes => [175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSPlatformBytes = MessagePack.Serialize("os.platform");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSPlatformBytes => new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#else
-        private static readonly byte[] OSPlatformBytes = new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#endif
+        private static ReadOnlySpan<byte> OSPlatformBytes => [171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109];
+
         // OSVersionBytes = MessagePack.Serialize("os.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSVersionBytes => new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OSVersionBytes = new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OSVersionBytes => [170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
@@ -15,275 +15,139 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSessionSpanTags
     {
         // LogicalCpuCountBytes = MessagePack.Serialize("_dd.host.vcpu_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LogicalCpuCountBytes => new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] LogicalCpuCountBytes = new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> LogicalCpuCountBytes => [179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("test.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // WorkingDirectoryBytes = MessagePack.Serialize("test.working_directory");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> WorkingDirectoryBytes => new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#else
-        private static readonly byte[] WorkingDirectoryBytes = new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> WorkingDirectoryBytes => [182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121];
+
         // CommandExitCodeBytes = MessagePack.Serialize("test.exit_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExitCodeBytes => new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] CommandExitCodeBytes = new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> CommandExitCodeBytes => [174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101];
+
         // StatusBytes = MessagePack.Serialize("test.status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusBytes => new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] StatusBytes = new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> StatusBytes => [171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115];
+
         // LibraryVersionBytes = MessagePack.Serialize("library_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LibraryVersionBytes => [175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // CIProviderBytes = MessagePack.Serialize("ci.provider.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIProviderBytes => new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIProviderBytes = new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIProviderBytes => [176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101];
+
         // CIPipelineIdBytes = MessagePack.Serialize("ci.pipeline.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineIdBytes => new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#else
-        private static readonly byte[] CIPipelineIdBytes = new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineIdBytes => [174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100];
+
         // CIPipelineNameBytes = MessagePack.Serialize("ci.pipeline.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNameBytes => new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIPipelineNameBytes = new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNameBytes => [176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101];
+
         // CIPipelineNumberBytes = MessagePack.Serialize("ci.pipeline.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNumberBytes => new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] CIPipelineNumberBytes = new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNumberBytes => [178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114];
+
         // CIPipelineUrlBytes = MessagePack.Serialize("ci.pipeline.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineUrlBytes => new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIPipelineUrlBytes = new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineUrlBytes => [175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108];
+
         // CIJobUrlBytes = MessagePack.Serialize("ci.job.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobUrlBytes => new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIJobUrlBytes = new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIJobUrlBytes => [170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108];
+
         // CIJobNameBytes = MessagePack.Serialize("ci.job.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobNameBytes => new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIJobNameBytes = new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIJobNameBytes => [171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101];
+
         // CIJobIdBytes = MessagePack.Serialize("ci.job.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobIdBytes => new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#else
-        private static readonly byte[] CIJobIdBytes = new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIJobIdBytes => [169, 99, 105, 46, 106, 111, 98, 46, 105, 100];
+
         // StageNameBytes = MessagePack.Serialize("ci.stage.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageNameBytes => new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StageNameBytes = new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageNameBytes => [173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101];
+
         // CIWorkspacePathBytes = MessagePack.Serialize("ci.workspace_path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIWorkspacePathBytes => new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] CIWorkspacePathBytes = new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> CIWorkspacePathBytes => [177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104];
+
         // GitRepositoryBytes = MessagePack.Serialize("git.repository_url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitRepositoryBytes => new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#else
-        private static readonly byte[] GitRepositoryBytes = new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitRepositoryBytes => [178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108];
+
         // GitCommitBytes = MessagePack.Serialize("git.commit.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitBytes => new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitCommitBytes = new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitBytes => [174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97];
+
         // GitBranchBytes = MessagePack.Serialize("git.branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitBranchBytes => new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitBranchBytes = new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitBranchBytes => [170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104];
+
         // GitTagBytes = MessagePack.Serialize("git.tag");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitTagBytes => new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#else
-        private static readonly byte[] GitTagBytes = new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> GitTagBytes => [167, 103, 105, 116, 46, 116, 97, 103];
+
         // GitCommitAuthorNameBytes = MessagePack.Serialize("git.commit.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorNameBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitAuthorEmailBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitCommitterNameBytes = MessagePack.Serialize("git.commit.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterNameBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitCommitterEmailBytes = new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => [186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitMessageBytes = MessagePack.Serialize("git.commit.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitMessageBytes => new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitCommitMessageBytes = new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitMessageBytes => [178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101];
+
         // BuildSourceRootBytes = MessagePack.Serialize("build.source_root");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BuildSourceRootBytes => new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#else
-        private static readonly byte[] BuildSourceRootBytes = new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#endif
+        private static ReadOnlySpan<byte> BuildSourceRootBytes => [177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116];
+
         // GitCommitAuthorDateBytes = MessagePack.Serialize("git.commit.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorDateBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitCommitCommitterDateBytes = MessagePack.Serialize("git.commit.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // CiEnvVarsBytes = MessagePack.Serialize("_dd.ci.env_vars");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CiEnvVarsBytes => new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#else
-        private static readonly byte[] CiEnvVarsBytes = new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CiEnvVarsBytes => [175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115];
+
         // TestsSkippedBytes = MessagePack.Serialize("_dd.ci.itr.tests_skipped");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestsSkippedBytes => new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#else
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TestsSkippedBytes => [184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100];
+
         // IntelligentTestRunnerSkippingTypeBytes = MessagePack.Serialize("test.itr.tests_skipping.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingTypeBytes = new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => [188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101];
+
         // EarlyFlakeDetectionTestEnabledBytes = MessagePack.Serialize("test.early_flake.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestEnabledBytes = new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => [184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100];
+
         // EarlyFlakeDetectionTestAbortReasonBytes = MessagePack.Serialize("test.early_flake.abort_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestAbortReasonBytes = new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => [189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110];
+
         // GitPrBaseHeadCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_head_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseHeadCommitBytes = new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => [217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97];
+
         // GitPrBaseCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseCommitBytes = new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => [217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97];
+
         // GitPrBaseBranchBytes = MessagePack.Serialize("git.pull_request.base_branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitPrBaseBranchBytes = new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => [188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104];
+
         // PrNumberBytes = MessagePack.Serialize("pr.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PrNumberBytes => new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] PrNumberBytes = new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> PrNumberBytes => [169, 112, 114, 46, 110, 117, 109, 98, 101, 114];
+
         // GitHeadCommitBytes = MessagePack.Serialize("git.commit.head.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitBytes => new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitHeadCommitBytes = new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitBytes => [179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97];
+
         // GitHeadCommitAuthorNameBytes = MessagePack.Serialize("git.commit.head.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorNameBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.head.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorEmailBytes = new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => [188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitAuthorDateBytes = MessagePack.Serialize("git.commit.head.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorDateBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitCommitterNameBytes = MessagePack.Serialize("git.commit.head.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterNameBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.head.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterEmailBytes = new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => [191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitCommitterDateBytes = MessagePack.Serialize("git.commit.head.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterDateBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitMessageBytes = MessagePack.Serialize("git.commit.head.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitHeadCommitMessageBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -15,185 +15,94 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSpanTags
     {
         // SourceStartBytes = MessagePack.Serialize("test.source.start");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceStartBytes => new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#else
-        private static readonly byte[] SourceStartBytes = new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> SourceStartBytes => [177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116];
+
         // SourceEndBytes = MessagePack.Serialize("test.source.end");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceEndBytes => new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#else
-        private static readonly byte[] SourceEndBytes = new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SourceEndBytes => [175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100];
+
         // NameBytes = MessagePack.Serialize("test.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [169, 116, 101, 115, 116, 46, 110, 97, 109, 101];
+
         // ParametersBytes = MessagePack.Serialize("test.parameters");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ParametersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#else
-        private static readonly byte[] ParametersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> ParametersBytes => [175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115];
+
         // TraitsBytes = MessagePack.Serialize("test.traits");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TraitsBytes => new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#else
-        private static readonly byte[] TraitsBytes = new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#endif
+        private static ReadOnlySpan<byte> TraitsBytes => [171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115];
+
         // SkipReasonBytes = MessagePack.Serialize("test.skip_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkipReasonBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] SkipReasonBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> SkipReasonBytes => [176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110];
+
         // SkippedByIntelligentTestRunnerBytes = MessagePack.Serialize("test.skipped_by_itr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#else
-        private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#endif
+        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => [179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114];
+
         // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> UnskippableBytes => [180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101];
+
         // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#else
-        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#endif
+        private static ReadOnlySpan<byte> ForcedRunBytes => [179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110];
+
         // TestIsNewBytes = MessagePack.Serialize("test.is_new");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsNewBytes => new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#else
-        private static readonly byte[] TestIsNewBytes = new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#endif
+        private static ReadOnlySpan<byte> TestIsNewBytes => [171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119];
+
         // TestIsRetryBytes = MessagePack.Serialize("test.is_retry");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsRetryBytes => new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#else
-        private static readonly byte[] TestIsRetryBytes = new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> TestIsRetryBytes => [173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121];
+
         // TestRetryReasonBytes = MessagePack.Serialize("test.retry_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestRetryReasonBytes => new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] TestRetryReasonBytes = new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> TestRetryReasonBytes => [177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110];
+
         // BrowserDriverBytes = MessagePack.Serialize("test.browser.driver");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverBytes => new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#else
-        private static readonly byte[] BrowserDriverBytes = new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverBytes => [179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114];
+
         // BrowserDriverVersionBytes = MessagePack.Serialize("test.browser.driver_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserDriverVersionBytes = new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => [187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // BrowserNameBytes = MessagePack.Serialize("test.browser.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserNameBytes => new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BrowserNameBytes = new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BrowserNameBytes => [177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101];
+
         // BrowserVersionBytes = MessagePack.Serialize("test.browser.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserVersionBytes = new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserVersionBytes => [180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#else
-        private static readonly byte[] IsRumActiveBytes = new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#endif
+        private static ReadOnlySpan<byte> IsRumActiveBytes => [178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101];
+
         // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#else
-        private static readonly byte[] IsModifiedBytes = new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsModifiedBytes => [176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100];
+
         // IsQuarantinedBytes = MessagePack.Serialize("test.test_management.is_quarantined");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsQuarantinedBytes => new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#else
-        private static readonly byte[] IsQuarantinedBytes = new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsQuarantinedBytes => [217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100];
+
         // IsDisabledBytes = MessagePack.Serialize("test.test_management.is_test_disabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsDisabledBytes => new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IsDisabledBytes = new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsDisabledBytes => [217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100];
+
         // IsAttemptToFixBytes = MessagePack.Serialize("test.test_management.is_attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsAttemptToFixBytes => new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] IsAttemptToFixBytes = new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> IsAttemptToFixBytes => [217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
+
         // HasFailedAllRetriesBytes = MessagePack.Serialize("test.has_failed_all_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] HasFailedAllRetriesBytes = new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => [187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // AttemptToFixPassedBytes = MessagePack.Serialize("test.test_management.attempt_to_fix_passed");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#else
-        private static readonly byte[] AttemptToFixPassedBytes = new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => [217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100];
+
         // FinalStatusBytes = MessagePack.Serialize("test.final_status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FinalStatusBytes => new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] FinalStatusBytes = new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> FinalStatusBytes => [177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115];
+
         // CapabilitiesTestImpactAnalysisBytes = MessagePack.Serialize("_dd.library_capabilities.test_impact_analysis");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#else
-        private static readonly byte[] CapabilitiesTestImpactAnalysisBytes = new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => [217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115];
+
         // CapabilitiesEarlyFlakeDetectionBytes = MessagePack.Serialize("_dd.library_capabilities.early_flake_detection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CapabilitiesEarlyFlakeDetectionBytes = new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => [217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110];
+
         // CapabilitiesAutoTestRetriesBytes = MessagePack.Serialize("_dd.library_capabilities.auto_test_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] CapabilitiesAutoTestRetriesBytes = new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => [217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // CapabilitiesTestManagementQuarantineBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.quarantine");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementQuarantineBytes = new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => [217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101];
+
         // CapabilitiesTestManagementDisableBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.disable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementDisableBytes = new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => [217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101];
+
         // CapabilitiesTestManagementAttemptToFixBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementAttemptToFixBytes = new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => [217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSuiteSpanTags
     {
         // SuiteBytes = MessagePack.Serialize("test.suite");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SuiteBytes => new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#else
-        private static readonly byte[] SuiteBytes = new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> SuiteBytes => [170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101];
+
         // SourceFileBytes = MessagePack.Serialize("test.source.file");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceFileBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#else
-        private static readonly byte[] SourceFileBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceFileBytes => [176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101];
+
         // CodeOwnersBytes = MessagePack.Serialize("test.codeowners");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CodeOwnersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#else
-        private static readonly byte[] CodeOwnersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CodeOwnersBytes => [175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class TraceAnnotationTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class WcfTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class WebTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // HttpUserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] HttpUserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpUserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpRequestHeadersHostBytes = MessagePack.Serialize("http.request.headers.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HttpRequestHeadersHostBytes = new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => [185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // NetworkClientIpBytes = MessagePack.Serialize("network.client.ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkClientIpBytes => new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#else
-        private static readonly byte[] NetworkClientIpBytes = new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> NetworkClientIpBytes => [177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112];
+
         // HttpClientIpBytes = MessagePack.Serialize("http.client_ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientIpBytes => new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#else
-        private static readonly byte[] HttpClientIpBytes = new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientIpBytes => [174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // KeyBytes = MessagePack.Serialize("aerospike.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121];
+
         // NamespaceBytes = MessagePack.Serialize("aerospike.namespace");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NamespaceBytes => new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#else
-        private static readonly byte[] NamespaceBytes = new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> NamespaceBytes => [179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101];
+
         // SetNameBytes = MessagePack.Serialize("aerospike.setname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SetNameBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] SetNameBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> SetNameBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101];
+
         // UserKeyBytes = MessagePack.Serialize("aerospike.userkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserKeyBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#else
-        private static readonly byte[] UserKeyBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> UserKeyBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreEndpointTags
     {
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreMvcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreControllerBytes = MessagePack.Serialize("aspnet_core.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetCoreControllerBytes = new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => [182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetCoreActionBytes = MessagePack.Serialize("aspnet_core.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreActionBytes => new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetCoreActionBytes = new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreActionBytes => [178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetCoreAreaBytes = MessagePack.Serialize("aspnet_core.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetCoreAreaBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97];
+
         // AspNetCorePageBytes = MessagePack.Serialize("aspnet_core.page");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCorePageBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#else
-        private static readonly byte[] AspNetCorePageBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCorePageBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreSingleSpanTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AspNetTags
     {
         // AspNetRouteBytes = MessagePack.Serialize("aspnet.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetRouteBytes => new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetRouteBytes = new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetRouteBytes => [172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101];
+
         // AspNetControllerBytes = MessagePack.Serialize("aspnet.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetControllerBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetControllerBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetControllerBytes => [177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetActionBytes = MessagePack.Serialize("aspnet.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetActionBytes => new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetActionBytes = new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetActionBytes => [173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetAreaBytes = MessagePack.Serialize("aspnet.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetAreaBytes => new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetAreaBytes = new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetAreaBytes => [171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsDynamoDbTags
     {
         // TableNameBytes = MessagePack.Serialize("tablename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TableNameBytes => new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TableNameBytes = new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TableNameBytes => [169, 116, 97, 98, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsEventBridgeTags
     {
         // RuleNameBytes = MessagePack.Serialize("rulename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuleNameBytes => new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuleNameBytes = new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuleNameBytes => [168, 114, 117, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsKinesisTags
     {
         // StreamNameBytes = MessagePack.Serialize("streamname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StreamNameBytes => new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StreamNameBytes = new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StreamNameBytes => [170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AwsS3Tags
     {
         // BucketNameBytes = MessagePack.Serialize("bucketname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketNameBytes => new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BucketNameBytes = new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BucketNameBytes => [170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101];
+
         // ObjectKeyBytes = MessagePack.Serialize("objectkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ObjectKeyBytes => new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#else
-        private static readonly byte[] ObjectKeyBytes = new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> ObjectKeyBytes => [169, 111, 98, 106, 101, 99, 116, 107, 101, 121];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AwsSdkTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AgentNameBytes = MessagePack.Serialize("aws.agent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AgentNameBytes => new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] AgentNameBytes = new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AgentNameBytes => [169, 97, 119, 115, 46, 97, 103, 101, 110, 116];
+
         // OperationBytes = MessagePack.Serialize("aws.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationBytes => new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] OperationBytes = new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OperationBytes => [173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // AwsRegionBytes = MessagePack.Serialize("aws.region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsRegionBytes => new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] AwsRegionBytes = new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AwsRegionBytes => [170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
+
         // RequestIdBytes = MessagePack.Serialize("aws.requestId");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RequestIdBytes => new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] RequestIdBytes = new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> RequestIdBytes => [173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100];
+
         // AwsServiceBytes = MessagePack.Serialize("aws.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsServiceBytes => new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] AwsServiceBytes = new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsServiceBytes => [171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // ServiceBytes = MessagePack.Serialize("aws_service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceBytes => new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] ServiceBytes = new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceBytes => [171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSnsTags
     {
         // AwsTopicNameBytes = MessagePack.Serialize("aws.topic.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsTopicNameBytes => new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsTopicNameBytes = new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsTopicNameBytes => [174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
+
         // TopicArnBytes = MessagePack.Serialize("aws.topic.arn");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicArnBytes => new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#else
-        private static readonly byte[] TopicArnBytes = new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#endif
+        private static ReadOnlySpan<byte> TopicArnBytes => [173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSqsTags
     {
         // AwsQueueNameBytes = MessagePack.Serialize("aws.queue.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsQueueNameBytes => new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsQueueNameBytes = new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsQueueNameBytes => [174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101];
+
         // QueueNameBytes = MessagePack.Serialize("queuename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueNameBytes => new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] QueueNameBytes = new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueNameBytes => [169, 113, 117, 101, 117, 101, 110, 97, 109, 101];
+
         // QueueUrlBytes = MessagePack.Serialize("aws.queue.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueUrlBytes => new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] QueueUrlBytes = new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> QueueUrlBytes => [173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsStepFunctionsTags
     {
         // StateMachineNameBytes = MessagePack.Serialize("statemachinename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StateMachineNameBytes => new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StateMachineNameBytes = new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StateMachineNameBytes => [176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
+
         // MessagingBatchMessageCountBytes = MessagePack.Serialize("messaging.batch.message_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] MessagingBatchMessageCountBytes = new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => [189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116];
+
         // MessagingMessageIdBytes = MessagePack.Serialize("messaging.message_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingMessageIdBytes => new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] MessagingMessageIdBytes = new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> MessagingMessageIdBytes => [180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AzureFunctionsTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ShortNameBytes = MessagePack.Serialize("aas.function.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ShortNameBytes => new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ShortNameBytes = new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ShortNameBytes => [177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // FullNameBytes = MessagePack.Serialize("aas.function.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FullNameBytes => new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] FullNameBytes = new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> FullNameBytes => [179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100];
+
         // BindingSourceBytes = MessagePack.Serialize("aas.function.binding");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BindingSourceBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#else
-        private static readonly byte[] BindingSourceBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#endif
+        private static ReadOnlySpan<byte> BindingSourceBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103];
+
         // TriggerTypeBytes = MessagePack.Serialize("aas.function.trigger");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TriggerTypeBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#else
-        private static readonly byte[] TriggerTypeBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> TriggerTypeBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
@@ -15,71 +15,37 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
+
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // ContainerIdBytes = MessagePack.Serialize("cosmosdb.container");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ContainerIdBytes => new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#else
-        private static readonly byte[] ContainerIdBytes = new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> ContainerIdBytes => [178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114];
+
         // DatabaseIdBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIdBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DatabaseIdBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIdBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // ResponseStatusCodeBytes = MessagePack.Serialize("db.response.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseStatusCodeBytes = new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => [183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // ResponseSubStatusCodeBytes = MessagePack.Serialize("cosmosdb.response.sub_status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseSubStatusCodeBytes = new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => [217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // UserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] UserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> UserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // ConnectionModeBytes = MessagePack.Serialize("cosmosdb.connection.mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConnectionModeBytes => new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] ConnectionModeBytes = new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ConnectionModeBytes => [184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbV1Tags
     {
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SeedNodesBytes = MessagePack.Serialize("db.couchbase.seed.nodes");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SeedNodesBytes => new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#else
-        private static readonly byte[] SeedNodesBytes = new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> SeedNodesBytes => [183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115];
+
         // OperationCodeBytes = MessagePack.Serialize("couchbase.operation.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationCodeBytes => new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OperationCodeBytes = new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationCodeBytes => [184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101];
+
         // BucketBytes = MessagePack.Serialize("couchbase.operation.bucket");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketBytes => new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#else
-        private static readonly byte[] BucketBytes = new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> BucketBytes => [186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116];
+
         // KeyBytes = MessagePack.Serialize("couchbase.operation.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ActionBytes = MessagePack.Serialize("elasticsearch.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ActionBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] ActionBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> ActionBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110];
+
         // MethodBytes = MessagePack.Serialize("elasticsearch.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100];
+
         // UrlBytes = MessagePack.Serialize("elasticsearch.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UrlBytes => new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] UrlBytes = new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> UrlBytes => [177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
     partial class GraphQLTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SourceBytes = MessagePack.Serialize("graphql.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceBytes => new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] SourceBytes = new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceBytes => [174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101];
+
         // OperationNameBytes = MessagePack.Serialize("graphql.operation.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationNameBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OperationNameBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationNameBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // OperationTypeBytes = MessagePack.Serialize("graphql.operation.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationTypeBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] OperationTypeBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationTypeBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientTags
     {
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PeerHostnameBytes = MessagePack.Serialize("peer.hostname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerHostnameBytes => new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] PeerHostnameBytes = new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerHostnameBytes => [173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class GrpcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodKindBytes = MessagePack.Serialize("grpc.method.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodKindBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] MethodKindBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodKindBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100];
+
         // MethodNameBytes = MessagePack.Serialize("grpc.method.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101];
+
         // MethodPathBytes = MessagePack.Serialize("grpc.method.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPathBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] MethodPathBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> MethodPathBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104];
+
         // MethodPackageBytes = MessagePack.Serialize("grpc.method.package");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPackageBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#else
-        private static readonly byte[] MethodPackageBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodPackageBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101];
+
         // MethodServiceBytes = MessagePack.Serialize("grpc.method.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // StatusCodeBytes = MessagePack.Serialize("grpc.status.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusCodeBytes => new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] StatusCodeBytes = new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> StatusCodeBytes => [176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class HangfireTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // CreatedAtBytes = MessagePack.Serialize("job.CreatedAt");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CreatedAtBytes => new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#else
-        private static readonly byte[] CreatedAtBytes = new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#endif
+        private static ReadOnlySpan<byte> CreatedAtBytes => [173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116];
+
         // JobIdBytes = MessagePack.Serialize("job.ID");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> JobIdBytes => new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#else
-        private static readonly byte[] JobIdBytes = new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#endif
+        private static ReadOnlySpan<byte> JobIdBytes => [166, 106, 111, 98, 46, 73, 68];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class HttpTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpClientHandlerTypeBytes = MessagePack.Serialize("http-client-handler-type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] HttpClientHandlerTypeBytes = new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => [184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class HttpV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Iast
     partial class IastTags
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#else
-        private static readonly byte[] IastJsonBytes = new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> IastJsonBytes => [173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110];
+
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IastEnabledBytes = new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IastEnabledBytes => [176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class IbmMqTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class InferredProxyTags
     {
         // InferredSpanBytes = MessagePack.Serialize("_dd.inferred_span");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InferredSpanBytes => new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#else
-        private static readonly byte[] InferredSpanBytes = new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#endif
+        private static ReadOnlySpan<byte> InferredSpanBytes => [177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // StageBytes = MessagePack.Serialize("stage");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageBytes => new byte[] { 165, 115, 116, 97, 103, 101 };
-#else
-        private static readonly byte[] StageBytes = new byte[] { 165, 115, 116, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageBytes => [165, 115, 116, 97, 103, 101];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class InstrumentationTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
 
         public override double? GetMetric(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class KafkaTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // BootstrapServersBytes = MessagePack.Serialize("messaging.kafka.bootstrap.servers");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BootstrapServersBytes => new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#else
-        private static readonly byte[] BootstrapServersBytes = new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> BootstrapServersBytes => [217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115];
+
         // ClusterIdBytes = MessagePack.Serialize("messaging.kafka.cluster_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ClusterIdBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#else
-        private static readonly byte[] ClusterIdBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ClusterIdBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100];
+
         // TopicBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // PartitionBytes = MessagePack.Serialize("kafka.partition");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] PartitionBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> PartitionBytes => [175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110];
+
         // OffsetBytes = MessagePack.Serialize("kafka.offset");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OffsetBytes => new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#else
-        private static readonly byte[] OffsetBytes = new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> OffsetBytes => [172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116];
+
         // TombstoneBytes = MessagePack.Serialize("kafka.tombstone");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TombstoneBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#else
-        private static readonly byte[] TombstoneBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> TombstoneBytes => [175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101];
+
         // ConsumerGroupBytes = MessagePack.Serialize("kafka.group");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConsumerGroupBytes => new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#else
-        private static readonly byte[] ConsumerGroupBytes = new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#endif
+        private static ReadOnlySpan<byte> ConsumerGroupBytes => [171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class KafkaV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // QueryBytes = MessagePack.Serialize("mongodb.query");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueryBytes => new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#else
-        private static readonly byte[] QueryBytes = new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> QueryBytes => [173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121];
+
         // CollectionBytes = MessagePack.Serialize("mongodb.collection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CollectionBytes => new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CollectionBytes = new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CollectionBytes => [178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class MsmqTags
     {
         // CommandBytes = MessagePack.Serialize("msmq.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PathBytes = MessagePack.Serialize("msmq.queue.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PathBytes => new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] PathBytes = new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> PathBytes => [175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104];
+
         // MessageWithTransactionBytes = MessagePack.Serialize("msmq.message.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageWithTransactionBytes => new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> MessageWithTransactionBytes => [186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
+
         // IsTransactionalQueueBytes = MessagePack.Serialize("msmq.queue.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => [184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class MsmqV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class OpenTelemetryTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // OtelTraceIdBytes = MessagePack.Serialize("otel.trace_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelTraceIdBytes => new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] OtelTraceIdBytes = new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> OtelTraceIdBytes => [173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100];
+
         // OtelLibraryNameBytes = MessagePack.Serialize("otel.library.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryNameBytes => new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OtelLibraryNameBytes = new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryNameBytes => [177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101];
+
         // OtelLibraryVersionBytes = MessagePack.Serialize("otel.library.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OtelLibraryVersionBytes = new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => [180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // OtelStatusCodeBytes = MessagePack.Serialize("otel.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelStatusCodeBytes => new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OtelStatusCodeBytes = new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelStatusCodeBytes => [176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class ProcessCommandStartTags
     {
         // ComponentBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ComponentBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] ComponentBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> ComponentBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // EnvironmentVariablesBytes = MessagePack.Serialize("cmd.environment_variables");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#else
-        private static readonly byte[] EnvironmentVariablesBytes = new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => [185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115];
+
         // CommandExecBytes = MessagePack.Serialize("cmd.exec");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExecBytes => new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#else
-        private static readonly byte[] CommandExecBytes = new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#endif
+        private static ReadOnlySpan<byte> CommandExecBytes => [168, 99, 109, 100, 46, 101, 120, 101, 99];
+
         // CommandShellBytes = MessagePack.Serialize("cmd.shell");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandShellBytes => new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#else
-        private static readonly byte[] CommandShellBytes = new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#endif
+        private static ReadOnlySpan<byte> CommandShellBytes => [169, 99, 109, 100, 46, 115, 104, 101, 108, 108];
+
         // TruncatedBytes = MessagePack.Serialize("cmd.truncated");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TruncatedBytes => new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#else
-        private static readonly byte[] TruncatedBytes = new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TruncatedBytes => [173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("amqp.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // DeliveryModeBytes = MessagePack.Serialize("amqp.delivery_mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DeliveryModeBytes => new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] DeliveryModeBytes = new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> DeliveryModeBytes => [178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101];
+
         // ExchangeBytes = MessagePack.Serialize("amqp.exchange");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ExchangeBytes => new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#else
-        private static readonly byte[] ExchangeBytes = new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> ExchangeBytes => [173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101];
+
         // RoutingKeyBytes = MessagePack.Serialize("amqp.routing_key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RoutingKeyBytes => new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#else
-        private static readonly byte[] RoutingKeyBytes = new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> RoutingKeyBytes => [176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121];
+
         // MessageSizeBytes = MessagePack.Serialize("message.size");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageSizeBytes => new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#else
-        private static readonly byte[] MessageSizeBytes = new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessageSizeBytes => [172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101];
+
         // QueueBytes = MessagePack.Serialize("amqp.queue");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueBytes => new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#else
-        private static readonly byte[] QueueBytes = new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueBytes => [170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisTags
     {
         // DatabaseIndexBytes = MessagePack.Serialize("db.redis.database_index");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIndexBytes => new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#else
-        private static readonly byte[] DatabaseIndexBytes = new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIndexBytes => [183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // RawCommandBytes = MessagePack.Serialize("redis.raw_command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RawCommandBytes => new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] RawCommandBytes = new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> RawCommandBytes => [177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class RemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodNameBytes = MessagePack.Serialize("rpc.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100];
+
         // MethodServiceBytes = MessagePack.Serialize("rpc.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RpcSystemBytes = MessagePack.Serialize("rpc.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RpcSystemBytes => new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] RpcSystemBytes = new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> RpcSystemBytes => [170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // ApplicationIdBytes = MessagePack.Serialize("service-fabric.application-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationIdBytes => new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] ApplicationIdBytes = new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationIdBytes => [189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100];
+
         // ApplicationNameBytes = MessagePack.Serialize("service-fabric.application-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationNameBytes => new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ApplicationNameBytes = new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationNameBytes => [191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101];
+
         // PartitionIdBytes = MessagePack.Serialize("service-fabric.partition-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionIdBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] PartitionIdBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> PartitionIdBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100];
+
         // NodeIdBytes = MessagePack.Serialize("service-fabric.node-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeIdBytes => new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] NodeIdBytes = new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> NodeIdBytes => [182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100];
+
         // NodeNameBytes = MessagePack.Serialize("service-fabric.node-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeNameBytes => new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NodeNameBytes = new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NodeNameBytes => [184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101];
+
         // ServiceNameBytes = MessagePack.Serialize("service-fabric.service-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceNameBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ServiceNameBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceNameBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101];
+
         // RemotingUriBytes = MessagePack.Serialize("service-fabric.service-remoting.uri");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingUriBytes => new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#else
-        private static readonly byte[] RemotingUriBytes = new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#endif
+        private static ReadOnlySpan<byte> RemotingUriBytes => [217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105];
+
         // RemotingServiceNameBytes = MessagePack.Serialize("service-fabric.service-remoting.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingServiceNameBytes => new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] RemotingServiceNameBytes = new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingServiceNameBytes => [217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RemotingMethodNameBytes = MessagePack.Serialize("service-fabric.service-remoting.method-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodNameBytes => new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RemotingMethodNameBytes = new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodNameBytes => [217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101];
+
         // RemotingMethodIdBytes = MessagePack.Serialize("service-fabric.service-remoting.method-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodIdBytes => new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingMethodIdBytes = new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodIdBytes => [217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100];
+
         // RemotingInterfaceIdBytes = MessagePack.Serialize("service-fabric.service-remoting.interface-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInterfaceIdBytes = new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => [217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100];
+
         // RemotingInvocationIdBytes = MessagePack.Serialize("service-fabric.service-remoting.invocation-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInvocationIdBytes = new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => [217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class SqlTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // DbUserBytes = MessagePack.Serialize("db.user");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbUserBytes => new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#else
-        private static readonly byte[] DbUserBytes = new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> DbUserBytes => [167, 100, 98, 46, 117, 115, 101, 114];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // DbmTraceInjectedBytes = MessagePack.Serialize("_dd.dbm_trace_injected");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#else
-        private static readonly byte[] DbmTraceInjectedBytes = new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => [182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100];
+
         // BaseHashBytes = MessagePack.Serialize("_dd.propagated_hash");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BaseHashBytes => new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#else
-        private static readonly byte[] BaseHashBytes = new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#endif
+        private static ReadOnlySpan<byte> BaseHashBytes => [179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class SqlV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
@@ -15,77 +15,40 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestModuleSpanTags
     {
         // IntelligentTestRunnerSkippingCountBytes = MessagePack.Serialize("test.itr.tests_skipping.count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingCountBytes = new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => [189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116];
+
         // TypeBytes = MessagePack.Serialize("test.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TypeBytes => new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] TypeBytes = new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> TypeBytes => [169, 116, 101, 115, 116, 46, 116, 121, 112, 101];
+
         // ModuleBytes = MessagePack.Serialize("test.module");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ModuleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#else
-        private static readonly byte[] ModuleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> ModuleBytes => [171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101];
+
         // BundleBytes = MessagePack.Serialize("test.bundle");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BundleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#else
-        private static readonly byte[] BundleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> BundleBytes => [171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101];
+
         // FrameworkBytes = MessagePack.Serialize("test.framework");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkBytes => new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#else
-        private static readonly byte[] FrameworkBytes = new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkBytes => [174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107];
+
         // FrameworkVersionBytes = MessagePack.Serialize("test.framework_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkVersionBytes => new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] FrameworkVersionBytes = new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkVersionBytes => [182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeNameBytes = MessagePack.Serialize("runtime.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeNameBytes => new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuntimeNameBytes = new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeNameBytes => [172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101];
+
         // RuntimeVersionBytes = MessagePack.Serialize("runtime.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeVersionBytes => new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] RuntimeVersionBytes = new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeVersionBytes => [175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeArchitectureBytes = MessagePack.Serialize("runtime.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] RuntimeArchitectureBytes = new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => [180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSArchitectureBytes = MessagePack.Serialize("os.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSArchitectureBytes => new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] OSArchitectureBytes = new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> OSArchitectureBytes => [175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSPlatformBytes = MessagePack.Serialize("os.platform");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSPlatformBytes => new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#else
-        private static readonly byte[] OSPlatformBytes = new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#endif
+        private static ReadOnlySpan<byte> OSPlatformBytes => [171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109];
+
         // OSVersionBytes = MessagePack.Serialize("os.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSVersionBytes => new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OSVersionBytes = new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OSVersionBytes => [170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
@@ -15,275 +15,139 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSessionSpanTags
     {
         // LogicalCpuCountBytes = MessagePack.Serialize("_dd.host.vcpu_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LogicalCpuCountBytes => new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] LogicalCpuCountBytes = new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> LogicalCpuCountBytes => [179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("test.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // WorkingDirectoryBytes = MessagePack.Serialize("test.working_directory");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> WorkingDirectoryBytes => new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#else
-        private static readonly byte[] WorkingDirectoryBytes = new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> WorkingDirectoryBytes => [182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121];
+
         // CommandExitCodeBytes = MessagePack.Serialize("test.exit_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExitCodeBytes => new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] CommandExitCodeBytes = new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> CommandExitCodeBytes => [174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101];
+
         // StatusBytes = MessagePack.Serialize("test.status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusBytes => new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] StatusBytes = new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> StatusBytes => [171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115];
+
         // LibraryVersionBytes = MessagePack.Serialize("library_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LibraryVersionBytes => [175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // CIProviderBytes = MessagePack.Serialize("ci.provider.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIProviderBytes => new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIProviderBytes = new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIProviderBytes => [176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101];
+
         // CIPipelineIdBytes = MessagePack.Serialize("ci.pipeline.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineIdBytes => new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#else
-        private static readonly byte[] CIPipelineIdBytes = new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineIdBytes => [174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100];
+
         // CIPipelineNameBytes = MessagePack.Serialize("ci.pipeline.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNameBytes => new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIPipelineNameBytes = new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNameBytes => [176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101];
+
         // CIPipelineNumberBytes = MessagePack.Serialize("ci.pipeline.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNumberBytes => new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] CIPipelineNumberBytes = new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNumberBytes => [178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114];
+
         // CIPipelineUrlBytes = MessagePack.Serialize("ci.pipeline.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineUrlBytes => new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIPipelineUrlBytes = new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineUrlBytes => [175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108];
+
         // CIJobUrlBytes = MessagePack.Serialize("ci.job.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobUrlBytes => new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIJobUrlBytes = new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIJobUrlBytes => [170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108];
+
         // CIJobNameBytes = MessagePack.Serialize("ci.job.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobNameBytes => new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIJobNameBytes = new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIJobNameBytes => [171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101];
+
         // CIJobIdBytes = MessagePack.Serialize("ci.job.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobIdBytes => new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#else
-        private static readonly byte[] CIJobIdBytes = new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIJobIdBytes => [169, 99, 105, 46, 106, 111, 98, 46, 105, 100];
+
         // StageNameBytes = MessagePack.Serialize("ci.stage.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageNameBytes => new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StageNameBytes = new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageNameBytes => [173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101];
+
         // CIWorkspacePathBytes = MessagePack.Serialize("ci.workspace_path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIWorkspacePathBytes => new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] CIWorkspacePathBytes = new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> CIWorkspacePathBytes => [177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104];
+
         // GitRepositoryBytes = MessagePack.Serialize("git.repository_url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitRepositoryBytes => new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#else
-        private static readonly byte[] GitRepositoryBytes = new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitRepositoryBytes => [178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108];
+
         // GitCommitBytes = MessagePack.Serialize("git.commit.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitBytes => new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitCommitBytes = new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitBytes => [174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97];
+
         // GitBranchBytes = MessagePack.Serialize("git.branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitBranchBytes => new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitBranchBytes = new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitBranchBytes => [170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104];
+
         // GitTagBytes = MessagePack.Serialize("git.tag");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitTagBytes => new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#else
-        private static readonly byte[] GitTagBytes = new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> GitTagBytes => [167, 103, 105, 116, 46, 116, 97, 103];
+
         // GitCommitAuthorNameBytes = MessagePack.Serialize("git.commit.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorNameBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitAuthorEmailBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitCommitterNameBytes = MessagePack.Serialize("git.commit.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterNameBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitCommitterEmailBytes = new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => [186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitMessageBytes = MessagePack.Serialize("git.commit.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitMessageBytes => new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitCommitMessageBytes = new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitMessageBytes => [178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101];
+
         // BuildSourceRootBytes = MessagePack.Serialize("build.source_root");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BuildSourceRootBytes => new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#else
-        private static readonly byte[] BuildSourceRootBytes = new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#endif
+        private static ReadOnlySpan<byte> BuildSourceRootBytes => [177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116];
+
         // GitCommitAuthorDateBytes = MessagePack.Serialize("git.commit.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorDateBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitCommitCommitterDateBytes = MessagePack.Serialize("git.commit.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // CiEnvVarsBytes = MessagePack.Serialize("_dd.ci.env_vars");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CiEnvVarsBytes => new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#else
-        private static readonly byte[] CiEnvVarsBytes = new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CiEnvVarsBytes => [175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115];
+
         // TestsSkippedBytes = MessagePack.Serialize("_dd.ci.itr.tests_skipped");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestsSkippedBytes => new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#else
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TestsSkippedBytes => [184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100];
+
         // IntelligentTestRunnerSkippingTypeBytes = MessagePack.Serialize("test.itr.tests_skipping.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingTypeBytes = new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => [188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101];
+
         // EarlyFlakeDetectionTestEnabledBytes = MessagePack.Serialize("test.early_flake.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestEnabledBytes = new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => [184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100];
+
         // EarlyFlakeDetectionTestAbortReasonBytes = MessagePack.Serialize("test.early_flake.abort_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestAbortReasonBytes = new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => [189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110];
+
         // GitPrBaseHeadCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_head_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseHeadCommitBytes = new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => [217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97];
+
         // GitPrBaseCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseCommitBytes = new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => [217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97];
+
         // GitPrBaseBranchBytes = MessagePack.Serialize("git.pull_request.base_branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitPrBaseBranchBytes = new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => [188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104];
+
         // PrNumberBytes = MessagePack.Serialize("pr.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PrNumberBytes => new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] PrNumberBytes = new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> PrNumberBytes => [169, 112, 114, 46, 110, 117, 109, 98, 101, 114];
+
         // GitHeadCommitBytes = MessagePack.Serialize("git.commit.head.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitBytes => new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitHeadCommitBytes = new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitBytes => [179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97];
+
         // GitHeadCommitAuthorNameBytes = MessagePack.Serialize("git.commit.head.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorNameBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.head.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorEmailBytes = new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => [188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitAuthorDateBytes = MessagePack.Serialize("git.commit.head.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorDateBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitCommitterNameBytes = MessagePack.Serialize("git.commit.head.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterNameBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.head.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterEmailBytes = new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => [191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitCommitterDateBytes = MessagePack.Serialize("git.commit.head.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterDateBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitMessageBytes = MessagePack.Serialize("git.commit.head.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitHeadCommitMessageBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -15,185 +15,94 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSpanTags
     {
         // SourceStartBytes = MessagePack.Serialize("test.source.start");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceStartBytes => new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#else
-        private static readonly byte[] SourceStartBytes = new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> SourceStartBytes => [177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116];
+
         // SourceEndBytes = MessagePack.Serialize("test.source.end");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceEndBytes => new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#else
-        private static readonly byte[] SourceEndBytes = new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SourceEndBytes => [175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100];
+
         // NameBytes = MessagePack.Serialize("test.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [169, 116, 101, 115, 116, 46, 110, 97, 109, 101];
+
         // ParametersBytes = MessagePack.Serialize("test.parameters");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ParametersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#else
-        private static readonly byte[] ParametersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> ParametersBytes => [175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115];
+
         // TraitsBytes = MessagePack.Serialize("test.traits");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TraitsBytes => new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#else
-        private static readonly byte[] TraitsBytes = new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#endif
+        private static ReadOnlySpan<byte> TraitsBytes => [171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115];
+
         // SkipReasonBytes = MessagePack.Serialize("test.skip_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkipReasonBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] SkipReasonBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> SkipReasonBytes => [176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110];
+
         // SkippedByIntelligentTestRunnerBytes = MessagePack.Serialize("test.skipped_by_itr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#else
-        private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#endif
+        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => [179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114];
+
         // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> UnskippableBytes => [180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101];
+
         // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#else
-        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#endif
+        private static ReadOnlySpan<byte> ForcedRunBytes => [179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110];
+
         // TestIsNewBytes = MessagePack.Serialize("test.is_new");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsNewBytes => new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#else
-        private static readonly byte[] TestIsNewBytes = new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#endif
+        private static ReadOnlySpan<byte> TestIsNewBytes => [171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119];
+
         // TestIsRetryBytes = MessagePack.Serialize("test.is_retry");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsRetryBytes => new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#else
-        private static readonly byte[] TestIsRetryBytes = new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> TestIsRetryBytes => [173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121];
+
         // TestRetryReasonBytes = MessagePack.Serialize("test.retry_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestRetryReasonBytes => new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] TestRetryReasonBytes = new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> TestRetryReasonBytes => [177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110];
+
         // BrowserDriverBytes = MessagePack.Serialize("test.browser.driver");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverBytes => new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#else
-        private static readonly byte[] BrowserDriverBytes = new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverBytes => [179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114];
+
         // BrowserDriverVersionBytes = MessagePack.Serialize("test.browser.driver_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserDriverVersionBytes = new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => [187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // BrowserNameBytes = MessagePack.Serialize("test.browser.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserNameBytes => new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BrowserNameBytes = new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BrowserNameBytes => [177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101];
+
         // BrowserVersionBytes = MessagePack.Serialize("test.browser.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserVersionBytes = new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserVersionBytes => [180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#else
-        private static readonly byte[] IsRumActiveBytes = new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#endif
+        private static ReadOnlySpan<byte> IsRumActiveBytes => [178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101];
+
         // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#else
-        private static readonly byte[] IsModifiedBytes = new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsModifiedBytes => [176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100];
+
         // IsQuarantinedBytes = MessagePack.Serialize("test.test_management.is_quarantined");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsQuarantinedBytes => new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#else
-        private static readonly byte[] IsQuarantinedBytes = new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsQuarantinedBytes => [217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100];
+
         // IsDisabledBytes = MessagePack.Serialize("test.test_management.is_test_disabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsDisabledBytes => new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IsDisabledBytes = new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsDisabledBytes => [217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100];
+
         // IsAttemptToFixBytes = MessagePack.Serialize("test.test_management.is_attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsAttemptToFixBytes => new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] IsAttemptToFixBytes = new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> IsAttemptToFixBytes => [217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
+
         // HasFailedAllRetriesBytes = MessagePack.Serialize("test.has_failed_all_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] HasFailedAllRetriesBytes = new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => [187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // AttemptToFixPassedBytes = MessagePack.Serialize("test.test_management.attempt_to_fix_passed");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#else
-        private static readonly byte[] AttemptToFixPassedBytes = new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => [217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100];
+
         // FinalStatusBytes = MessagePack.Serialize("test.final_status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FinalStatusBytes => new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] FinalStatusBytes = new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> FinalStatusBytes => [177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115];
+
         // CapabilitiesTestImpactAnalysisBytes = MessagePack.Serialize("_dd.library_capabilities.test_impact_analysis");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#else
-        private static readonly byte[] CapabilitiesTestImpactAnalysisBytes = new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => [217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115];
+
         // CapabilitiesEarlyFlakeDetectionBytes = MessagePack.Serialize("_dd.library_capabilities.early_flake_detection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CapabilitiesEarlyFlakeDetectionBytes = new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => [217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110];
+
         // CapabilitiesAutoTestRetriesBytes = MessagePack.Serialize("_dd.library_capabilities.auto_test_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] CapabilitiesAutoTestRetriesBytes = new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => [217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // CapabilitiesTestManagementQuarantineBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.quarantine");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementQuarantineBytes = new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => [217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101];
+
         // CapabilitiesTestManagementDisableBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.disable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementDisableBytes = new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => [217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101];
+
         // CapabilitiesTestManagementAttemptToFixBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementAttemptToFixBytes = new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => [217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSuiteSpanTags
     {
         // SuiteBytes = MessagePack.Serialize("test.suite");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SuiteBytes => new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#else
-        private static readonly byte[] SuiteBytes = new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> SuiteBytes => [170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101];
+
         // SourceFileBytes = MessagePack.Serialize("test.source.file");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceFileBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#else
-        private static readonly byte[] SourceFileBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceFileBytes => [176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101];
+
         // CodeOwnersBytes = MessagePack.Serialize("test.codeowners");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CodeOwnersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#else
-        private static readonly byte[] CodeOwnersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CodeOwnersBytes => [175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class TraceAnnotationTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class WcfTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class WebTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // HttpUserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] HttpUserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpUserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpRequestHeadersHostBytes = MessagePack.Serialize("http.request.headers.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HttpRequestHeadersHostBytes = new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => [185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // NetworkClientIpBytes = MessagePack.Serialize("network.client.ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkClientIpBytes => new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#else
-        private static readonly byte[] NetworkClientIpBytes = new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> NetworkClientIpBytes => [177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112];
+
         // HttpClientIpBytes = MessagePack.Serialize("http.client_ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientIpBytes => new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#else
-        private static readonly byte[] HttpClientIpBytes = new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientIpBytes => [174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // KeyBytes = MessagePack.Serialize("aerospike.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121];
+
         // NamespaceBytes = MessagePack.Serialize("aerospike.namespace");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NamespaceBytes => new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#else
-        private static readonly byte[] NamespaceBytes = new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> NamespaceBytes => [179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101];
+
         // SetNameBytes = MessagePack.Serialize("aerospike.setname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SetNameBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] SetNameBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> SetNameBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101];
+
         // UserKeyBytes = MessagePack.Serialize("aerospike.userkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserKeyBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#else
-        private static readonly byte[] UserKeyBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> UserKeyBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreEndpointTags
     {
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreMvcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreControllerBytes = MessagePack.Serialize("aspnet_core.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetCoreControllerBytes = new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => [182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetCoreActionBytes = MessagePack.Serialize("aspnet_core.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreActionBytes => new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetCoreActionBytes = new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreActionBytes => [178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetCoreAreaBytes = MessagePack.Serialize("aspnet_core.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetCoreAreaBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97];
+
         // AspNetCorePageBytes = MessagePack.Serialize("aspnet_core.page");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCorePageBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#else
-        private static readonly byte[] AspNetCorePageBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCorePageBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreSingleSpanTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AspNetTags
     {
         // AspNetRouteBytes = MessagePack.Serialize("aspnet.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetRouteBytes => new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetRouteBytes = new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetRouteBytes => [172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101];
+
         // AspNetControllerBytes = MessagePack.Serialize("aspnet.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetControllerBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetControllerBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetControllerBytes => [177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetActionBytes = MessagePack.Serialize("aspnet.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetActionBytes => new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetActionBytes = new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetActionBytes => [173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetAreaBytes = MessagePack.Serialize("aspnet.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetAreaBytes => new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetAreaBytes = new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetAreaBytes => [171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsDynamoDbTags
     {
         // TableNameBytes = MessagePack.Serialize("tablename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TableNameBytes => new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TableNameBytes = new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TableNameBytes => [169, 116, 97, 98, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsEventBridgeTags
     {
         // RuleNameBytes = MessagePack.Serialize("rulename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuleNameBytes => new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuleNameBytes = new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuleNameBytes => [168, 114, 117, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsKinesisTags
     {
         // StreamNameBytes = MessagePack.Serialize("streamname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StreamNameBytes => new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StreamNameBytes = new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StreamNameBytes => [170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AwsS3Tags
     {
         // BucketNameBytes = MessagePack.Serialize("bucketname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketNameBytes => new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BucketNameBytes = new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BucketNameBytes => [170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101];
+
         // ObjectKeyBytes = MessagePack.Serialize("objectkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ObjectKeyBytes => new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#else
-        private static readonly byte[] ObjectKeyBytes = new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> ObjectKeyBytes => [169, 111, 98, 106, 101, 99, 116, 107, 101, 121];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AwsSdkTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AgentNameBytes = MessagePack.Serialize("aws.agent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AgentNameBytes => new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] AgentNameBytes = new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AgentNameBytes => [169, 97, 119, 115, 46, 97, 103, 101, 110, 116];
+
         // OperationBytes = MessagePack.Serialize("aws.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationBytes => new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] OperationBytes = new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OperationBytes => [173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // AwsRegionBytes = MessagePack.Serialize("aws.region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsRegionBytes => new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] AwsRegionBytes = new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AwsRegionBytes => [170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
+
         // RequestIdBytes = MessagePack.Serialize("aws.requestId");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RequestIdBytes => new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] RequestIdBytes = new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> RequestIdBytes => [173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100];
+
         // AwsServiceBytes = MessagePack.Serialize("aws.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsServiceBytes => new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] AwsServiceBytes = new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsServiceBytes => [171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // ServiceBytes = MessagePack.Serialize("aws_service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceBytes => new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] ServiceBytes = new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceBytes => [171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSnsTags
     {
         // AwsTopicNameBytes = MessagePack.Serialize("aws.topic.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsTopicNameBytes => new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsTopicNameBytes = new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsTopicNameBytes => [174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
+
         // TopicArnBytes = MessagePack.Serialize("aws.topic.arn");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicArnBytes => new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#else
-        private static readonly byte[] TopicArnBytes = new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#endif
+        private static ReadOnlySpan<byte> TopicArnBytes => [173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSqsTags
     {
         // AwsQueueNameBytes = MessagePack.Serialize("aws.queue.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsQueueNameBytes => new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsQueueNameBytes = new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsQueueNameBytes => [174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101];
+
         // QueueNameBytes = MessagePack.Serialize("queuename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueNameBytes => new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] QueueNameBytes = new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueNameBytes => [169, 113, 117, 101, 117, 101, 110, 97, 109, 101];
+
         // QueueUrlBytes = MessagePack.Serialize("aws.queue.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueUrlBytes => new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] QueueUrlBytes = new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> QueueUrlBytes => [173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsStepFunctionsTags
     {
         // StateMachineNameBytes = MessagePack.Serialize("statemachinename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StateMachineNameBytes => new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StateMachineNameBytes = new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StateMachineNameBytes => [176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
+
         // MessagingBatchMessageCountBytes = MessagePack.Serialize("messaging.batch.message_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] MessagingBatchMessageCountBytes = new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => [189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116];
+
         // MessagingMessageIdBytes = MessagePack.Serialize("messaging.message_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingMessageIdBytes => new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] MessagingMessageIdBytes = new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> MessagingMessageIdBytes => [180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AzureFunctionsTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ShortNameBytes = MessagePack.Serialize("aas.function.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ShortNameBytes => new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ShortNameBytes = new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ShortNameBytes => [177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // FullNameBytes = MessagePack.Serialize("aas.function.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FullNameBytes => new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] FullNameBytes = new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> FullNameBytes => [179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100];
+
         // BindingSourceBytes = MessagePack.Serialize("aas.function.binding");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BindingSourceBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#else
-        private static readonly byte[] BindingSourceBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#endif
+        private static ReadOnlySpan<byte> BindingSourceBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103];
+
         // TriggerTypeBytes = MessagePack.Serialize("aas.function.trigger");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TriggerTypeBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#else
-        private static readonly byte[] TriggerTypeBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> TriggerTypeBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
@@ -15,71 +15,37 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
+
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // ContainerIdBytes = MessagePack.Serialize("cosmosdb.container");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ContainerIdBytes => new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#else
-        private static readonly byte[] ContainerIdBytes = new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> ContainerIdBytes => [178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114];
+
         // DatabaseIdBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIdBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DatabaseIdBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIdBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // ResponseStatusCodeBytes = MessagePack.Serialize("db.response.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseStatusCodeBytes = new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => [183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // ResponseSubStatusCodeBytes = MessagePack.Serialize("cosmosdb.response.sub_status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseSubStatusCodeBytes = new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => [217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // UserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] UserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> UserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // ConnectionModeBytes = MessagePack.Serialize("cosmosdb.connection.mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConnectionModeBytes => new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] ConnectionModeBytes = new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ConnectionModeBytes => [184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbV1Tags
     {
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SeedNodesBytes = MessagePack.Serialize("db.couchbase.seed.nodes");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SeedNodesBytes => new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#else
-        private static readonly byte[] SeedNodesBytes = new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> SeedNodesBytes => [183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115];
+
         // OperationCodeBytes = MessagePack.Serialize("couchbase.operation.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationCodeBytes => new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OperationCodeBytes = new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationCodeBytes => [184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101];
+
         // BucketBytes = MessagePack.Serialize("couchbase.operation.bucket");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketBytes => new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#else
-        private static readonly byte[] BucketBytes = new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> BucketBytes => [186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116];
+
         // KeyBytes = MessagePack.Serialize("couchbase.operation.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ActionBytes = MessagePack.Serialize("elasticsearch.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ActionBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] ActionBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> ActionBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110];
+
         // MethodBytes = MessagePack.Serialize("elasticsearch.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100];
+
         // UrlBytes = MessagePack.Serialize("elasticsearch.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UrlBytes => new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] UrlBytes = new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> UrlBytes => [177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
     partial class GraphQLTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SourceBytes = MessagePack.Serialize("graphql.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceBytes => new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] SourceBytes = new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceBytes => [174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101];
+
         // OperationNameBytes = MessagePack.Serialize("graphql.operation.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationNameBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OperationNameBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationNameBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // OperationTypeBytes = MessagePack.Serialize("graphql.operation.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationTypeBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] OperationTypeBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationTypeBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientTags
     {
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PeerHostnameBytes = MessagePack.Serialize("peer.hostname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerHostnameBytes => new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] PeerHostnameBytes = new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerHostnameBytes => [173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class GrpcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodKindBytes = MessagePack.Serialize("grpc.method.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodKindBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] MethodKindBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodKindBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100];
+
         // MethodNameBytes = MessagePack.Serialize("grpc.method.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101];
+
         // MethodPathBytes = MessagePack.Serialize("grpc.method.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPathBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] MethodPathBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> MethodPathBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104];
+
         // MethodPackageBytes = MessagePack.Serialize("grpc.method.package");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPackageBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#else
-        private static readonly byte[] MethodPackageBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodPackageBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101];
+
         // MethodServiceBytes = MessagePack.Serialize("grpc.method.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // StatusCodeBytes = MessagePack.Serialize("grpc.status.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusCodeBytes => new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] StatusCodeBytes = new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> StatusCodeBytes => [176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class HangfireTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // CreatedAtBytes = MessagePack.Serialize("job.CreatedAt");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CreatedAtBytes => new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#else
-        private static readonly byte[] CreatedAtBytes = new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#endif
+        private static ReadOnlySpan<byte> CreatedAtBytes => [173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116];
+
         // JobIdBytes = MessagePack.Serialize("job.ID");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> JobIdBytes => new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#else
-        private static readonly byte[] JobIdBytes = new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#endif
+        private static ReadOnlySpan<byte> JobIdBytes => [166, 106, 111, 98, 46, 73, 68];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class HttpTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpClientHandlerTypeBytes = MessagePack.Serialize("http-client-handler-type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] HttpClientHandlerTypeBytes = new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => [184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class HttpV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Iast
     partial class IastTags
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#else
-        private static readonly byte[] IastJsonBytes = new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> IastJsonBytes => [173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110];
+
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IastEnabledBytes = new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IastEnabledBytes => [176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class IbmMqTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class InferredProxyTags
     {
         // InferredSpanBytes = MessagePack.Serialize("_dd.inferred_span");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InferredSpanBytes => new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#else
-        private static readonly byte[] InferredSpanBytes = new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#endif
+        private static ReadOnlySpan<byte> InferredSpanBytes => [177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // StageBytes = MessagePack.Serialize("stage");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageBytes => new byte[] { 165, 115, 116, 97, 103, 101 };
-#else
-        private static readonly byte[] StageBytes = new byte[] { 165, 115, 116, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageBytes => [165, 115, 116, 97, 103, 101];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class InstrumentationTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
 
         public override double? GetMetric(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class KafkaTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // BootstrapServersBytes = MessagePack.Serialize("messaging.kafka.bootstrap.servers");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BootstrapServersBytes => new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#else
-        private static readonly byte[] BootstrapServersBytes = new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> BootstrapServersBytes => [217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115];
+
         // ClusterIdBytes = MessagePack.Serialize("messaging.kafka.cluster_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ClusterIdBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#else
-        private static readonly byte[] ClusterIdBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ClusterIdBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100];
+
         // TopicBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // PartitionBytes = MessagePack.Serialize("kafka.partition");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] PartitionBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> PartitionBytes => [175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110];
+
         // OffsetBytes = MessagePack.Serialize("kafka.offset");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OffsetBytes => new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#else
-        private static readonly byte[] OffsetBytes = new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> OffsetBytes => [172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116];
+
         // TombstoneBytes = MessagePack.Serialize("kafka.tombstone");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TombstoneBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#else
-        private static readonly byte[] TombstoneBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> TombstoneBytes => [175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101];
+
         // ConsumerGroupBytes = MessagePack.Serialize("kafka.group");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConsumerGroupBytes => new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#else
-        private static readonly byte[] ConsumerGroupBytes = new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#endif
+        private static ReadOnlySpan<byte> ConsumerGroupBytes => [171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class KafkaV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // QueryBytes = MessagePack.Serialize("mongodb.query");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueryBytes => new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#else
-        private static readonly byte[] QueryBytes = new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> QueryBytes => [173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121];
+
         // CollectionBytes = MessagePack.Serialize("mongodb.collection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CollectionBytes => new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CollectionBytes = new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CollectionBytes => [178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class MsmqTags
     {
         // CommandBytes = MessagePack.Serialize("msmq.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PathBytes = MessagePack.Serialize("msmq.queue.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PathBytes => new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] PathBytes = new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> PathBytes => [175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104];
+
         // MessageWithTransactionBytes = MessagePack.Serialize("msmq.message.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageWithTransactionBytes => new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> MessageWithTransactionBytes => [186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
+
         // IsTransactionalQueueBytes = MessagePack.Serialize("msmq.queue.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => [184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class MsmqV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class OpenTelemetryTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // OtelTraceIdBytes = MessagePack.Serialize("otel.trace_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelTraceIdBytes => new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] OtelTraceIdBytes = new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> OtelTraceIdBytes => [173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100];
+
         // OtelLibraryNameBytes = MessagePack.Serialize("otel.library.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryNameBytes => new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OtelLibraryNameBytes = new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryNameBytes => [177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101];
+
         // OtelLibraryVersionBytes = MessagePack.Serialize("otel.library.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OtelLibraryVersionBytes = new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => [180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // OtelStatusCodeBytes = MessagePack.Serialize("otel.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelStatusCodeBytes => new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OtelStatusCodeBytes = new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelStatusCodeBytes => [176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class ProcessCommandStartTags
     {
         // ComponentBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ComponentBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] ComponentBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> ComponentBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // EnvironmentVariablesBytes = MessagePack.Serialize("cmd.environment_variables");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#else
-        private static readonly byte[] EnvironmentVariablesBytes = new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => [185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115];
+
         // CommandExecBytes = MessagePack.Serialize("cmd.exec");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExecBytes => new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#else
-        private static readonly byte[] CommandExecBytes = new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#endif
+        private static ReadOnlySpan<byte> CommandExecBytes => [168, 99, 109, 100, 46, 101, 120, 101, 99];
+
         // CommandShellBytes = MessagePack.Serialize("cmd.shell");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandShellBytes => new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#else
-        private static readonly byte[] CommandShellBytes = new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#endif
+        private static ReadOnlySpan<byte> CommandShellBytes => [169, 99, 109, 100, 46, 115, 104, 101, 108, 108];
+
         // TruncatedBytes = MessagePack.Serialize("cmd.truncated");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TruncatedBytes => new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#else
-        private static readonly byte[] TruncatedBytes = new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TruncatedBytes => [173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("amqp.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // DeliveryModeBytes = MessagePack.Serialize("amqp.delivery_mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DeliveryModeBytes => new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] DeliveryModeBytes = new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> DeliveryModeBytes => [178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101];
+
         // ExchangeBytes = MessagePack.Serialize("amqp.exchange");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ExchangeBytes => new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#else
-        private static readonly byte[] ExchangeBytes = new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> ExchangeBytes => [173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101];
+
         // RoutingKeyBytes = MessagePack.Serialize("amqp.routing_key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RoutingKeyBytes => new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#else
-        private static readonly byte[] RoutingKeyBytes = new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> RoutingKeyBytes => [176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121];
+
         // MessageSizeBytes = MessagePack.Serialize("message.size");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageSizeBytes => new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#else
-        private static readonly byte[] MessageSizeBytes = new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessageSizeBytes => [172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101];
+
         // QueueBytes = MessagePack.Serialize("amqp.queue");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueBytes => new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#else
-        private static readonly byte[] QueueBytes = new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueBytes => [170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisTags
     {
         // DatabaseIndexBytes = MessagePack.Serialize("db.redis.database_index");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIndexBytes => new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#else
-        private static readonly byte[] DatabaseIndexBytes = new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIndexBytes => [183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // RawCommandBytes = MessagePack.Serialize("redis.raw_command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RawCommandBytes => new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] RawCommandBytes = new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> RawCommandBytes => [177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class RemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodNameBytes = MessagePack.Serialize("rpc.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100];
+
         // MethodServiceBytes = MessagePack.Serialize("rpc.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RpcSystemBytes = MessagePack.Serialize("rpc.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RpcSystemBytes => new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] RpcSystemBytes = new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> RpcSystemBytes => [170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // ApplicationIdBytes = MessagePack.Serialize("service-fabric.application-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationIdBytes => new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] ApplicationIdBytes = new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationIdBytes => [189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100];
+
         // ApplicationNameBytes = MessagePack.Serialize("service-fabric.application-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationNameBytes => new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ApplicationNameBytes = new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationNameBytes => [191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101];
+
         // PartitionIdBytes = MessagePack.Serialize("service-fabric.partition-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionIdBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] PartitionIdBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> PartitionIdBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100];
+
         // NodeIdBytes = MessagePack.Serialize("service-fabric.node-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeIdBytes => new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] NodeIdBytes = new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> NodeIdBytes => [182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100];
+
         // NodeNameBytes = MessagePack.Serialize("service-fabric.node-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeNameBytes => new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NodeNameBytes = new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NodeNameBytes => [184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101];
+
         // ServiceNameBytes = MessagePack.Serialize("service-fabric.service-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceNameBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ServiceNameBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceNameBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101];
+
         // RemotingUriBytes = MessagePack.Serialize("service-fabric.service-remoting.uri");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingUriBytes => new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#else
-        private static readonly byte[] RemotingUriBytes = new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#endif
+        private static ReadOnlySpan<byte> RemotingUriBytes => [217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105];
+
         // RemotingServiceNameBytes = MessagePack.Serialize("service-fabric.service-remoting.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingServiceNameBytes => new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] RemotingServiceNameBytes = new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingServiceNameBytes => [217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RemotingMethodNameBytes = MessagePack.Serialize("service-fabric.service-remoting.method-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodNameBytes => new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RemotingMethodNameBytes = new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodNameBytes => [217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101];
+
         // RemotingMethodIdBytes = MessagePack.Serialize("service-fabric.service-remoting.method-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodIdBytes => new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingMethodIdBytes = new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodIdBytes => [217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100];
+
         // RemotingInterfaceIdBytes = MessagePack.Serialize("service-fabric.service-remoting.interface-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInterfaceIdBytes = new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => [217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100];
+
         // RemotingInvocationIdBytes = MessagePack.Serialize("service-fabric.service-remoting.invocation-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInvocationIdBytes = new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => [217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class SqlTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // DbUserBytes = MessagePack.Serialize("db.user");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbUserBytes => new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#else
-        private static readonly byte[] DbUserBytes = new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> DbUserBytes => [167, 100, 98, 46, 117, 115, 101, 114];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // DbmTraceInjectedBytes = MessagePack.Serialize("_dd.dbm_trace_injected");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#else
-        private static readonly byte[] DbmTraceInjectedBytes = new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => [182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100];
+
         // BaseHashBytes = MessagePack.Serialize("_dd.propagated_hash");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BaseHashBytes => new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#else
-        private static readonly byte[] BaseHashBytes = new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#endif
+        private static ReadOnlySpan<byte> BaseHashBytes => [179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class SqlV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
@@ -15,77 +15,40 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestModuleSpanTags
     {
         // IntelligentTestRunnerSkippingCountBytes = MessagePack.Serialize("test.itr.tests_skipping.count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingCountBytes = new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => [189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116];
+
         // TypeBytes = MessagePack.Serialize("test.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TypeBytes => new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] TypeBytes = new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> TypeBytes => [169, 116, 101, 115, 116, 46, 116, 121, 112, 101];
+
         // ModuleBytes = MessagePack.Serialize("test.module");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ModuleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#else
-        private static readonly byte[] ModuleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> ModuleBytes => [171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101];
+
         // BundleBytes = MessagePack.Serialize("test.bundle");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BundleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#else
-        private static readonly byte[] BundleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> BundleBytes => [171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101];
+
         // FrameworkBytes = MessagePack.Serialize("test.framework");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkBytes => new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#else
-        private static readonly byte[] FrameworkBytes = new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkBytes => [174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107];
+
         // FrameworkVersionBytes = MessagePack.Serialize("test.framework_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkVersionBytes => new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] FrameworkVersionBytes = new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkVersionBytes => [182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeNameBytes = MessagePack.Serialize("runtime.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeNameBytes => new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuntimeNameBytes = new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeNameBytes => [172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101];
+
         // RuntimeVersionBytes = MessagePack.Serialize("runtime.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeVersionBytes => new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] RuntimeVersionBytes = new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeVersionBytes => [175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeArchitectureBytes = MessagePack.Serialize("runtime.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] RuntimeArchitectureBytes = new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => [180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSArchitectureBytes = MessagePack.Serialize("os.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSArchitectureBytes => new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] OSArchitectureBytes = new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> OSArchitectureBytes => [175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSPlatformBytes = MessagePack.Serialize("os.platform");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSPlatformBytes => new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#else
-        private static readonly byte[] OSPlatformBytes = new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#endif
+        private static ReadOnlySpan<byte> OSPlatformBytes => [171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109];
+
         // OSVersionBytes = MessagePack.Serialize("os.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSVersionBytes => new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OSVersionBytes = new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OSVersionBytes => [170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
@@ -15,275 +15,139 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSessionSpanTags
     {
         // LogicalCpuCountBytes = MessagePack.Serialize("_dd.host.vcpu_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LogicalCpuCountBytes => new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] LogicalCpuCountBytes = new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> LogicalCpuCountBytes => [179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("test.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // WorkingDirectoryBytes = MessagePack.Serialize("test.working_directory");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> WorkingDirectoryBytes => new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#else
-        private static readonly byte[] WorkingDirectoryBytes = new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> WorkingDirectoryBytes => [182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121];
+
         // CommandExitCodeBytes = MessagePack.Serialize("test.exit_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExitCodeBytes => new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] CommandExitCodeBytes = new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> CommandExitCodeBytes => [174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101];
+
         // StatusBytes = MessagePack.Serialize("test.status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusBytes => new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] StatusBytes = new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> StatusBytes => [171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115];
+
         // LibraryVersionBytes = MessagePack.Serialize("library_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LibraryVersionBytes => [175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // CIProviderBytes = MessagePack.Serialize("ci.provider.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIProviderBytes => new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIProviderBytes = new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIProviderBytes => [176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101];
+
         // CIPipelineIdBytes = MessagePack.Serialize("ci.pipeline.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineIdBytes => new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#else
-        private static readonly byte[] CIPipelineIdBytes = new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineIdBytes => [174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100];
+
         // CIPipelineNameBytes = MessagePack.Serialize("ci.pipeline.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNameBytes => new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIPipelineNameBytes = new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNameBytes => [176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101];
+
         // CIPipelineNumberBytes = MessagePack.Serialize("ci.pipeline.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNumberBytes => new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] CIPipelineNumberBytes = new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNumberBytes => [178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114];
+
         // CIPipelineUrlBytes = MessagePack.Serialize("ci.pipeline.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineUrlBytes => new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIPipelineUrlBytes = new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineUrlBytes => [175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108];
+
         // CIJobUrlBytes = MessagePack.Serialize("ci.job.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobUrlBytes => new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIJobUrlBytes = new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIJobUrlBytes => [170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108];
+
         // CIJobNameBytes = MessagePack.Serialize("ci.job.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobNameBytes => new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIJobNameBytes = new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIJobNameBytes => [171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101];
+
         // CIJobIdBytes = MessagePack.Serialize("ci.job.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobIdBytes => new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#else
-        private static readonly byte[] CIJobIdBytes = new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIJobIdBytes => [169, 99, 105, 46, 106, 111, 98, 46, 105, 100];
+
         // StageNameBytes = MessagePack.Serialize("ci.stage.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageNameBytes => new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StageNameBytes = new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageNameBytes => [173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101];
+
         // CIWorkspacePathBytes = MessagePack.Serialize("ci.workspace_path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIWorkspacePathBytes => new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] CIWorkspacePathBytes = new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> CIWorkspacePathBytes => [177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104];
+
         // GitRepositoryBytes = MessagePack.Serialize("git.repository_url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitRepositoryBytes => new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#else
-        private static readonly byte[] GitRepositoryBytes = new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitRepositoryBytes => [178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108];
+
         // GitCommitBytes = MessagePack.Serialize("git.commit.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitBytes => new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitCommitBytes = new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitBytes => [174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97];
+
         // GitBranchBytes = MessagePack.Serialize("git.branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitBranchBytes => new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitBranchBytes = new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitBranchBytes => [170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104];
+
         // GitTagBytes = MessagePack.Serialize("git.tag");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitTagBytes => new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#else
-        private static readonly byte[] GitTagBytes = new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> GitTagBytes => [167, 103, 105, 116, 46, 116, 97, 103];
+
         // GitCommitAuthorNameBytes = MessagePack.Serialize("git.commit.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorNameBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitAuthorEmailBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitCommitterNameBytes = MessagePack.Serialize("git.commit.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterNameBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitCommitterEmailBytes = new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => [186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitMessageBytes = MessagePack.Serialize("git.commit.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitMessageBytes => new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitCommitMessageBytes = new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitMessageBytes => [178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101];
+
         // BuildSourceRootBytes = MessagePack.Serialize("build.source_root");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BuildSourceRootBytes => new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#else
-        private static readonly byte[] BuildSourceRootBytes = new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#endif
+        private static ReadOnlySpan<byte> BuildSourceRootBytes => [177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116];
+
         // GitCommitAuthorDateBytes = MessagePack.Serialize("git.commit.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorDateBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitCommitCommitterDateBytes = MessagePack.Serialize("git.commit.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // CiEnvVarsBytes = MessagePack.Serialize("_dd.ci.env_vars");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CiEnvVarsBytes => new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#else
-        private static readonly byte[] CiEnvVarsBytes = new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CiEnvVarsBytes => [175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115];
+
         // TestsSkippedBytes = MessagePack.Serialize("_dd.ci.itr.tests_skipped");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestsSkippedBytes => new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#else
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TestsSkippedBytes => [184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100];
+
         // IntelligentTestRunnerSkippingTypeBytes = MessagePack.Serialize("test.itr.tests_skipping.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingTypeBytes = new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => [188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101];
+
         // EarlyFlakeDetectionTestEnabledBytes = MessagePack.Serialize("test.early_flake.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestEnabledBytes = new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => [184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100];
+
         // EarlyFlakeDetectionTestAbortReasonBytes = MessagePack.Serialize("test.early_flake.abort_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestAbortReasonBytes = new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => [189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110];
+
         // GitPrBaseHeadCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_head_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseHeadCommitBytes = new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => [217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97];
+
         // GitPrBaseCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseCommitBytes = new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => [217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97];
+
         // GitPrBaseBranchBytes = MessagePack.Serialize("git.pull_request.base_branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitPrBaseBranchBytes = new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => [188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104];
+
         // PrNumberBytes = MessagePack.Serialize("pr.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PrNumberBytes => new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] PrNumberBytes = new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> PrNumberBytes => [169, 112, 114, 46, 110, 117, 109, 98, 101, 114];
+
         // GitHeadCommitBytes = MessagePack.Serialize("git.commit.head.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitBytes => new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitHeadCommitBytes = new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitBytes => [179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97];
+
         // GitHeadCommitAuthorNameBytes = MessagePack.Serialize("git.commit.head.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorNameBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.head.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorEmailBytes = new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => [188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitAuthorDateBytes = MessagePack.Serialize("git.commit.head.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorDateBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitCommitterNameBytes = MessagePack.Serialize("git.commit.head.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterNameBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.head.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterEmailBytes = new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => [191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitCommitterDateBytes = MessagePack.Serialize("git.commit.head.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterDateBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitMessageBytes = MessagePack.Serialize("git.commit.head.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitHeadCommitMessageBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -15,185 +15,94 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSpanTags
     {
         // SourceStartBytes = MessagePack.Serialize("test.source.start");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceStartBytes => new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#else
-        private static readonly byte[] SourceStartBytes = new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> SourceStartBytes => [177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116];
+
         // SourceEndBytes = MessagePack.Serialize("test.source.end");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceEndBytes => new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#else
-        private static readonly byte[] SourceEndBytes = new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SourceEndBytes => [175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100];
+
         // NameBytes = MessagePack.Serialize("test.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [169, 116, 101, 115, 116, 46, 110, 97, 109, 101];
+
         // ParametersBytes = MessagePack.Serialize("test.parameters");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ParametersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#else
-        private static readonly byte[] ParametersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> ParametersBytes => [175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115];
+
         // TraitsBytes = MessagePack.Serialize("test.traits");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TraitsBytes => new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#else
-        private static readonly byte[] TraitsBytes = new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#endif
+        private static ReadOnlySpan<byte> TraitsBytes => [171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115];
+
         // SkipReasonBytes = MessagePack.Serialize("test.skip_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkipReasonBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] SkipReasonBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> SkipReasonBytes => [176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110];
+
         // SkippedByIntelligentTestRunnerBytes = MessagePack.Serialize("test.skipped_by_itr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#else
-        private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#endif
+        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => [179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114];
+
         // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> UnskippableBytes => [180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101];
+
         // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#else
-        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#endif
+        private static ReadOnlySpan<byte> ForcedRunBytes => [179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110];
+
         // TestIsNewBytes = MessagePack.Serialize("test.is_new");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsNewBytes => new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#else
-        private static readonly byte[] TestIsNewBytes = new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#endif
+        private static ReadOnlySpan<byte> TestIsNewBytes => [171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119];
+
         // TestIsRetryBytes = MessagePack.Serialize("test.is_retry");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsRetryBytes => new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#else
-        private static readonly byte[] TestIsRetryBytes = new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> TestIsRetryBytes => [173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121];
+
         // TestRetryReasonBytes = MessagePack.Serialize("test.retry_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestRetryReasonBytes => new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] TestRetryReasonBytes = new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> TestRetryReasonBytes => [177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110];
+
         // BrowserDriverBytes = MessagePack.Serialize("test.browser.driver");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverBytes => new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#else
-        private static readonly byte[] BrowserDriverBytes = new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverBytes => [179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114];
+
         // BrowserDriverVersionBytes = MessagePack.Serialize("test.browser.driver_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserDriverVersionBytes = new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => [187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // BrowserNameBytes = MessagePack.Serialize("test.browser.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserNameBytes => new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BrowserNameBytes = new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BrowserNameBytes => [177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101];
+
         // BrowserVersionBytes = MessagePack.Serialize("test.browser.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserVersionBytes = new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserVersionBytes => [180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#else
-        private static readonly byte[] IsRumActiveBytes = new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#endif
+        private static ReadOnlySpan<byte> IsRumActiveBytes => [178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101];
+
         // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#else
-        private static readonly byte[] IsModifiedBytes = new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsModifiedBytes => [176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100];
+
         // IsQuarantinedBytes = MessagePack.Serialize("test.test_management.is_quarantined");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsQuarantinedBytes => new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#else
-        private static readonly byte[] IsQuarantinedBytes = new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsQuarantinedBytes => [217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100];
+
         // IsDisabledBytes = MessagePack.Serialize("test.test_management.is_test_disabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsDisabledBytes => new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IsDisabledBytes = new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsDisabledBytes => [217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100];
+
         // IsAttemptToFixBytes = MessagePack.Serialize("test.test_management.is_attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsAttemptToFixBytes => new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] IsAttemptToFixBytes = new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> IsAttemptToFixBytes => [217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
+
         // HasFailedAllRetriesBytes = MessagePack.Serialize("test.has_failed_all_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] HasFailedAllRetriesBytes = new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => [187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // AttemptToFixPassedBytes = MessagePack.Serialize("test.test_management.attempt_to_fix_passed");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#else
-        private static readonly byte[] AttemptToFixPassedBytes = new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => [217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100];
+
         // FinalStatusBytes = MessagePack.Serialize("test.final_status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FinalStatusBytes => new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] FinalStatusBytes = new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> FinalStatusBytes => [177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115];
+
         // CapabilitiesTestImpactAnalysisBytes = MessagePack.Serialize("_dd.library_capabilities.test_impact_analysis");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#else
-        private static readonly byte[] CapabilitiesTestImpactAnalysisBytes = new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => [217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115];
+
         // CapabilitiesEarlyFlakeDetectionBytes = MessagePack.Serialize("_dd.library_capabilities.early_flake_detection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CapabilitiesEarlyFlakeDetectionBytes = new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => [217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110];
+
         // CapabilitiesAutoTestRetriesBytes = MessagePack.Serialize("_dd.library_capabilities.auto_test_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] CapabilitiesAutoTestRetriesBytes = new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => [217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // CapabilitiesTestManagementQuarantineBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.quarantine");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementQuarantineBytes = new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => [217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101];
+
         // CapabilitiesTestManagementDisableBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.disable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementDisableBytes = new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => [217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101];
+
         // CapabilitiesTestManagementAttemptToFixBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementAttemptToFixBytes = new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => [217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSuiteSpanTags
     {
         // SuiteBytes = MessagePack.Serialize("test.suite");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SuiteBytes => new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#else
-        private static readonly byte[] SuiteBytes = new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> SuiteBytes => [170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101];
+
         // SourceFileBytes = MessagePack.Serialize("test.source.file");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceFileBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#else
-        private static readonly byte[] SourceFileBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceFileBytes => [176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101];
+
         // CodeOwnersBytes = MessagePack.Serialize("test.codeowners");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CodeOwnersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#else
-        private static readonly byte[] CodeOwnersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CodeOwnersBytes => [175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class TraceAnnotationTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class WcfTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class WebTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // HttpUserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] HttpUserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpUserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpRequestHeadersHostBytes = MessagePack.Serialize("http.request.headers.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HttpRequestHeadersHostBytes = new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => [185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // NetworkClientIpBytes = MessagePack.Serialize("network.client.ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkClientIpBytes => new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#else
-        private static readonly byte[] NetworkClientIpBytes = new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> NetworkClientIpBytes => [177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112];
+
         // HttpClientIpBytes = MessagePack.Serialize("http.client_ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientIpBytes => new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#else
-        private static readonly byte[] HttpClientIpBytes = new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientIpBytes => [174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // KeyBytes = MessagePack.Serialize("aerospike.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [173, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 107, 101, 121];
+
         // NamespaceBytes = MessagePack.Serialize("aerospike.namespace");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NamespaceBytes => new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#else
-        private static readonly byte[] NamespaceBytes = new byte[] { 179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> NamespaceBytes => [179, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 110, 97, 109, 101, 115, 112, 97, 99, 101];
+
         // SetNameBytes = MessagePack.Serialize("aerospike.setname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SetNameBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] SetNameBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> SetNameBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 115, 101, 116, 110, 97, 109, 101];
+
         // UserKeyBytes = MessagePack.Serialize("aerospike.userkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserKeyBytes => new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#else
-        private static readonly byte[] UserKeyBytes = new byte[] { 177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> UserKeyBytes => [177, 97, 101, 114, 111, 115, 112, 105, 107, 101, 46, 117, 115, 101, 114, 107, 101, 121];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AerospikeV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AerospikeV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreEndpointTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreEndpointTags
     {
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreMvcTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreMvcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreControllerBytes = MessagePack.Serialize("aspnet_core.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetCoreControllerBytes = new byte[] { 182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreControllerBytes => [182, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetCoreActionBytes = MessagePack.Serialize("aspnet_core.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreActionBytes => new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetCoreActionBytes = new byte[] { 178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreActionBytes => [178, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetCoreAreaBytes = MessagePack.Serialize("aspnet_core.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetCoreAreaBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreAreaBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 97, 114, 101, 97];
+
         // AspNetCorePageBytes = MessagePack.Serialize("aspnet_core.page");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCorePageBytes => new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#else
-        private static readonly byte[] AspNetCorePageBytes = new byte[] { 176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCorePageBytes => [176, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 112, 97, 103, 101];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreSingleSpanTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // AspNetCoreEndpointBytes = MessagePack.Serialize("aspnet_core.endpoint");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#else
-        private static readonly byte[] AspNetCoreEndpointBytes = new byte[] { 180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreEndpointBytes => [180, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 101, 110, 100, 112, 111, 105, 110, 116];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AspNetCoreTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AspNetCoreRouteBytes = MessagePack.Serialize("aspnet_core.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetCoreRouteBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetCoreRouteBytes => [177, 97, 115, 112, 110, 101, 116, 95, 99, 111, 114, 101, 46, 114, 111, 117, 116, 101];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AspNetTags
     {
         // AspNetRouteBytes = MessagePack.Serialize("aspnet.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetRouteBytes => new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] AspNetRouteBytes = new byte[] { 172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> AspNetRouteBytes => [172, 97, 115, 112, 110, 101, 116, 46, 114, 111, 117, 116, 101];
+
         // AspNetControllerBytes = MessagePack.Serialize("aspnet.controller");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetControllerBytes => new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#else
-        private static readonly byte[] AspNetControllerBytes = new byte[] { 177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> AspNetControllerBytes => [177, 97, 115, 112, 110, 101, 116, 46, 99, 111, 110, 116, 114, 111, 108, 108, 101, 114];
+
         // AspNetActionBytes = MessagePack.Serialize("aspnet.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetActionBytes => new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] AspNetActionBytes = new byte[] { 173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AspNetActionBytes => [173, 97, 115, 112, 110, 101, 116, 46, 97, 99, 116, 105, 111, 110];
+
         // AspNetAreaBytes = MessagePack.Serialize("aspnet.area");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AspNetAreaBytes => new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#else
-        private static readonly byte[] AspNetAreaBytes = new byte[] { 171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97 };
-#endif
+        private static ReadOnlySpan<byte> AspNetAreaBytes => [171, 97, 115, 112, 110, 101, 116, 46, 97, 114, 101, 97];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsDynamoDbTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsDynamoDbTags
     {
         // TableNameBytes = MessagePack.Serialize("tablename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TableNameBytes => new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TableNameBytes = new byte[] { 169, 116, 97, 98, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TableNameBytes => [169, 116, 97, 98, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsEventBridgeTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsEventBridgeTags
     {
         // RuleNameBytes = MessagePack.Serialize("rulename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuleNameBytes => new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuleNameBytes = new byte[] { 168, 114, 117, 108, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuleNameBytes => [168, 114, 117, 108, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsKinesisTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsKinesisTags
     {
         // StreamNameBytes = MessagePack.Serialize("streamname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StreamNameBytes => new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StreamNameBytes = new byte[] { 170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StreamNameBytes => [170, 115, 116, 114, 101, 97, 109, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsS3Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class AwsS3Tags
     {
         // BucketNameBytes = MessagePack.Serialize("bucketname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketNameBytes => new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BucketNameBytes = new byte[] { 170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BucketNameBytes => [170, 98, 117, 99, 107, 101, 116, 110, 97, 109, 101];
+
         // ObjectKeyBytes = MessagePack.Serialize("objectkey");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ObjectKeyBytes => new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#else
-        private static readonly byte[] ObjectKeyBytes = new byte[] { 169, 111, 98, 106, 101, 99, 116, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> ObjectKeyBytes => [169, 111, 98, 106, 101, 99, 116, 107, 101, 121];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSdkTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AwsSdkTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // AgentNameBytes = MessagePack.Serialize("aws.agent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AgentNameBytes => new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] AgentNameBytes = new byte[] { 169, 97, 119, 115, 46, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> AgentNameBytes => [169, 97, 119, 115, 46, 97, 103, 101, 110, 116];
+
         // OperationBytes = MessagePack.Serialize("aws.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationBytes => new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] OperationBytes = new byte[] { 173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OperationBytes => [173, 97, 119, 115, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // AwsRegionBytes = MessagePack.Serialize("aws.region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsRegionBytes => new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] AwsRegionBytes = new byte[] { 170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> AwsRegionBytes => [170, 97, 119, 115, 46, 114, 101, 103, 105, 111, 110];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
+
         // RequestIdBytes = MessagePack.Serialize("aws.requestId");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RequestIdBytes => new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] RequestIdBytes = new byte[] { 173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> RequestIdBytes => [173, 97, 119, 115, 46, 114, 101, 113, 117, 101, 115, 116, 73, 100];
+
         // AwsServiceBytes = MessagePack.Serialize("aws.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsServiceBytes => new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] AwsServiceBytes = new byte[] { 171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsServiceBytes => [171, 97, 119, 115, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // ServiceBytes = MessagePack.Serialize("aws_service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceBytes => new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] ServiceBytes = new byte[] { 171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceBytes => [171, 97, 119, 115, 95, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSnsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSnsTags
     {
         // AwsTopicNameBytes = MessagePack.Serialize("aws.topic.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsTopicNameBytes => new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsTopicNameBytes = new byte[] { 174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsTopicNameBytes => [174, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 110, 97, 109, 101];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
+
         // TopicArnBytes = MessagePack.Serialize("aws.topic.arn");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicArnBytes => new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#else
-        private static readonly byte[] TopicArnBytes = new byte[] { 173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110 };
-#endif
+        private static ReadOnlySpan<byte> TopicArnBytes => [173, 97, 119, 115, 46, 116, 111, 112, 105, 99, 46, 97, 114, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsSqsTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class AwsSqsTags
     {
         // AwsQueueNameBytes = MessagePack.Serialize("aws.queue.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AwsQueueNameBytes => new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] AwsQueueNameBytes = new byte[] { 174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> AwsQueueNameBytes => [174, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 110, 97, 109, 101];
+
         // QueueNameBytes = MessagePack.Serialize("queuename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueNameBytes => new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] QueueNameBytes = new byte[] { 169, 113, 117, 101, 117, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueNameBytes => [169, 113, 117, 101, 117, 101, 110, 97, 109, 101];
+
         // QueueUrlBytes = MessagePack.Serialize("aws.queue.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueUrlBytes => new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] QueueUrlBytes = new byte[] { 173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> QueueUrlBytes => [173, 97, 119, 115, 46, 113, 117, 101, 117, 101, 46, 117, 114, 108];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AwsStepFunctionsTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AwsStepFunctionsTags
     {
         // StateMachineNameBytes = MessagePack.Serialize("statemachinename");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StateMachineNameBytes => new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StateMachineNameBytes = new byte[] { 176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StateMachineNameBytes => [176, 115, 116, 97, 116, 101, 109, 97, 99, 104, 105, 110, 101, 110, 97, 109, 101];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
+
         // MessagingBatchMessageCountBytes = MessagePack.Serialize("messaging.batch.message_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] MessagingBatchMessageCountBytes = new byte[] { 189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> MessagingBatchMessageCountBytes => [189, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 98, 97, 116, 99, 104, 46, 109, 101, 115, 115, 97, 103, 101, 95, 99, 111, 117, 110, 116];
+
         // MessagingMessageIdBytes = MessagePack.Serialize("messaging.message_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingMessageIdBytes => new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] MessagingMessageIdBytes = new byte[] { 180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> MessagingMessageIdBytes => [180, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 101, 115, 115, 97, 103, 101, 95, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureEventHubsV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureEventHubsV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureFunctionsTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class AzureFunctionsTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ShortNameBytes = MessagePack.Serialize("aas.function.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ShortNameBytes => new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ShortNameBytes = new byte[] { 177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ShortNameBytes => [177, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // FullNameBytes = MessagePack.Serialize("aas.function.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FullNameBytes => new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] FullNameBytes = new byte[] { 179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> FullNameBytes => [179, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 109, 101, 116, 104, 111, 100];
+
         // BindingSourceBytes = MessagePack.Serialize("aas.function.binding");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BindingSourceBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#else
-        private static readonly byte[] BindingSourceBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103 };
-#endif
+        private static ReadOnlySpan<byte> BindingSourceBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 98, 105, 110, 100, 105, 110, 103];
+
         // TriggerTypeBytes = MessagePack.Serialize("aas.function.trigger");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TriggerTypeBytes => new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#else
-        private static readonly byte[] TriggerTypeBytes = new byte[] { 180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> TriggerTypeBytes => [180, 97, 97, 115, 46, 102, 117, 110, 99, 116, 105, 111, 110, 46, 116, 114, 105, 103, 103, 101, 114];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusTags.g.cs
@@ -15,71 +15,37 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
+
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MessagingSystemBytes = MessagePack.Serialize("messaging.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSystemBytes => new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] MessagingSystemBytes = new byte[] { 176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSystemBytes => [176, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 121, 115, 116, 101, 109];
+
         // MessagingOperationBytes = MessagePack.Serialize("messaging.operation");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingOperationBytes => new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] MessagingOperationBytes = new byte[] { 179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> MessagingOperationBytes => [179, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110];
+
         // MessagingSourceNameBytes = MessagePack.Serialize("messaging.source.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingSourceNameBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingSourceNameBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingSourceNameBytes => [181, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 115, 111, 117, 114, 99, 101, 46, 110, 97, 109, 101];
+
         // MessagingDestinationNameBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MessagingDestinationNameBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessagingDestinationNameBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // LegacyMessageBusDestinationBytes = MessagePack.Serialize("message_bus.destination");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] LegacyMessageBusDestinationBytes = new byte[] { 183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LegacyMessageBusDestinationBytes => [183, 109, 101, 115, 115, 97, 103, 101, 95, 98, 117, 115, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110];
+
         // NetworkDestinationNameBytes = MessagePack.Serialize("network.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NetworkDestinationNameBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationNameBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // NetworkDestinationPortBytes = MessagePack.Serialize("network.destination.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] NetworkDestinationPortBytes = new byte[] { 184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> NetworkDestinationPortBytes => [184, 110, 101, 116, 119, 111, 114, 107, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 112, 111, 114, 116];
+
         // ServerAddressBytes = MessagePack.Serialize("server.address");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServerAddressBytes => new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#else
-        private static readonly byte[] ServerAddressBytes = new byte[] { 174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115 };
-#endif
+        private static ReadOnlySpan<byte> ServerAddressBytes => [174, 115, 101, 114, 118, 101, 114, 46, 97, 100, 100, 114, 101, 115, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AzureServiceBusV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class AzureServiceBusV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // ContainerIdBytes = MessagePack.Serialize("cosmosdb.container");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ContainerIdBytes => new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#else
-        private static readonly byte[] ContainerIdBytes = new byte[] { 178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> ContainerIdBytes => [178, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 116, 97, 105, 110, 101, 114];
+
         // DatabaseIdBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIdBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DatabaseIdBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIdBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // ResponseStatusCodeBytes = MessagePack.Serialize("db.response.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseStatusCodeBytes = new byte[] { 183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseStatusCodeBytes => [183, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // ResponseSubStatusCodeBytes = MessagePack.Serialize("cosmosdb.response.sub_status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] ResponseSubStatusCodeBytes = new byte[] { 217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ResponseSubStatusCodeBytes => [217, 33, 99, 111, 115, 109, 111, 115, 100, 98, 46, 114, 101, 115, 112, 111, 110, 115, 101, 46, 115, 117, 98, 95, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // UserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] UserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> UserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // ConnectionModeBytes = MessagePack.Serialize("cosmosdb.connection.mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConnectionModeBytes => new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] ConnectionModeBytes = new byte[] { 184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> ConnectionModeBytes => [184, 99, 111, 115, 109, 111, 115, 100, 98, 46, 99, 111, 110, 110, 101, 99, 116, 105, 111, 110, 46, 109, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CosmosDbV1Tags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class CosmosDbV1Tags
     {
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
+
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SeedNodesBytes = MessagePack.Serialize("db.couchbase.seed.nodes");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SeedNodesBytes => new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#else
-        private static readonly byte[] SeedNodesBytes = new byte[] { 183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> SeedNodesBytes => [183, 100, 98, 46, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 115, 101, 101, 100, 46, 110, 111, 100, 101, 115];
+
         // OperationCodeBytes = MessagePack.Serialize("couchbase.operation.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationCodeBytes => new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OperationCodeBytes = new byte[] { 184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationCodeBytes => [184, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 99, 111, 100, 101];
+
         // BucketBytes = MessagePack.Serialize("couchbase.operation.bucket");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BucketBytes => new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#else
-        private static readonly byte[] BucketBytes = new byte[] { 186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> BucketBytes => [186, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 98, 117, 99, 107, 101, 116];
+
         // KeyBytes = MessagePack.Serialize("couchbase.operation.key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> KeyBytes => new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#else
-        private static readonly byte[] KeyBytes = new byte[] { 183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> KeyBytes => [183, 99, 111, 117, 99, 104, 98, 97, 115, 101, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 107, 101, 121];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/CouchbaseV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class CouchbaseV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // ActionBytes = MessagePack.Serialize("elasticsearch.action");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ActionBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] ActionBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> ActionBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 97, 99, 116, 105, 111, 110];
+
         // MethodBytes = MessagePack.Serialize("elasticsearch.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodBytes => new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodBytes = new byte[] { 180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodBytes => [180, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 109, 101, 116, 104, 111, 100];
+
         // UrlBytes = MessagePack.Serialize("elasticsearch.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UrlBytes => new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] UrlBytes = new byte[] { 177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> UrlBytes => [177, 101, 108, 97, 115, 116, 105, 99, 115, 101, 97, 114, 99, 104, 46, 117, 114, 108];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ElasticsearchV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
     partial class ElasticsearchV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GraphQLTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
     partial class GraphQLTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SourceBytes = MessagePack.Serialize("graphql.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceBytes => new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] SourceBytes = new byte[] { 174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceBytes => [174, 103, 114, 97, 112, 104, 113, 108, 46, 115, 111, 117, 114, 99, 101];
+
         // OperationNameBytes = MessagePack.Serialize("graphql.operation.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationNameBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OperationNameBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationNameBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // OperationTypeBytes = MessagePack.Serialize("graphql.operation.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OperationTypeBytes => new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] OperationTypeBytes = new byte[] { 182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> OperationTypeBytes => [182, 103, 114, 97, 112, 104, 113, 108, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110, 46, 116, 121, 112, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientTags
     {
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PeerHostnameBytes = MessagePack.Serialize("peer.hostname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerHostnameBytes => new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] PeerHostnameBytes = new byte[] { 173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerHostnameBytes => [173, 112, 101, 101, 114, 46, 104, 111, 115, 116, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class GrpcClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/GrpcTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class GrpcTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodKindBytes = MessagePack.Serialize("grpc.method.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodKindBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] MethodKindBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodKindBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 107, 105, 110, 100];
+
         // MethodNameBytes = MessagePack.Serialize("grpc.method.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 110, 97, 109, 101];
+
         // MethodPathBytes = MessagePack.Serialize("grpc.method.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPathBytes => new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] MethodPathBytes = new byte[] { 176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> MethodPathBytes => [176, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 116, 104];
+
         // MethodPackageBytes = MessagePack.Serialize("grpc.method.package");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodPackageBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#else
-        private static readonly byte[] MethodPackageBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodPackageBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 112, 97, 99, 107, 97, 103, 101];
+
         // MethodServiceBytes = MessagePack.Serialize("grpc.method.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [179, 103, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // StatusCodeBytes = MessagePack.Serialize("grpc.status.code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusCodeBytes => new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] StatusCodeBytes = new byte[] { 176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> StatusCodeBytes => [176, 103, 114, 112, 99, 46, 115, 116, 97, 116, 117, 115, 46, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/HangfireTags.g.cs
@@ -15,29 +15,16 @@ namespace Datadog.Trace.Tagging
     partial class HangfireTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // CreatedAtBytes = MessagePack.Serialize("job.CreatedAt");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CreatedAtBytes => new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#else
-        private static readonly byte[] CreatedAtBytes = new byte[] { 173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116 };
-#endif
+        private static ReadOnlySpan<byte> CreatedAtBytes => [173, 106, 111, 98, 46, 67, 114, 101, 97, 116, 101, 100, 65, 116];
+
         // JobIdBytes = MessagePack.Serialize("job.ID");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> JobIdBytes => new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#else
-        private static readonly byte[] JobIdBytes = new byte[] { 166, 106, 111, 98, 46, 73, 68 };
-#endif
+        private static ReadOnlySpan<byte> JobIdBytes => [166, 106, 111, 98, 46, 73, 68];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class HttpTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpClientHandlerTypeBytes = MessagePack.Serialize("http-client-handler-type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] HttpClientHandlerTypeBytes = new byte[] { 184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientHandlerTypeBytes => [184, 104, 116, 116, 112, 45, 99, 108, 105, 101, 110, 116, 45, 104, 97, 110, 100, 108, 101, 114, 45, 116, 121, 112, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/HttpV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class HttpV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Iast
     partial class IastTags
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#else
-        private static readonly byte[] IastJsonBytes = new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> IastJsonBytes => [173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110];
+
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IastEnabledBytes = new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IastEnabledBytes => [176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/IbmMqTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Tagging
     partial class IbmMqTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // TopicNameBytes = MessagePack.Serialize("topicname");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicNameBytes => new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicNameBytes = new byte[] { 169, 116, 111, 112, 105, 99, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicNameBytes => [169, 116, 111, 112, 105, 99, 110, 97, 109, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/InferredProxyTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class InferredProxyTags
     {
         // InferredSpanBytes = MessagePack.Serialize("_dd.inferred_span");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InferredSpanBytes => new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#else
-        private static readonly byte[] InferredSpanBytes = new byte[] { 177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110 };
-#endif
+        private static ReadOnlySpan<byte> InferredSpanBytes => [177, 95, 100, 100, 46, 105, 110, 102, 101, 114, 114, 101, 100, 95, 115, 112, 97, 110];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpRouteBytes = MessagePack.Serialize("http.route");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRouteBytes => new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#else
-        private static readonly byte[] HttpRouteBytes = new byte[] { 170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpRouteBytes => [170, 104, 116, 116, 112, 46, 114, 111, 117, 116, 101];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // StageBytes = MessagePack.Serialize("stage");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageBytes => new byte[] { 165, 115, 116, 97, 103, 101 };
-#else
-        private static readonly byte[] StageBytes = new byte[] { 165, 115, 116, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageBytes => [165, 115, 116, 97, 103, 101];
+
         // RegionBytes = MessagePack.Serialize("region");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RegionBytes => new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#else
-        private static readonly byte[] RegionBytes = new byte[] { 166, 114, 101, 103, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RegionBytes => [166, 114, 101, 103, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/InstrumentationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class InstrumentationTags
     {
         // AnalyticsSampleRateBytes = MessagePack.Serialize("_dd1.sr.eausr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#else
-        private static readonly byte[] AnalyticsSampleRateBytes = new byte[] { 173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114 };
-#endif
+        private static ReadOnlySpan<byte> AnalyticsSampleRateBytes => [173, 95, 100, 100, 49, 46, 115, 114, 46, 101, 97, 117, 115, 114];
 
         public override double? GetMetric(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaTags.g.cs
@@ -15,65 +15,34 @@ namespace Datadog.Trace.Tagging
     partial class KafkaTags
     {
         // MessageQueueTimeMsBytes = MessagePack.Serialize("message.queue_time_ms");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#else
-        private static readonly byte[] MessageQueueTimeMsBytes = new byte[] { 181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115 };
-#endif
+        private static ReadOnlySpan<byte> MessageQueueTimeMsBytes => [181, 109, 101, 115, 115, 97, 103, 101, 46, 113, 117, 101, 117, 101, 95, 116, 105, 109, 101, 95, 109, 115];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // BootstrapServersBytes = MessagePack.Serialize("messaging.kafka.bootstrap.servers");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BootstrapServersBytes => new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#else
-        private static readonly byte[] BootstrapServersBytes = new byte[] { 217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> BootstrapServersBytes => [217, 33, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 98, 111, 111, 116, 115, 116, 114, 97, 112, 46, 115, 101, 114, 118, 101, 114, 115];
+
         // ClusterIdBytes = MessagePack.Serialize("messaging.kafka.cluster_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ClusterIdBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#else
-        private static readonly byte[] ClusterIdBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ClusterIdBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 107, 97, 102, 107, 97, 46, 99, 108, 117, 115, 116, 101, 114, 95, 105, 100];
+
         // TopicBytes = MessagePack.Serialize("messaging.destination.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TopicBytes => new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] TopicBytes = new byte[] { 186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> TopicBytes => [186, 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110, 46, 110, 97, 109, 101];
+
         // PartitionBytes = MessagePack.Serialize("kafka.partition");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] PartitionBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> PartitionBytes => [175, 107, 97, 102, 107, 97, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110];
+
         // OffsetBytes = MessagePack.Serialize("kafka.offset");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OffsetBytes => new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#else
-        private static readonly byte[] OffsetBytes = new byte[] { 172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116 };
-#endif
+        private static ReadOnlySpan<byte> OffsetBytes => [172, 107, 97, 102, 107, 97, 46, 111, 102, 102, 115, 101, 116];
+
         // TombstoneBytes = MessagePack.Serialize("kafka.tombstone");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TombstoneBytes => new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#else
-        private static readonly byte[] TombstoneBytes = new byte[] { 175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> TombstoneBytes => [175, 107, 97, 102, 107, 97, 46, 116, 111, 109, 98, 115, 116, 111, 110, 101];
+
         // ConsumerGroupBytes = MessagePack.Serialize("kafka.group");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ConsumerGroupBytes => new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#else
-        private static readonly byte[] ConsumerGroupBytes = new byte[] { 171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112 };
-#endif
+        private static ReadOnlySpan<byte> ConsumerGroupBytes => [171, 107, 97, 102, 107, 97, 46, 103, 114, 111, 117, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/KafkaV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class KafkaV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // QueryBytes = MessagePack.Serialize("mongodb.query");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueryBytes => new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#else
-        private static readonly byte[] QueryBytes = new byte[] { 173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> QueryBytes => [173, 109, 111, 110, 103, 111, 100, 98, 46, 113, 117, 101, 114, 121];
+
         // CollectionBytes = MessagePack.Serialize("mongodb.collection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CollectionBytes => new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CollectionBytes = new byte[] { 178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CollectionBytes => [178, 109, 111, 110, 103, 111, 100, 98, 46, 99, 111, 108, 108, 101, 99, 116, 105, 111, 110];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MongoDbV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
     partial class MongoDbV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqTags.g.cs
@@ -15,47 +15,25 @@ namespace Datadog.Trace.Tagging
     partial class MsmqTags
     {
         // CommandBytes = MessagePack.Serialize("msmq.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PathBytes = MessagePack.Serialize("msmq.queue.path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PathBytes => new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] PathBytes = new byte[] { 175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> PathBytes => [175, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 112, 97, 116, 104];
+
         // MessageWithTransactionBytes = MessagePack.Serialize("msmq.message.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageWithTransactionBytes => new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> MessageWithTransactionBytes => [186, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
+
         // IsTransactionalQueueBytes = MessagePack.Serialize("msmq.queue.transactional");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#else
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-#endif
+        private static ReadOnlySpan<byte> IsTransactionalQueueBytes => [184, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/MsmqV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class MsmqV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/OpenTelemetryTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class OpenTelemetryTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // OtelTraceIdBytes = MessagePack.Serialize("otel.trace_id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelTraceIdBytes => new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#else
-        private static readonly byte[] OtelTraceIdBytes = new byte[] { 173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> OtelTraceIdBytes => [173, 111, 116, 101, 108, 46, 116, 114, 97, 99, 101, 95, 105, 100];
+
         // OtelLibraryNameBytes = MessagePack.Serialize("otel.library.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryNameBytes => new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] OtelLibraryNameBytes = new byte[] { 177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryNameBytes => [177, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 110, 97, 109, 101];
+
         // OtelLibraryVersionBytes = MessagePack.Serialize("otel.library.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OtelLibraryVersionBytes = new byte[] { 180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OtelLibraryVersionBytes => [180, 111, 116, 101, 108, 46, 108, 105, 98, 114, 97, 114, 121, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // OtelStatusCodeBytes = MessagePack.Serialize("otel.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OtelStatusCodeBytes => new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] OtelStatusCodeBytes = new byte[] { 176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> OtelStatusCodeBytes => [176, 111, 116, 101, 108, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ProcessCommandStartTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.Tagging
     partial class ProcessCommandStartTags
     {
         // ComponentBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ComponentBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] ComponentBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> ComponentBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // EnvironmentVariablesBytes = MessagePack.Serialize("cmd.environment_variables");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#else
-        private static readonly byte[] EnvironmentVariablesBytes = new byte[] { 185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> EnvironmentVariablesBytes => [185, 99, 109, 100, 46, 101, 110, 118, 105, 114, 111, 110, 109, 101, 110, 116, 95, 118, 97, 114, 105, 97, 98, 108, 101, 115];
+
         // CommandExecBytes = MessagePack.Serialize("cmd.exec");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExecBytes => new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#else
-        private static readonly byte[] CommandExecBytes = new byte[] { 168, 99, 109, 100, 46, 101, 120, 101, 99 };
-#endif
+        private static ReadOnlySpan<byte> CommandExecBytes => [168, 99, 109, 100, 46, 101, 120, 101, 99];
+
         // CommandShellBytes = MessagePack.Serialize("cmd.shell");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandShellBytes => new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#else
-        private static readonly byte[] CommandShellBytes = new byte[] { 169, 99, 109, 100, 46, 115, 104, 101, 108, 108 };
-#endif
+        private static ReadOnlySpan<byte> CommandShellBytes => [169, 99, 109, 100, 46, 115, 104, 101, 108, 108];
+
         // TruncatedBytes = MessagePack.Serialize("cmd.truncated");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TruncatedBytes => new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#else
-        private static readonly byte[] TruncatedBytes = new byte[] { 173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TruncatedBytes => [173, 99, 109, 100, 46, 116, 114, 117, 110, 99, 97, 116, 101, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQTags.g.cs
@@ -15,59 +15,31 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("amqp.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 97, 109, 113, 112, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // DeliveryModeBytes = MessagePack.Serialize("amqp.delivery_mode");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DeliveryModeBytes => new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#else
-        private static readonly byte[] DeliveryModeBytes = new byte[] { 178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> DeliveryModeBytes => [178, 97, 109, 113, 112, 46, 100, 101, 108, 105, 118, 101, 114, 121, 95, 109, 111, 100, 101];
+
         // ExchangeBytes = MessagePack.Serialize("amqp.exchange");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ExchangeBytes => new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#else
-        private static readonly byte[] ExchangeBytes = new byte[] { 173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> ExchangeBytes => [173, 97, 109, 113, 112, 46, 101, 120, 99, 104, 97, 110, 103, 101];
+
         // RoutingKeyBytes = MessagePack.Serialize("amqp.routing_key");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RoutingKeyBytes => new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#else
-        private static readonly byte[] RoutingKeyBytes = new byte[] { 176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121 };
-#endif
+        private static ReadOnlySpan<byte> RoutingKeyBytes => [176, 97, 109, 113, 112, 46, 114, 111, 117, 116, 105, 110, 103, 95, 107, 101, 121];
+
         // MessageSizeBytes = MessagePack.Serialize("message.size");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MessageSizeBytes => new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#else
-        private static readonly byte[] MessageSizeBytes = new byte[] { 172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101 };
-#endif
+        private static ReadOnlySpan<byte> MessageSizeBytes => [172, 109, 101, 115, 115, 97, 103, 101, 46, 115, 105, 122, 101];
+
         // QueueBytes = MessagePack.Serialize("amqp.queue");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> QueueBytes => new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#else
-        private static readonly byte[] QueueBytes = new byte[] { 170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101 };
-#endif
+        private static ReadOnlySpan<byte> QueueBytes => [170, 97, 109, 113, 112, 46, 113, 117, 101, 117, 101];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RabbitMQV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RabbitMQV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisTags.g.cs
@@ -15,41 +15,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisTags
     {
         // DatabaseIndexBytes = MessagePack.Serialize("db.redis.database_index");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DatabaseIndexBytes => new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#else
-        private static readonly byte[] DatabaseIndexBytes = new byte[] { 183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120 };
-#endif
+        private static ReadOnlySpan<byte> DatabaseIndexBytes => [183, 100, 98, 46, 114, 101, 100, 105, 115, 46, 100, 97, 116, 97, 98, 97, 115, 101, 95, 105, 110, 100, 101, 120];
+
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // RawCommandBytes = MessagePack.Serialize("redis.raw_command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RawCommandBytes => new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] RawCommandBytes = new byte[] { 177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> RawCommandBytes => [177, 114, 101, 100, 105, 115, 46, 114, 97, 119, 95, 99, 111, 109, 109, 97, 110, 100];
+
         // HostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // PortBytes = MessagePack.Serialize("out.port");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PortBytes => new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#else
-        private static readonly byte[] PortBytes = new byte[] { 168, 111, 117, 116, 46, 112, 111, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> PortBytes => [168, 111, 117, 116, 46, 112, 111, 114, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RedisV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
     partial class RedisV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class RemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/RemotingTags.g.cs
@@ -15,35 +15,19 @@ namespace Datadog.Trace.Tagging
     partial class RemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // MethodNameBytes = MessagePack.Serialize("rpc.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodNameBytes => new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] MethodNameBytes = new byte[] { 170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> MethodNameBytes => [170, 114, 112, 99, 46, 109, 101, 116, 104, 111, 100];
+
         // MethodServiceBytes = MessagePack.Serialize("rpc.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> MethodServiceBytes => new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] MethodServiceBytes = new byte[] { 171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> MethodServiceBytes => [171, 114, 112, 99, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RpcSystemBytes = MessagePack.Serialize("rpc.system");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RpcSystemBytes => new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#else
-        private static readonly byte[] RpcSystemBytes = new byte[] { 170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109 };
-#endif
+        private static ReadOnlySpan<byte> RpcSystemBytes => [170, 114, 112, 99, 46, 115, 121, 115, 116, 101, 109];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingClientV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingClientV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/ServiceRemotingTags.g.cs
@@ -15,83 +15,43 @@ namespace Datadog.Trace.ServiceFabric
     partial class ServiceRemotingTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // ApplicationIdBytes = MessagePack.Serialize("service-fabric.application-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationIdBytes => new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] ApplicationIdBytes = new byte[] { 189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationIdBytes => [189, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 105, 100];
+
         // ApplicationNameBytes = MessagePack.Serialize("service-fabric.application-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ApplicationNameBytes => new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ApplicationNameBytes = new byte[] { 191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ApplicationNameBytes => [191, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 97, 112, 112, 108, 105, 99, 97, 116, 105, 111, 110, 45, 110, 97, 109, 101];
+
         // PartitionIdBytes = MessagePack.Serialize("service-fabric.partition-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PartitionIdBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] PartitionIdBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> PartitionIdBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 112, 97, 114, 116, 105, 116, 105, 111, 110, 45, 105, 100];
+
         // NodeIdBytes = MessagePack.Serialize("service-fabric.node-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeIdBytes => new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] NodeIdBytes = new byte[] { 182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> NodeIdBytes => [182, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 105, 100];
+
         // NodeNameBytes = MessagePack.Serialize("service-fabric.node-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NodeNameBytes => new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NodeNameBytes = new byte[] { 184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NodeNameBytes => [184, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 110, 111, 100, 101, 45, 110, 97, 109, 101];
+
         // ServiceNameBytes = MessagePack.Serialize("service-fabric.service-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ServiceNameBytes => new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] ServiceNameBytes = new byte[] { 187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> ServiceNameBytes => [187, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 110, 97, 109, 101];
+
         // RemotingUriBytes = MessagePack.Serialize("service-fabric.service-remoting.uri");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingUriBytes => new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#else
-        private static readonly byte[] RemotingUriBytes = new byte[] { 217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105 };
-#endif
+        private static ReadOnlySpan<byte> RemotingUriBytes => [217, 35, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 117, 114, 105];
+
         // RemotingServiceNameBytes = MessagePack.Serialize("service-fabric.service-remoting.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingServiceNameBytes => new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] RemotingServiceNameBytes = new byte[] { 217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingServiceNameBytes => [217, 39, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // RemotingMethodNameBytes = MessagePack.Serialize("service-fabric.service-remoting.method-name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodNameBytes => new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RemotingMethodNameBytes = new byte[] { 217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodNameBytes => [217, 43, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 110, 97, 109, 101];
+
         // RemotingMethodIdBytes = MessagePack.Serialize("service-fabric.service-remoting.method-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingMethodIdBytes => new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingMethodIdBytes = new byte[] { 217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingMethodIdBytes => [217, 41, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 109, 101, 116, 104, 111, 100, 45, 105, 100];
+
         // RemotingInterfaceIdBytes = MessagePack.Serialize("service-fabric.service-remoting.interface-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInterfaceIdBytes = new byte[] { 217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInterfaceIdBytes => [217, 44, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 116, 101, 114, 102, 97, 99, 101, 45, 105, 100];
+
         // RemotingInvocationIdBytes = MessagePack.Serialize("service-fabric.service-remoting.invocation-id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#else
-        private static readonly byte[] RemotingInvocationIdBytes = new byte[] { 217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> RemotingInvocationIdBytes => [217, 45, 115, 101, 114, 118, 105, 99, 101, 45, 102, 97, 98, 114, 105, 99, 46, 115, 101, 114, 118, 105, 99, 101, 45, 114, 101, 109, 111, 116, 105, 110, 103, 46, 105, 110, 118, 111, 99, 97, 116, 105, 111, 110, 45, 105, 100];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class SqlTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // DbTypeBytes = MessagePack.Serialize("db.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbTypeBytes => new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] DbTypeBytes = new byte[] { 167, 100, 98, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbTypeBytes => [167, 100, 98, 46, 116, 121, 112, 101];
+
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
+
         // DbNameBytes = MessagePack.Serialize("db.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbNameBytes => new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] DbNameBytes = new byte[] { 167, 100, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> DbNameBytes => [167, 100, 98, 46, 110, 97, 109, 101];
+
         // DbUserBytes = MessagePack.Serialize("db.user");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbUserBytes => new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#else
-        private static readonly byte[] DbUserBytes = new byte[] { 167, 100, 98, 46, 117, 115, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> DbUserBytes => [167, 100, 98, 46, 117, 115, 101, 114];
+
         // OutHostBytes = MessagePack.Serialize("out.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OutHostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] OutHostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> OutHostBytes => [168, 111, 117, 116, 46, 104, 111, 115, 116];
+
         // DbmTraceInjectedBytes = MessagePack.Serialize("_dd.dbm_trace_injected");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#else
-        private static readonly byte[] DbmTraceInjectedBytes = new byte[] { 182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> DbmTraceInjectedBytes => [182, 95, 100, 100, 46, 100, 98, 109, 95, 116, 114, 97, 99, 101, 95, 105, 110, 106, 101, 99, 116, 101, 100];
+
         // BaseHashBytes = MessagePack.Serialize("_dd.propagated_hash");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BaseHashBytes => new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#else
-        private static readonly byte[] BaseHashBytes = new byte[] { 179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104 };
-#endif
+        private static ReadOnlySpan<byte> BaseHashBytes => [179, 95, 100, 100, 46, 112, 114, 111, 112, 97, 103, 97, 116, 101, 100, 95, 104, 97, 115, 104];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/SqlV1Tags.g.cs
@@ -15,17 +15,10 @@ namespace Datadog.Trace.Tagging
     partial class SqlV1Tags
     {
         // PeerServiceBytes = MessagePack.Serialize("peer.service");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceBytes => new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceBytes = new byte[] { 172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceBytes => [172, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101];
+
         // PeerServiceSourceBytes = MessagePack.Serialize("_dd.peer.service.source");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PeerServiceSourceBytes => new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#else
-        private static readonly byte[] PeerServiceSourceBytes = new byte[] { 183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101 };
-#endif
+        private static ReadOnlySpan<byte> PeerServiceSourceBytes => [183, 95, 100, 100, 46, 112, 101, 101, 114, 46, 115, 101, 114, 118, 105, 99, 101, 46, 115, 111, 117, 114, 99, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestModuleSpanTags.g.cs
@@ -15,77 +15,40 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestModuleSpanTags
     {
         // IntelligentTestRunnerSkippingCountBytes = MessagePack.Serialize("test.itr.tests_skipping.count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingCountBytes = new byte[] { 189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingCountBytes => [189, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 99, 111, 117, 110, 116];
+
         // TypeBytes = MessagePack.Serialize("test.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TypeBytes => new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] TypeBytes = new byte[] { 169, 116, 101, 115, 116, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> TypeBytes => [169, 116, 101, 115, 116, 46, 116, 121, 112, 101];
+
         // ModuleBytes = MessagePack.Serialize("test.module");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ModuleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#else
-        private static readonly byte[] ModuleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> ModuleBytes => [171, 116, 101, 115, 116, 46, 109, 111, 100, 117, 108, 101];
+
         // BundleBytes = MessagePack.Serialize("test.bundle");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BundleBytes => new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#else
-        private static readonly byte[] BundleBytes = new byte[] { 171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> BundleBytes => [171, 116, 101, 115, 116, 46, 98, 117, 110, 100, 108, 101];
+
         // FrameworkBytes = MessagePack.Serialize("test.framework");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkBytes => new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#else
-        private static readonly byte[] FrameworkBytes = new byte[] { 174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkBytes => [174, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107];
+
         // FrameworkVersionBytes = MessagePack.Serialize("test.framework_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FrameworkVersionBytes => new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] FrameworkVersionBytes = new byte[] { 182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> FrameworkVersionBytes => [182, 116, 101, 115, 116, 46, 102, 114, 97, 109, 101, 119, 111, 114, 107, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeNameBytes = MessagePack.Serialize("runtime.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeNameBytes => new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] RuntimeNameBytes = new byte[] { 172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeNameBytes => [172, 114, 117, 110, 116, 105, 109, 101, 46, 110, 97, 109, 101];
+
         // RuntimeVersionBytes = MessagePack.Serialize("runtime.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeVersionBytes => new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] RuntimeVersionBytes = new byte[] { 175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeVersionBytes => [175, 114, 117, 110, 116, 105, 109, 101, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // RuntimeArchitectureBytes = MessagePack.Serialize("runtime.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] RuntimeArchitectureBytes = new byte[] { 180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> RuntimeArchitectureBytes => [180, 114, 117, 110, 116, 105, 109, 101, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSArchitectureBytes = MessagePack.Serialize("os.architecture");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSArchitectureBytes => new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#else
-        private static readonly byte[] OSArchitectureBytes = new byte[] { 175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101 };
-#endif
+        private static ReadOnlySpan<byte> OSArchitectureBytes => [175, 111, 115, 46, 97, 114, 99, 104, 105, 116, 101, 99, 116, 117, 114, 101];
+
         // OSPlatformBytes = MessagePack.Serialize("os.platform");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSPlatformBytes => new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#else
-        private static readonly byte[] OSPlatformBytes = new byte[] { 171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
-#endif
+        private static ReadOnlySpan<byte> OSPlatformBytes => [171, 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109];
+
         // OSVersionBytes = MessagePack.Serialize("os.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> OSVersionBytes => new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] OSVersionBytes = new byte[] { 170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> OSVersionBytes => [170, 111, 115, 46, 118, 101, 114, 115, 105, 111, 110];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSessionSpanTags.g.cs
@@ -15,275 +15,139 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSessionSpanTags
     {
         // LogicalCpuCountBytes = MessagePack.Serialize("_dd.host.vcpu_count");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LogicalCpuCountBytes => new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#else
-        private static readonly byte[] LogicalCpuCountBytes = new byte[] { 179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> LogicalCpuCountBytes => [179, 95, 100, 100, 46, 104, 111, 115, 116, 46, 118, 99, 112, 117, 95, 99, 111, 117, 110, 116];
+
         // CommandBytes = MessagePack.Serialize("test.command");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandBytes => new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#else
-        private static readonly byte[] CommandBytes = new byte[] { 172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> CommandBytes => [172, 116, 101, 115, 116, 46, 99, 111, 109, 109, 97, 110, 100];
+
         // WorkingDirectoryBytes = MessagePack.Serialize("test.working_directory");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> WorkingDirectoryBytes => new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#else
-        private static readonly byte[] WorkingDirectoryBytes = new byte[] { 182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> WorkingDirectoryBytes => [182, 116, 101, 115, 116, 46, 119, 111, 114, 107, 105, 110, 103, 95, 100, 105, 114, 101, 99, 116, 111, 114, 121];
+
         // CommandExitCodeBytes = MessagePack.Serialize("test.exit_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CommandExitCodeBytes => new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] CommandExitCodeBytes = new byte[] { 174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> CommandExitCodeBytes => [174, 116, 101, 115, 116, 46, 101, 120, 105, 116, 95, 99, 111, 100, 101];
+
         // StatusBytes = MessagePack.Serialize("test.status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StatusBytes => new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] StatusBytes = new byte[] { 171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> StatusBytes => [171, 116, 101, 115, 116, 46, 115, 116, 97, 116, 117, 115];
+
         // LibraryVersionBytes = MessagePack.Serialize("library_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> LibraryVersionBytes => new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] LibraryVersionBytes = new byte[] { 175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> LibraryVersionBytes => [175, 108, 105, 98, 114, 97, 114, 121, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // CIProviderBytes = MessagePack.Serialize("ci.provider.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIProviderBytes => new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIProviderBytes = new byte[] { 176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIProviderBytes => [176, 99, 105, 46, 112, 114, 111, 118, 105, 100, 101, 114, 46, 110, 97, 109, 101];
+
         // CIPipelineIdBytes = MessagePack.Serialize("ci.pipeline.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineIdBytes => new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#else
-        private static readonly byte[] CIPipelineIdBytes = new byte[] { 174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineIdBytes => [174, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 105, 100];
+
         // CIPipelineNameBytes = MessagePack.Serialize("ci.pipeline.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNameBytes => new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIPipelineNameBytes = new byte[] { 176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNameBytes => [176, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 97, 109, 101];
+
         // CIPipelineNumberBytes = MessagePack.Serialize("ci.pipeline.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineNumberBytes => new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] CIPipelineNumberBytes = new byte[] { 178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineNumberBytes => [178, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 110, 117, 109, 98, 101, 114];
+
         // CIPipelineUrlBytes = MessagePack.Serialize("ci.pipeline.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIPipelineUrlBytes => new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIPipelineUrlBytes = new byte[] { 175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIPipelineUrlBytes => [175, 99, 105, 46, 112, 105, 112, 101, 108, 105, 110, 101, 46, 117, 114, 108];
+
         // CIJobUrlBytes = MessagePack.Serialize("ci.job.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobUrlBytes => new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] CIJobUrlBytes = new byte[] { 170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> CIJobUrlBytes => [170, 99, 105, 46, 106, 111, 98, 46, 117, 114, 108];
+
         // CIJobNameBytes = MessagePack.Serialize("ci.job.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobNameBytes => new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] CIJobNameBytes = new byte[] { 171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> CIJobNameBytes => [171, 99, 105, 46, 106, 111, 98, 46, 110, 97, 109, 101];
+
         // CIJobIdBytes = MessagePack.Serialize("ci.job.id");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIJobIdBytes => new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#else
-        private static readonly byte[] CIJobIdBytes = new byte[] { 169, 99, 105, 46, 106, 111, 98, 46, 105, 100 };
-#endif
+        private static ReadOnlySpan<byte> CIJobIdBytes => [169, 99, 105, 46, 106, 111, 98, 46, 105, 100];
+
         // StageNameBytes = MessagePack.Serialize("ci.stage.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> StageNameBytes => new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] StageNameBytes = new byte[] { 173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> StageNameBytes => [173, 99, 105, 46, 115, 116, 97, 103, 101, 46, 110, 97, 109, 101];
+
         // CIWorkspacePathBytes = MessagePack.Serialize("ci.workspace_path");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CIWorkspacePathBytes => new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#else
-        private static readonly byte[] CIWorkspacePathBytes = new byte[] { 177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104 };
-#endif
+        private static ReadOnlySpan<byte> CIWorkspacePathBytes => [177, 99, 105, 46, 119, 111, 114, 107, 115, 112, 97, 99, 101, 95, 112, 97, 116, 104];
+
         // GitRepositoryBytes = MessagePack.Serialize("git.repository_url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitRepositoryBytes => new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#else
-        private static readonly byte[] GitRepositoryBytes = new byte[] { 178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitRepositoryBytes => [178, 103, 105, 116, 46, 114, 101, 112, 111, 115, 105, 116, 111, 114, 121, 95, 117, 114, 108];
+
         // GitCommitBytes = MessagePack.Serialize("git.commit.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitBytes => new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitCommitBytes = new byte[] { 174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitBytes => [174, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 115, 104, 97];
+
         // GitBranchBytes = MessagePack.Serialize("git.branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitBranchBytes => new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitBranchBytes = new byte[] { 170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitBranchBytes => [170, 103, 105, 116, 46, 98, 114, 97, 110, 99, 104];
+
         // GitTagBytes = MessagePack.Serialize("git.tag");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitTagBytes => new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#else
-        private static readonly byte[] GitTagBytes = new byte[] { 167, 103, 105, 116, 46, 116, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> GitTagBytes => [167, 103, 105, 116, 46, 116, 97, 103];
+
         // GitCommitAuthorNameBytes = MessagePack.Serialize("git.commit.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorNameBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorNameBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitAuthorEmailBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorEmailBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitCommitterNameBytes = MessagePack.Serialize("git.commit.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterNameBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterNameBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitCommitCommitterEmailBytes = new byte[] { 186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterEmailBytes => [186, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitCommitMessageBytes = MessagePack.Serialize("git.commit.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitMessageBytes => new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitCommitMessageBytes = new byte[] { 178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitMessageBytes => [178, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 109, 101, 115, 115, 97, 103, 101];
+
         // BuildSourceRootBytes = MessagePack.Serialize("build.source_root");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BuildSourceRootBytes => new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#else
-        private static readonly byte[] BuildSourceRootBytes = new byte[] { 177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116 };
-#endif
+        private static ReadOnlySpan<byte> BuildSourceRootBytes => [177, 98, 117, 105, 108, 100, 46, 115, 111, 117, 114, 99, 101, 95, 114, 111, 111, 116];
+
         // GitCommitAuthorDateBytes = MessagePack.Serialize("git.commit.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitAuthorDateBytes = new byte[] { 182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitAuthorDateBytes => [182, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitCommitCommitterDateBytes = MessagePack.Serialize("git.commit.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitCommitCommitterDateBytes => [185, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // CiEnvVarsBytes = MessagePack.Serialize("_dd.ci.env_vars");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CiEnvVarsBytes => new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#else
-        private static readonly byte[] CiEnvVarsBytes = new byte[] { 175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CiEnvVarsBytes => [175, 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115];
+
         // TestsSkippedBytes = MessagePack.Serialize("_dd.ci.itr.tests_skipped");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestsSkippedBytes => new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#else
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> TestsSkippedBytes => [184, 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100];
+
         // IntelligentTestRunnerSkippingTypeBytes = MessagePack.Serialize("test.itr.tests_skipping.type");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#else
-        private static readonly byte[] IntelligentTestRunnerSkippingTypeBytes = new byte[] { 188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101 };
-#endif
+        private static ReadOnlySpan<byte> IntelligentTestRunnerSkippingTypeBytes => [188, 116, 101, 115, 116, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 105, 110, 103, 46, 116, 121, 112, 101];
+
         // EarlyFlakeDetectionTestEnabledBytes = MessagePack.Serialize("test.early_flake.enabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestEnabledBytes = new byte[] { 184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestEnabledBytes => [184, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 101, 110, 97, 98, 108, 101, 100];
+
         // EarlyFlakeDetectionTestAbortReasonBytes = MessagePack.Serialize("test.early_flake.abort_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] EarlyFlakeDetectionTestAbortReasonBytes = new byte[] { 189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> EarlyFlakeDetectionTestAbortReasonBytes => [189, 116, 101, 115, 116, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 46, 97, 98, 111, 114, 116, 95, 114, 101, 97, 115, 111, 110];
+
         // GitPrBaseHeadCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_head_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseHeadCommitBytes = new byte[] { 217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseHeadCommitBytes => [217, 37, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 104, 101, 97, 100, 95, 115, 104, 97];
+
         // GitPrBaseCommitBytes = MessagePack.Serialize("git.pull_request.base_branch_sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#else
-        private static readonly byte[] GitPrBaseCommitBytes = new byte[] { 217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseCommitBytes => [217, 32, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104, 95, 115, 104, 97];
+
         // GitPrBaseBranchBytes = MessagePack.Serialize("git.pull_request.base_branch");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#else
-        private static readonly byte[] GitPrBaseBranchBytes = new byte[] { 188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104 };
-#endif
+        private static ReadOnlySpan<byte> GitPrBaseBranchBytes => [188, 103, 105, 116, 46, 112, 117, 108, 108, 95, 114, 101, 113, 117, 101, 115, 116, 46, 98, 97, 115, 101, 95, 98, 114, 97, 110, 99, 104];
+
         // PrNumberBytes = MessagePack.Serialize("pr.number");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> PrNumberBytes => new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#else
-        private static readonly byte[] PrNumberBytes = new byte[] { 169, 112, 114, 46, 110, 117, 109, 98, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> PrNumberBytes => [169, 112, 114, 46, 110, 117, 109, 98, 101, 114];
+
         // GitHeadCommitBytes = MessagePack.Serialize("git.commit.head.sha");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitBytes => new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#else
-        private static readonly byte[] GitHeadCommitBytes = new byte[] { 179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitBytes => [179, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 115, 104, 97];
+
         // GitHeadCommitAuthorNameBytes = MessagePack.Serialize("git.commit.head.author.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorNameBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorNameBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitAuthorEmailBytes = MessagePack.Serialize("git.commit.head.author.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorEmailBytes = new byte[] { 188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorEmailBytes => [188, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitAuthorDateBytes = MessagePack.Serialize("git.commit.head.author.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitAuthorDateBytes = new byte[] { 187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitAuthorDateBytes => [187, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 97, 117, 116, 104, 111, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitCommitterNameBytes = MessagePack.Serialize("git.commit.head.committer.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterNameBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterNameBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 110, 97, 109, 101];
+
         // GitHeadCommitCommitterEmailBytes = MessagePack.Serialize("git.commit.head.committer.email");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterEmailBytes = new byte[] { 191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterEmailBytes => [191, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 101, 109, 97, 105, 108];
+
         // GitHeadCommitCommitterDateBytes = MessagePack.Serialize("git.commit.head.committer.date");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#else
-        private static readonly byte[] GitHeadCommitCommitterDateBytes = new byte[] { 190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitCommitterDateBytes => [190, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101];
+
         // GitHeadCommitMessageBytes = MessagePack.Serialize("git.commit.head.message");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#else
-        private static readonly byte[] GitHeadCommitMessageBytes = new byte[] { 183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101 };
-#endif
+        private static ReadOnlySpan<byte> GitHeadCommitMessageBytes => [183, 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 104, 101, 97, 100, 46, 109, 101, 115, 115, 97, 103, 101];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSpanTags.g.cs
@@ -15,185 +15,94 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSpanTags
     {
         // SourceStartBytes = MessagePack.Serialize("test.source.start");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceStartBytes => new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#else
-        private static readonly byte[] SourceStartBytes = new byte[] { 177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116 };
-#endif
+        private static ReadOnlySpan<byte> SourceStartBytes => [177, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 115, 116, 97, 114, 116];
+
         // SourceEndBytes = MessagePack.Serialize("test.source.end");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceEndBytes => new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#else
-        private static readonly byte[] SourceEndBytes = new byte[] { 175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SourceEndBytes => [175, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 101, 110, 100];
+
         // NameBytes = MessagePack.Serialize("test.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 169, 116, 101, 115, 116, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [169, 116, 101, 115, 116, 46, 110, 97, 109, 101];
+
         // ParametersBytes = MessagePack.Serialize("test.parameters");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ParametersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#else
-        private static readonly byte[] ParametersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> ParametersBytes => [175, 116, 101, 115, 116, 46, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115];
+
         // TraitsBytes = MessagePack.Serialize("test.traits");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TraitsBytes => new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#else
-        private static readonly byte[] TraitsBytes = new byte[] { 171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115 };
-#endif
+        private static ReadOnlySpan<byte> TraitsBytes => [171, 116, 101, 115, 116, 46, 116, 114, 97, 105, 116, 115];
+
         // SkipReasonBytes = MessagePack.Serialize("test.skip_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkipReasonBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] SkipReasonBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> SkipReasonBytes => [176, 116, 101, 115, 116, 46, 115, 107, 105, 112, 95, 114, 101, 97, 115, 111, 110];
+
         // SkippedByIntelligentTestRunnerBytes = MessagePack.Serialize("test.skipped_by_itr");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#else
-        private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
-#endif
+        private static ReadOnlySpan<byte> SkippedByIntelligentTestRunnerBytes => [179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114];
+
         // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> UnskippableBytes => [180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101];
+
         // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#else
-        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
-#endif
+        private static ReadOnlySpan<byte> ForcedRunBytes => [179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110];
+
         // TestIsNewBytes = MessagePack.Serialize("test.is_new");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsNewBytes => new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#else
-        private static readonly byte[] TestIsNewBytes = new byte[] { 171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119 };
-#endif
+        private static ReadOnlySpan<byte> TestIsNewBytes => [171, 116, 101, 115, 116, 46, 105, 115, 95, 110, 101, 119];
+
         // TestIsRetryBytes = MessagePack.Serialize("test.is_retry");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestIsRetryBytes => new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#else
-        private static readonly byte[] TestIsRetryBytes = new byte[] { 173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121 };
-#endif
+        private static ReadOnlySpan<byte> TestIsRetryBytes => [173, 116, 101, 115, 116, 46, 105, 115, 95, 114, 101, 116, 114, 121];
+
         // TestRetryReasonBytes = MessagePack.Serialize("test.retry_reason");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestRetryReasonBytes => new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#else
-        private static readonly byte[] TestRetryReasonBytes = new byte[] { 177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> TestRetryReasonBytes => [177, 116, 101, 115, 116, 46, 114, 101, 116, 114, 121, 95, 114, 101, 97, 115, 111, 110];
+
         // BrowserDriverBytes = MessagePack.Serialize("test.browser.driver");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverBytes => new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#else
-        private static readonly byte[] BrowserDriverBytes = new byte[] { 179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverBytes => [179, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114];
+
         // BrowserDriverVersionBytes = MessagePack.Serialize("test.browser.driver_version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserDriverVersionBytes = new byte[] { 187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserDriverVersionBytes => [187, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 100, 114, 105, 118, 101, 114, 95, 118, 101, 114, 115, 105, 111, 110];
+
         // BrowserNameBytes = MessagePack.Serialize("test.browser.name");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserNameBytes => new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#else
-        private static readonly byte[] BrowserNameBytes = new byte[] { 177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101 };
-#endif
+        private static ReadOnlySpan<byte> BrowserNameBytes => [177, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 110, 97, 109, 101];
+
         // BrowserVersionBytes = MessagePack.Serialize("test.browser.version");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> BrowserVersionBytes => new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#else
-        private static readonly byte[] BrowserVersionBytes = new byte[] { 180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> BrowserVersionBytes => [180, 116, 101, 115, 116, 46, 98, 114, 111, 119, 115, 101, 114, 46, 118, 101, 114, 115, 105, 111, 110];
+
         // IsRumActiveBytes = MessagePack.Serialize("test.is_rum_active");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsRumActiveBytes => new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#else
-        private static readonly byte[] IsRumActiveBytes = new byte[] { 178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101 };
-#endif
+        private static ReadOnlySpan<byte> IsRumActiveBytes => [178, 116, 101, 115, 116, 46, 105, 115, 95, 114, 117, 109, 95, 97, 99, 116, 105, 118, 101];
+
         // IsModifiedBytes = MessagePack.Serialize("test.is_modified");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsModifiedBytes => new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#else
-        private static readonly byte[] IsModifiedBytes = new byte[] { 176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsModifiedBytes => [176, 116, 101, 115, 116, 46, 105, 115, 95, 109, 111, 100, 105, 102, 105, 101, 100];
+
         // IsQuarantinedBytes = MessagePack.Serialize("test.test_management.is_quarantined");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsQuarantinedBytes => new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#else
-        private static readonly byte[] IsQuarantinedBytes = new byte[] { 217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsQuarantinedBytes => [217, 35, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101, 100];
+
         // IsDisabledBytes = MessagePack.Serialize("test.test_management.is_test_disabled");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsDisabledBytes => new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#else
-        private static readonly byte[] IsDisabledBytes = new byte[] { 217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> IsDisabledBytes => [217, 37, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 116, 101, 115, 116, 95, 100, 105, 115, 97, 98, 108, 101, 100];
+
         // IsAttemptToFixBytes = MessagePack.Serialize("test.test_management.is_attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IsAttemptToFixBytes => new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] IsAttemptToFixBytes = new byte[] { 217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> IsAttemptToFixBytes => [217, 38, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 105, 115, 95, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
+
         // HasFailedAllRetriesBytes = MessagePack.Serialize("test.has_failed_all_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] HasFailedAllRetriesBytes = new byte[] { 187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> HasFailedAllRetriesBytes => [187, 116, 101, 115, 116, 46, 104, 97, 115, 95, 102, 97, 105, 108, 101, 100, 95, 97, 108, 108, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // AttemptToFixPassedBytes = MessagePack.Serialize("test.test_management.attempt_to_fix_passed");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#else
-        private static readonly byte[] AttemptToFixPassedBytes = new byte[] { 217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100 };
-#endif
+        private static ReadOnlySpan<byte> AttemptToFixPassedBytes => [217, 42, 116, 101, 115, 116, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120, 95, 112, 97, 115, 115, 101, 100];
+
         // FinalStatusBytes = MessagePack.Serialize("test.final_status");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> FinalStatusBytes => new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#else
-        private static readonly byte[] FinalStatusBytes = new byte[] { 177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115 };
-#endif
+        private static ReadOnlySpan<byte> FinalStatusBytes => [177, 116, 101, 115, 116, 46, 102, 105, 110, 97, 108, 95, 115, 116, 97, 116, 117, 115];
+
         // CapabilitiesTestImpactAnalysisBytes = MessagePack.Serialize("_dd.library_capabilities.test_impact_analysis");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#else
-        private static readonly byte[] CapabilitiesTestImpactAnalysisBytes = new byte[] { 217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestImpactAnalysisBytes => [217, 45, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 105, 109, 112, 97, 99, 116, 95, 97, 110, 97, 108, 121, 115, 105, 115];
+
         // CapabilitiesEarlyFlakeDetectionBytes = MessagePack.Serialize("_dd.library_capabilities.early_flake_detection");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#else
-        private static readonly byte[] CapabilitiesEarlyFlakeDetectionBytes = new byte[] { 217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesEarlyFlakeDetectionBytes => [217, 46, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 101, 97, 114, 108, 121, 95, 102, 108, 97, 107, 101, 95, 100, 101, 116, 101, 99, 116, 105, 111, 110];
+
         // CapabilitiesAutoTestRetriesBytes = MessagePack.Serialize("_dd.library_capabilities.auto_test_retries");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#else
-        private static readonly byte[] CapabilitiesAutoTestRetriesBytes = new byte[] { 217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesAutoTestRetriesBytes => [217, 42, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 97, 117, 116, 111, 95, 116, 101, 115, 116, 95, 114, 101, 116, 114, 105, 101, 115];
+
         // CapabilitiesTestManagementQuarantineBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.quarantine");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementQuarantineBytes = new byte[] { 217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementQuarantineBytes => [217, 51, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 113, 117, 97, 114, 97, 110, 116, 105, 110, 101];
+
         // CapabilitiesTestManagementDisableBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.disable");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementDisableBytes = new byte[] { 217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementDisableBytes => [217, 48, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 100, 105, 115, 97, 98, 108, 101];
+
         // CapabilitiesTestManagementAttemptToFixBytes = MessagePack.Serialize("_dd.library_capabilities.test_management.attempt_to_fix");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#else
-        private static readonly byte[] CapabilitiesTestManagementAttemptToFixBytes = new byte[] { 217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120 };
-#endif
+        private static ReadOnlySpan<byte> CapabilitiesTestManagementAttemptToFixBytes => [217, 55, 95, 100, 100, 46, 108, 105, 98, 114, 97, 114, 121, 95, 99, 97, 112, 97, 98, 105, 108, 105, 116, 105, 101, 115, 46, 116, 101, 115, 116, 95, 109, 97, 110, 97, 103, 101, 109, 101, 110, 116, 46, 97, 116, 116, 101, 109, 112, 116, 95, 116, 111, 95, 102, 105, 120];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TestSuiteSpanTags.g.cs
@@ -15,23 +15,13 @@ namespace Datadog.Trace.Ci.Tagging
     partial class TestSuiteSpanTags
     {
         // SuiteBytes = MessagePack.Serialize("test.suite");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SuiteBytes => new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#else
-        private static readonly byte[] SuiteBytes = new byte[] { 170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101 };
-#endif
+        private static ReadOnlySpan<byte> SuiteBytes => [170, 116, 101, 115, 116, 46, 115, 117, 105, 116, 101];
+
         // SourceFileBytes = MessagePack.Serialize("test.source.file");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SourceFileBytes => new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#else
-        private static readonly byte[] SourceFileBytes = new byte[] { 176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101 };
-#endif
+        private static ReadOnlySpan<byte> SourceFileBytes => [176, 116, 101, 115, 116, 46, 115, 111, 117, 114, 99, 101, 46, 102, 105, 108, 101];
+
         // CodeOwnersBytes = MessagePack.Serialize("test.codeowners");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> CodeOwnersBytes => new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#else
-        private static readonly byte[] CodeOwnersBytes = new byte[] { 175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115 };
-#endif
+        private static ReadOnlySpan<byte> CodeOwnersBytes => [175, 116, 101, 115, 116, 46, 99, 111, 100, 101, 111, 119, 110, 101, 114, 115];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/TraceAnnotationTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class TraceAnnotationTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/WcfTags.g.cs
@@ -15,11 +15,7 @@ namespace Datadog.Trace.Tagging
     partial class WcfTags
     {
         // InstrumentationNameBytes = MessagePack.Serialize("component");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> InstrumentationNameBytes => new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#else
-        private static readonly byte[] InstrumentationNameBytes = new byte[] { 169, 99, 111, 109, 112, 111, 110, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> InstrumentationNameBytes => [169, 99, 111, 109, 112, 111, 110, 101, 110, 116];
 
         public override string? GetTag(string key)
         {

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/WebTags.g.cs
@@ -15,53 +15,28 @@ namespace Datadog.Trace.Tagging
     partial class WebTags
     {
         // SpanKindBytes = MessagePack.Serialize("span.kind");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> SpanKindBytes => new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#else
-        private static readonly byte[] SpanKindBytes = new byte[] { 169, 115, 112, 97, 110, 46, 107, 105, 110, 100 };
-#endif
+        private static ReadOnlySpan<byte> SpanKindBytes => [169, 115, 112, 97, 110, 46, 107, 105, 110, 100];
+
         // HttpUserAgentBytes = MessagePack.Serialize("http.useragent");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUserAgentBytes => new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#else
-        private static readonly byte[] HttpUserAgentBytes = new byte[] { 174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpUserAgentBytes => [174, 104, 116, 116, 112, 46, 117, 115, 101, 114, 97, 103, 101, 110, 116];
+
         // HttpMethodBytes = MessagePack.Serialize("http.method");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpMethodBytes => new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#else
-        private static readonly byte[] HttpMethodBytes = new byte[] { 171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100 };
-#endif
+        private static ReadOnlySpan<byte> HttpMethodBytes => [171, 104, 116, 116, 112, 46, 109, 101, 116, 104, 111, 100];
+
         // HttpRequestHeadersHostBytes = MessagePack.Serialize("http.request.headers.host");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#else
-        private static readonly byte[] HttpRequestHeadersHostBytes = new byte[] { 185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116 };
-#endif
+        private static ReadOnlySpan<byte> HttpRequestHeadersHostBytes => [185, 104, 116, 116, 112, 46, 114, 101, 113, 117, 101, 115, 116, 46, 104, 101, 97, 100, 101, 114, 115, 46, 104, 111, 115, 116];
+
         // HttpUrlBytes = MessagePack.Serialize("http.url");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpUrlBytes => new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#else
-        private static readonly byte[] HttpUrlBytes = new byte[] { 168, 104, 116, 116, 112, 46, 117, 114, 108 };
-#endif
+        private static ReadOnlySpan<byte> HttpUrlBytes => [168, 104, 116, 116, 112, 46, 117, 114, 108];
+
         // HttpStatusCodeBytes = MessagePack.Serialize("http.status_code");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpStatusCodeBytes => new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#else
-        private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
-#endif
+        private static ReadOnlySpan<byte> HttpStatusCodeBytes => [176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101];
+
         // NetworkClientIpBytes = MessagePack.Serialize("network.client.ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NetworkClientIpBytes => new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#else
-        private static readonly byte[] NetworkClientIpBytes = new byte[] { 177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> NetworkClientIpBytes => [177, 110, 101, 116, 119, 111, 114, 107, 46, 99, 108, 105, 101, 110, 116, 46, 105, 112];
+
         // HttpClientIpBytes = MessagePack.Serialize("http.client_ip");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> HttpClientIpBytes => new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#else
-        private static readonly byte[] HttpClientIpBytes = new byte[] { 174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112 };
-#endif
+        private static ReadOnlySpan<byte> HttpClientIpBytes => [174, 104, 116, 116, 112, 46, 99, 108, 105, 101, 110, 116, 95, 105, 112];
 
         public override string? GetTag(string key)
         {

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/TagsListGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/TagsListGeneratorTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Immutable;
+using System.Text;
 using Datadog.Trace.SourceGenerators.TagsListGenerator;
 using Datadog.Trace.SourceGenerators.TagsListGenerator.Diagnostics;
 using Xunit;
@@ -32,11 +34,7 @@ namespace MyTests.TestListNameSpace
     partial class TestList
     {
         // IdBytes = MessagePack.Serialize(""TestId"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IdBytes => new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] IdBytes = new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> IdBytes => [166, 84, 101, 115, 116, 73, 100];
 
         public override string? GetTag(string key)
         {
@@ -111,11 +109,7 @@ namespace MyTests.TestListNameSpace
     partial class TestList
     {
         // IdBytes = MessagePack.Serialize(""TestId"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IdBytes => new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] IdBytes = new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> IdBytes => [166, 84, 101, 115, 116, 73, 100];
 
         public override double? GetMetric(string key)
         {
@@ -193,17 +187,10 @@ namespace MyTests.TestListNameSpace
     partial class TestList
     {
         // IdBytes = MessagePack.Serialize(""IdTag"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IdBytes => new byte[] { 165, 73, 100, 84, 97, 103 };
-#else
-        private static readonly byte[] IdBytes = new byte[] { 165, 73, 100, 84, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> IdBytes => [165, 73, 100, 84, 97, 103];
+
         // NameBytes = MessagePack.Serialize(""NameTag"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 167, 78, 97, 109, 101, 84, 97, 103 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 167, 78, 97, 109, 101, 84, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [167, 78, 97, 109, 101, 84, 97, 103];
 
         public override string? GetTag(string key)
         {
@@ -296,17 +283,10 @@ namespace MyTests.TestListNameSpace
     partial class TestList
     {
         // IdBytes = MessagePack.Serialize(""IdMetric"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IdBytes => new byte[] { 168, 73, 100, 77, 101, 116, 114, 105, 99 };
-#else
-        private static readonly byte[] IdBytes = new byte[] { 168, 73, 100, 77, 101, 116, 114, 105, 99 };
-#endif
+        private static ReadOnlySpan<byte> IdBytes => [168, 73, 100, 77, 101, 116, 114, 105, 99];
+
         // NameBytes = MessagePack.Serialize(""NameMetric"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 170, 78, 97, 109, 101, 77, 101, 116, 114, 105, 99 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 170, 78, 97, 109, 101, 77, 101, 116, 114, 105, 99 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [170, 78, 97, 109, 101, 77, 101, 116, 114, 105, 99];
 
         public override double? GetMetric(string key)
         {
@@ -402,23 +382,13 @@ namespace MyTests.TestListNameSpace
     partial class TestList
     {
         // IdBytes = MessagePack.Serialize(""IdTag"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IdBytes => new byte[] { 165, 73, 100, 84, 97, 103 };
-#else
-        private static readonly byte[] IdBytes = new byte[] { 165, 73, 100, 84, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> IdBytes => [165, 73, 100, 84, 97, 103];
+
         // TestBytes = MessagePack.Serialize(""TestId"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestBytes => new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] TestBytes = new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> TestBytes => [166, 84, 101, 115, 116, 73, 100];
+
         // NameBytes = MessagePack.Serialize(""NameTag"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 167, 78, 97, 109, 101, 84, 97, 103 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 167, 78, 97, 109, 101, 84, 97, 103 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [167, 78, 97, 109, 101, 84, 97, 103];
 
         public override string? GetTag(string key)
         {
@@ -528,23 +498,13 @@ namespace MyTests.TestListNameSpace
     partial class TestList
     {
         // IdBytes = MessagePack.Serialize(""IdMetric"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> IdBytes => new byte[] { 168, 73, 100, 77, 101, 116, 114, 105, 99 };
-#else
-        private static readonly byte[] IdBytes = new byte[] { 168, 73, 100, 77, 101, 116, 114, 105, 99 };
-#endif
+        private static ReadOnlySpan<byte> IdBytes => [168, 73, 100, 77, 101, 116, 114, 105, 99];
+
         // TestBytes = MessagePack.Serialize(""TestId"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> TestBytes => new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#else
-        private static readonly byte[] TestBytes = new byte[] { 166, 84, 101, 115, 116, 73, 100 };
-#endif
+        private static ReadOnlySpan<byte> TestBytes => [166, 84, 101, 115, 116, 73, 100];
+
         // NameBytes = MessagePack.Serialize(""NameMetric"");
-#if NETCOREAPP
-        private static ReadOnlySpan<byte> NameBytes => new byte[] { 170, 78, 97, 109, 101, 77, 101, 116, 114, 105, 99 };
-#else
-        private static readonly byte[] NameBytes = new byte[] { 170, 78, 97, 109, 101, 77, 101, 116, 114, 105, 99 };
-#endif
+        private static ReadOnlySpan<byte> NameBytes => [170, 78, 97, 109, 101, 77, 101, 116, 114, 105, 99];
 
         public override double? GetMetric(string key)
         {


### PR DESCRIPTION
## Summary of changes

Update the tag list generator to always use `ReadOnlySpan<byte>` properties instead of `byte[]`

## Reason for change

After moving our vendored `Span<T>` implementation into the `System` namespace, various optimizations open up to us, including using `ReadOnlySpan<byte>` properties on .NET Framework instead of `static readonly byte[]` to avoid startup costs.

## Implementation details

Replace the code generated by the generator, and update the generated code

## Test coverage

Covered by snapshot tests and behaviour is covered by existing tests. We'll check the benchmarks to make sure that we _don't_ see any perf impact (there shouldn't be, impact should just be reduced startup costs)

## Other details

Depends on a stack updating our vendored system code

- https://github.com/DataDog/dd-trace-dotnet/pull/8391
- https://github.com/DataDog/dd-trace-dotnet/pull/8454
- https://github.com/DataDog/dd-trace-dotnet/pull/8455
- https://github.com/DataDog/dd-trace-dotnet/pull/8459
- https://github.com/DataDog/dd-trace-dotnet/pull/8461
- https://github.com/DataDog/dd-trace-dotnet/pull/8469
- https://github.com/DataDog/dd-trace-dotnet/pull/8476
- https://github.com/DataDog/dd-trace-dotnet/pull/8477
