### PR TITLE
Convert `Encoding.Utf8.GetBytes` calls to static constants using UTF8 string literals

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -23,95 +23,92 @@ namespace Datadog.Trace.Agent.MessagePack
     {
         public static readonly SpanMessagePackFormatter Instance = new();
 
-        // Cache the UTF-8 bytes for string constants (like tag names)
-        // and values that are constant within the lifetime of a service (like process id).
-        //
-        // Don't make these fields static to avoid the additional redirection when this
-        // assembly is loaded in the shared domain. We only create a single instance of
-        // this class, so that's fine.
-
-        // span fields
-        private readonly byte[] _traceIdBytes = StringEncoding.UTF8.GetBytes("trace_id");
-        private readonly byte[] _traceIdHighBytes = StringEncoding.UTF8.GetBytes("trace_id_high");
-        private readonly byte[] _spanIdBytes = StringEncoding.UTF8.GetBytes("span_id");
-        private readonly byte[] _nameBytes = StringEncoding.UTF8.GetBytes("name");
-        private readonly byte[] _resourceBytes = StringEncoding.UTF8.GetBytes("resource");
-        private readonly byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("service");
-        private readonly byte[] _typeBytes = StringEncoding.UTF8.GetBytes("type");
-        private readonly byte[] _startBytes = StringEncoding.UTF8.GetBytes("start");
-        private readonly byte[] _durationBytes = StringEncoding.UTF8.GetBytes("duration");
-        private readonly byte[] _parentIdBytes = StringEncoding.UTF8.GetBytes("parent_id");
-        private readonly byte[] _errorBytes = StringEncoding.UTF8.GetBytes("error");
-        private readonly byte[] _metaStructBytes = StringEncoding.UTF8.GetBytes("meta_struct");
-
-        // span links and span events metadata
-        private readonly byte[] _spanLinkBytes = StringEncoding.UTF8.GetBytes("span_links");
-        private readonly byte[] _traceStateBytes = StringEncoding.UTF8.GetBytes("tracestate");
-        private readonly byte[] _traceFlagBytes = StringEncoding.UTF8.GetBytes("flags");
-        private readonly byte[] _eventBytes = StringEncoding.UTF8.GetBytes("events");
-        private readonly byte[] _spanEventBytes = StringEncoding.UTF8.GetBytes("span_events");
-        private readonly byte[] _timeUnixNanoBytes = StringEncoding.UTF8.GetBytes("time_unix_nano");
-        private readonly byte[] _attributesBytes = StringEncoding.UTF8.GetBytes("attributes");
-        private readonly byte[] _typeFieldBytes = StringEncoding.UTF8.GetBytes("type");
-        private readonly byte[] _stringValueFieldBytes = StringEncoding.UTF8.GetBytes("string_value");
-        private readonly byte[] _boolValueFieldBytes = StringEncoding.UTF8.GetBytes("bool_value");
-        private readonly byte[] _intValueFieldBytes = StringEncoding.UTF8.GetBytes("int_value");
-        private readonly byte[] _doubleValueFieldBytes = StringEncoding.UTF8.GetBytes("double_value");
-        private readonly byte[] _arrayValueFieldBytes = StringEncoding.UTF8.GetBytes("array_value");
-        private readonly byte[] _valuesFieldBytes = StringEncoding.UTF8.GetBytes("values");
-
-        // string tags
-        private readonly byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
-
-        private readonly byte[] _languageNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Language);
-        private readonly byte[] _languageValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.Language);
-
-        private readonly byte[] _runtimeIdNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.RuntimeId);
         private readonly byte[] _runtimeIdValueBytes = StringEncoding.UTF8.GetBytes(Tracer.RuntimeId);
-
-        private readonly byte[] _processTagsNameBytes = StringEncoding.UTF8.GetBytes(Tags.ProcessTags);
-        private readonly byte[] _environmentNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Env);
-        private readonly byte[] _gitCommitShaNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.GitCommitSha);
-        private readonly byte[] _gitRepositoryUrlNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.GitRepositoryUrl);
-        private readonly byte[] _versionNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Version);
-        private readonly byte[] _originNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Origin);
-        private readonly byte[] _lastParentIdBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.LastParentId);
-        private readonly byte[] _baseServiceNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.BaseService);
-        private readonly byte[] _serviceNameSourceNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.ServiceNameSource);
-
-        // numeric tags
-        private readonly byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");
-        private readonly byte[] _samplingPriorityNameBytes = StringEncoding.UTF8.GetBytes(Metrics.SamplingPriority);
-        private readonly byte[] _agentSamplingRateNameBytes = StringEncoding.UTF8.GetBytes(Metrics.SamplingAgentDecision);
-        private readonly byte[] _ruleSamplingRateNameBytes = StringEncoding.UTF8.GetBytes(Metrics.SamplingRuleDecision);
-        private readonly byte[] _limitSamplingRateNameBytes = StringEncoding.UTF8.GetBytes(Metrics.SamplingLimitDecision);
-        private readonly byte[] _keepRateNameBytes = StringEncoding.UTF8.GetBytes(Metrics.TracesKeepRate);
-        private readonly byte[] _processIdNameBytes = StringEncoding.UTF8.GetBytes(Metrics.ProcessId);
-        private readonly byte[] _apmEnabledNameBytes = StringEncoding.UTF8.GetBytes(Metrics.ApmEnabled);
-        private readonly byte[] _topLevelSpanNameBytes = StringEncoding.UTF8.GetBytes(Metrics.TopLevelSpan);
-
-        // ASM tags
-        private readonly byte[] _appSecEnabledBytes = StringEncoding.UTF8.GetBytes(Metrics.AppSecEnabled);
-        private readonly byte[] _wafRuleFileVersionBytes = StringEncoding.UTF8.GetBytes(Tags.AppSecRuleFileVersion);
-        private readonly byte[] _runtimeFamilyBytes = StringEncoding.UTF8.GetBytes(Tags.RuntimeFamily);
         private readonly Dictionary<string, byte[]> _wafRuleFileVersionValues = new();
-
-        // Azure App Service tag names and values
-        private byte[] _aasSiteNameTagNameBytes;
-        private byte[] _aasSiteKindTagNameBytes;
-        private byte[] _aasSiteTypeTagNameBytes;
-        private byte[] _aasResourceGroupTagNameBytes;
-        private byte[] _aasSubscriptionIdTagNameBytes;
-        private byte[] _aasResourceIdTagNameBytes;
-        private byte[] _aasInstanceIdTagNameBytes;
-        private byte[] _aasInstanceNameTagNameBytes;
-        private byte[] _aasOperatingSystemTagNameBytes;
-        private byte[] _aasRuntimeTagNameBytes;
-        private byte[] _aasExtensionVersionTagNameBytes;
 
         private SpanMessagePackFormatter()
         {
         }
+
+        // UTF-8 bytes for string constants are embedded in the PE as static data via u8 literals.
+        // Using ReadOnlySpan<byte> property getters avoids heap allocations and static field
+        // indirection (important when the assembly is loaded in the shared domain on .NET Framework).
+#pragma warning disable SA1516 // Elements should be separated by blank line
+        // span fields
+        private static ReadOnlySpan<byte> TraceIdBytes => "trace_id"u8;
+        private static ReadOnlySpan<byte> TraceIdHighBytes => "trace_id_high"u8;
+        private static ReadOnlySpan<byte> SpanIdBytes => "span_id"u8;
+        private static ReadOnlySpan<byte> NameBytes => "name"u8;
+        private static ReadOnlySpan<byte> ResourceBytes => "resource"u8;
+        private static ReadOnlySpan<byte> ServiceBytes => "service"u8;
+        private static ReadOnlySpan<byte> TypeBytes => "type"u8;
+        private static ReadOnlySpan<byte> StartBytes => "start"u8;
+        private static ReadOnlySpan<byte> DurationBytes => "duration"u8;
+        private static ReadOnlySpan<byte> ParentIdBytes => "parent_id"u8;
+        private static ReadOnlySpan<byte> ErrorBytes => "error"u8;
+        private static ReadOnlySpan<byte> MetaStructBytes => "meta_struct"u8;
+
+        // span links and span events metadata
+        private static ReadOnlySpan<byte> SpanLinkBytes => "span_links"u8;
+        private static ReadOnlySpan<byte> TraceStateBytes => "tracestate"u8;
+        private static ReadOnlySpan<byte> TraceFlagBytes => "flags"u8;
+        private static ReadOnlySpan<byte> EventBytes => "events"u8;
+        private static ReadOnlySpan<byte> SpanEventBytes => "span_events"u8;
+        private static ReadOnlySpan<byte> TimeUnixNanoBytes => "time_unix_nano"u8;
+        private static ReadOnlySpan<byte> AttributesBytes => "attributes"u8;
+        private static ReadOnlySpan<byte> TypeFieldBytes => "type"u8;
+        private static ReadOnlySpan<byte> StringValueFieldBytes => "string_value"u8;
+        private static ReadOnlySpan<byte> BoolValueFieldBytes => "bool_value"u8;
+        private static ReadOnlySpan<byte> IntValueFieldBytes => "int_value"u8;
+        private static ReadOnlySpan<byte> DoubleValueFieldBytes => "double_value"u8;
+        private static ReadOnlySpan<byte> ArrayValueFieldBytes => "array_value"u8;
+        private static ReadOnlySpan<byte> ValuesFieldBytes => "values"u8;
+
+        // string tags
+        private static ReadOnlySpan<byte> MetaBytes => "meta"u8;
+
+        private static ReadOnlySpan<byte> LanguageNameBytes => "language"u8; // Tags.Language
+        private static ReadOnlySpan<byte> LanguageValueBytes => "dotnet"u8; // TracerConstants.Language
+
+        private static ReadOnlySpan<byte> RuntimeIdNameBytes => "runtime-id"u8; // Tags.RuntimeId
+        private static ReadOnlySpan<byte> ProcessTagsNameBytes => "_dd.tags.process"u8; // Tags.ProcessTags
+        private static ReadOnlySpan<byte> EnvironmentNameBytes => "env"u8; // Tags.Env
+        private static ReadOnlySpan<byte> GitCommitShaNameBytes => "_dd.git.commit.sha"u8; // Tags.GitCommitSha
+        private static ReadOnlySpan<byte> GitRepositoryUrlNameBytes => "_dd.git.repository_url"u8; // Tags.GitRepositoryUrl
+        private static ReadOnlySpan<byte> VersionNameBytes => "version"u8; // Tags.Version
+        private static ReadOnlySpan<byte> OriginNameBytes => "_dd.origin"u8; // Tags.Origin
+        private static ReadOnlySpan<byte> LastParentIdBytes => "_dd.parent_id"u8; // Tags.LastParentId
+        private static ReadOnlySpan<byte> BaseServiceNameBytes => "_dd.base_service"u8; // Tags.BaseService
+        private static ReadOnlySpan<byte> ServiceNameSourceNameBytes => "_dd.svc_src"u8; // Tags.ServiceNameSource
+
+        // numeric tags
+        private static ReadOnlySpan<byte> MetricsBytes => "metrics"u8;
+        private static ReadOnlySpan<byte> SamplingPriorityNameBytes => "_sampling_priority_v1"u8; // Metrics.SamplingPriority
+        private static ReadOnlySpan<byte> AgentSamplingRateNameBytes => "_dd.agent_psr"u8; // Metrics.SamplingAgentDecision
+        private static ReadOnlySpan<byte> RuleSamplingRateNameBytes => "_dd.rule_psr"u8; // Metrics.SamplingRuleDecision
+        private static ReadOnlySpan<byte> LimitSamplingRateNameBytes => "_dd.limit_psr"u8; // Metrics.SamplingLimitDecision
+        private static ReadOnlySpan<byte> KeepRateNameBytes => "_dd.tracer_kr"u8; // Metrics.TracesKeepRate
+        private static ReadOnlySpan<byte> ProcessIdNameBytes => "process_id"u8; // Metrics.ProcessId
+        private static ReadOnlySpan<byte> ApmEnabledNameBytes => "_dd.apm.enabled"u8; // Metrics.ApmEnabled
+        private static ReadOnlySpan<byte> TopLevelSpanNameBytes => "_dd.top_level"u8; // Metrics.TopLevelSpan
+
+        // ASM tags
+        private static ReadOnlySpan<byte> AppSecEnabledBytes => "_dd.appsec.enabled"u8; // Metrics.AppSecEnabled
+        private static ReadOnlySpan<byte> WafRuleFileVersionBytes => "_dd.appsec.event_rules.version"u8; // Tags.AppSecRuleFileVersion
+        private static ReadOnlySpan<byte> RuntimeFamilyBytes => "_dd.runtime_family"u8; // Tags.RuntimeFamily
+        // Azure App Service tag names
+        private static ReadOnlySpan<byte> AasSiteNameTagNameBytes => "aas.site.name"u8; // Tags.AzureAppServicesSiteName
+        private static ReadOnlySpan<byte> AasSiteKindTagNameBytes => "aas.site.kind"u8; // Tags.AzureAppServicesSiteKind
+        private static ReadOnlySpan<byte> AasSiteTypeTagNameBytes => "aas.site.type"u8; // Tags.AzureAppServicesSiteType
+        private static ReadOnlySpan<byte> AasResourceGroupTagNameBytes => "aas.resource.group"u8; // Tags.AzureAppServicesResourceGroup
+        private static ReadOnlySpan<byte> AasSubscriptionIdTagNameBytes => "aas.subscription.id"u8; // Tags.AzureAppServicesSubscriptionId
+        private static ReadOnlySpan<byte> AasResourceIdTagNameBytes => "aas.resource.id"u8; // Tags.AzureAppServicesResourceId
+        private static ReadOnlySpan<byte> AasInstanceIdTagNameBytes => "aas.environment.instance_id"u8; // Tags.AzureAppServicesInstanceId
+        private static ReadOnlySpan<byte> AasInstanceNameTagNameBytes => "aas.environment.instance_name"u8; // Tags.AzureAppServicesInstanceName
+        private static ReadOnlySpan<byte> AasOperatingSystemTagNameBytes => "aas.environment.os"u8; // Tags.AzureAppServicesOperatingSystem
+        private static ReadOnlySpan<byte> AasRuntimeTagNameBytes => "aas.environment.runtime"u8; // Tags.AzureAppServicesRuntime
+        private static ReadOnlySpan<byte> AasExtensionVersionTagNameBytes => "aas.environment.extension_version"u8; // Tags.AzureAppServicesExtensionVersion
+#pragma warning restore SA1201
 
         int IMessagePackFormatter<TraceChunkModel>.Serialize(ref byte[] bytes, int offset, TraceChunkModel traceChunk, IFormatterResolver formatterResolver)
         {
@@ -199,39 +196,39 @@ namespace Datadog.Trace.Agent.MessagePack
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, len);
 
             // trace_id field is 64-bits, truncate by using TraceId128.Lower
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TraceIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.Context.TraceId128.Lower);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SpanIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.Context.SpanId);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _nameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, NameBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, span.OperationName);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _resourceBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ResourceBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, span.ResourceName);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ServiceBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, span.ServiceName);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _typeBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TypeBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, span.Type);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _startBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, StartBytes);
             offset += MessagePackBinary.WriteInt64(ref bytes, offset, span.StartTime.ToUnixTimeNanoseconds());
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, DurationBytes);
             offset += MessagePackBinary.WriteInt64(ref bytes, offset, span.Duration.ToNanoseconds());
 
             if (span.Context.ParentId > 0)
             {
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentIdBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ParentIdBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, (ulong)span.Context.ParentId);
             }
 
             if (span.Error)
             {
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _errorBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ErrorBytes);
                 offset += MessagePackBinary.WriteByte(ref bytes, offset, 1);
             }
 
@@ -266,7 +263,7 @@ namespace Datadog.Trace.Agent.MessagePack
         {
             int originalOffset = offset;
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanLinkBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SpanLinkBytes);
             offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, spanModel.Span.SpanLinks.Count);
 
             foreach (var spanLink in spanModel.Span.SpanLinks)
@@ -302,18 +299,18 @@ namespace Datadog.Trace.Agent.MessagePack
 
                 offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, len);
                 // individual key-value pairs - traceid - lower
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TraceIdBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.TraceId128.Lower);
                 // individual key-value pairs - traceid - higher
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdHighBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TraceIdHighBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.TraceId128.Upper);
                 // spanid
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SpanIdBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.SpanId);
                 // optional serialization
                 if (hasAttributes)
                 {
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _attributesBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AttributesBytes);
                     offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, spanLink.Attributes.Count);
                     foreach (var attribute in spanLink.Attributes)
                     {
@@ -326,13 +323,13 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (context.IsRemote)
                 {
                     var traceState = W3CTraceContextPropagator.CreateTraceStateHeader(context);
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceStateBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TraceStateBytes);
                     offset += MessagePackBinary.WriteString(ref bytes, offset, traceState);
                 }
 
                 if (traceFlags > 0)
                 {
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceFlagBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TraceFlagBytes);
                     offset += MessagePackBinary.WriteUInt32(ref bytes, offset, traceFlags);
                 }
             }
@@ -344,7 +341,7 @@ namespace Datadog.Trace.Agent.MessagePack
         {
             int originalOffset = offset;
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanEventBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SpanEventBytes);
             offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, spanModel.Span.SpanEvents.Count);
 
             foreach (var spanEvent in spanModel.Span.SpanEvents)
@@ -352,18 +349,18 @@ namespace Datadog.Trace.Agent.MessagePack
                 offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, spanEvent.Attributes?.Count > 0 ? 3 : 2);
 
                 // time_unix_nano
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _timeUnixNanoBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TimeUnixNanoBytes);
                 offset += MessagePackBinary.WriteInt64(ref bytes, offset, spanEvent.Timestamp.ToUnixTimeNanoseconds());
 
                 // name
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _nameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, NameBytes);
                 offset += MessagePackBinary.WriteString(ref bytes, offset, spanEvent.Name);
 
                 // attributes (strings only)
                 if (spanEvent.Attributes?.Count > 0)
                 {
                     // Reserve space to patch the correct map header count later
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _attributesBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AttributesBytes);
                     int attributeCountOffset = offset;
                     offset += MessagePackBinary.WriteMapHeaderForceMap32Block(ref bytes, offset, 0); // placeholder
 
@@ -377,7 +374,7 @@ namespace Datadog.Trace.Agent.MessagePack
 
                         offset += MessagePackBinary.WriteString(ref bytes, offset, attribute.Key);
                         offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 2);
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _typeFieldBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TypeFieldBytes);
 
                         if (attribute.Value is not Array)
                         {
@@ -387,15 +384,15 @@ namespace Datadog.Trace.Agent.MessagePack
                         else if (attribute.Value is Array arrayVal)
                         {
                             offset += MessagePackBinary.WriteInt32(ref bytes, offset, 4);
-                            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _arrayValueFieldBytes);
+                            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ArrayValueFieldBytes);
                             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 1);
-                            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _valuesFieldBytes);
+                            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ValuesFieldBytes);
                             offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, arrayVal.Length);
 
                             foreach (var item in arrayVal)
                             {
                                 offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 2);
-                                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _typeFieldBytes);
+                                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TypeFieldBytes);
                                 offset += WriteEventAttribute(ref bytes, offset, item);
                             }
 
@@ -409,7 +406,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     }
                     else
                     {
-                        offset = attributeCountOffset - _attributesBytes.Length;
+                        offset = attributeCountOffset - AttributesBytes.Length;
                     }
                 }
             }
@@ -426,25 +423,25 @@ namespace Datadog.Trace.Agent.MessagePack
                 case string stringVal:
                 case char charVal:
                     offset += MessagePackBinary.WriteInt32(ref bytes, offset, 0);
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _stringValueFieldBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, StringValueFieldBytes);
                     offset += MessagePackBinary.WriteString(ref bytes, offset, value.ToString());
                     break;
 
                 case bool boolVal:
                     offset += MessagePackBinary.WriteInt32(ref bytes, offset, 1);
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _boolValueFieldBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, BoolValueFieldBytes);
                     offset += MessagePackBinary.WriteBoolean(ref bytes, offset, boolVal);
                     break;
 
                 case sbyte or byte or short or ushort or int or uint or long:
                     offset += MessagePackBinary.WriteInt32(ref bytes, offset, 2);
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _intValueFieldBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, IntValueFieldBytes);
                     offset += MessagePackBinary.WriteInt64(ref bytes, offset, Convert.ToInt64(value));
                     break;
 
                 case float or double:
                     offset += MessagePackBinary.WriteInt32(ref bytes, offset, 3);
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _doubleValueFieldBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, DoubleValueFieldBytes);
                     offset += MessagePackBinary.WriteDouble(ref bytes, offset, Convert.ToDouble(value));
                     break;
             }
@@ -459,7 +456,7 @@ namespace Datadog.Trace.Agent.MessagePack
             var settings = new JsonSerializerSettings { Converters = new List<JsonConverter> { new SpanEventConverter() }, Formatting = Formatting.None };
             var eventsJson = JsonHelper.SerializeObject(spanModel.Span.SpanEvents, settings);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _eventBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, EventBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, eventsJson);
 
             return offset - originalOffset;
@@ -468,7 +465,7 @@ namespace Datadog.Trace.Agent.MessagePack
         private int WriteMetaStruct(ref byte[] bytes, int offset, in SpanModel model)
         {
             int originalOffset = offset;
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metaStructBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, MetaStructBytes);
 
             // We don't know the final count yet, depending on it, a different amount of bytes will be used for the header
             // of the dictionary, so we need a temporary buffer
@@ -499,7 +496,7 @@ namespace Datadog.Trace.Agent.MessagePack
             int originalOffset = offset;
 
             // Start of "meta" dictionary. Do not add any string tags before this line.
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metaBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, MetaBytes);
 
             int count = 0;
 
@@ -541,7 +538,7 @@ namespace Datadog.Trace.Agent.MessagePack
             if (!string.IsNullOrEmpty(span.Context.LastParentId))
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _lastParentIdBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LastParentIdBytes);
                 offset += MessagePackBinary.WriteString(ref bytes, offset, span.Context.LastParentId);
             }
 
@@ -550,7 +547,7 @@ namespace Datadog.Trace.Agent.MessagePack
             if (span.IsTopLevel && (!testOptimization.IsRunning || !testOptimization.Settings.Agentless))
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, RuntimeIdNameBytes);
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdValueBytes);
             }
 
@@ -560,7 +557,7 @@ namespace Datadog.Trace.Agent.MessagePack
             if (originRawBytes is not null)
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _originNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, OriginNameBytes);
                 offset += MessagePackBinary.WriteRaw(ref bytes, offset, originRawBytes);
             }
 
@@ -570,14 +567,14 @@ namespace Datadog.Trace.Agent.MessagePack
             if (envRawBytes is not null)
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, EnvironmentNameBytes);
                 offset += MessagePackBinary.WriteRaw(ref bytes, offset, envRawBytes);
             }
 
             // add "language=dotnet" tag to all spans
             count++;
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageNameBytes);
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageValueBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LanguageNameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LanguageValueBytes);
 
             // add "version" tags to all spans whose service name is the default service name
             var serviceNameEqualsDefault = string.Equals(span.Context.ServiceName, model.TraceChunk.DefaultServiceName, StringComparison.OrdinalIgnoreCase);
@@ -588,7 +585,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (versionRawBytes is not null)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _versionNameBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, VersionNameBytes);
                     offset += MessagePackBinary.WriteRaw(ref bytes, offset, versionRawBytes);
                 }
             }
@@ -601,7 +598,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (serviceNameRawBytes is not null)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _baseServiceNameBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, BaseServiceNameBytes);
                     offset += MessagePackBinary.WriteRaw(ref bytes, offset, serviceNameRawBytes);
                 }
             }
@@ -618,7 +615,7 @@ namespace Datadog.Trace.Agent.MessagePack
             if (serviceNameSource is not null)
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceNameSourceNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ServiceNameSourceNameBytes);
                 offset += MessagePackBinary.WriteString(ref bytes, offset, serviceNameSource);
             }
 
@@ -630,7 +627,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (processTagsRawBytes is not null)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _processTagsNameBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ProcessTagsNameBytes);
                     offset += MessagePackBinary.WriteRaw(ref bytes, offset, processTagsRawBytes);
                 }
             }
@@ -642,7 +639,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (gitCommitShaRawBytes is not null)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _gitCommitShaNameBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, GitCommitShaNameBytes);
                     offset += MessagePackBinary.WriteRaw(ref bytes, offset, gitCommitShaRawBytes);
                 }
 
@@ -650,7 +647,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (gitRepositoryUrlRawBytes is not null)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _gitRepositoryUrlNameBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, GitRepositoryUrlNameBytes);
                     offset += MessagePackBinary.WriteRaw(ref bytes, offset, gitRepositoryUrlRawBytes);
                 }
             }
@@ -658,11 +655,11 @@ namespace Datadog.Trace.Agent.MessagePack
             if (Security.Instance.AppsecEnabled && model.IsLocalRoot && span.Context.TraceContext?.WafExecuted is true)
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeFamilyBytes);
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageValueBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, RuntimeFamilyBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LanguageValueBytes);
 
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _wafRuleFileVersionBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, WafRuleFileVersionBytes);
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, GetAppSecRulesetVersion(Security.Instance.WafRuleFileVersion));
             }
 
@@ -673,8 +670,6 @@ namespace Datadog.Trace.Agent.MessagePack
                 model.TraceChunk.AzureAppServiceSettings is { } azureAppServiceSettings &&
                 span.Tags is not InferredProxyTags { InferredSpan: 1.0 })
             {
-                // Done here to avoid initializing in most cases
-                InitializeAasTags();
                 byte[] tagBytes;
 
                 if (model.IsLocalRoot || model.IsChunkOrphan)
@@ -683,7 +678,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasSiteKindTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasSiteKindTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -691,7 +686,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasResourceGroupTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasResourceGroupTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -699,7 +694,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasSubscriptionIdTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasSubscriptionIdTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -707,7 +702,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasResourceIdTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasResourceIdTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -715,7 +710,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasInstanceIdTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasInstanceIdTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -723,7 +718,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasInstanceNameTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasInstanceNameTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -731,7 +726,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasOperatingSystemTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasOperatingSystemTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -740,7 +735,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasRuntimeTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasRuntimeTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
 
@@ -748,7 +743,7 @@ namespace Datadog.Trace.Agent.MessagePack
                     if (tagBytes is not null)
                     {
                         count++;
-                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasExtensionVersionTagNameBytes);
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasExtensionVersionTagNameBytes);
                         offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                     }
                 }
@@ -758,7 +753,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (tagBytes is not null)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasSiteNameTagNameBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasSiteNameTagNameBytes);
                     offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                 }
 
@@ -766,7 +761,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (tagBytes is not null)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _aasSiteTypeTagNameBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AasSiteTypeTagNameBytes);
                     offset += MessagePackBinary.WriteRaw(ref bytes, offset, tagBytes);
                 }
             }
@@ -820,7 +815,7 @@ namespace Datadog.Trace.Agent.MessagePack
             int originalOffset = offset;
 
             // Start of "metrics" dictionary. Do not add any numeric tags before this line.
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metricsBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, MetricsBytes);
 
             int count = 0;
 
@@ -843,23 +838,23 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (processId != 0)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _processIdNameBytes); // "process_id"
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ProcessIdNameBytes); // "process_id"
                     offset += MessagePackBinary.WriteDouble(ref bytes, offset, processId);
                 }
 
                 // add agent or rule sampling rate
                 if (model.TraceChunk is { AppliedSamplingRate: { } samplingRate, SamplingMechanism: { } samplingMechanism })
                 {
-                    var samplingRateTagName = samplingMechanism switch
+                    ReadOnlySpan<byte> samplingRateTagName = samplingMechanism switch
                     {
-                        SamplingMechanism.AgentRate => _agentSamplingRateNameBytes,                 // "_dd.agent_psr"
-                        SamplingMechanism.LocalTraceSamplingRule => _ruleSamplingRateNameBytes,     // "_dd.rule_psr"
-                        SamplingMechanism.RemoteAdaptiveSamplingRule => _ruleSamplingRateNameBytes, // "_dd.rule_psr"
-                        SamplingMechanism.RemoteUserSamplingRule => _ruleSamplingRateNameBytes,     // "_dd.rule_psr"
-                        _ => null
+                        SamplingMechanism.AgentRate => AgentSamplingRateNameBytes,                 // "_dd.agent_psr"
+                        SamplingMechanism.LocalTraceSamplingRule => RuleSamplingRateNameBytes,     // "_dd.rule_psr"
+                        SamplingMechanism.RemoteAdaptiveSamplingRule => RuleSamplingRateNameBytes, // "_dd.rule_psr"
+                        SamplingMechanism.RemoteUserSamplingRule => RuleSamplingRateNameBytes,     // "_dd.rule_psr"
+                        _ => default
                     };
 
-                    if (samplingRateTagName is not null)
+                    if (!samplingRateTagName.IsEmpty)
                     {
                         count++;
                         offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, samplingRateTagName);
@@ -871,7 +866,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (model.TraceChunk.RateLimiterRate is { } limitSamplingRate)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _limitSamplingRateNameBytes); // "_dd.limit_psr"
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LimitSamplingRateNameBytes); // "_dd.limit_psr"
                     offset += MessagePackBinary.WriteDouble(ref bytes, offset, limitSamplingRate);
                 }
 
@@ -879,7 +874,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 if (model.TraceChunk.TracesKeepRate is { } keepRate)
                 {
                     count++;
-                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _keepRateNameBytes); // "_dd.tracer_kr"
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, KeepRateNameBytes); // "_dd.tracer_kr"
                     offset += MessagePackBinary.WriteDouble(ref bytes, offset, keepRate);
                 }
             }
@@ -889,14 +884,14 @@ namespace Datadog.Trace.Agent.MessagePack
             if (!model.TraceChunk.IsApmEnabled && model.IsLocalRoot)
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _apmEnabledNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ApmEnabledNameBytes);
                 offset += MessagePackBinary.WriteDouble(ref bytes, offset, 0);
             }
 
             if (Security.Instance.AppsecEnabled && model.IsLocalRoot && span.Context.TraceContext?.WafExecuted is true)
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _appSecEnabledBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AppSecEnabledBytes);
                 offset += MessagePackBinary.WriteDouble(ref bytes, offset, 1.0);
             }
 
@@ -905,7 +900,7 @@ namespace Datadog.Trace.Agent.MessagePack
             if (model is { IsChunkOrphan: true, TraceChunk.SamplingPriority: { } samplingPriority })
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _samplingPriorityNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SamplingPriorityNameBytes);
                 offset += MessagePackBinary.WriteDouble(ref bytes, offset, samplingPriority);
             }
 
@@ -914,7 +909,7 @@ namespace Datadog.Trace.Agent.MessagePack
             if (span.IsTopLevel && (!testOptimization.IsRunning || !testOptimization.Settings.Agentless))
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _topLevelSpanNameBytes); // "_dd.top_level"
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TopLevelSpanNameBytes); // "_dd.top_level"
                 offset += MessagePackBinary.WriteDouble(ref bytes, offset, 1);
             }
 
@@ -975,25 +970,6 @@ namespace Datadog.Trace.Agent.MessagePack
                 bytes = StringEncoding.UTF8.GetBytes(version);
                 _wafRuleFileVersionValues.Add(version, bytes);
                 return bytes;
-            }
-        }
-
-        private void InitializeAasTags()
-        {
-            if (_aasSiteNameTagNameBytes == null)
-            {
-                // AAS Tags are all computed from environment variables, they shouldn't change during the life of the process
-                _aasSiteNameTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesSiteName);
-                _aasSiteKindTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesSiteKind);
-                _aasSiteTypeTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesSiteType);
-                _aasResourceGroupTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesResourceGroup);
-                _aasSubscriptionIdTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesSubscriptionId);
-                _aasResourceIdTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesResourceId);
-                _aasInstanceIdTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesInstanceId);
-                _aasInstanceNameTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesInstanceName);
-                _aasOperatingSystemTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesOperatingSystem);
-                _aasRuntimeTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesRuntime);
-                _aasExtensionVersionTagNameBytes = StringEncoding.UTF8.GetBytes(Datadog.Trace.Tags.AzureAppServicesExtensionVersion);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
@@ -7,7 +7,6 @@
 
 using System;
 using Datadog.Trace.Ci.Agent.Payloads;
-using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Vendors.MessagePack;
 
@@ -15,27 +14,9 @@ namespace Datadog.Trace.Ci.Agent.MessagePack;
 
 internal sealed class CIEventMessagePackFormatter : EventMessagePackFormatter<CIVisibilityProtocolPayload>
 {
-    private readonly byte[] _metadataBytes = StringEncoding.UTF8.GetBytes("metadata");
-
-    private readonly byte[] _asteriskBytes = StringEncoding.UTF8.GetBytes("*");
-    private readonly byte[] _runtimeIdBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.RuntimeId);
     private readonly byte[] _runtimeIdValueBytes = StringEncoding.UTF8.GetBytes(Tracer.RuntimeId);
-    private readonly byte[] _languageNameBytes = StringEncoding.UTF8.GetBytes("language");
-    private readonly byte[] _languageNameValueBytes = StringEncoding.UTF8.GetBytes("dotnet");
-    private readonly byte[] _libraryVersionBytes = StringEncoding.UTF8.GetBytes(CommonTags.LibraryVersion);
-    private readonly byte[] _libraryVersionValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.AssemblyVersion);
-    private readonly byte[] _environmentBytes = StringEncoding.UTF8.GetBytes("env");
     private readonly byte[]? _environmentValueBytes;
-
-    private readonly byte[] _testBytes = StringEncoding.UTF8.GetBytes(SpanTypes.Test);
-    private readonly byte[] _testSuiteEndBytes = StringEncoding.UTF8.GetBytes(SpanTypes.TestSuite);
-    private readonly byte[] _testModuleEndBytes = StringEncoding.UTF8.GetBytes(SpanTypes.TestModule);
-    private readonly byte[] _testSessionEndBytes = StringEncoding.UTF8.GetBytes(SpanTypes.TestSession);
-    private readonly byte[] _testSessionNameBytes = StringEncoding.UTF8.GetBytes("test_session.name");
     private readonly byte[]? _testSessionNameValueBytes;
-
-    private readonly byte[] _eventsBytes = StringEncoding.UTF8.GetBytes("events");
-
     private readonly ArraySegment<byte> _envelopBytes;
 
     public CIEventMessagePackFormatter(TracerSettings tracerSettings)
@@ -54,6 +35,23 @@ internal sealed class CIEventMessagePackFormatter : EventMessagePackFormatter<CI
 
         _envelopBytes = GetEnvelopeArraySegment();
     }
+
+#pragma warning disable SA1516 // Elements should be separated by blank line
+    private static ReadOnlySpan<byte> MetadataBytes => "metadata"u8;
+    private static ReadOnlySpan<byte> AsteriskBytes => "*"u8;
+    private static ReadOnlySpan<byte> RuntimeIdBytes => "runtime-id"u8;
+    private static ReadOnlySpan<byte> LanguageNameBytes => "language"u8;
+    private static ReadOnlySpan<byte> LanguageNameValueBytes => "dotnet"u8;
+    private static ReadOnlySpan<byte> LibraryVersionBytes => "library_version"u8;
+    private static ReadOnlySpan<byte> LibraryVersionValueBytes => TracerConstants.AssemblyVersionBytes;
+    private static ReadOnlySpan<byte> EnvironmentBytes => "env"u8;
+    private static ReadOnlySpan<byte> TestBytes => "test"u8;
+    private static ReadOnlySpan<byte> TestSuiteEndBytes => "test_suite_end"u8;
+    private static ReadOnlySpan<byte> TestModuleEndBytes => "test_module_end"u8;
+    private static ReadOnlySpan<byte> TestSessionEndBytes => "test_session_end"u8;
+    private static ReadOnlySpan<byte> TestSessionNameBytes => "test_session.name"u8;
+    private static ReadOnlySpan<byte> EventsBytes => "events"u8;
+#pragma warning restore SA1516
 
     public override int Serialize(ref byte[] bytes, int offset, CIVisibilityProtocolPayload? value, IFormatterResolver formatterResolver)
     {
@@ -104,7 +102,7 @@ internal sealed class CIEventMessagePackFormatter : EventMessagePackFormatter<CI
         // # Metadata
 
         // Key
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metadataBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, MetadataBytes);
 
         // Value
         var metadataValuesCount = _testSessionNameValueBytes is not null ? 5 : 1;
@@ -113,7 +111,7 @@ internal sealed class CIEventMessagePackFormatter : EventMessagePackFormatter<CI
         // ->  * : {}
 
         // Key
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _asteriskBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, AsteriskBytes);
 
         // Value (RuntimeId, Language, library_version, Env?)
         int valuesCount = 3;
@@ -124,56 +122,56 @@ internal sealed class CIEventMessagePackFormatter : EventMessagePackFormatter<CI
 
         offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, valuesCount);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, RuntimeIdBytes);
         offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdValueBytes);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageNameBytes);
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageNameValueBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LanguageNameBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LanguageNameValueBytes);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _libraryVersionBytes);
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _libraryVersionValueBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LibraryVersionBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LibraryVersionValueBytes);
 
         if (_environmentValueBytes is not null)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, EnvironmentBytes);
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentValueBytes);
         }
 
         if (_testSessionNameValueBytes is not null)
         {
             // -> test : {}
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestBytes);
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 1);
             // -> test_session.name : "value"
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSessionNameBytes);
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameValueBytes);
 
             // -> test_suite_end : {}
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSuiteEndBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSuiteEndBytes);
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 1);
             // -> test_session.name : "value"
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSessionNameBytes);
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameValueBytes);
 
             // -> test_module_end : {}
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testModuleEndBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestModuleEndBytes);
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 1);
             // -> test_session.name : "value"
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSessionNameBytes);
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameValueBytes);
 
             // -> test_session_end : {}
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionEndBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSessionEndBytes);
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 1);
             // -> test_session.name : "value"
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSessionNameBytes);
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionNameValueBytes);
         }
 
         // # Events
 
         // Key
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _eventsBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, EventsBytes);
 
         return new ArraySegment<byte>(bytes, 0, offset);
     }

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
@@ -12,8 +12,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack;
 
 internal sealed class CoveragePayloadMessagePackFormatter : EventMessagePackFormatter<CICodeCoveragePayload.CoveragePayload>
 {
-    private readonly byte[] _versionBytes = StringEncoding.UTF8.GetBytes("version");
-    private readonly byte[] _coveragesBytes = StringEncoding.UTF8.GetBytes("coverages");
+    private static ReadOnlySpan<byte> CoveragesBytes => "coverages"u8;
 
     public override int Serialize(ref byte[] bytes, int offset, CICodeCoveragePayload.CoveragePayload value, IFormatterResolver formatterResolver)
     {
@@ -21,10 +20,10 @@ internal sealed class CoveragePayloadMessagePackFormatter : EventMessagePackForm
 
         offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 2);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _versionBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, VersionBytes);
         offset += MessagePackBinary.WriteInt32(ref bytes, offset, 2);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _coveragesBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, CoveragesBytes);
 
         // Write events
         if (value.TestCoverageData.Lock())

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/EventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/EventMessagePackFormatter.cs
@@ -16,14 +16,16 @@ internal abstract class EventMessagePackFormatter
 {
     private readonly IDatadogLogger _log;
 
-    protected static readonly byte[] TypeBytes = StringEncoding.UTF8.GetBytes("type");
-    protected static readonly byte[] VersionBytes = StringEncoding.UTF8.GetBytes("version");
-    protected static readonly byte[] ContentBytes = StringEncoding.UTF8.GetBytes("content");
-
     protected EventMessagePackFormatter()
     {
         _log = DatadogLogging.GetLoggerFor(GetType());
     }
+
+#pragma warning disable SA1516 // Elements should be separated by blank line
+    protected static ReadOnlySpan<byte> TypeBytes => "type"u8;
+    protected static ReadOnlySpan<byte> VersionBytes => "version"u8;
+    protected static ReadOnlySpan<byte> ContentBytes => "content"u8;
+#pragma warning restore SA1516
 
     protected IDatadogLogger Log => _log;
 }

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Datadog.Trace.Ci.Tagging;
-using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Processors;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
@@ -22,43 +21,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
 {
     public static readonly IMessagePackFormatter<Span> Instance = new SpanMessagePackFormatter();
 
-    private readonly byte[] _traceIdBytes = StringEncoding.UTF8.GetBytes("trace_id");
-    private readonly byte[] _spanIdBytes = StringEncoding.UTF8.GetBytes("span_id");
-    private readonly byte[] _nameBytes = StringEncoding.UTF8.GetBytes("name");
-    private readonly byte[] _resourceBytes = StringEncoding.UTF8.GetBytes("resource");
-    private readonly byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("service");
-    private readonly byte[] _typeBytes = StringEncoding.UTF8.GetBytes("type");
-    private readonly byte[] _startBytes = StringEncoding.UTF8.GetBytes("start");
-    private readonly byte[] _durationBytes = StringEncoding.UTF8.GetBytes("duration");
-    private readonly byte[] _parentIdBytes = StringEncoding.UTF8.GetBytes("parent_id");
-    private readonly byte[] _errorBytes = StringEncoding.UTF8.GetBytes("error");
-    private readonly byte[] _itrCorrelationId = StringEncoding.UTF8.GetBytes("itr_correlation_id");
-
-    // SuiteId, ModuleId, SessionId tags
-    private readonly byte[] _testSuiteIdBytes = StringEncoding.UTF8.GetBytes(TestSuiteVisibilityTags.TestSuiteId);
-    private readonly byte[] _testModuleIdBytes = StringEncoding.UTF8.GetBytes(TestSuiteVisibilityTags.TestModuleId);
-    private readonly byte[] _testSessionIdBytes = StringEncoding.UTF8.GetBytes(TestSuiteVisibilityTags.TestSessionId);
-
-    // string tags
-    private readonly byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
-
-    private readonly byte[] _languageNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Language);
-    private readonly byte[] _languageValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.Language);
-
-    private readonly byte[] _environmentNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Env);
-
-    private readonly byte[] _versionNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Version);
-
-    private readonly byte[] _originNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Origin);
-    private readonly byte[] _originValueBytes = StringEncoding.UTF8.GetBytes(TestTags.CIAppTestOriginName);
-
-    // numeric tags
-    private readonly byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");
-
-    private readonly byte[] _samplingPriorityNameBytes = StringEncoding.UTF8.GetBytes(Metrics.SamplingPriority);
     private readonly byte[][] _samplingPriorityValueBytes;
-
-    private readonly byte[] _processIdNameBytes = StringEncoding.UTF8.GetBytes(Trace.Metrics.ProcessId);
     private readonly byte[]? _processIdValueBytes;
 
     private SpanMessagePackFormatter()
@@ -76,6 +39,33 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
             MessagePackSerializer.Serialize((double)SamplingPriorityValues.UserKeep)
         ];
     }
+
+#pragma warning disable SA1516 // Elements should be separated by blank line
+    private static ReadOnlySpan<byte> TraceIdBytes => "trace_id"u8;
+    private static ReadOnlySpan<byte> SpanIdBytes => "span_id"u8;
+    private static ReadOnlySpan<byte> NameBytes => "name"u8;
+    private static ReadOnlySpan<byte> ResourceBytes => "resource"u8;
+    private static ReadOnlySpan<byte> ServiceBytes => "service"u8;
+    private static ReadOnlySpan<byte> TypeBytes => "type"u8;
+    private static ReadOnlySpan<byte> StartBytes => "start"u8;
+    private static ReadOnlySpan<byte> DurationBytes => "duration"u8;
+    private static ReadOnlySpan<byte> ParentIdBytes => "parent_id"u8;
+    private static ReadOnlySpan<byte> ErrorBytes => "error"u8;
+    private static ReadOnlySpan<byte> ItrCorrelationIdBytes => "itr_correlation_id"u8;
+    private static ReadOnlySpan<byte> TestSuiteIdBytes => "test_suite_id"u8; // TestSuiteVisibilityTags.TestSuiteId
+    private static ReadOnlySpan<byte> TestModuleIdBytes => "test_module_id"u8; // TestSuiteVisibilityTags.TestModuleId
+    private static ReadOnlySpan<byte> TestSessionIdBytes => "test_session_id"u8; // TestSuiteVisibilityTags.TestSessionId
+    private static ReadOnlySpan<byte> MetaBytes => "meta"u8;
+    private static ReadOnlySpan<byte> LanguageNameBytes => "language"u8; // Tags.Language
+    private static ReadOnlySpan<byte> LanguageValueBytes => "dotnet"u8; // TracerConstants.Language
+    private static ReadOnlySpan<byte> EnvironmentNameBytes => "env"u8; // Tags.Env
+    private static ReadOnlySpan<byte> VersionNameBytes => "version"u8; // Tags.Version
+    private static ReadOnlySpan<byte> OriginNameBytes => "_dd.origin"u8; // Tags.Origin
+    private static ReadOnlySpan<byte> OriginValueBytes => "ciapp-test"u8; // TestTags.CIAppTestOriginName
+    private static ReadOnlySpan<byte> MetricsBytes => "metrics"u8;
+    private static ReadOnlySpan<byte> SamplingPriorityNameBytes => "_sampling_priority_v1"u8; // Metrics.SamplingPriority
+    private static ReadOnlySpan<byte> ProcessIdNameBytes => "process_id"u8; // Metrics.ProcessId
+#pragma warning restore SA1516
 
     public int Serialize(ref byte[] bytes, int offset, Span value, IFormatterResolver formatterResolver)
     {
@@ -133,62 +123,62 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
         if (isSpan)
         {
             // trace_id field is 64-bits, truncate by using TraceId128.Lower
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TraceIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.TraceId128.Lower);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SpanIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.SpanId);
         }
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _nameBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, NameBytes);
         offset += MessagePackBinary.WriteString(ref bytes, offset, value.OperationName);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _resourceBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ResourceBytes);
         offset += MessagePackBinary.WriteString(ref bytes, offset, value.ResourceName);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ServiceBytes);
         offset += MessagePackBinary.WriteString(ref bytes, offset, value.ServiceName);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _typeBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TypeBytes);
         offset += MessagePackBinary.WriteString(ref bytes, offset, value.Type);
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _startBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, StartBytes);
         offset += MessagePackBinary.WriteInt64(ref bytes, offset, value.StartTime.ToUnixTimeNanoseconds());
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, DurationBytes);
         offset += MessagePackBinary.WriteInt64(ref bytes, offset, value.Duration.ToNanoseconds());
 
         if (context.ParentId is not null)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ParentIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.ParentId.Value);
         }
 
         if (testSuiteTags is not null)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSuiteIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSuiteIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, testSuiteTags.SuiteId);
         }
 
         if (testModuleTags is not null)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testModuleIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestModuleIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, testModuleTags.ModuleId);
         }
 
         if (testSessionTags is not null && testSessionTags.SessionId != 0)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSessionIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, testSessionTags.SessionId);
         }
 
         if (correlationId is not null)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _itrCorrelationId);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ItrCorrelationIdBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, correlationId);
         }
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _errorBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ErrorBytes);
         offset += MessagePackBinary.WriteByte(ref bytes, offset, (byte)(value.Error ? 1 : 0));
 
         ITagProcessor[]? tagProcessors = null;
@@ -220,7 +210,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
         var traceContext = span.Context.TraceContext;
 
         // Start of "meta" dictionary. Do not add any string tags before this line.
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metaBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, MetaBytes);
 
         int count = 0;
 
@@ -249,8 +239,8 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
 
         // add "_dd.origin" tag to all spans
         count++;
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _originNameBytes);
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _originValueBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, OriginNameBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, OriginValueBytes);
 
         // add "env" to all spans
         var env = traceContext?.Environment;
@@ -258,7 +248,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
         if (!string.IsNullOrWhiteSpace(env))
         {
             count++;
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentNameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, EnvironmentNameBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, env);
         }
 
@@ -267,8 +257,8 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
         if (span.Tags is not InstrumentationTags { SpanKind: SpanKinds.Client or SpanKinds.Producer })
         {
             count++;
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageNameBytes);
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageValueBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LanguageNameBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, LanguageValueBytes);
         }
 
         // add "version" tags to all spans whose service name is the default service name
@@ -279,7 +269,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
             if (!string.IsNullOrWhiteSpace(version))
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _versionNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, VersionNameBytes);
                 offset += MessagePackBinary.WriteString(ref bytes, offset, version);
             }
         }
@@ -332,7 +322,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
         int originalOffset = offset;
 
         // Start of "metrics" dictionary. Do not add any numeric tags before this line.
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metricsBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, MetricsBytes);
 
         int count = 0;
 
@@ -353,7 +343,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
             {
                 // add "process_id" tag
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _processIdNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ProcessIdNameBytes);
                 offset += MessagePackBinary.WriteRaw(ref bytes, offset, _processIdValueBytes);
             }
 
@@ -361,7 +351,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
             if (span.Context.TraceContext.SamplingPriority is { } samplingPriority)
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _samplingPriorityNameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SamplingPriorityNameBytes);
 
                 if (samplingPriority is >= -1 and <= 2)
                 {

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/TestCoverageMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/TestCoverageMessagePackFormatter.cs
@@ -4,6 +4,7 @@
 // </copyright>
 #nullable enable
 
+using System;
 using Datadog.Trace.Ci.Coverage.Models.Tests;
 using Datadog.Trace.Vendors.MessagePack;
 
@@ -11,12 +12,14 @@ namespace Datadog.Trace.Ci.Agent.MessagePack;
 
 internal sealed class TestCoverageMessagePackFormatter : EventMessagePackFormatter<TestCoverage>
 {
-    private readonly byte[] _testSessionIdBytes = StringEncoding.UTF8.GetBytes("test_session_id");
-    private readonly byte[] _testSuiteIdBytes = StringEncoding.UTF8.GetBytes("test_suite_id");
-    private readonly byte[] _spanIdBytes = StringEncoding.UTF8.GetBytes("span_id");
-    private readonly byte[] _filesBytes = StringEncoding.UTF8.GetBytes("files");
-    private readonly byte[] _filenameBytes = StringEncoding.UTF8.GetBytes("filename");
-    private readonly byte[] _bitmapBytes = StringEncoding.UTF8.GetBytes("bitmap");
+#pragma warning disable SA1516 // Elements should be separated by blank line
+    private static ReadOnlySpan<byte> TestSessionIdBytes => "test_session_id"u8;
+    private static ReadOnlySpan<byte> TestSuiteIdBytes => "test_suite_id"u8;
+    private static ReadOnlySpan<byte> SpanIdBytes => "span_id"u8;
+    private static ReadOnlySpan<byte> FilesBytes => "files"u8;
+    private static ReadOnlySpan<byte> FilenameBytes => "filename"u8;
+    private static ReadOnlySpan<byte> BitmapBytes => "bitmap"u8;
+#pragma warning restore SA1516
 
     public override int Serialize(ref byte[] bytes, int offset, TestCoverage value, IFormatterResolver formatterResolver)
     {
@@ -47,23 +50,23 @@ internal sealed class TestCoverageMessagePackFormatter : EventMessagePackFormatt
 
         if (value.SessionId != 0)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSessionIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.SessionId);
         }
 
         if (value.SuiteId != 0)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSuiteIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, TestSuiteIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.SuiteId);
         }
 
         if (value.SpanId != 0)
         {
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, SpanIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.SpanId);
         }
 
-        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _filesBytes);
+        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, FilesBytes);
         if (value.Files is { Count: > 0 } files)
         {
             offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, (uint)files.Count);
@@ -71,10 +74,10 @@ internal sealed class TestCoverageMessagePackFormatter : EventMessagePackFormatt
             {
                 offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 2);
 
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _filenameBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, FilenameBytes);
                 offset += MessagePackBinary.WriteString(ref bytes, offset, file.FileName);
 
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _bitmapBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, BitmapBytes);
                 offset += MessagePackBinary.WriteBytes(ref bytes, offset, file.Bitmap);
             }
         }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
@@ -20,43 +20,9 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
 {
     internal sealed class DataStreamsMessagePackFormatter
     {
-        private readonly byte[] _environmentBytes = StringEncoding.UTF8.GetBytes("Env");
-        private readonly byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("Service");
         private readonly long _productMask;
         private readonly bool _isInDefaultState;
         private readonly bool _writeProcessTags;
-
-        // private readonly byte[] _primaryTagBytes = StringEncoding.UTF8.GetBytes("PrimaryTag");
-        // private readonly byte[] _primaryTagValueBytes;
-        private readonly byte[] _statsBytes = StringEncoding.UTF8.GetBytes("Stats");
-        private readonly byte[] _backlogsBytes = StringEncoding.UTF8.GetBytes("Backlogs");
-        private readonly byte[] _tracerVersionBytes = StringEncoding.UTF8.GetBytes("TracerVersion");
-        private readonly byte[] _tracerVersionValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.AssemblyVersion);
-        private readonly byte[] _langBytes = StringEncoding.UTF8.GetBytes("Lang");
-        private readonly byte[] _langValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.Language);
-
-        private readonly byte[] _startBytes = StringEncoding.UTF8.GetBytes("Start");
-        private readonly byte[] _durationBytes = StringEncoding.UTF8.GetBytes("Duration");
-
-        private readonly byte[] _edgeTagsBytes = StringEncoding.UTF8.GetBytes("EdgeTags");
-        private readonly byte[] _hashBytes = StringEncoding.UTF8.GetBytes("Hash");
-        private readonly byte[] _parentHashBytes = StringEncoding.UTF8.GetBytes("ParentHash");
-        private readonly byte[] _pathwayLatencyBytes = StringEncoding.UTF8.GetBytes("PathwayLatency");
-        private readonly byte[] _edgeLatencyBytes = StringEncoding.UTF8.GetBytes("EdgeLatency");
-        private readonly byte[] _payloadSizeBytes = StringEncoding.UTF8.GetBytes("PayloadSize");
-        private readonly byte[] _timestampTypeBytes = StringEncoding.UTF8.GetBytes("TimestampType");
-        private readonly byte[] _currentTimestampTypeBytes = StringEncoding.UTF8.GetBytes("current");
-        private readonly byte[] _originTimestampTypeBytes = StringEncoding.UTF8.GetBytes("origin");
-
-        private readonly byte[] _backlogTagsBytes = StringEncoding.UTF8.GetBytes("Tags");
-        private readonly byte[] _backlogValueBytes = StringEncoding.UTF8.GetBytes("Value");
-        private readonly byte[] _productMaskBytes = StringEncoding.UTF8.GetBytes("ProductMask");
-        private readonly byte[] _processTagsBytes = StringEncoding.UTF8.GetBytes("ProcessTags");
-        private readonly byte[] _isInDefaultStateBytes = StringEncoding.UTF8.GetBytes("IsInDefaultState");
-
-        private readonly byte[] _transactions = StringEncoding.UTF8.GetBytes("Transactions");
-        private readonly byte[] _transactionCheckpointIds = StringEncoding.UTF8.GetBytes("TransactionCheckpointIds");
-
         private byte[] _environmentValueBytes;
         private byte[] _serviceValueBytes;
         private ProcessTags? _processTags;
@@ -104,6 +70,35 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
             Profiling = 1 << 3, // 00001000
         }
 
+#pragma warning disable SA1516 // Elements should be separated by a blank line
+        private static ReadOnlySpan<byte> EnvironmentBytes => "Env"u8;
+        private static ReadOnlySpan<byte> ServiceBytes => "Service"u8;
+        private static ReadOnlySpan<byte> StatsBytes => "Stats"u8;
+        private static ReadOnlySpan<byte> BacklogsBytes => "Backlogs"u8;
+        private static ReadOnlySpan<byte> TracerVersionBytes => "TracerVersion"u8;
+        private static ReadOnlySpan<byte> TracerVersionValueBytes => TracerConstants.AssemblyVersionBytes;
+        private static ReadOnlySpan<byte> LangBytes => "Lang"u8;
+        private static ReadOnlySpan<byte> LangValueBytes => "dotnet"u8;
+        private static ReadOnlySpan<byte> StartBytes => "Start"u8;
+        private static ReadOnlySpan<byte> DurationBytes => "Duration"u8;
+        private static ReadOnlySpan<byte> EdgeTagsBytes => "EdgeTags"u8;
+        private static ReadOnlySpan<byte> HashBytes => "Hash"u8;
+        private static ReadOnlySpan<byte> ParentHashBytes => "ParentHash"u8;
+        private static ReadOnlySpan<byte> PathwayLatencyBytes => "PathwayLatency"u8;
+        private static ReadOnlySpan<byte> EdgeLatencyBytes => "EdgeLatency"u8;
+        private static ReadOnlySpan<byte> PayloadSizeBytes => "PayloadSize"u8;
+        private static ReadOnlySpan<byte> TimestampTypeBytes => "TimestampType"u8;
+        private static ReadOnlySpan<byte> CurrentTimestampTypeBytes => "current"u8;
+        private static ReadOnlySpan<byte> OriginTimestampTypeBytes => "origin"u8;
+        private static ReadOnlySpan<byte> BacklogTagsBytes => "Tags"u8;
+        private static ReadOnlySpan<byte> BacklogValueBytes => "Value"u8;
+        private static ReadOnlySpan<byte> ProductMaskBytes => "ProductMask"u8;
+        private static ReadOnlySpan<byte> ProcessTagsBytes => "ProcessTags"u8;
+        private static ReadOnlySpan<byte> IsInDefaultStateBytes => "IsInDefaultState"u8;
+        private static ReadOnlySpan<byte> TransactionsBytes => "Transactions"u8;
+        private static ReadOnlySpan<byte> TransactionCheckpointIdsBytes => "TransactionCheckpointIds"u8;
+#pragma warning restore SA1516
+
         private static long GetProductsMask(TracerSettings tracerSettings, ProfilerSettings profilerSettings)
         {
             var productsMask = (long)Products.Apm;
@@ -138,23 +133,23 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
             // -1 because service name override is not supported
             bytesWritten += MessagePackBinary.WriteMapHeader(stream, 7 + (withProcessTags ? 1 : 0));
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _environmentBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, EnvironmentBytes);
             bytesWritten += MessagePackBinary.WriteStringBytes(stream, _environmentValueBytes);
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _serviceBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, ServiceBytes);
             bytesWritten += MessagePackBinary.WriteStringBytes(stream, _serviceValueBytes);
 
             // We never have a primary tag currently, make sure to increase header size if/when we add it
             // offset += MessagePackBinary.WriteStringBytes(stream, _primaryTagBytes);
             // offset += MessagePackBinary.WriteStringBytes(stream, _primaryTagValueBytes);
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _langBytes);
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _langValueBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, LangBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, LangValueBytes);
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _tracerVersionBytes);
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _tracerVersionValueBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, TracerVersionBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, TracerVersionValueBytes);
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _statsBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, StatsBytes);
             bytesWritten += MessagePackBinary.WriteArrayHeader(stream, statsBuckets.Count + backlogsBuckets.Count + (hasTransactions ? 1 : 0));
 
             if (hasTransactions)
@@ -163,10 +158,10 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                 var bucketStartTime = currentTs - (currentTs % bucketDurationNs);
                 bytesWritten += WriteBucketsHeader(stream, bucketStartTime, bucketDurationNs, 0, 0, true);
 
-                bytesWritten += MessagePackBinary.WriteStringBytes(stream, _transactions);
+                bytesWritten += MessagePackBinary.WriteStringBytes(stream, TransactionsBytes);
                 bytesWritten += MessagePackBinary.WriteBytes(stream, transactionData);
 
-                bytesWritten += MessagePackBinary.WriteStringBytes(stream, _transactionCheckpointIds);
+                bytesWritten += MessagePackBinary.WriteStringBytes(stream, TransactionCheckpointIdsBytes);
                 bytesWritten += MessagePackBinary.WriteBytes(stream, DataStreamsTransactionInfo.GetCacheBytes());
             }
 
@@ -178,11 +173,11 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                 {
                     bytesWritten += MessagePackBinary.WriteMapHeader(stream, 2);
 
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _backlogValueBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, BacklogValueBytes);
                     bytesWritten += MessagePackBinary.WriteInt64(stream, point.Value);
 
                     var tags = point.Tags.Split(',');
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _backlogTagsBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, BacklogTagsBytes);
                     bytesWritten += MessagePackBinary.WriteArrayHeader(stream, tags.Length);
                     foreach (var tag in tags)
                     {
@@ -195,9 +190,9 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
             {
                 bytesWritten += WriteBucketsHeader(stream, statsBucket.BucketStartTimeNs, bucketDurationNs, statsBucket.Bucket.Values.Count, 0, false);
 
-                var timestampTypeBytes = statsBucket.TimestampType == TimestampType.Current
-                                             ? _currentTimestampTypeBytes
-                                             : _originTimestampTypeBytes;
+                ReadOnlySpan<byte> timestampTypeBytes = statsBucket.TimestampType == TimestampType.Current
+                                             ? CurrentTimestampTypeBytes
+                                             : OriginTimestampTypeBytes;
 
                 foreach (var point in statsBucket.Bucket.Values)
                 {
@@ -209,27 +204,27 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                     var itemCount = hasEdges ? 7 : 6;
                     bytesWritten += MessagePackBinary.WriteMapHeader(stream, itemCount);
 
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _hashBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, HashBytes);
                     bytesWritten += MessagePackBinary.WriteUInt64(stream, point.Hash.Value);
 
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _parentHashBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, ParentHashBytes);
                     bytesWritten += MessagePackBinary.WriteUInt64(stream, point.ParentHash.Value);
 
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _timestampTypeBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, TimestampTypeBytes);
                     bytesWritten += MessagePackBinary.WriteStringBytes(stream, timestampTypeBytes);
 
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _pathwayLatencyBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, PathwayLatencyBytes);
                     bytesWritten += SerializeSketch(stream, point.PathwayLatency);
 
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _edgeLatencyBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, EdgeLatencyBytes);
                     bytesWritten += SerializeSketch(stream, point.EdgeLatency);
 
-                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _payloadSizeBytes);
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, PayloadSizeBytes);
                     bytesWritten += SerializeSketch(stream, point.PayloadSize);
 
                     if (hasEdges)
                     {
-                        bytesWritten += MessagePackBinary.WriteStringBytes(stream, _edgeTagsBytes);
+                        bytesWritten += MessagePackBinary.WriteStringBytes(stream, EdgeTagsBytes);
                         bytesWritten += MessagePackBinary.WriteArrayHeader(stream, point.EdgeTags.Length);
 
                         foreach (var edgeTag in point.EdgeTags)
@@ -240,12 +235,12 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                 }
             }
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _productMaskBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, ProductMaskBytes);
             bytesWritten += MessagePackBinary.WriteInt64(stream, _productMask);
 
             if (processTags is not null)
             {
-                bytesWritten += MessagePackBinary.WriteStringBytes(stream, _processTagsBytes);
+                bytesWritten += MessagePackBinary.WriteStringBytes(stream, ProcessTagsBytes);
                 bytesWritten += MessagePackBinary.WriteArrayHeader(stream, processTags.Count);
                 foreach (var tag in processTags)
                 {
@@ -253,7 +248,7 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                 }
             }
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _isInDefaultStateBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, IsInDefaultStateBytes);
             bytesWritten += MessagePackBinary.WriteBoolean(stream, _isInDefaultState);
 
             return bytesWritten;
@@ -284,21 +279,21 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
             // https://github.com/DataDog/data-streams-go/blob/60ba06aec619850aef8ed0b9b1f0f5e310438362/datastreams/payload.go#L48
             bytesWritten += MessagePackBinary.WriteMapHeader(stream, count);
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _startBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, StartBytes);
             bytesWritten += MessagePackBinary.WriteInt64(stream, bucketStartTimeNs);
 
-            bytesWritten += MessagePackBinary.WriteStringBytes(stream, _durationBytes);
+            bytesWritten += MessagePackBinary.WriteStringBytes(stream, DurationBytes);
             bytesWritten += MessagePackBinary.WriteInt64(stream, bucketDurationNs);
 
             if (statsBucketCount > 0)
             {
-                bytesWritten += MessagePackBinary.WriteStringBytes(stream, _statsBytes);
+                bytesWritten += MessagePackBinary.WriteStringBytes(stream, StatsBytes);
                 bytesWritten += MessagePackBinary.WriteArrayHeader(stream, statsBucketCount);
             }
 
             if (backlogBucketCount > 0)
             {
-                bytesWritten += MessagePackBinary.WriteStringBytes(stream, _backlogsBytes);
+                bytesWritten += MessagePackBinary.WriteStringBytes(stream, BacklogsBytes);
                 bytesWritten += MessagePackBinary.WriteArrayHeader(stream, backlogBucketCount);
             }
 

--- a/tracer/src/Datadog.Trace/ExtensionMethods/MessagePackBinaryExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/MessagePackBinaryExtensions.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.IO;
 
 namespace Datadog.Trace.Vendors.MessagePack
 {
@@ -102,6 +103,14 @@ namespace Datadog.Trace.Vendors.MessagePack
                 utf8stringBytes.CopyTo(bytes.AsSpan(offset + 5, byteCount));
                 return byteCount + 5;
             }
+        }
+
+        public static int WriteStringBytes(Stream stream, ReadOnlySpan<byte> utf8stringBytes)
+        {
+            var buffer = StreamDecodeMemoryPool.GetBuffer();
+            var writeCount = WriteStringBytes(ref buffer, 0, utf8stringBytes);
+            stream.Write(buffer, 0, writeCount);
+            return writeCount;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesJsonSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesJsonSerializer.cs
@@ -33,7 +33,7 @@ internal sealed class OtlpTracesJsonSerializer : ISpanBufferSerializer
     internal const int AttributePerLinkCountLimit = 128;
 
     // Cache several strings required for encoding OTLP JSON
-    private readonly byte[] _closingTracesBytes = EncodingHelpers.Utf8NoBom.GetBytes("]}]}]}");
+    private static ReadOnlySpan<byte> ClosingTracesBytes => "]}]}]}"u8;
 
     public int HeaderSize => 0;
 
@@ -605,10 +605,10 @@ internal sealed class OtlpTracesJsonSerializer : ISpanBufferSerializer
         // jsonWriter.WriteEndObject(); // Close ResourceSpans message
         // jsonWriter.WriteEndArray(); // Close repeated ResourceSpans field
         // jsonWriter.WriteEndObject(); // Close ExportTraceServiceRequest message
-        var buffer = _closingTracesBytes;
+        ReadOnlySpan<byte> closingBytes = ClosingTracesBytes;
 
         // Get the length of the written JSON
-        var length = buffer.Length;
+        var length = closingBytes.Length;
 
         if (length + offset - HeaderSize >= maxSize)
         {
@@ -618,7 +618,7 @@ internal sealed class OtlpTracesJsonSerializer : ISpanBufferSerializer
 
         // Ensure the target buffer has enough space
         MessagePackBinary.EnsureCapacity(ref bytes, offset, length);
-        Array.Copy(buffer, 0, bytes, offset, length);
+        closingBytes.CopyTo(bytes.AsSpan(offset, length));
         return length;
     }
 

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+
 namespace Datadog.Trace
 {
     internal static class TracerConstants
@@ -11,5 +13,7 @@ namespace Datadog.Trace
         public const string Language = "dotnet";
         public const string AssemblyVersion = "3.43.0.0";
         public const string ThreePartVersion = "3.43.0";
+
+        public static ReadOnlySpan<byte> AssemblyVersionBytes => "3.43.0.0"u8;
     }
 }


### PR DESCRIPTION
## Summary of changes

Convert `Encoding.Utf8.GetBytes` calls to static constants using UTF8 string literals

## Reason for change

After moving our vendored `Span<T>` implementation into the `System` namespace, various optimizations open up to us, including using UTF-8 string literals, to encode strings to UTF-8 at compile time instead of at runtime. By combing with `static ReadOnlySpan<byte>` properties, these also become zero allocation, so we get reduced overall memory usage as well as better startup time

## Implementation details

Replace the following with utf8 string literals:
- `StringEncoding.UTF8.GetBytes`
- `Encoding.UTF8.GetBytes`
- `EncodingHelpers.UTF8NoBom.GetBytes`

## Test coverage

All covered by existing tests

## Other details

Depends on a stack updating our vendored system code

- https://github.com/DataDog/dd-trace-dotnet/pull/8391
- https://github.com/DataDog/dd-trace-dotnet/pull/8454
- https://github.com/DataDog/dd-trace-dotnet/pull/8455
- https://github.com/DataDog/dd-trace-dotnet/pull/8459
- https://github.com/DataDog/dd-trace-dotnet/pull/8461
- https://github.com/DataDog/dd-trace-dotnet/pull/8469
- https://github.com/DataDog/dd-trace-dotnet/pull/8476
- https://github.com/DataDog/dd-trace-dotnet/pull/8477
- https://github.com/DataDog/dd-trace-dotnet/pull/8486