### PR TITLE
Log4Net guard AppenderAttachedImpl integration against NullReferenceException.

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -585,7 +585,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmissi
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/ILoggingEventLegacyDuck.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/LevelDuck.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/LevelDuckExtensions.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/ILoggingEvent.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogConstants.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/DiagnosticContextHelper.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
@@ -9,6 +9,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
 {
@@ -28,6 +29,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
     [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class AppenderAttachedImplIntegration
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AppenderAttachedImplIntegration));
+        private static bool _loggedNullSettings;
+
         /// <summary>
         /// OnMethodBegin callback
         /// </summary>
@@ -47,7 +51,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
             var tracer = Tracer.Instance;
 
             var mutableSettings = tracer.CurrentTraceSettings?.Settings;
-            if (mutableSettings is null || !mutableSettings.LogsInjectionEnabled)
+            if (mutableSettings is null)
+            {
+                if (!_loggedNullSettings)
+                {
+                    _loggedNullSettings = true;
+                    Log.Debug("log4net logs-injection skipped: CurrentTraceSettings was null.");
+                }
+
+                return CallTargetState.GetDefault();
+            }
+
+            if (!mutableSettings.LogsInjectionEnabled)
             {
                 return CallTargetState.GetDefault();
             }
@@ -55,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
             var properties = loggingEvent.Properties;
             if (properties is not null && !properties.Contains(CorrelationIdentifier.ServiceKey))
             {
-                properties[CorrelationIdentifier.ServiceKey] = mutableSettings.DefaultServiceName ?? string.Empty;
+                properties[CorrelationIdentifier.ServiceKey] = mutableSettings.DefaultServiceName;
                 properties[CorrelationIdentifier.VersionKey] = mutableSettings.ServiceVersion ?? string.Empty;
                 properties[CorrelationIdentifier.EnvKey] = mutableSettings.Environment ?? string.Empty;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
         /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
         /// <param name="loggingEvent">The logging event</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget, TLoggingEvent>(TTarget instance, TLoggingEvent? loggingEvent)
+        internal static CallTargetState OnMethodBegin<TTarget, TLoggingEvent>(TTarget instance, TLoggingEvent loggingEvent)
             where TLoggingEvent : ILoggingEvent
         {
             if (loggingEvent?.Instance is null)
@@ -95,9 +95,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
         /// <param name="exception">Exception instance in case the original code threw an exception.</param>
         /// <param name="state">Calltarget state value</param>
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-        internal static CallTargetReturn<TReturn?> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn? returnValue, Exception? exception, in CallTargetState state)
+        internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception? exception, in CallTargetState state)
         {
-            return new CallTargetReturn<TReturn?>(returnValue);
+            return new CallTargetReturn<TReturn>(returnValue);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging;
@@ -34,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
         /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
         /// <param name="loggingEvent">The logging event</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget, TLoggingEvent>(TTarget instance, TLoggingEvent loggingEvent)
+        internal static CallTargetState OnMethodBegin<TTarget, TLoggingEvent>(TTarget instance, TLoggingEvent? loggingEvent)
             where TLoggingEvent : ILoggingEvent
         {
             if (loggingEvent?.Instance is null)
@@ -44,11 +46,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
 
             var tracer = Tracer.Instance;
 
-            var mutableSettings = tracer.CurrentTraceSettings.Settings;
-            var properties = loggingEvent.Properties;
-            if (mutableSettings.LogsInjectionEnabled && properties != null && !properties.Contains(CorrelationIdentifier.ServiceKey))
+            var mutableSettings = tracer.CurrentTraceSettings?.Settings;
+            if (mutableSettings is null || !mutableSettings.LogsInjectionEnabled)
             {
-                properties[CorrelationIdentifier.ServiceKey] = mutableSettings.DefaultServiceName;
+                return CallTargetState.GetDefault();
+            }
+
+            var properties = loggingEvent.Properties;
+            if (properties is not null && !properties.Contains(CorrelationIdentifier.ServiceKey))
+            {
+                properties[CorrelationIdentifier.ServiceKey] = mutableSettings.DefaultServiceName ?? string.Empty;
                 properties[CorrelationIdentifier.VersionKey] = mutableSettings.ServiceVersion ?? string.Empty;
                 properties[CorrelationIdentifier.EnvKey] = mutableSettings.Environment ?? string.Empty;
 
@@ -60,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
                 }
             }
 
-            return new CallTargetState(scope: null, state: null);
+            return CallTargetState.GetDefault();
         }
 
         /// <summary>
@@ -73,9 +80,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
         /// <param name="exception">Exception instance in case the original code threw an exception.</param>
         /// <param name="state">Calltarget state value</param>
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-        internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+        internal static CallTargetReturn<TReturn?> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn? returnValue, Exception? exception, in CallTargetState state)
         {
-            return new CallTargetReturn<TReturn>(returnValue);
+            return new CallTargetReturn<TReturn?>(returnValue);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Guards the log4net `AppenderAttachedImpl.AppendLoopOnAppenders` CallTarget integration against a `NullReferenceException`.

## Reason for change

We have observed [the following error](https://app.datadoghq.com/error-tracking?query=service%3Ainstrumentation-telemetry-data%20-%2Aappsec%2A%20%40lib_language%3Adotnet&code_gen_fix_states=STATE_COMPLETED&fromUser=false&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%221a4e860c-3b5f-11f0-8d52-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1776157162701&to_ts=1776761962701&live=true) in customer installations:
```
Error : Exception occurred when calling the CallTarget integration continuation.
System.NullReferenceException
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.BeginMethodHandler`3.Invoke(TTarget instance, TArg1& arg1)
   at Datadog.Trace.ClrProfiler.CallTarget.CallTargetInvoker.BeginMethod[TIntegration,TTarget,TArg1](TTarget instance, TArg1& arg1)
   at log4net.Util.AppenderAttachedImpl.AppendLoopOnAppenders(LoggingEvent loggingEvent)
```

### How it can be thrown

Hypothesis - Startup race: the field backing `Tracer.Instance.CurrentTraceSettings` is only assigned partway through the `TracerManager` constructor (line 116), so there's a window — roughly lines 84–115 of the ctor — where `Tracer.Instance.CurrentTraceSettings` returns `null`, and the subsequent `.Settings` access NREs.

## Implementation details

- Null-check `tracer.CurrentTraceSettings?.Settings`; short-circuit with `CallTargetState.GetDefault()` if `null` or if `LogsInjectionEnabled` is `false`.
- `Log.Debug` during startup if `CurrentTraceSettings` is `null`, so the condition stays diagnosable. Bounded naturally by the brief startup window; no flag / atomic needed.
- `#nullable enable` on the file, with matching annotations on the `OnMethodBegin` / `OnMethodEnd` signatures.
- Replaced `new CallTargetState(scope: null, state: null)` with `CallTargetState.GetDefault()` for consistency across the three return paths (same value, clearer intent).

## Test coverage

## Other details