### PR TITLE
Add .NET service names to macrobenchmarks

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -157,6 +157,7 @@ build-dd-trace-dotnet-macrobenchmarks-ami:
 baseline-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: baseline-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 0
@@ -166,6 +167,7 @@ baseline-x86:
 calltarget_ngen-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: calltarget-ngen-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -177,6 +179,7 @@ calltarget_ngen-x86:
 single_span-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: single-span-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -189,6 +192,7 @@ single_span-x86:
 trace_stats-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: trace-stats-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -201,6 +205,7 @@ trace_stats-x86:
 manual_only-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: manual-only-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 0
@@ -211,6 +216,7 @@ manual_only-x86:
 manual_and_automatic-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: manual-and-automatic-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -221,6 +227,7 @@ manual_and_automatic-x86:
 ddtraceenabled_false-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: ddtraceenabled-false-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -231,6 +238,7 @@ ddtraceenabled_false-x86:
 profiler_exceptions_baseline-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: profiler-exceptions-baseline-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 0
@@ -240,6 +248,7 @@ profiler_exceptions_baseline-x86:
 profiler-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: profiler-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -251,6 +260,7 @@ profiler-x86:
 profiler_walltime-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: profiler-walltime-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -264,6 +274,7 @@ profiler_walltime-x86:
 profiler_exceptions-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: profiler-exceptions-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -276,6 +287,7 @@ profiler_exceptions-x86:
 profiler_cpu-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: profiler-cpu-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -289,6 +301,7 @@ profiler_cpu-x86:
 profiler_cpu_timer_create-x86:
   extends: .benchmarks-x86
   variables:
+    DD_SERVICE: profiler-cpu-timer-create-x86
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux"
     COR_ENABLE_PROFILING: 1
@@ -354,6 +367,7 @@ baseline-arm64:
   extends: .benchmarks-arm64
   tags: ["runner:apm-k8s-arm-metal"]
   variables:
+    DD_SERVICE: baseline-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 0
@@ -364,6 +378,7 @@ calltarget_ngen-arm64:
   extends: .benchmarks-arm64
   tags: ["runner:apm-k8s-arm-metal"]
   variables:
+    DD_SERVICE: calltarget-ngen-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -376,6 +391,7 @@ single_span-arm64:
   extends: .benchmarks-arm64
   tags: ["runner:apm-k8s-arm-metal"]
   variables:
+    DD_SERVICE: single-span-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -389,6 +405,7 @@ trace_stats-arm64:
   extends: .benchmarks-arm64
   tags: ["runner:apm-k8s-arm-metal"]
   variables:
+    DD_SERVICE: trace-stats-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -402,6 +419,7 @@ manual_only-arm64:
   extends: .benchmarks-arm64
   tags: ["runner:apm-k8s-arm-metal"]
   variables:
+    DD_SERVICE: manual-only-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 0
@@ -413,6 +431,7 @@ manual_and_automatic-arm64:
   extends: .benchmarks-arm64
   tags: ["runner:apm-k8s-arm-metal"]
   variables:
+    DD_SERVICE: manual-and-automatic-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -424,6 +443,7 @@ ddtraceenabled_false-arm64:
   extends: .benchmarks-arm64
   tags: ["runner:apm-k8s-arm-metal"]
   variables:
+    DD_SERVICE: ddtraceenabled-false-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -435,6 +455,7 @@ profiler_exceptions_baseline-arm64:
   tags: ["runner:apm-k8s-arm-metal"]
   extends: .benchmarks-arm64
   variables:
+    DD_SERVICE: profiler-exceptions-baseline-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 0
@@ -445,6 +466,7 @@ profiler-arm64:
   tags: ["runner:apm-k8s-arm-metal"]
   extends: .benchmarks-arm64
   variables:
+    DD_SERVICE: profiler-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -457,6 +479,7 @@ profiler_walltime-arm64:
   tags: ["runner:apm-k8s-arm-metal"]
   extends: .benchmarks-arm64
   variables:
+    DD_SERVICE: profiler-walltime-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -471,6 +494,7 @@ profiler_exceptions-arm64:
   tags: ["runner:apm-k8s-arm-metal"]
   extends: .benchmarks-arm64
   variables:
+    DD_SERVICE: profiler-exceptions-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -484,6 +508,7 @@ profiler_cpu-arm64:
   tags: ["runner:apm-k8s-arm-metal"]
   extends: .benchmarks-arm64
   variables:
+    DD_SERVICE: profiler-cpu-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -498,6 +523,7 @@ profiler_cpu_timer_create-arm64:
   tags: ["runner:apm-k8s-arm-metal"]
   extends: .benchmarks-arm64
   variables:
+    DD_SERVICE: profiler-cpu-timer-create-arm64
     NATIVE_PROFILER_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
     TRACER_HOME_PATH: "dd-trace-dotnet/tracer/tracer-home-linux-arm64"
     COR_ENABLE_PROFILING: 1
@@ -604,11 +630,13 @@ profiler_cpu_timer_create-arm64:
 baseline-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: baseline-win
     ENDPOINT: "hello"
 
 calltarget_ngen-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: calltarget-ngen-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
@@ -618,6 +646,7 @@ calltarget_ngen-win:
 single_span-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: single-span-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
@@ -628,6 +657,7 @@ single_span-win:
 trace_stats-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: trace-stats-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_CLR_ENABLE_INLINING: 1
@@ -638,6 +668,7 @@ trace_stats-win:
 manual_only-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: manual-only-win
     COR_ENABLE_PROFILING: 0
     CORECLR_ENABLE_PROFILING: 0
     DOTNET_BUILD_ARGS: "/p:MANUAL_INSTRUMENTATION=true /p:MANUAL_ONLY_INSTRUMENTATION=true"
@@ -646,6 +677,7 @@ manual_only-win:
 manual_and_automatic-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: manual-and-automatic-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DOTNET_BUILD_ARGS: "/p:MANUAL_INSTRUMENTATION=true"
@@ -654,6 +686,7 @@ manual_and_automatic-win:
 ddtraceenabled_false-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: ddtraceenabled-false-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_TRACE_ENABLED: 0
@@ -662,6 +695,7 @@ ddtraceenabled_false-win:
 profiler_exceptions_baseline-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: profiler-exceptions-baseline-win
     COR_ENABLE_PROFILING: 0
     CORECLR_ENABLE_PROFILING: 0
     ENDPOINT: "hello/Exception"
@@ -669,6 +703,7 @@ profiler_exceptions_baseline-win:
 profiler-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: profiler-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_PROFILING_ENABLED: 1
@@ -678,6 +713,7 @@ profiler-win:
 profiler_walltime-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: profiler-walltime-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_PROFILING_ENABLED: 1
@@ -689,6 +725,7 @@ profiler_walltime-win:
 profiler_exceptions-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: profiler-exceptions-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_PROFILING_ENABLED: 1
@@ -699,6 +736,7 @@ profiler_exceptions-win:
 profiler_cpu-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: profiler-cpu-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_PROFILING_ENABLED: 1
@@ -710,6 +748,7 @@ profiler_cpu-win:
 profiler_cpu_timer_create-win:
   extends: .benchmarks-win
   variables:
+    DD_SERVICE: profiler-cpu-timer-create-win
     COR_ENABLE_PROFILING: 1
     CORECLR_ENABLE_PROFILING: 1
     DD_PROFILING_ENABLED: 1


### PR DESCRIPTION
## Summary of changes

Adds `DD_SERVICE` to each of the benchmark jobs

## Reason for change

Lets us compare between scenarios [in telemetry metrics](https://app.datadoghq.com/dashboard/55y-54i-63y?fromUser=false&refresh_mode=sliding&tpl_var_org_id%5B0%5D=197728&tpl_var_service%5B0%5D=gitlab-runner&from_ts=1776675694767&to_ts=1776762094767&live=true)

## Implementation details

Manually added `DD_SERVICE` to each job

## Test coverage

I'll trigger a manual run for the branch to confirm we can see this data as expected

## Other details

We _may_ want to make the service name dynamic in the future, so we can isolate these to a specific commit, but I think that's not critical atm, given that these mostly only run on master, so we should _generally_ be able to distinguish based on start time (except when there are multiple commits to master)