### PR TITLE
Fix RCM version tag to use app version instead of service name

### DIFF
--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientTracer.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientTracer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RcmClientTracer.cs" company="Datadog">
+// <copyright file="RcmClientTracer.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -73,7 +73,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
             string? appVersion,
             ReadOnlyDictionary<string, string> globalTags,
             IReadOnlyCollection<string>? processTags)
-            => new(runtimeId, tracerVersion, service, env, appVersion, GetTags(env, service, globalTags), processTags);
+            => new(runtimeId, tracerVersion, service, env, appVersion, GetTags(env, appVersion, globalTags), processTags);
 
         private static List<string> GetTags(string? environment, string? serviceVersion, ReadOnlyDictionary<string, string>? globalTags)
         {

--- a/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmClientTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmClientTracerTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="RcmClientTracerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Datadog.Trace.RemoteConfigurationManagement.Protocol;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.RemoteConfigurationManagement;
+
+public class RcmClientTracerTests
+{
+    [Fact]
+    public void Create_VersionTag_UsesAppVersion()
+    {
+        var tracer = RcmClientTracer.Create(
+            runtimeId: "runtime-id",
+            tracerVersion: "5.55.555", // gets overrode to be the _real_ tracer version
+            service: "my-service",
+            env: "env",
+            appVersion: "1.2.3",
+            globalTags: new ReadOnlyDictionary<string, string>(new Dictionary<string, string>()),
+            processTags: null);
+
+        tracer.Tags.Should().Contain("version:1.2.3");
+        tracer.Tags.Should().NotContain("version:my-service");
+    }
+
+    [Fact]
+    public void Create_NoVersionTag_WhenAppVersionIsNull()
+    {
+        var tracer = RcmClientTracer.Create(
+            runtimeId: "runtime-id",
+            tracerVersion: "5.55.555", // gets overrode to be the _real_ tracer version
+            service: "my-service",
+            env: "env",
+            appVersion: null,
+            globalTags: new ReadOnlyDictionary<string, string>(new Dictionary<string, string>()),
+            processTags: null);
+
+        tracer.Tags.Should().NotContain(t => t.StartsWith("version:"));
+    }
+}


### PR DESCRIPTION
## Summary of changes

> Identified by AI

Sending `service` instead of `appVersion` in `RcmClientTracer`. This fixes that.

## Reason for change

It was supposed to be `appVersion`.

## Implementation details

`service`->`appVersion`

## Test coverage

I added unit tests, they failed.
I made the change, they passed.

I'm unsure where else this would be asserted (if it is at all)

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
