### PR TITLE
Update System.Text.Json to latest in source generators project

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.csproj
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.11" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>    
     <Compile Include="..\Datadog.Trace\ClrProfiler\InstrumentationCategory.cs" Link="InstrumentationDefinitions\InstrumentationCategory.cs" />    


### PR DESCRIPTION
## Summary of changes

Update System.Text.Json to latest in source generators project

## Reason for change

In #7944 we downgraded the version of System.Text.Json due to a [bug in Rider](https://youtrack.jetbrains.com/projects/RIDER/issues/RIDER-132634/Source-Generated-files-missing-when-using-System.Text.Json), which caused the IDE doesn't index source generated files using the last version of the package properly, causing invalid missing values:

<img width="2148" height="980" alt="image" src="https://github.com/user-attachments/assets/5c113a18-9126-4a57-9cda-eb1168a41876" />

The issue is marked as fixed, and I can't reproduce it locally any more, so we should be safe to update

<img width="695" height="235" alt="image" src="https://github.com/user-attachments/assets/7a1392bb-751f-46a6-b2e5-bfca27eff0ad" />

## Implementation details

Bummp the System.Text.Json value to latest

## Test coverage

Tested the impact locally, and everything else is covered by CI

## Other details

Supersedes https://github.com/DataDog/dd-trace-dotnet/pull/7900