### PR TITLE
Remove agent check in client-side-stats

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -552,16 +552,8 @@ namespace Datadog.Trace.Agent
 
         private void HandleConfigUpdate(AgentConfiguration config)
         {
-            // Client-side stats requires agent >= 7.65.0 which has full CSS v1.2.0 support.
-            // However, if the version is not parseable (e.g. test agents returning "test"), we don't
-            // block stats — the presence of the stats endpoint and client_drop_p0s is sufficient.
-
             CanComputeStats = !string.IsNullOrWhiteSpace(config.StatsEndpoint)
-                           && config.ClientDropP0s
-                           && (config.AgentVersion is null
-                            || !Version.TryParse(config.AgentVersion, out var parsedVersion)
-                            || parsedVersion.Major >= 8
-                            || (parsedVersion.Major == 7 && parsedVersion.Minor >= 65));
+                           && config.ClientDropP0s;
 
             if (CanComputeStats.Value)
             {

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -77,31 +77,6 @@ namespace Datadog.Trace.Tests.Agent
             }
         }
 
-        [Theory]
-        [InlineData("7.65.0", true)]
-        [InlineData("7.66.0", true)]
-        [InlineData("8.0.0", true)]
-        [InlineData("7.64.0", false)]
-        [InlineData("7.64.99", false)]
-        [InlineData("7.0.0", false)]
-        [InlineData("not-a-version", true)]  // Unparseable versions don't block (e.g. test agents)
-        [InlineData(null, true)]              // Null version doesn't block
-        public async Task StatsComputation_RequiresMinimumAgentVersion(string agentVersion, bool expectedEnabled)
-        {
-            var api = new Mock<IApi>();
-            var discovery = new StubDiscoveryService(agentVersion);
-            var aggregator = new StatsAggregator(api.Object, GetSettings(), discovery, isOtlp: false);
-
-            try
-            {
-                aggregator.CanComputeStats.Should().Be(expectedEnabled);
-            }
-            finally
-            {
-                await aggregator.DisposeAsync();
-            }
-        }
-
         [Fact]
         public async Task EmptyBuckets()
         {
@@ -1367,7 +1342,6 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         private class StubDiscoveryService(
-            string agentVersion = "7.65.0",
             int obfuscationVersion = 0,
             AgentTraceFilterConfig traceFilterConfig = null) : IDiscoveryService
         {
@@ -1379,7 +1353,7 @@ namespace Datadog.Trace.Tests.Agent
                              debuggerV2Endpoint: "debuggerV2Endpoint",
                              diagnosticsEndpoint: "diagnosticsEndpoint",
                              symbolDbEndpoint: "symbolDbEndpoint",
-                             agentVersion: agentVersion,
+                             agentVersion: null,
                              statsEndpoint: "traceStatsEndpoint",
                              dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
                              eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",


### PR DESCRIPTION
## Summary of changes

Removes the minimum-agent version check from the client-side-stats check

## Reason for change

We didn't have it before, which means people who previously had stats, suddenly won't have them. Also other agents (like bottlecap etc) don't have the version. And we haven't figured out how to handle that yet. While CSS is off by default, this seems like the best option to take.

## Implementation details

Remove the code that is checking for CSS support.

## Test coverage

Covered by existing (and removed a test for the behaviour)

## Other details

Follows on from 
- https://github.com/DataDog/dd-trace-dotnet/pull/8417
- https://github.com/DataDog/dd-trace-dotnet/pull/8418
- https://github.com/DataDog/dd-trace-dotnet/pull/8420
- https://github.com/DataDog/dd-trace-dotnet/pull/8435
- https://github.com/DataDog/dd-trace-dotnet/pull/8436
- https://github.com/DataDog/dd-trace-dotnet/pull/8444
- https://github.com/DataDog/dd-trace-dotnet/pull/8445