### PR TITLE
Run the docker-compose version tagging update manually instead of using Dependabot

### DIFF
--- a/.github/chainguard/self.auto_bump_smoke_test_docker_images.create-pr.sts.yaml
+++ b/.github/chainguard/self.auto_bump_smoke_test_docker_images.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: repo:DataDog/dd-trace-dotnet:.*
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_bump_smoke_test_docker_images\.yml@refs/heads/master
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,21 +102,6 @@ updates:
     cooldown:
       default-days: 2
 
-  # Docker images used in smoke tests - Dependabot updates pinned digests
-  - package-ecosystem: "docker-compose"
-    directory: "/tracer/build/_build/SmokeTests"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-      - "area:dependabot"
-    groups:
-      smoke-test-images:
-        patterns:
-          - "*"
-    cooldown:
-      default-days: 2
-
   - package-ecosystem: "github-actions"
     directories:
       - "/"

--- a/.github/workflows/auto_bump_smoke_test_docker_images.yml
+++ b/.github/workflows/auto_bump_smoke_test_docker_images.yml
@@ -1,0 +1,77 @@
+name: Auto bump smoke test docker images
+
+on:
+  schedule:
+    - cron: "0 0 * * 1" # Every Monday at midnight
+    - cron: "0 0 * * 4" # Every Thursday at midnight
+  workflow_dispatch:
+
+jobs:
+  bump_smoke_test_docker_images:
+    runs-on: windows-latest
+    permissions:
+      actions: read # read secrets
+      id-token: write # Required for dd-octo-sts authentication
+
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - name: Get dd-octo-sts token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto_bump_smoke_test_docker_images.create-pr
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          global-json-file: global.json
+
+      - name: "Regenerating docker image versions"
+        run: .\tracer\build.ps1 UpdateSmokeTestImageDigests --PackageVersionCooldownDays 2
+
+      - name: Read cooldown report
+        id: cooldown
+        if: always()
+        shell: pwsh
+        run: |
+          $report = ""
+          $reportPath = ".nuke/temp/smoke_test_image_cooldown_report.md"
+          if (Test-Path $reportPath) {
+            $report = Get-Content $reportPath -Raw
+          }
+          "report<<EOF" >> $env:GITHUB_OUTPUT
+          $report >> $env:GITHUB_OUTPUT
+          "EOF" >> $env:GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        id: pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          branch: "bot/smoke-test-docker-image-bump"
+          commit-message: "[Smoke Test Docker Image Bump]"
+          delete-branch: true
+          base: master
+          title: "[Smoke Test Docker Image Bump] Updating docker image tags "
+          labels: "area:dependabot,area:test-apps,dependencies"
+          body: |
+            Updates the docker images used for smoke tests.
+
+            ${{ steps.cooldown.outputs.report }}
+
+      - name: Send Slack notification about generating failure
+        if: failure()
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          # This data can be any valid JSON from a previous step in the GitHub Action
+          payload: |
+            {
+              "github_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBOOK_URL_GENERATEPACKAGEVERSIONS }}

--- a/tracer/build/_build/Build.SmokeTests.cs
+++ b/tracer/build/_build/Build.SmokeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Nuke.Common;
 using static Nuke.Common.IO.FileSystemTasks;
 using Logger = Serilog.Log;
@@ -24,5 +25,18 @@ partial class Build
                 BuildDataDirectory,
                 Version,
                 GetDotnetSdkVersion(RootDirectory));
+        });
+
+    Target UpdateSmokeTestImageDigests => _ => _
+        .Description("Queries each registry and updates pinned sha256 digests in smoke-test-images.docker-compose.yml, respecting a 2-day cooldown")
+        .Unlisted()
+        .Executes(async () =>
+        {
+            var composeFile = TracerDirectory / "build" / "_build" / "SmokeTests" / "smoke-test-images.docker-compose.yml";
+            var cooldown = PackageVersionCooldownDays.HasValue
+                             ? TimeSpan.FromDays(PackageVersionCooldownDays.Value)
+                             : TimeSpan.FromDays(0);
+            using var updater = new SmokeTests.SmokeTestImageDigestUpdater(cooldown);
+            await updater.UpdateAsync(composeFile);
         });
 }

--- a/tracer/build/_build/Build.SmokeTests.cs
+++ b/tracer/build/_build/Build.SmokeTests.cs
@@ -38,5 +38,12 @@ partial class Build
                              : TimeSpan.FromDays(0);
             using var updater = new SmokeTests.SmokeTestImageDigestUpdater(cooldown);
             await updater.UpdateAsync(composeFile);
+
+            if (updater.CooldownReport.HasEntries)
+            {
+                var reportPath = TemporaryDirectory / "smoke_test_image_cooldown_report.md";
+                await updater.CooldownReport.SaveToFile(reportPath);
+                Logger.Information("Image digest cooldown report saved to {Path}", reportPath);
+            }
         });
 }

--- a/tracer/build/_build/Build.SmokeTests.cs
+++ b/tracer/build/_build/Build.SmokeTests.cs
@@ -33,17 +33,11 @@ partial class Build
         .Executes(async () =>
         {
             var composeFile = TracerDirectory / "build" / "_build" / "SmokeTests" / "smoke-test-images.docker-compose.yml";
+            var reportPath = TemporaryDirectory / "smoke_test_image_cooldown_report.md";
             var cooldown = PackageVersionCooldownDays.HasValue
                              ? TimeSpan.FromDays(PackageVersionCooldownDays.Value)
                              : TimeSpan.FromDays(0);
             using var updater = new SmokeTests.SmokeTestImageDigestUpdater(cooldown);
-            await updater.UpdateAsync(composeFile);
-
-            if (updater.CooldownReport.HasEntries)
-            {
-                var reportPath = TemporaryDirectory / "smoke_test_image_cooldown_report.md";
-                await updater.CooldownReport.SaveToFile(reportPath);
-                Logger.Information("Image digest cooldown report saved to {Path}", reportPath);
-            }
+            await updater.UpdateAsync(composeFile, reportPath);
         });
 }

--- a/tracer/build/_build/SmokeTests/CooldownReport.cs
+++ b/tracer/build/_build/SmokeTests/CooldownReport.cs
@@ -19,46 +19,77 @@ namespace SmokeTests;
 public class CooldownReport
 {
     readonly TimeSpan _cooldown;
-    readonly List<CooldownEntry> _entries = new();
+    readonly List<CooldownEntry> _cooldownEntries = new();
+    readonly List<FailureEntry> _failureEntries = new();
 
     public CooldownReport(TimeSpan cooldown)
     {
         _cooldown = cooldown;
     }
 
-    public bool HasEntries => _entries.Count > 0;
+    public bool HasEntries => _cooldownEntries.Count > 0 || _failureEntries.Count > 0;
 
-    public IReadOnlyList<CooldownEntry> Entries => _entries;
+    public IReadOnlyList<CooldownEntry> Entries => _cooldownEntries;
+
+    public IReadOnlyList<FailureEntry> Failures => _failureEntries;
 
     public void Add(CooldownEntry entry)
     {
-        _entries.Add(entry);
+        _cooldownEntries.Add(entry);
+    }
+
+    public void AddFailure(FailureEntry entry)
+    {
+        _failureEntries.Add(entry);
     }
 
     public string ToMarkdown()
     {
-        if (_entries.Count == 0)
+        if (!HasEntries)
         {
             return string.Empty;
         }
 
         var sb = new StringBuilder();
-        sb.AppendLine("## Smoke Test Image Digest Cooldown Report");
-        sb.AppendLine();
-        sb.AppendLine($"The following images have newer digests available but were published less than **{(int)_cooldown.TotalDays} day(s)** ago, so the existing pin is retained.");
-        sb.AppendLine("They will be picked up automatically by a future run once they age out of the cooldown window.");
-        sb.AppendLine();
-        sb.AppendLine("| Image | Current pinned | Available digest | Published | Age |");
-        sb.AppendLine("|-------|----------------|------------------|-----------|-----|");
 
-        foreach (var entry in _entries)
+        if (_cooldownEntries.Count > 0)
         {
-            var published = entry.PublishedDate?.UtcDateTime.ToString("yyyy-MM-dd") ?? "unknown";
-            var age = entry.PublishedDate.HasValue
-                ? FormatAge(DateTimeOffset.UtcNow - entry.PublishedDate.Value)
-                : "?";
+            sb.AppendLine("## Smoke Test Image Digest Cooldown Report");
+            sb.AppendLine();
+            sb.AppendLine($"The following images have newer digests available but were published less than **{(int)_cooldown.TotalDays} day(s)** ago, so the existing pin is retained.");
+            sb.AppendLine("They will be picked up automatically by a future run once they age out of the cooldown window.");
+            sb.AppendLine();
+            sb.AppendLine("| Image | Current pinned | Available digest | Published | Age |");
+            sb.AppendLine("|-------|----------------|------------------|-----------|-----|");
 
-            sb.AppendLine($"| `{entry.Image}` | `{Shorten(entry.CurrentDigest)}` | `{Shorten(entry.AvailableDigest)}` | {published} | {age} |");
+            foreach (var entry in _cooldownEntries)
+            {
+                var published = entry.PublishedDate?.UtcDateTime.ToString("yyyy-MM-dd") ?? "unknown";
+                var age = entry.PublishedDate.HasValue
+                    ? FormatAge(DateTimeOffset.UtcNow - entry.PublishedDate.Value)
+                    : "?";
+
+                sb.AppendLine($"| `{entry.Image}` | `{Shorten(entry.CurrentDigest)}` | `{Shorten(entry.AvailableDigest)}` | {published} | {age} |");
+            }
+        }
+
+        if (_failureEntries.Count > 0)
+        {
+            if (_cooldownEntries.Count > 0)
+            {
+                sb.AppendLine();
+            }
+            sb.AppendLine("## Smoke Test Image Digest Failures");
+            sb.AppendLine();
+            sb.AppendLine("The following images could not be evaluated this run. The existing pin has been kept. Investigate before the next scheduled run if these persist.");
+            sb.AppendLine();
+            sb.AppendLine("| Image | Error |");
+            sb.AppendLine("|-------|-------|");
+
+            foreach (var entry in _failureEntries)
+            {
+                sb.AppendLine($"| `{entry.Image}` | {EscapeTableCell(entry.ErrorMessage)} |");
+            }
         }
 
         return sb.ToString();
@@ -72,6 +103,15 @@ public class CooldownReport
             // Saved to disk so it can later be fed into the PR description of the automation workflow.
             await File.WriteAllTextAsync(path, markdown);
         }
+    }
+
+    static string EscapeTableCell(string value)
+    {
+        // Collapse newlines and escape the pipe so a single error string can't blow up the table.
+        return value
+            .Replace("\r", " ")
+            .Replace("\n", " ")
+            .Replace("|", "\\|");
     }
 
     static string FormatAge(TimeSpan age)
@@ -95,4 +135,8 @@ public class CooldownReport
         string CurrentDigest,
         string AvailableDigest,
         DateTimeOffset? PublishedDate);
+
+    public record FailureEntry(
+        string Image,
+        string ErrorMessage);
 }

--- a/tracer/build/_build/SmokeTests/CooldownReport.cs
+++ b/tracer/build/_build/SmokeTests/CooldownReport.cs
@@ -1,0 +1,98 @@
+// <copyright file="CooldownReport.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SmokeTests;
+
+/// <summary>
+/// Collects smoke-test image digests that were skipped by the cooldown filter
+/// and renders them as a markdown report for inclusion in the PR body.
+/// </summary>
+public class CooldownReport
+{
+    readonly TimeSpan _cooldown;
+    readonly List<CooldownEntry> _entries = new();
+
+    public CooldownReport(TimeSpan cooldown)
+    {
+        _cooldown = cooldown;
+    }
+
+    public bool HasEntries => _entries.Count > 0;
+
+    public IReadOnlyList<CooldownEntry> Entries => _entries;
+
+    public void Add(CooldownEntry entry)
+    {
+        _entries.Add(entry);
+    }
+
+    public string ToMarkdown()
+    {
+        if (_entries.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## Smoke Test Image Digest Cooldown Report");
+        sb.AppendLine();
+        sb.AppendLine($"The following images have newer digests available but were published less than **{(int)_cooldown.TotalDays} day(s)** ago, so the existing pin is retained.");
+        sb.AppendLine("They will be picked up automatically by a future run once they age out of the cooldown window.");
+        sb.AppendLine();
+        sb.AppendLine("| Image | Current pinned | Available digest | Published | Age |");
+        sb.AppendLine("|-------|----------------|------------------|-----------|-----|");
+
+        foreach (var entry in _entries)
+        {
+            var published = entry.PublishedDate?.UtcDateTime.ToString("yyyy-MM-dd") ?? "unknown";
+            var age = entry.PublishedDate.HasValue
+                ? FormatAge(DateTimeOffset.UtcNow - entry.PublishedDate.Value)
+                : "?";
+
+            sb.AppendLine($"| `{entry.Image}` | `{Shorten(entry.CurrentDigest)}` | `{Shorten(entry.AvailableDigest)}` | {published} | {age} |");
+        }
+
+        return sb.ToString();
+    }
+
+    public async Task SaveToFile(string path)
+    {
+        var markdown = ToMarkdown();
+        if (!string.IsNullOrEmpty(markdown))
+        {
+            // Saved to disk so it can later be fed into the PR description of the automation workflow.
+            await File.WriteAllTextAsync(path, markdown);
+        }
+    }
+
+    static string FormatAge(TimeSpan age)
+    {
+        if (age.TotalDays >= 1)
+        {
+            return $"{(int)age.TotalDays}d";
+        }
+        return $"{(int)age.TotalHours}h";
+    }
+
+    static string Shorten(string digest)
+    {
+        var colon = digest.IndexOf(':');
+        var hex = colon >= 0 ? digest[(colon + 1)..] : digest;
+        return hex.Length > 12 ? hex.Substring(0, 12) : hex;
+    }
+
+    public record CooldownEntry(
+        string Image,
+        string CurrentDigest,
+        string AvailableDigest,
+        DateTimeOffset? PublishedDate);
+}

--- a/tracer/build/_build/SmokeTests/SmokeTestImageDigestUpdater.cs
+++ b/tracer/build/_build/SmokeTests/SmokeTestImageDigestUpdater.cs
@@ -53,7 +53,7 @@ public class SmokeTestImageDigestUpdater : IDisposable
     /// </summary>
     public CooldownReport CooldownReport { get; }
 
-    public async Task UpdateAsync(AbsolutePath composeFile)
+    public async Task UpdateAsync(AbsolutePath composeFile, AbsolutePath? reportPath = null)
     {
         Helpers.LogSection($"Updating pinned digests in {composeFile}");
 
@@ -91,6 +91,7 @@ public class SmokeTestImageDigestUpdater : IDisposable
             {
                 failed++;
                 Logger.Warning(ex, "Failed to evaluate {Image}", entry.ImagePrefix);
+                CooldownReport.AddFailure(new CooldownReport.FailureEntry(entry.ImagePrefix, ex.Message));
             }
         }
 
@@ -107,6 +108,22 @@ public class SmokeTestImageDigestUpdater : IDisposable
         Logger.Information(
             "Summary - updated: {Updated}, cooldown: {Cooldown}, unchanged: {Unchanged}, failed: {Failed}",
             updated, cooled, unchanged, failed);
+
+        // Save the report only when there's an update worth opening a PR for —
+        // the report is PR-body fodder, not a standalone artifact.
+        if (updated > 0 && reportPath is not null && CooldownReport.HasEntries)
+        {
+            await CooldownReport.SaveToFile(reportPath);
+            Logger.Information("Image digest report saved to {Path}", reportPath);
+        }
+
+        // With no updates to ship, failures have no visible channel but the build log —
+        // fail the target so the scheduled workflow's failure notification fires.
+        if (updated == 0 && failed > 0)
+        {
+            throw new InvalidOperationException(
+                $"{failed} image(s) failed to evaluate and no digest updates were produced; see warnings above for details.");
+        }
     }
 
     async Task<UpdateOutcome> EvaluateAsync(ImageEntry entry)

--- a/tracer/build/_build/SmokeTests/SmokeTestImageDigestUpdater.cs
+++ b/tracer/build/_build/SmokeTests/SmokeTestImageDigestUpdater.cs
@@ -1,0 +1,527 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Nuke.Common.IO;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using Logger = Serilog.Log;
+
+namespace SmokeTests;
+
+/// <summary>
+/// Queries each registry for the current digest of every pinned tag in
+/// smoke-test-images.docker-compose.yml, applies a cooldown based on the image's
+/// config.created timestamp, and rewrites the compose file with any updates.
+///
+/// This exists because Dependabot's docker_registry2 cooldown check performs
+/// HEAD /v2/&lt;repo&gt;/blobs/&lt;manifest-digest&gt;, which 404s on MCR. Owning the
+/// update flow avoids that bug while preserving the mandatory cooldown.
+/// </summary>
+public class SmokeTestImageDigestUpdater : IDisposable
+{
+    static readonly string[] AcceptedManifestMediaTypes =
+    {
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.oci.image.index.v1+json",
+    };
+
+    readonly TimeSpan _cooldown;
+    readonly RegistryClient _registry;
+
+    public SmokeTestImageDigestUpdater(TimeSpan cooldown)
+    {
+        _cooldown = cooldown;
+        _registry = new RegistryClient();
+    }
+
+    public async Task UpdateAsync(AbsolutePath composeFile)
+    {
+        Helpers.LogSection($"Updating pinned digests in {composeFile}");
+
+        if (!File.Exists(composeFile))
+        {
+            throw new FileNotFoundException($"Compose file not found: {composeFile}", composeFile);
+        }
+
+        var entries = ReadEntries(composeFile);
+        Logger.Information("Found {Count} pinned images to evaluate", entries.Count);
+
+        var updates = new Dictionary<string, string>(StringComparer.Ordinal);
+        int updated = 0, cooled = 0, unchanged = 0, failed = 0;
+
+        foreach (var entry in entries)
+        {
+            try
+            {
+                var outcome = await EvaluateAsync(entry);
+                switch (outcome.Kind)
+                {
+                    case UpdateKind.Unchanged:
+                        unchanged++;
+                        break;
+                    case UpdateKind.Cooldown:
+                        cooled++;
+                        break;
+                    case UpdateKind.Update:
+                        updated++;
+                        updates[entry.ImagePrefix] = outcome.NewDigest!;
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                failed++;
+                Logger.Warning(ex, "Failed to evaluate {Image}", entry.ImagePrefix);
+            }
+        }
+
+        if (updates.Count > 0)
+        {
+            RewriteComposeFile(composeFile, updates);
+            Logger.Information("Rewrote {File} with {Count} digest update(s)", composeFile, updates.Count);
+        }
+        else
+        {
+            Logger.Information("No digest updates to apply");
+        }
+
+        Logger.Information(
+            "Summary - updated: {Updated}, cooldown: {Cooldown}, unchanged: {Unchanged}, failed: {Failed}",
+            updated, cooled, unchanged, failed);
+    }
+
+    async Task<UpdateOutcome> EvaluateAsync(ImageEntry entry)
+    {
+        Logger.Debug("Evaluating {Image}", entry.ImagePrefix);
+
+        var latestDigest = await _registry.GetTagDigestAsync(entry.Registry, entry.Repository, entry.Tag, AcceptedManifestMediaTypes);
+        if (string.IsNullOrEmpty(latestDigest))
+        {
+            throw new InvalidOperationException($"Registry did not return a Docker-Content-Digest for {entry.ImagePrefix}");
+        }
+
+        if (string.Equals(latestDigest, entry.Digest, StringComparison.OrdinalIgnoreCase))
+        {
+            Logger.Information("Unchanged {Image} (digest {Digest})", entry.ImagePrefix, Shorten(latestDigest));
+            return UpdateOutcome.Unchanged;
+        }
+
+        var created = await GetImageCreatedAsync(entry.Registry, entry.Repository, latestDigest);
+        if (created is null)
+        {
+            throw new InvalidOperationException($"Unable to determine created timestamp for {entry.ImagePrefix}@{latestDigest}");
+        }
+
+        var age = DateTime.UtcNow - created.Value;
+        if (age < _cooldown)
+        {
+            Logger.Information(
+                "Cooldown {Image}: new digest {Digest} is only {AgeH}h old (< {CooldownH}h cooldown)",
+                entry.ImagePrefix, Shorten(latestDigest), (int)age.TotalHours, (int)_cooldown.TotalHours);
+            return UpdateOutcome.Cooldown;
+        }
+
+        Logger.Information(
+            "Updating {Image}: {Old} -> {New} (published {AgeDays}d ago)",
+            entry.ImagePrefix, Shorten(entry.Digest), Shorten(latestDigest), (int)age.TotalDays);
+        return UpdateOutcome.Update(latestDigest);
+    }
+
+    async Task<DateTime?> GetImageCreatedAsync(string registry, string repository, string digest)
+    {
+        using var manifestDoc = await _registry.GetManifestAsync(registry, repository, digest, AcceptedManifestMediaTypes);
+        var root = manifestDoc.RootElement;
+
+        // Manifest list / OCI image index: pick a concrete child (prefer linux/amd64, else first).
+        if (root.TryGetProperty("manifests", out var children) && children.ValueKind == JsonValueKind.Array)
+        {
+            string? childDigest = null;
+            foreach (var child in children.EnumerateArray())
+            {
+                if (!child.TryGetProperty("platform", out var platform)) continue;
+                var os = platform.TryGetProperty("os", out var osProp) ? osProp.GetString() : null;
+                var arch = platform.TryGetProperty("architecture", out var archProp) ? archProp.GetString() : null;
+                if (os == "linux" && arch == "amd64")
+                {
+                    childDigest = child.TryGetProperty("digest", out var d) ? d.GetString() : null;
+                    break;
+                }
+            }
+
+            if (childDigest is null)
+            {
+                foreach (var child in children.EnumerateArray())
+                {
+                    if (child.TryGetProperty("digest", out var d))
+                    {
+                        childDigest = d.GetString();
+                        if (!string.IsNullOrEmpty(childDigest)) break;
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(childDigest)) return null;
+            return await GetImageCreatedAsync(registry, repository, childDigest!);
+        }
+
+        // Single-platform manifest: follow config blob for the 'created' timestamp.
+        if (!root.TryGetProperty("config", out var config)) return null;
+        if (!config.TryGetProperty("digest", out var configDigestEl)) return null;
+        var configDigest = configDigestEl.GetString();
+        if (string.IsNullOrEmpty(configDigest)) return null;
+
+        using var blobDoc = await _registry.GetBlobAsync(registry, repository, configDigest!);
+        if (!blobDoc.RootElement.TryGetProperty("created", out var createdProp)) return null;
+        var createdStr = createdProp.GetString();
+        if (string.IsNullOrEmpty(createdStr)) return null;
+
+        return DateTime.Parse(
+            createdStr!,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+    }
+
+    static string Shorten(string digest)
+    {
+        var colon = digest.IndexOf(':');
+        var hex = colon >= 0 ? digest[(colon + 1)..] : digest;
+        return hex.Length > 12 ? hex.Substring(0, 12) : hex;
+    }
+
+    static List<ImageEntry> ReadEntries(string filePath)
+    {
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        using var reader = new StreamReader(filePath);
+        var compose = deserializer.Deserialize<DockerComposeFile?>(reader);
+
+        var result = new List<ImageEntry>();
+        if (compose?.Services is null) return result;
+
+        foreach (var (serviceName, details) in compose.Services)
+        {
+            if (string.IsNullOrEmpty(details.Image)) continue;
+
+            var entry = ImageEntry.TryParse(serviceName, details.Image!);
+            if (entry is null)
+            {
+                Logger.Warning("Skipping malformed entry for service {Service}: {Image}", serviceName, details.Image);
+                continue;
+            }
+
+            result.Add(entry);
+        }
+
+        return result;
+    }
+
+    static void RewriteComposeFile(string filePath, Dictionary<string, string> updatesByRepoTag)
+    {
+        // Regex-replace on full text preserves original line endings, comments, and formatting.
+        var content = File.ReadAllText(filePath);
+        foreach (var (repoTag, newDigest) in updatesByRepoTag)
+        {
+            var escaped = Regex.Escape(repoTag);
+            var pattern = $@"(?<prefix>\s*image:\s*){escaped}@sha256:[a-f0-9]+";
+            content = Regex.Replace(content, pattern, m => $"{m.Groups["prefix"].Value}{repoTag}@{newDigest}");
+        }
+        File.WriteAllText(filePath, content);
+    }
+
+    public void Dispose() => _registry.Dispose();
+
+    class DockerComposeFile
+    {
+        public Dictionary<string, DockerComposeService>? Services { get; set; }
+    }
+
+    class DockerComposeService
+    {
+        public string? Image { get; set; }
+    }
+
+    class ImageEntry
+    {
+        ImageEntry(string service, string imagePrefix, string digest, string registry, string repository, string tag)
+        {
+            Service = service;
+            ImagePrefix = imagePrefix;
+            Digest = digest;
+            Registry = registry;
+            Repository = repository;
+            Tag = tag;
+        }
+
+        public string Service { get; }
+        // Literal "<registry>/<repo>:<tag>" portion (everything before '@') — used as the YAML rewrite key.
+        public string ImagePrefix { get; }
+        // Full digest, including "sha256:" prefix.
+        public string Digest { get; }
+        // API hostname to contact, e.g. "mcr.microsoft.com" or "registry-1.docker.io".
+        public string Registry { get; }
+        // Repository path for /v2/ URLs, e.g. "dotnet/aspnet" or "andrewlock/dotnet-centos".
+        public string Repository { get; }
+        public string Tag { get; }
+
+        public static ImageEntry? TryParse(string service, string imageField)
+        {
+            var atIdx = imageField.IndexOf('@');
+            if (atIdx <= 0) return null;
+            var digest = imageField[(atIdx + 1)..];
+            if (!digest.StartsWith("sha256:", StringComparison.Ordinal)) return null;
+
+            var prefix = imageField[..atIdx];
+            var colonIdx = prefix.LastIndexOf(':');
+            var slashIdx = prefix.LastIndexOf('/');
+            if (colonIdx < 0 || colonIdx < slashIdx) return null;
+
+            var path = prefix[..colonIdx];
+            var tag = prefix[(colonIdx + 1)..];
+
+            string registry;
+            string repository;
+            var firstSlashIdx = path.IndexOf('/');
+            if (firstSlashIdx > 0)
+            {
+                var firstSegment = path[..firstSlashIdx];
+                if (firstSegment.Contains('.') || firstSegment.Contains(':') || firstSegment == "localhost")
+                {
+                    registry = firstSegment;
+                    repository = path[(firstSlashIdx + 1)..];
+                }
+                else
+                {
+                    // Implicit Docker Hub repo like "andrewlock/dotnet-centos".
+                    registry = "registry-1.docker.io";
+                    repository = path;
+                }
+            }
+            else
+            {
+                // Bare repo name defaults to Docker Hub's official-images namespace.
+                registry = "registry-1.docker.io";
+                repository = "library/" + path;
+            }
+
+            return new ImageEntry(service, prefix, digest, registry, repository, tag);
+        }
+    }
+
+    enum UpdateKind
+    {
+        Unchanged,
+        Cooldown,
+        Update,
+    }
+
+    readonly struct UpdateOutcome
+    {
+        UpdateOutcome(UpdateKind kind, string? digest)
+        {
+            Kind = kind;
+            NewDigest = digest;
+        }
+
+        public UpdateKind Kind { get; }
+        public string? NewDigest { get; }
+
+        public static readonly UpdateOutcome Unchanged = new(UpdateKind.Unchanged, null);
+        public static readonly UpdateOutcome Cooldown = new(UpdateKind.Cooldown, null);
+        public static UpdateOutcome Update(string digest) => new(UpdateKind.Update, digest);
+    }
+
+    /// <summary>
+    /// Minimal Docker Registry v2 client with anonymous bearer-token challenge support.
+    /// Supports MCR (typically open) and Docker Hub (requires anonymous pull token).
+    /// </summary>
+    sealed class RegistryClient : IDisposable
+    {
+        readonly HttpClient _client;
+        readonly Dictionary<string, string> _tokenCache = new(StringComparer.Ordinal);
+
+        public RegistryClient()
+        {
+            _client = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(30),
+            };
+            _client.DefaultRequestHeaders.UserAgent.ParseAdd("dd-trace-dotnet-smoke-test-updater/1.0");
+        }
+
+        public async Task<string?> GetTagDigestAsync(string registry, string repository, string tag, string[] acceptMediaTypes)
+        {
+            using var response = await SendWithAuthAsync(
+                () => BuildRequest(HttpMethod.Head, registry, $"/v2/{repository}/manifests/{tag}", acceptMediaTypes),
+                repository);
+            response.EnsureSuccessStatusCode();
+
+            if (response.Headers.TryGetValues("Docker-Content-Digest", out var values))
+            {
+                foreach (var v in values)
+                {
+                    if (!string.IsNullOrEmpty(v)) return v;
+                }
+            }
+            return null;
+        }
+
+        public async Task<JsonDocument> GetManifestAsync(string registry, string repository, string reference, string[] acceptMediaTypes)
+        {
+            using var response = await SendWithAuthAsync(
+                () => BuildRequest(HttpMethod.Get, registry, $"/v2/{repository}/manifests/{reference}", acceptMediaTypes),
+                repository);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            return await JsonDocument.ParseAsync(stream);
+        }
+
+        public async Task<JsonDocument> GetBlobAsync(string registry, string repository, string digest)
+        {
+            using var response = await SendWithAuthAsync(
+                () => BuildRequest(HttpMethod.Get, registry, $"/v2/{repository}/blobs/{digest}", acceptMediaTypes: null),
+                repository);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            return await JsonDocument.ParseAsync(stream);
+        }
+
+        static HttpRequestMessage BuildRequest(HttpMethod method, string registry, string path, string[]? acceptMediaTypes)
+        {
+            var request = new HttpRequestMessage(method, $"https://{registry}{path}");
+            if (acceptMediaTypes is not null)
+            {
+                foreach (var mt in acceptMediaTypes)
+                {
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(mt));
+                }
+            }
+            return request;
+        }
+
+        async Task<HttpResponseMessage> SendWithAuthAsync(Func<HttpRequestMessage> buildRequest, string repository)
+        {
+            var request = buildRequest();
+            var host = request.RequestUri!.Host;
+            var authKey = $"{host}::{repository}";
+
+            if (_tokenCache.TryGetValue(authKey, out var cachedToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", cachedToken);
+            }
+
+            var response = await _client.SendAsync(request);
+            request.Dispose();
+
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                return response;
+            }
+
+            var challenge = response.Headers.WwwAuthenticate
+                .FirstOrDefault(h => string.Equals(h.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase));
+            if (challenge is null || string.IsNullOrEmpty(challenge.Parameter))
+            {
+                return response;
+            }
+
+            response.Dispose();
+
+            var parameters = ParseChallenge(challenge.Parameter!);
+            if (!parameters.TryGetValue("realm", out var realm))
+            {
+                throw new InvalidOperationException($"Bearer challenge from {host} did not include a realm");
+            }
+
+            var scope = parameters.TryGetValue("scope", out var s) ? s : $"repository:{repository}:pull";
+            var query = new List<string> { $"scope={Uri.EscapeDataString(scope)}" };
+            if (parameters.TryGetValue("service", out var svc))
+            {
+                query.Add($"service={Uri.EscapeDataString(svc)}");
+            }
+            var tokenUrl = $"{realm}?{string.Join("&", query)}";
+
+            using var tokenResponse = await _client.GetAsync(tokenUrl);
+            tokenResponse.EnsureSuccessStatusCode();
+            await using var tokenStream = await tokenResponse.Content.ReadAsStreamAsync();
+            using var tokenDoc = await JsonDocument.ParseAsync(tokenStream);
+            string? newToken = null;
+            if (tokenDoc.RootElement.TryGetProperty("token", out var t))
+            {
+                newToken = t.GetString();
+            }
+            else if (tokenDoc.RootElement.TryGetProperty("access_token", out var at))
+            {
+                newToken = at.GetString();
+            }
+            if (string.IsNullOrEmpty(newToken))
+            {
+                throw new InvalidOperationException($"Auth endpoint {realm} did not return a token");
+            }
+            _tokenCache[authKey] = newToken!;
+
+            var retry = buildRequest();
+            retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", newToken);
+            var retryResponse = await _client.SendAsync(retry);
+            retry.Dispose();
+            return retryResponse;
+        }
+
+        static Dictionary<string, string> ParseChallenge(string parameter)
+        {
+            // Example: realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:foo:pull"
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var i = 0;
+            while (i < parameter.Length)
+            {
+                while (i < parameter.Length && (char.IsWhiteSpace(parameter[i]) || parameter[i] == ',')) i++;
+                if (i >= parameter.Length) break;
+
+                var nameStart = i;
+                while (i < parameter.Length && parameter[i] != '=') i++;
+                if (i >= parameter.Length) break;
+                var name = parameter[nameStart..i].Trim();
+                i++; // skip '='
+
+                string value;
+                if (i < parameter.Length && parameter[i] == '"')
+                {
+                    i++;
+                    var valStart = i;
+                    while (i < parameter.Length && parameter[i] != '"') i++;
+                    value = parameter[valStart..i];
+                    if (i < parameter.Length) i++; // closing quote
+                }
+                else
+                {
+                    var valStart = i;
+                    while (i < parameter.Length && parameter[i] != ',') i++;
+                    value = parameter[valStart..i].Trim();
+                }
+
+                if (!string.IsNullOrEmpty(name))
+                {
+                    result[name] = value;
+                }
+            }
+            return result;
+        }
+
+        public void Dispose() => _client.Dispose();
+    }
+}

--- a/tracer/build/_build/SmokeTests/SmokeTestImageDigestUpdater.cs
+++ b/tracer/build/_build/SmokeTests/SmokeTestImageDigestUpdater.cs
@@ -43,7 +43,15 @@ public class SmokeTestImageDigestUpdater : IDisposable
     {
         _cooldown = cooldown;
         _registry = new RegistryClient();
+        CooldownReport = new CooldownReport(cooldown);
     }
+
+    /// <summary>
+    /// Collected entries for images whose latest digest fell within the cooldown window.
+    /// Populated by <see cref="UpdateAsync"/>; intended to be rendered into a markdown
+    /// report and attached to the automation PR.
+    /// </summary>
+    public CooldownReport CooldownReport { get; }
 
     public async Task UpdateAsync(AbsolutePath composeFile)
     {
@@ -126,9 +134,14 @@ public class SmokeTestImageDigestUpdater : IDisposable
         var age = DateTime.UtcNow - created.Value;
         if (age < _cooldown)
         {
-            Logger.Information(
-                "Cooldown {Image}: new digest {Digest} is only {AgeH}h old (< {CooldownH}h cooldown)",
-                entry.ImagePrefix, Shorten(latestDigest), (int)age.TotalHours, (int)_cooldown.TotalHours);
+            Logger.Warning(
+                "Cooldown {Image}: new digest {Digest} is only {AgeH}h old (< {CooldownH}h cooldown); keeping current pin {Current}",
+                entry.ImagePrefix, Shorten(latestDigest), (int)age.TotalHours, (int)_cooldown.TotalHours, Shorten(entry.Digest));
+            CooldownReport.Add(new CooldownReport.CooldownEntry(
+                Image: entry.ImagePrefix,
+                CurrentDigest: entry.Digest,
+                AvailableDigest: latestDigest,
+                PublishedDate: new DateTimeOffset(created.Value, TimeSpan.Zero)));
             return UpdateOutcome.Cooldown;
         }
 

--- a/tracer/build/_build/SmokeTests/smoke-test-images.docker-compose.yml
+++ b/tracer/build/_build/SmokeTests/smoke-test-images.docker-compose.yml
@@ -56,13 +56,13 @@ services:
   aspnet-8_0-bookworm-slim:
     image: mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim@sha256:f24d74e8185b14aba4c7563e059e0f526699d4730998a83515d3af03058e1266
   aspnet-8_0-jammy:
-    image: mcr.microsoft.com/dotnet/aspnet:8.0-jammy@sha256:5008ae5422cbc7c55a03df6f8bd26e176624eb2449010927fb6be0af36148793
+    image: mcr.microsoft.com/dotnet/aspnet:8.0-jammy@sha256:dcfab093eb4da3ccc3d9704cf608036c7170f862d4103a367ca0dd765d3a54cb
   aspnet-8_0-jammy-chiseled:
-    image: mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled@sha256:f38c3006789a9b584f079dadf68bbb2338dddde835dbd94795494d7c547d7c08
+    image: mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled@sha256:aa0322db92908fc10b63ab2a74b5064131fa37c07c84bae4718cf20c77a07c9e
   aspnet-8_0-jammy-chiseled-composite:
-    image: mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite@sha256:7f7a1dde47aa8582e33ab5e28d409b047837b6a83642ab87b1cd5322fa54b3e5
+    image: mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled-composite@sha256:d89cedaab0731915c29ed4d2e64265019a7d4cf05e1a659bb2acb8451b9da306
   aspnet-8_0-windowsservercore-ltsc2022:
-    image: mcr.microsoft.com/dotnet/aspnet:8.0-windowsservercore-ltsc2022@sha256:8e73e9002982b3652dd28829526af3a3a0041e1bc6854a15829b9154422ba34e
+    image: mcr.microsoft.com/dotnet/aspnet:8.0-windowsservercore-ltsc2022@sha256:f4bd2390df968ea7bdb3c6a90bc36a5651346611d101af5768ae0c8141386447
   aspnet-9_0-alpine3_20:
     image: mcr.microsoft.com/dotnet/aspnet:9.0-alpine3.20@sha256:bc0050c8c9beaf382941d074ef1b522551015b55199e061f4930639953ab9a42
   aspnet-9_0-alpine3_20-composite:
@@ -70,13 +70,13 @@ services:
   aspnet-9_0-bookworm-slim:
     image: mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim@sha256:d6c93f1bd94fd5782b8aff29b2693921ea13cb2b716021f709a21ec5c27adc3c
   aspnet-9_0-noble:
-    image: mcr.microsoft.com/dotnet/aspnet:9.0-noble@sha256:729acff37e0859d9a69ad19cb43145b2306743c235397220fd6cb301d059e0e5
+    image: mcr.microsoft.com/dotnet/aspnet:9.0-noble@sha256:4180d760569fdf8f639cc79d62de294356c166eeebe3e4ab19d4f012960b5be8
   aspnet-9_0-noble-chiseled:
-    image: mcr.microsoft.com/dotnet/aspnet:9.0-noble-chiseled@sha256:ba37191d6ce7e65cfb845f3fe96d124b51f4d0c55805d9ec595c6bedbcc077e0
+    image: mcr.microsoft.com/dotnet/aspnet:9.0-noble-chiseled@sha256:141f41835c40203fea20b66789f97afea82ce12fc223f6b8880aa8c3b472ac67
   aspnet-9_0-noble-chiseled-composite:
-    image: mcr.microsoft.com/dotnet/aspnet:9.0-noble-chiseled-composite@sha256:e751c88cc6ebc6817f859ba5e157c0f7e27e2520d264af83cb15f243749d1d92
+    image: mcr.microsoft.com/dotnet/aspnet:9.0-noble-chiseled-composite@sha256:1d6660e319aba0fd0df99a2689d9ab3eb390613b9e2ec18a5a239e41be99030c
   aspnet-9_0-windowsservercore-ltsc2022:
-    image: mcr.microsoft.com/dotnet/aspnet:9.0-windowsservercore-ltsc2022@sha256:8bc5c5c52ebfda9eb80f89f70275ec59fac0b4d1db73b7f92cf647ed8f0da35e
+    image: mcr.microsoft.com/dotnet/aspnet:9.0-windowsservercore-ltsc2022@sha256:0e1d78d2cf79ba69c032e822847354ba0a93d921fa3f93361f9f976f2f7a579a
   aspnet-10_0-alpine3_22:
     image: mcr.microsoft.com/dotnet/aspnet:10.0-alpine3.22@sha256:e0fd89188698106364ea47cd6bbedc1fdea99363766932a1f4c256c87631ec53
   aspnet-10_0-alpine3_22-composite:
@@ -110,13 +110,13 @@ services:
   sdk-8_0-alpine3_18:
     image: mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18@sha256:b16fdc4c48d4627bd5c4e8e569f1cc295b8cda938a29ead7d2df981d410a4175
   sdk-8_0-jammy:
-    image: mcr.microsoft.com/dotnet/sdk:8.0-jammy@sha256:db2aea895095cbb76eeb3d0b2828d15ec01aa6456c0e416d1518cf6c97b24441
+    image: mcr.microsoft.com/dotnet/sdk:8.0-jammy@sha256:5a8fe3f3b17490b07ea836d020485d1c4631a0d00c5289ce1f37e3cf927913c1
   sdk-9_0-alpine3_20:
     image: mcr.microsoft.com/dotnet/sdk:9.0-alpine3.20@sha256:823a26bb53762a51795dbcdcf67659360d6f62823f5a83dc380cbef226d4ded3
   sdk-9_0-bookworm-slim:
     image: mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim@sha256:dbbdd47fae7a98f78932eea912a5233d746073ffb485849a5540d9ed135c922d
   sdk-9_0-noble:
-    image: mcr.microsoft.com/dotnet/sdk:9.0-noble@sha256:446c032fc8de02409c2aa1f34cbcceffae22bb6ab9a93bf19fa99a578cd066f3
+    image: mcr.microsoft.com/dotnet/sdk:9.0-noble@sha256:c4d10394421c0e7c116b6f8866b7c80fa74352ea294629cda1fe4f2acd8f8f6f
   sdk-10_0-alpine3_22:
     image: mcr.microsoft.com/dotnet/sdk:10.0-alpine3.22@sha256:bb9890f2f2dbefa91b161feecfe6f85fd4c8c9e3933158c54287f37f611d5ed5
   sdk-10_0-noble:


### PR DESCRIPTION
## Summary of changes

- Dependabot sucks
- I guess we'll do it ourselves

## Reason for change

tl;dr; [Dependabot continues to be terrible at its job](https://github.com/DataDog/dd-trace-dotnet/actions/runs/24776168750/job/72494856573#step:3:1525)

<details><summary>🤖 explanation</summary>
<p>

```
 Root cause

  The dependabot job fails on the first image it checks (dotnet/aspnet 2.1-stretch-slim) with DockerRegistry2::NotFound — Image not found at mcr.microsoft.com, and because the whole group shares a single job, one failure kills the run.

  The actual HTTP call that 404s (from the proxy log):

  HEAD https://mcr.microsoft.com/v2/dotnet/aspnet/blobs/sha256:80ddf066edeeb7e489b23c3c90d8e5dd741037d4a4875150c1dec777fd24cc76
  → 404

  That digest is the one we pinned in smoke-test-images.docker-compose.yml:15. I verified against MCR:

  ┌───────────────────────────────────────────────────┬────────────────────────────────────┐
  │                     Endpoint                      │               Result               │
  ├───────────────────────────────────────────────────┼────────────────────────────────────┤
  │ HEAD /v2/dotnet/aspnet/manifests/sha256:80ddf066… │ 200 (it's a valid manifest digest) │
  ├───────────────────────────────────────────────────┼────────────────────────────────────┤
  │ HEAD /v2/dotnet/aspnet/blobs/sha256:80ddf066…     │ 404                                │
  └───────────────────────────────────────────────────┴────────────────────────────────────┘

  So the digest is fine — the problem is Dependabot is querying the wrong endpoint for it.

  Why Dependabot does this

  The stack trace leads to apply_cooldown → publication_detail → get_tag_publication_details (docker/update_checker.rb:346 → 362 → 380). That method:

  1. Calls client.digest(repo, tag) which does a HEAD /manifests/<tag> and returns the Docker-Content-Digest header — that's the manifest digest.
  2. Then does client.dohead "v2/#{repo}/blobs/#{digest}" and reads Last-Modified from the response to know when the image was published (so it can apply the 2-day cooldown).

  Step 2 assumes the manifest digest is also accessible via the /blobs/ endpoint. MCR doesn't do that cross-storage, so every cooldown lookup 404s. The docker-compose ecosystem is the only one of ours where we enabled cooldown and target
  MCR, so it's the only one this surfaces on. This is a bug in dependabot-core's Docker update checker, not in our config per se.
```

</p>
</details> 

We could either remove the cool down (not acceptable) or we could try to fix the bug in dependabot (not worth the hassle), or we can just do it ourselves (what I settled on)

## Implementation details

Told 🤖 to "implement it properly" and it did a good enough job 😄 It handles getting an anonymous token for the docker hub registry and managing the cool down, but there _is_ a possibility that we could hit rate limits. For now I'm inclined to just "meh" over it, as these _should_ be very rare, because most of the requests don't count towards it, and it shouldn't be an issue for mcr.

One slight issue is the way the tagging works we can't get "all the recent new images", so that we can update to the latest image _outside_ the cooldown. We get the latest, see if it's in the cooldown, and if not, don't update. In the pathological case, we could end up never updating. In practice, that shouldn't be an issue for the images we're using

## Test coverage

We can't actually test this properly until it's merged, but I ran a test locally, and it output the following (abbreviated)

```
╬════════════════════════════════
║ UpdateSmokeTestImageDigests
╬═══════════════════════
​
09:46:16 [INF] ────────────────────────────────────────────────────────────
09:46:16 [INF] Updating pinned digests in C:\repos\dd-trace-dotnet-5\tracer\build\_build\SmokeTests\smoke-test-images.docker-compose.yml
09:46:16 [INF] ────────────────────────────────────────────────────────────
09:46:16 [INF] Found 96 pinned images to evaluate
09:46:16 [DBG] Evaluating mcr.microsoft.com/dotnet/aspnet:2.1-alpine3.12
09:46:16 [INF] Unchanged mcr.microsoft.com/dotnet/aspnet:2.1-alpine3.12 (digest 43ff07984cea)
09:46:16 [DBG] Evaluating mcr.microsoft.com/dotnet/aspnet:2.1-stretch-slim
...
09:46:33 [DBG] Evaluating andrewlock/dotnet-ubuntu:25.04-9.0
09:46:33 [INF] Unchanged andrewlock/dotnet-ubuntu:25.04-9.0 (digest 0e5c1ae3e68d)
09:46:33 [INF] Rewrote C:\repos\dd-trace-dotnet-5\tracer\build\_build\SmokeTests\smoke-test-images.docker-compose.yml with 10 digest update(s)
09:46:33 [INF] Summary - updated: 10, cooldown: 8, unchanged: 78, failed: 0
09:46:33 [INF] Image digest cooldown report saved to C:\repos\dd-trace-dotnet-5\.nuke\temp\smoke_test_image_cooldown_report.md
​
╬══════════════════════
║ Errors & Warnings
╬═════════════
​
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim: new digest f88c77644f4c is only 28h old (< 48h cooldown); keeping current pin f24d74e8185b
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim: new digest 4e07e00025f1 is only 28h old (< 48h cooldown); keeping current pin d6c93f1bd94f
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/aspnet:10.0-noble: new digest 55e37c7795bf is only 41h old (< 48h cooldown); keeping current pin ccdca44cd4f2
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled: new digest f43461f1774d is only 41h old (< 48h cooldown); keeping current pin 1191b4891ae8
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-composite: new digest a6fe6804ff21 is only 41h old (< 48h cooldown); keeping current pin 168f51340812
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/aspnet:10.0-windowsservercore-ltsc2022: new digest 17c963b25ddb is only 41h old (< 48h cooldown); keeping current pin 31eccd550269
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim: new digest f9ddb8a31ae9 is only 28h old (< 48h cooldown); keeping current pin dbbdd47fae7a
[WRN] UpdateSmokeTestImage: Cooldown mcr.microsoft.com/dotnet/sdk:10.0-noble: new digest 8a90a473da52 is only 41h old (< 48h cooldown); keeping current pin f061e5a7532b
```

And seems to work 🤞 

## Other details

I'd _like_ to update the pipeline to always run _all_ smoke tests for these PRs, but I'll move that to a separate PR so as not to block this, as might require some faffing

https://datadoghq.atlassian.net/browse/APMLP-1282