### PR TITLE
Try fix flake in OTLP logs tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -628,7 +628,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL", protocol);
             // Short delay gives the OTel SDK multiple periodic exports before LoggerProviderSdk.Dispose() hits its 5s shutdown timeout.
             // This is especially important for gRPC, where the first export warms the HTTP/2 connection.
-            SetEnvironmentVariable("OTEL_BLRP_SCHEDULE_DELAY", "500");
+            SetEnvironmentVariable("OTEL_BLRP_SCHEDULE_DELAY", "100");
             SetEnvironmentVariable("DD_LOGS_DIRECT_SUBMISSION_MINIMUM_LEVEL", "Verbose");
 
             if (useAgentHostBackup)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -698,6 +698,58 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     }
                 }
 
+                // The OTel SDK can emit multiple OTLP batches during the sample run (periodic export(s) plus shutdown flush),
+                // and the test-agent can return them as separate top-level elements in any order. Collapse everything
+                // into a single batch, then sort scope_logs by scope.name and log_records by body.string_value so the
+                // snapshot is stable regardless of batch split, arrival order, or the exporter's internal scope grouping.
+                if (logsData is JArray logsArray && logsArray.Count > 1)
+                {
+                    // Add all the subsequent logs to the first array
+                    var mergedScopeLogs = (JArray)logsArray[0]["resource_logs"][0]["scope_logs"];
+                    for (var i = 1; i < logsArray.Count; i++)
+                    {
+                        foreach (var scopeLog in (JArray)logsArray[i]["resource_logs"][0]["scope_logs"])
+                        {
+                            var scopeName = scopeLog["scope"]?["name"]?.ToString();
+                            var existing = mergedScopeLogs.FirstOrDefault(s => s["scope"]?["name"]?.ToString() == scopeName);
+                            if (existing != null && scopeLog["log_records"] is JArray incoming)
+                            {
+                                var existingRecords = (JArray)existing["log_records"];
+                                foreach (var record in incoming)
+                                {
+                                    existingRecords.Add(record);
+                                }
+                            }
+                            else
+                            {
+                                mergedScopeLogs.Add(scopeLog);
+                            }
+                        }
+                    }
+
+                    while (logsArray.Count > 1)
+                    {
+                        logsArray.RemoveAt(1);
+                    }
+                }
+
+                // Fix the ordering to ensure it's deterministic
+                foreach (var resourceLog in logsData.SelectTokens("$[0].resource_logs[*]"))
+                {
+                    if (resourceLog["scope_logs"] is JArray scopeLogsArray)
+                    {
+                        foreach (var scopeLog in scopeLogsArray)
+                        {
+                            if (scopeLog["log_records"] is JArray recordsArray)
+                            {
+                                scopeLog["log_records"] = new JArray(recordsArray.OrderBy(r => r["body"]?["string_value"]?.ToString()));
+                            }
+                        }
+
+                        resourceLog["scope_logs"] = new JArray(scopeLogsArray.OrderBy(s => s["scope"]?["name"]?.ToString()));
+                    }
+                }
+
                 var formattedJson = logsData.ToString(Formatting.Indented);
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 var suffix = GetSuffix(packageVersion);

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpLogs.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpLogs.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "resource_logs": [
       {
@@ -47,10 +47,28 @@
                 "severity_number": "SEVERITY_NUMBER_INFO",
                 "severity_text": "Information",
                 "body": {
+                  "string_value": "Hello from OpenTelemetry logger outside span context"
+                },
+                "observed_time_unix_nano": "0"
+              },
+              {
+                "time_unix_nano": "0",
+                "severity_number": "SEVERITY_NUMBER_INFO",
+                "severity_text": "Information",
+                "body": {
                   "string_value": "Hello from OpenTelemetry logger within span context"
                 },
                 "trace_id": "normalized-trace-id",
                 "span_id": "normalized-span-id",
+                "observed_time_unix_nano": "0"
+              },
+              {
+                "time_unix_nano": "0",
+                "severity_number": "SEVERITY_NUMBER_FATAL",
+                "severity_text": "Critical",
+                "body": {
+                  "string_value": "This is a critical message"
+                },
                 "observed_time_unix_nano": "0"
               },
               {
@@ -85,24 +103,6 @@
                 "trace_id": "normalized-trace-id",
                 "span_id": "normalized-span-id",
                 "observed_time_unix_nano": "0"
-              },
-              {
-                "time_unix_nano": "0",
-                "severity_number": "SEVERITY_NUMBER_INFO",
-                "severity_text": "Information",
-                "body": {
-                  "string_value": "Hello from OpenTelemetry logger outside span context"
-                },
-                "observed_time_unix_nano": "0"
-              },
-              {
-                "time_unix_nano": "0",
-                "severity_number": "SEVERITY_NUMBER_FATAL",
-                "severity_text": "Critical",
-                "body": {
-                  "string_value": "This is a critical message"
-                },
-                "observed_time_unix_nano": "0"
               }
             ]
           },
@@ -113,10 +113,10 @@
             "log_records": [
               {
                 "time_unix_nano": "0",
-                "severity_number": "SEVERITY_NUMBER_INFO",
-                "severity_text": "Information",
+                "severity_number": "SEVERITY_NUMBER_DEBUG",
+                "severity_text": "Debug",
                 "body": {
-                  "string_value": "Response from other library"
+                  "string_value": "Debug information from other library"
                 },
                 "trace_id": "normalized-trace-id",
                 "span_id": "normalized-span-id",
@@ -124,10 +124,10 @@
               },
               {
                 "time_unix_nano": "0",
-                "severity_number": "SEVERITY_NUMBER_DEBUG",
-                "severity_text": "Debug",
+                "severity_number": "SEVERITY_NUMBER_INFO",
+                "severity_text": "Information",
                 "body": {
-                  "string_value": "Debug information from other library"
+                  "string_value": "Response from other library"
                 },
                 "trace_id": "normalized-trace-id",
                 "span_id": "normalized-span-id",


### PR DESCRIPTION
## Summary of changes

Try to fix flake in OTLP logs test

## Reason for change

The test [was flaking](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=200195&view=logs&j=097629cb-2f2c-5a7a-5863-2f4098319dcf&t=8bbd8d43-64e2-541f-6e73-698bf685d1df), because it was sending logs in multiple batches.

## Implementation details

Collapse the log groups into one, and sort them to make sure the order is deterministic

## Test coverage

It passes locally, hopefully CI is good too...

## Other details

Follow on from #8488 