### PR TITLE
Fix race condition in Client Side Stats enablement

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Agent
         private int _tracerObfuscationVersion;
         private TraceFilter _traceFilter;
         private List<PeerTagKey> _peerTagKeys = [];
-        private int _computStatsState;
+        private int _computeStatsState;
 
         internal StatsAggregator(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
         {
@@ -117,8 +117,8 @@ namespace Datadog.Trace.Agent
         public bool? CanComputeStats
         {
             // convert between -1 = false, 0 = null, 1 = true because we can't use volatile with a bool?
-            get => Volatile.Read(ref _computStatsState) switch { 1 => true, -1 => false, _ => null, };
-            private set => Volatile.Write(ref _computStatsState, value switch { true => 1, false => -1, _ => 0, });
+            get => Volatile.Read(ref _computeStatsState) switch { 1 => true, -1 => false, _ => null, };
+            private set => Volatile.Write(ref _computeStatsState, value switch { true => 1, false => -1, _ => 0, });
         }
 
         public static IStatsAggregator Create(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -552,20 +552,22 @@ namespace Datadog.Trace.Agent
 
         private void HandleConfigUpdate(AgentConfiguration config)
         {
-            CanComputeStats = !string.IsNullOrWhiteSpace(config.StatsEndpoint)
-                           && config.ClientDropP0s;
+            var shouldCompute = !string.IsNullOrWhiteSpace(config.StatsEndpoint)
+                             && config.ClientDropP0s;
 
-            if (CanComputeStats.Value)
-            {
-                Log.Debug("Stats computation enabled.");
-            }
-            else
+            if (!shouldCompute)
             {
                 Log.Warning("Stats computation disabled because the detected agent does not support this feature.");
-                // early return, because there's no point doing all the extra work if stats isn't enabled anyway
+                // No point setting up the rest of the config if stats isn't enabled anyway
+                CanComputeStats = false;
                 return;
             }
 
+            // Publish all config-derived state BEFORE CanComputeStats becomes true, so that any
+            // observer that sees CanComputeStats == true also sees the consistent config. Each of
+            // the writes below already uses release semantics (Interlocked / Volatile.Write); the
+            // final Volatile.Write to _tracerObfuscationVersion acts as a release fence for the
+            // plain store to CanComputeStats that follows.
             if (config.PeerTags is { Count: > 0 })
             {
                 // Sort, deduplicate, and pre-compute the UTF-8 key prefixes so that
@@ -584,19 +586,17 @@ namespace Datadog.Trace.Agent
             }
 
             // Update trace filter from agent configuration
-            if (config.TraceFilterConfig.HasFilters)
-            {
-                Volatile.Write(ref _traceFilter, new TraceFilter(config.TraceFilterConfig));
-            }
-            else
-            {
-                Volatile.Write(ref _traceFilter, null);
-            }
+            Volatile.Write(
+                ref _traceFilter,
+                config.TraceFilterConfig.HasFilters ? new TraceFilter(config.TraceFilterConfig) : null);
 
             // Tracer obfuscation version is 1. If the agent's version is > 0 and <= ours, the tracer obfuscates.
             const int tracerObfuscationVersion = 1;
             var agentVersion = config.ObfuscationVersion;
             Volatile.Write(ref _tracerObfuscationVersion, agentVersion > 0 && agentVersion <= tracerObfuscationVersion ? tracerObfuscationVersion : 0);
+
+            CanComputeStats = true;
+            Log.Debug("Stats computation enabled.");
         }
 
         internal readonly struct PeerTagKey(string name)

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -57,6 +57,7 @@ namespace Datadog.Trace.Agent
         private int _tracerObfuscationVersion;
         private TraceFilter _traceFilter;
         private List<PeerTagKey> _peerTagKeys = [];
+        private int _computStatsState;
 
         internal StatsAggregator(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
         {
@@ -113,7 +114,12 @@ namespace Datadog.Trace.Agent
         /// </summary>
         internal StatsBuffer CurrentBuffer => _buffers[_currentBuffer];
 
-        public bool? CanComputeStats { get; private set; }
+        public bool? CanComputeStats
+        {
+            // convert between -1 = false, 0 = null, 1 = true because we can't use volatile with a bool?
+            get => Volatile.Read(ref _computStatsState) switch { 1 => true, -1 => false, _ => null, };
+            private set => Volatile.Write(ref _computStatsState, value switch { true => 1, false => -1, _ => 0, });
+        }
 
         public static IStatsAggregator Create(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
         {


### PR DESCRIPTION
## Summary of changes

Fixes a race condition in client-side-stats enablement

## Reason for change

A unit test was flaking, where there was a delay in obfuscation, so we had 2 buckets - one with obfuscated resource name, and one without.

## Implementation details

Move the setting of `CanComputeStats = true` to the _end_ of the method, _after_ setting peer tags and obfuscation, so that when it switches `false` -> `true`, it already has the full config.

> [!WARNING]
> There _is_ still a race condition when config is _updated_ for an _already enabled_ stats config. In that case the obfuscation/peer tags will be briefly out of sync theoretically. But I don't think that's a big issue, and would only occur if the agent changes during application execution, which is rare 

## Test coverage

Covered by the unit tests already (they shouldn't flake now).

## Other details