### PR TITLE
[Dynamic instrumentation] DEBUG-3374 support @key and @value in EL hash iteration

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -52,18 +52,7 @@ internal partial class ProbeExpressionParser<T>
                 throw new InvalidOperationException("Source must be an array or implement ICollection or IReadOnlyCollection");
             }
 
-            Type itParameterType = null;
-            if (source.Type.IsArray)
-            {
-                itParameterType = source.Type.GetElementType();
-            }
-            else
-            {
-                if (source.Type.GetGenericArguments().Length > 0)
-                {
-                    itParameterType = source.Type.GetGenericArguments()[0];
-                }
-            }
+            var itParameterType = GetIteratorParameterType(source.Type);
 
             if (predicateMethod == null)
             {
@@ -213,6 +202,58 @@ internal partial class ProbeExpressionParser<T>
         var countOrLength = ProbeExpressionParserHelper.GetMethodByReflection(source.Type, source.Type.IsArray ? "get_Length" : "get_Count", Type.EmptyTypes);
 
         return Expression.Call(source, countOrLength);
+    }
+
+    private Type GetIteratorParameterType(Type sourceType)
+    {
+        if (sourceType.IsArray)
+        {
+            return sourceType.GetElementType();
+        }
+
+        var genericDictionaryType = sourceType.IsGenericType && sourceType.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                                        ? sourceType
+                                        : sourceType.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+        if (genericDictionaryType != null)
+        {
+            return typeof(KeyValuePair<,>).MakeGenericType(genericDictionaryType.GetGenericArguments());
+        }
+
+        if (typeof(IDictionary).IsAssignableFrom(sourceType))
+        {
+            return typeof(DictionaryEntry);
+        }
+
+        var enumerableType = sourceType.IsGenericType && sourceType.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+                                 ? sourceType
+                                 : sourceType.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        if (enumerableType != null)
+        {
+            return enumerableType.GetGenericArguments()[0];
+        }
+
+        throw new InvalidOperationException("Fail to determined the iterator parameter type");
+    }
+
+    private bool TryGetCollectionIteratorProperty(ParameterExpression itParameter, string propertyName, out MemberExpression propertyExpression)
+    {
+        propertyExpression = null;
+
+        if (itParameter.Type == typeof(DictionaryEntry))
+        {
+            propertyExpression = Expression.Property(itParameter, propertyName);
+            return true;
+        }
+
+        if (itParameter.Type.IsGenericType && itParameter.Type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+        {
+            propertyExpression = Expression.Property(itParameter, propertyName);
+            return true;
+        }
+
+        return false;
     }
 
     private bool IsSafeCollection(Type type)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -47,9 +47,9 @@ internal partial class ProbeExpressionParser<T>
                 ReturnDefaultValueExpression();
             }
 
-            if (!IsSafeCollection(source.Type))
+            if (!IsSafeCollection(source.Type) && !IsSafeNonGenericDictionary(source.Type))
             {
-                throw new InvalidOperationException("Source must be an array or implement ICollection or IReadOnlyCollection");
+                throw new InvalidOperationException("Source must be an array or implement ICollection, IReadOnlyCollection, or IDictionary");
             }
 
             var itParameterType = GetIteratorParameterType(source.Type);
@@ -63,7 +63,7 @@ internal partial class ProbeExpressionParser<T>
             var predicate = ParseTree(reader, new List<ParameterExpression> { Expression.Parameter(source.Type) }, itParameter);
             var lambda = Expression.Lambda(predicate, itParameter);
             var genericPredicateMethod = predicateMethod.MakeGenericMethod(itParameterType);
-            callExpression = Expression.Call(null, genericPredicateMethod, source, lambda);
+            callExpression = Expression.Call(null, genericPredicateMethod, PredicateSource(source, itParameterType), lambda);
             if (IsIEnumerable(callExpression.Type))
             {
                 var toListMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(Enumerable), nameof(Enumerable.ToList), null);
@@ -237,6 +237,17 @@ internal partial class ProbeExpressionParser<T>
         throw new InvalidOperationException("Fail to determined the iterator parameter type");
     }
 
+    private Expression PredicateSource(Expression source, Type itParameterType)
+    {
+        if (itParameterType != typeof(DictionaryEntry) || !IsSafeNonGenericDictionary(source.Type))
+        {
+            return source;
+        }
+
+        var castMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(Enumerable), nameof(Enumerable.Cast), [typeof(IEnumerable)], [typeof(DictionaryEntry)]);
+        return Expression.Call(null, castMethod, source);
+    }
+
     private bool TryGetCollectionIteratorProperty(ParameterExpression itParameter, string propertyName, out MemberExpression propertyExpression)
     {
         propertyExpression = null;
@@ -264,6 +275,11 @@ internal partial class ProbeExpressionParser<T>
         }
 
         return type.IsArray || (IsMicrosoftType(type) && IsCollection(type));
+    }
+
+    private bool IsSafeNonGenericDictionary(Type type)
+    {
+        return type != null && IsMicrosoftType(type) && typeof(IDictionary).IsAssignableFrom(type);
     }
 
     private bool IsIEnumerable(Type type)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -25,6 +25,8 @@ internal partial class ProbeExpressionParser<T>
     private const string @Exceptions = "@exception";
     private const string @Duration = "@duration";
     private const string @It = "@it";
+    private const string @Key = "@key";
+    private const string @Value = "@value";
     private const string @This = "this";
 
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProbeExpressionParser<T>));
@@ -55,7 +57,8 @@ internal partial class ProbeExpressionParser<T>
 
     private Expression ParseRoot(
         JsonTextReader reader,
-        List<ParameterExpression> parameters)
+        List<ParameterExpression> parameters,
+        ParameterExpression itParameter = null)
     {
         var readerValue = reader.Value?.ToString();
         switch (reader.TokenType)
@@ -65,27 +68,27 @@ internal partial class ProbeExpressionParser<T>
                 {
                     case "and":
                         {
-                            return ConditionalOperator(reader, Expression.AndAlso, parameters);
+                            return ConditionalOperator(reader, Expression.AndAlso, parameters, itParameter);
                         }
 
                     case "or":
                         {
-                            return ConditionalOperator(reader, Expression.OrElse, parameters);
+                            return ConditionalOperator(reader, Expression.OrElse, parameters, itParameter);
                         }
 
                     default:
-                        return ParseTree(reader, parameters, null, false);
+                        return ParseTree(reader, parameters, itParameter, false);
                 }
         }
 
         return null;
     }
 
-    private Expression ConditionalOperator(JsonTextReader reader, Combiner combiner, List<ParameterExpression> parameters)
+    private Expression ConditionalOperator(JsonTextReader reader, Combiner combiner, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         _arrayStack++;
         reader.Read();
-        var right = ParseTree(reader, parameters, null);
+        var right = ParseTree(reader, parameters, itParameter);
         var left = Combine(null, right, combiner);
 
         while (reader.Read())
@@ -111,7 +114,7 @@ internal partial class ProbeExpressionParser<T>
                 break;
             }
 
-            right = ParseTree(reader, parameters, null, false);
+            right = ParseTree(reader, parameters, itParameter, false);
             left = Combine(left, right, combiner);
         }
 
@@ -153,14 +156,14 @@ internal partial class ProbeExpressionParser<T>
                                 case "and":
                                 case "&&":
                                     {
-                                        var right = ParseRoot(reader, parameters);
+                                        var right = ParseRoot(reader, parameters, itParameter);
                                         return right;
                                     }
 
                                 case "or":
                                 case "||":
                                     {
-                                        var right = ParseRoot(reader, parameters);
+                                        var right = ParseRoot(reader, parameters, itParameter);
                                         return right;
                                     }
 
@@ -356,6 +359,40 @@ internal partial class ProbeExpressionParser<T>
                                 }
 
                                 return itParameter;
+                            }
+
+                            if (readerValue == Key)
+                            {
+                                if (itParameter == null)
+                                {
+                                    AddError(readerValue, "current item in iterator is null");
+                                    return UndefinedValue();
+                                }
+
+                                if (TryGetCollectionIteratorProperty(itParameter, nameof(KeyValuePair<int, int>.Key), out var keyExpression))
+                                {
+                                    return keyExpression;
+                                }
+
+                                AddError(readerValue, $"{readerValue} is only supported when iterating over dictionary entries");
+                                return UndefinedValue();
+                            }
+
+                            if (readerValue == Value)
+                            {
+                                if (itParameter == null)
+                                {
+                                    AddError(readerValue, "current item in iterator is null");
+                                    return UndefinedValue();
+                                }
+
+                                if (TryGetCollectionIteratorProperty(itParameter, nameof(KeyValuePair<int, int>.Value), out var valueExpression))
+                                {
+                                    return valueExpression;
+                                }
+
+                                AddError(readerValue, $"{readerValue} is only supported when iterating over dictionary entries");
+                                return UndefinedValue();
                             }
 
                             return Expression.Constant(readerValue);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -44,7 +44,11 @@ namespace Datadog.Trace.Tests.Debugger
                 HashInt = [1, 2, 3],
                 Array = ["first", "second"],
                 CustomArray = [new TestStruct.NestedObject() { NestedString = "Nested" }, new TestStruct.ChildNestedObject() { NestedString = "Nested Child" }],
-                Dictionary = new Dictionary<string, string> { { "hello", "world" } },
+                Dictionary = new Dictionary<string, string>
+                {
+                    { "hello", "world" },
+                    { "goodbye", "moon" },
+                },
                 IntNumber = 42,
                 DoubleNumber = 3.14159,
                 String = "Hello world!",

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -213,6 +214,95 @@ namespace Datadog.Trace.Tests.Debugger
             Assert.NotNull(result);
             Assert.IsType<TimeSpan>(result);
             Assert.Equal(default(TimeSpan), (TimeSpan)result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Theory]
+        [InlineData("""
+                    {
+                      "any": [
+                        {
+                          "ref": "HashtableLocal"
+                        },
+                        {
+                          "and": [
+                            {
+                              "eq": [
+                                "@key",
+                                "hello"
+                              ]
+                            },
+                            {
+                              "eq": [
+                                "@value",
+                                "world"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """)]
+        [InlineData("""
+                    {
+                      "all": [
+                        {
+                          "ref": "HashtableLocal"
+                        },
+                        {
+                          "ne": [
+                            "@value",
+                            "sun"
+                          ]
+                        }
+                      ]
+                    }
+                    """)]
+        [InlineData("""
+                    {
+                      "any": [
+                        {
+                          "filter": [
+                            {
+                              "ref": "HashtableLocal"
+                            },
+                            {
+                              "eq": [
+                                "@key",
+                                "hello"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "eq": [
+                            "@value",
+                            "world"
+                          ]
+                        }
+                      ]
+                    }
+                    """)]
+        public void ProbeExpressionParser_NonGenericDictionaryPredicates_CanUseKeyAndValue(string json)
+        {
+            var hashtable = new Hashtable
+            {
+                { "hello", "world" },
+                { "goodbye", "moon" },
+            };
+
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember("HashtableLocal", typeof(Hashtable), hashtable, ScopeMemberKind.Local));
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashAnyKeyValueAnd.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashAnyKeyValueAnd.verified.txt
@@ -1,0 +1,66 @@
+﻿Condition:
+Json:
+{
+  "any": [
+    {
+      "ref": "DictionaryLocal"
+    },
+    {
+      "and": [
+        {
+          "eq": [
+            "@key",
+            "hello"
+          ]
+        },
+        {
+          "eq": [
+            "@value",
+            "world"
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (scopeMember.Value == null)
+        ? default(DebuggerExpressionLanguageTests.TestStruct)
+        : (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (scopeMember.Value == null) ? default(TimeSpan) : (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var CollectionIntLocal = (List<int>)scopeMemberArray[4].Value;
+    var HashIntLocal = (HashSet<int>)scopeMemberArray[5].Value;
+    var ArrayLocal = (string[])scopeMemberArray[6].Value;
+    var CustomArrayLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject[])scopeMemberArray[7].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[8].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[9].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[10].Value;
+    var BooleanValue = (bool)scopeMemberArray[11].Value;
+    var Char = (char)scopeMemberArray[12].Value;
+    var AnotherChar = (char)scopeMemberArray[13].Value;
+    var NullableNotNullValueLocal = (Guid)scopeMemberArray[14].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[15].Value;
+    var IntArg = (int)scopeMemberArray[16].Value;
+    var DoubleArg = (double)scopeMemberArray[17].Value;
+    var StringArg = (string)scopeMemberArray[18].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[19].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
+    var $dd_el_result = DictionaryLocal.Any(
+        stringStringKeyValuePair => (stringStringKeyValuePair.Key == "hello") && (stringStringKeyValuePair.Value == "world"));
+
+    return $dd_el_result;
+}
+Result: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashFilterKeyValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashFilterKeyValue.verified.txt
@@ -1,0 +1,68 @@
+﻿Condition:
+Json:
+{
+  "any": [
+    {
+      "filter": [
+        {
+          "ref": "DictionaryLocal"
+        },
+        {
+          "eq": [
+            "@key",
+            "hello"
+          ]
+        }
+      ]
+    },
+    {
+      "eq": [
+        "@value",
+        "world"
+      ]
+    }
+  ]
+}
+
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (scopeMember.Value == null)
+        ? default(DebuggerExpressionLanguageTests.TestStruct)
+        : (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (scopeMember.Value == null) ? default(TimeSpan) : (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var CollectionIntLocal = (List<int>)scopeMemberArray[4].Value;
+    var HashIntLocal = (HashSet<int>)scopeMemberArray[5].Value;
+    var ArrayLocal = (string[])scopeMemberArray[6].Value;
+    var CustomArrayLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject[])scopeMemberArray[7].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[8].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[9].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[10].Value;
+    var BooleanValue = (bool)scopeMemberArray[11].Value;
+    var Char = (char)scopeMemberArray[12].Value;
+    var AnotherChar = (char)scopeMemberArray[13].Value;
+    var NullableNotNullValueLocal = (Guid)scopeMemberArray[14].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[15].Value;
+    var IntArg = (int)scopeMemberArray[16].Value;
+    var DoubleArg = (double)scopeMemberArray[17].Value;
+    var StringArg = (string)scopeMemberArray[18].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[19].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
+    var $dd_el_result = DictionaryLocal
+        .Where(stringStringKeyValuePair1 => stringStringKeyValuePair1.Key == "hello")
+        .ToList()
+        .Any(stringStringKeyValuePair2 => stringStringKeyValuePair2.Value == "world");
+
+    return $dd_el_result;
+}
+Result: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/HashAnyKeyValueAnd.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/HashAnyKeyValueAnd.json
@@ -1,0 +1,24 @@
+{
+  "dsl": "any(ref DictionaryLocal, { @key == 'hello' && @value == 'world' })",
+  "any": [
+    {
+      "ref": "DictionaryLocal"
+    },
+    {
+      "and": [
+        {
+          "eq": [
+            "@key",
+            "hello"
+          ]
+        },
+        {
+          "eq": [
+            "@value",
+            "world"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/HashFilterKeyValue.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/HashFilterKeyValue.json
@@ -1,0 +1,24 @@
+{
+  "dsl": "any(filter(ref DictionaryLocal, { @key == 'hello' }), { @value == 'world' })",
+  "any": [
+    {
+      "filter": [
+        {
+          "ref": "DictionaryLocal"
+        },
+        {
+          "eq": [
+            "@key",
+            "hello"
+          ]
+        }
+      ]
+    },
+    {
+      "eq": [
+        "@value",
+        "world"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of changes

Add `@key` and `@value` iterator tokens to the debugger expression language for dictionary/hash iteration.

## Reason for change

- The debugger EL already supported `@it` for collection iteration, but it could not express dictionary entry predicates using key/value semantics.

## Implementation details

- Dictionary iteration now resolves to `KeyValuePair<TKey, TValue>` for generic dictionaries and `DictionaryEntry` for non-generic `IDictionary` implementations.
- `@key` and `@value` are only valid inside dictionary-entry iteration; outside that context they fall back to the existing undefined/error behavior.
- Nested conditional parsing now threads the iterator parameter through `and` / `or`, which is required for combined predicates inside collection lambdas.
- Tests cover both a decomposed form:
  - `any(filter(ref DictionaryLocal, { @key == 'hello' }), { @value == 'world' })`
- And the direct combined form:
  - `any(ref DictionaryLocal, { @key == 'hello' && @value == 'world' })`

## Test coverage

- `DebuggerExpressionLanguageTests.TestConditions`
- `DebuggerExpressionLanguageTests.TestConditions`