### PR TITLE
fix(ci): avoid branch-name command injection in image dispatch

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4320,7 +4320,7 @@ stages:
       - checkout: none
       - template: steps/create-github-app-token.yml
       - bash: |
-          REF=$(Build.SourceBranch)
+          REF="$(Build.SourceBranch)"
           BRANCH_NAME="latest_snapshot"
           if [ "$(Build.Reason)" = "PullRequest" ]; then
             LABELS=$(curl -s $(CURL_RETRY_FLAGS) \
@@ -4329,7 +4329,8 @@ stages:
             | jq -r '.labels[].name')
 
             if echo "$LABELS" | grep -q "docker_image_artifacts"; then
-              BRANCH_NAME="$(System.PullRequest.SourceBranch)"
+              BRANCH_NAME="$PR_SOURCE_BRANCH"
+              BRANCH_NAME="${BRANCH_NAME#refs/heads/}"
               REF="refs/heads/$BRANCH_NAME"
             else
               echo "Label 'docker_image_artifacts' not found in PR — skipping Docker image build"
@@ -4358,6 +4359,7 @@ stages:
           )
         env:
           GITHUB_TOKEN: $(retrieve_github_token.GITHUB_APP_TOKEN)
+          PR_SOURCE_BRANCH: $(System.PullRequest.SourceBranch)
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['runCodeCoverage'], 'True'))

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -52,13 +52,15 @@ jobs:
     - name: "Sanitize branch name"
       id: image_tag
       run: |
-        BRANCH="${{github.event.inputs.branch_name}}"
+        BRANCH="$BRANCH_NAME_INPUT"
         if [[ -z "$BRANCH" ]]; then
           echo "ERROR: Missing required 'branch_name' input. Aborting docker image build."
           exit 1
         fi
         SAFE_TAG="${BRANCH//\//_}"
         echo "tag=$SAFE_TAG" >> $GITHUB_OUTPUT
+      env:
+        BRANCH_NAME_INPUT: "${{ github.event.inputs.branch_name }}"
 
     - uses: ./.github/actions/create-system-test-docker-base-images
       name: 'Create system test docker images'


### PR DESCRIPTION
### Motivation
- Prevent command injection and secret exfiltration risk when a labeled PR triggers the image-dispatch path by ensuring untrusted branch names are not interpolated directly into shell script bodies.

### Description
- In the Azure Pipelines job, read the PR source branch from an environment variable `PR_SOURCE_BRANCH` instead of embedding `$(System.PullRequest.SourceBranch)` directly into the script, and normalize it by stripping the `refs/heads/` prefix with `BRANCH_NAME="${BRANCH_NAME#refs/heads/}"` before use.
- Quote the `REF` assignment (`REF="$(Build.SourceBranch)"`) to avoid accidental word-splitting during parsing.
- Expose `PR_SOURCE_BRANCH` via the job `env` so the pipeline consumes an env var rather than untrusted inline interpolation.
- In the dispatched GitHub Actions workflow, stop embedding `${{ github.event.inputs.branch_name }}` directly in the script and instead pass the input through a step `env` variable `BRANCH_NAME_INPUT` and then sanitize/normalize that variable in-shell before generating the `image_tag`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e94906c8248327bc2843e43daeaef7)