### PR TITLE
[Dynamic Instrumentation] DEBUG-2387 Sample evaluation error snapshots

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -345,7 +345,6 @@ namespace Datadog.Trace.Debugger.Expressions
 
                 evaluationResult.Errors ??= new List<EvaluationError>();
                 evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {ProbeInfo.ProbeId}. Error: {e.Message}" });
-                return evaluationResult;
             }
 
             if (evaluationResult.IsNull())
@@ -354,7 +353,6 @@ namespace Datadog.Trace.Debugger.Expressions
 
                 Log.Error("Evaluation result should not be null. Probe: {ProbeId}", ProbeInfo.ProbeId);
                 evaluationResult.Errors = new List<EvaluationError> { new() { Message = $"Evaluation result is null. Probe ID: {ProbeInfo.ProbeId}" } };
-                return evaluationResult;
             }
 
             if (Log.IsEnabled(LogEventLevel.Debug) && evaluationResult.HasError)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -378,6 +378,13 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (evaluationResult.HasError)
             {
+                // Probes with conditions defer sampling until after the condition is evaluated,
+                // so evaluation errors must honor that same sampler before emitting a snapshot.
+                if (ProbeInfo.HasCondition && !sampler.Sample())
+                {
+                    shouldStopCapture = true;
+                }
+
                 return evaluationResult;
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -608,8 +608,8 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void SetEvaluationResult(ref ExpressionEvaluationResult evaluationResult)
         {
-            _message = evaluationResult.Template;
             _errors = evaluationResult.Errors;
+            _message = _errors?.FirstOrDefault(error => !string.IsNullOrEmpty(error.Message)).Message ?? evaluationResult.Template;
         }
 
         private void CaptureAsyncMethodArguments(System.Reflection.FieldInfo[] asyncHoistedArguments, object moveNextInvocationTarget)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -6,8 +6,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.Debugger;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.Models;
+using Datadog.Trace.Debugger.Snapshots;
 using Newtonsoft.Json.Linq;
 using VerifyTests;
 using VerifyXunit;
@@ -117,6 +122,51 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void Message_UsesFirstEvaluationError()
+        {
+            var captureLimitInfo = new CaptureLimitInfo(
+                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+                MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+
+            var snapshotCreator = new DebuggerSnapshotCreator(
+                isFullSnapshot: false,
+                Datadog.Trace.Debugger.Expressions.ProbeLocation.Method,
+                hasCondition: true,
+                tags: [],
+                limitInfo: captureLimitInfo,
+                processTagsProvider: static () => null,
+                serviceNameProvider: static () => "test-service");
+
+            var evaluationResult = new ExpressionEvaluationResult
+            {
+                Template = "template message",
+                Errors =
+                [
+                    new EvaluationError { Expression = "badCondition", Message = "first evaluation error" },
+                    new EvaluationError { Expression = "other", Message = "second evaluation error" }
+                ]
+            };
+
+            snapshotCreator.SetEvaluationResult(ref evaluationResult);
+
+            var captureInfo = new CaptureInfo<object>(
+                methodMetadataIndex: 0,
+                methodState: MethodState.EntryEnd,
+                value: new object(),
+                method: typeof(DebuggerSnapshotCreatorTests).GetMethod(nameof(DummyMethod), BindingFlags.NonPublic | BindingFlags.Static)!,
+                type: typeof(object),
+                invocationTargetType: typeof(object),
+                memberKind: ScopeMemberKind.This);
+
+            var snapshot = JObject.Parse(snapshotCreator.FinalizeMethodSnapshot("probe-id", 1, ref captureInfo));
+
+            Assert.Equal("first evaluation error", snapshot["message"]?.Value<string>());
+            Assert.Equal("first evaluation error", snapshot.SelectToken("debugger.snapshot.evaluationErrors[0].message")?.Value<string>());
+        }
+
+        [Fact]
         public async Task SpecialType_StringBuilder()
         {
             await ValidateSingleValue(new StringBuilder("hi from stringbuilder"));
@@ -148,6 +198,10 @@ namespace Datadog.Trace.Tests.Debugger
             verifierSettings.ScrubLinesContaining(new[] { "id", "timestamp", "duration" });
             var localVariableAsJson = JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return.locals");
             await Verifier.Verify(localVariableAsJson, verifierSettings);
+        }
+
+        private static void DummyMethod()
+        {
         }
 
         private class InfiniteRecursion

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -59,6 +59,24 @@ public class ProbeProcessorTests
         Assert.Equal(1, sampler.SampleCalls);
     }
 
+    [Fact]
+    public void ConditionEvaluationExceptionsAreDroppedWhenSamplerRejects()
+    {
+        var processor = CreateConditionalProbeProcessor();
+        var snapshotCreator = CreateSnapshotCreator();
+        var sampler = new TestAdaptiveSampler(false);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+
+        Assert.True(processor.ShouldProcess(in probeData));
+        Assert.Equal(0, sampler.SampleCalls);
+
+        Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
+        ClearMethodScopeMembers(snapshotCreator);
+        Assert.False(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+        Assert.Equal(1, sampler.SampleCalls);
+    }
+
     private static ProbeProcessor CreateConditionalProbeProcessor()
     {
         return new ProbeProcessor(
@@ -123,6 +141,13 @@ public class ProbeProcessorTests
             hasLocalOrArgument: true);
 
         return processor.Process(ref captureInfo, snapshotCreator, in probeData);
+    }
+
+    private static void ClearMethodScopeMembers(DebuggerSnapshotCreator snapshotCreator)
+    {
+        typeof(DebuggerSnapshotCreator)
+           .GetProperty(nameof(DebuggerSnapshotCreator.MethodScopeMembers), BindingFlags.Instance | BindingFlags.NonPublic)!
+           .SetValue(snapshotCreator, null);
     }
 
     private sealed class SampleTarget

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -1,0 +1,156 @@
+// <copyright file="ProbeProcessorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+using Datadog.Trace.Debugger;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.Helpers;
+using Datadog.Trace.Debugger.Instrumentation.Collections;
+using Datadog.Trace.Debugger.RateLimiting;
+using Datadog.Trace.Debugger.Snapshots;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ProbeProcessorTests
+{
+    private const string InvalidConditionJson = @"{
+    ""gt"": [
+      {""ref"": ""undefined""},
+      2
+    ]
+}";
+
+    [Fact]
+    public void ConditionEvaluationErrorsAreDroppedWhenSamplerRejects()
+    {
+        var processor = CreateConditionalProbeProcessor();
+        var snapshotCreator = CreateSnapshotCreator();
+        var sampler = new TestAdaptiveSampler(false);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+
+        Assert.True(processor.ShouldProcess(in probeData));
+        Assert.Equal(0, sampler.SampleCalls);
+
+        Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
+        Assert.False(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+        Assert.Equal(1, sampler.SampleCalls);
+    }
+
+    [Fact]
+    public void ConditionEvaluationErrorsAreCapturedWhenSamplerKeeps()
+    {
+        var processor = CreateConditionalProbeProcessor();
+        var snapshotCreator = CreateSnapshotCreator();
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+
+        Assert.True(processor.ShouldProcess(in probeData));
+        Assert.Equal(0, sampler.SampleCalls);
+
+        Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+        Assert.Equal(1, sampler.SampleCalls);
+    }
+
+    private static ProbeProcessor CreateConditionalProbeProcessor()
+    {
+        return new ProbeProcessor(
+            new LogProbe
+            {
+                Id = "probe-id",
+                CaptureSnapshot = false,
+                EvaluateAt = EvaluateAt.Entry,
+                Tags = [],
+                Where = new Where
+                {
+                    TypeName = typeof(SampleTarget).FullName!,
+                    MethodName = nameof(SampleTarget.Execute)
+                },
+                When = new SnapshotSegment(dsl: string.Empty, json: InvalidConditionJson, str: string.Empty)
+            });
+    }
+
+    private static DebuggerSnapshotCreator CreateSnapshotCreator()
+    {
+        var captureLimitInfo = new CaptureLimitInfo(
+            MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+            MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+            MaxLength: DebuggerSettings.DefaultMaxStringLength,
+            MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+
+        return new DebuggerSnapshotCreator(
+            isFullSnapshot: false,
+            ProbeLocation.Method,
+            hasCondition: true,
+            tags: [],
+            limitInfo: captureLimitInfo,
+            processTagsProvider: static () => null,
+            serviceNameProvider: static () => "test-service");
+    }
+
+    private static bool ProcessEntryStart(ProbeProcessor processor, DebuggerSnapshotCreator snapshotCreator, in ProbeData probeData, MethodInfo method)
+    {
+        var captureInfo = new CaptureInfo<Type>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.EntryStart,
+            method: method,
+            type: method.DeclaringType!,
+            invocationTargetType: method.DeclaringType!,
+            localsCount: 0,
+            argumentsCount: 0);
+
+        return processor.Process(ref captureInfo, snapshotCreator, in probeData);
+    }
+
+    private static bool ProcessEntryEnd(ProbeProcessor processor, DebuggerSnapshotCreator snapshotCreator, in ProbeData probeData, MethodInfo method)
+    {
+        var target = new SampleTarget();
+        var captureInfo = new CaptureInfo<SampleTarget>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.EntryEnd,
+            value: target,
+            method: method,
+            type: target.GetType(),
+            invocationTargetType: target.GetType(),
+            memberKind: ScopeMemberKind.This,
+            hasLocalOrArgument: true);
+
+        return processor.Process(ref captureInfo, snapshotCreator, in probeData);
+    }
+
+    private sealed class SampleTarget
+    {
+        public void Execute()
+        {
+        }
+    }
+
+    private sealed class TestAdaptiveSampler(params bool[] samples) : IAdaptiveSampler
+    {
+        private readonly bool[] _samples = samples.Length == 0 ? [true] : samples;
+        private int _sampleIndex;
+
+        public int SampleCalls { get; private set; }
+
+        public bool Sample()
+        {
+            SampleCalls++;
+            var index = Math.Min(_sampleIndex, _samples.Length - 1);
+            _sampleIndex++;
+            return _samples[index];
+        }
+
+        public bool Keep() => Sample();
+
+        public bool Drop() => !Sample();
+
+        public double NextDouble() => 0;
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Make Dynamic Instrumentation evaluation-error snapshots honor the same per-probe sampling path as normal condition-matched snapshots.
- Populate debugger snapshot `message` from the first evaluation error when expression evaluation fails.
- Add focused debugger unit tests covering sampled vs dropped evaluation-error snapshots.
- Add a snapshot creator test verifying the emitted message is derived from the first evaluation error.

## Reason for change

- Align .NET debugger behavior with Java so evaluation errors are surfaced through normal snapshot output without bypassing rate limiting.
- Ensure snapshots generated from evaluation failures have a useful message for customers and reviewers.


## Test coverage

- `ProbeProcessorTests.ConditionEvaluationErrorsAreDroppedWhenSamplerRejects|ProbeProcessorTests.ConditionEvaluationErrorsAreCapturedWhenSamplerKeeps|DebuggerSnapshotCreatorTests.Message_UsesFirstEvaluationError`