### PR TITLE
Apply .cctor deadlock defense on .NET Core (follow-up to #8498)

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/ManagedProfilerAssemblyResolver.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/ManagedProfilerAssemblyResolver.NetCore.cs
@@ -13,150 +13,149 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 
-namespace Datadog.Trace.ClrProfiler.Managed.Loader
+namespace Datadog.Trace.ClrProfiler.Managed.Loader;
+
+// Owns the AppDomain.AssemblyResolve and AssemblyLoadContext.Default.Resolving
+// callbacks on .NET Core. Kept on a separate class from Startup so the handlers
+// can be dispatched without forcing Startup's type-initializer to have finished -
+// the same defense applied to the .NET Framework path. The Framework-specific
+// configBuilder trigger doesn't exist on .NET Core, but any sync-over-async work
+// in the Startup..cctor chain whose continuation probes Type.GetType or the ALC
+// on a ThreadPool thread would hit the same .cctor x sync-over-async hazard.
+internal static class ManagedProfilerAssemblyResolver
 {
-    // Owns the AppDomain.AssemblyResolve and AssemblyLoadContext.Default.Resolving
-    // callbacks on .NET Core. Kept on a separate class from Startup so the handlers
-    // can be dispatched without forcing Startup's type-initializer to have finished -
-    // the same defense applied to the .NET Framework path. The Framework-specific
-    // configBuilder trigger doesn't exist on .NET Core, but any sync-over-async work
-    // in the Startup..cctor chain whose continuation probes Type.GetType or the ALC
-    // on a ThreadPool thread would hit the same .cctor x sync-over-async hazard.
-    internal static class ManagedProfilerAssemblyResolver
+    private static readonly AssemblyLoadContext DependencyLoadContext = new ManagedProfilerAssemblyLoadContext();
+
+    private static CachedAssembly[]? _assemblies;
+
+    // Seeded by Startup..cctor before the handlers are subscribed.
+    internal static string? ManagedProfilerDirectory { get; set; }
+
+    internal static void PopulateAssemblyCache(string directory)
     {
-        private static readonly AssemblyLoadContext DependencyLoadContext = new ManagedProfilerAssemblyLoadContext();
-
-        private static CachedAssembly[]? _assemblies;
-
-        // Seeded by Startup..cctor before the handlers are subscribed.
-        internal static string? ManagedProfilerDirectory { get; set; }
-
-        internal static void PopulateAssemblyCache(string directory)
+        if (!Directory.Exists(directory))
         {
-            if (!Directory.Exists(directory))
-            {
-                return;
-            }
-
-            // List/Array due to the number of files in the tracer home folder
-            // (7 in netstandard, 2 netcoreapp3.1+)
-            var assemblies = new List<CachedAssembly>();
-            foreach (var file in Directory.EnumerateFiles(directory, "*.dll", SearchOption.TopDirectoryOnly))
-            {
-                assemblies.Add(new CachedAssembly(file, null));
-            }
-
-            _assemblies = [..assemblies];
-            StartupLogger.Debug("Total number of assemblies: {0}", _assemblies.Length);
+            return;
         }
 
-        internal static Assembly? OnAssemblyResolve(object sender, ResolveEventArgs args)
+        // List/Array due to the number of files in the tracer home folder
+        // (7 in netstandard, 2 netcoreapp3.1+)
+        var assemblies = new List<CachedAssembly>();
+        foreach (var file in Directory.EnumerateFiles(directory, "*.dll", SearchOption.TopDirectoryOnly))
         {
-            return ResolveAssembly(args.Name);
+            assemblies.Add(new CachedAssembly(file, null));
         }
 
-        internal static Assembly? OnAssemblyLoadContextResolving(AssemblyLoadContext context, AssemblyName assemblyName)
+        _assemblies = [..assemblies];
+        StartupLogger.Debug("Total number of assemblies: {0}", _assemblies.Length);
+    }
+
+    internal static Assembly? OnAssemblyResolve(object sender, ResolveEventArgs args)
+    {
+        return ResolveAssembly(args.Name);
+    }
+
+    internal static Assembly? OnAssemblyLoadContextResolving(AssemblyLoadContext context, AssemblyName assemblyName)
+    {
+        return ResolveAssembly(assemblyName.Name);
+    }
+
+    internal static Assembly? ResolveAssembly(string name)
+    {
+        var assemblyName = new AssemblyName(name);
+
+        // On .NET Framework, having a non-US locale can cause mscorlib
+        // to enter the AssemblyResolve event when searching for resources
+        // in its satellite assemblies. This seems to have been fixed in
+        // .NET Core in the 2.0 servicing branch, so we should not see this
+        // occur but guard against it anyway. If we do see it, exit early
+        // so we don't cause infinite recursion.
+        if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
         {
-            return ResolveAssembly(assemblyName.Name);
-        }
-
-        internal static Assembly? ResolveAssembly(string name)
-        {
-            var assemblyName = new AssemblyName(name);
-
-            // On .NET Framework, having a non-US locale can cause mscorlib
-            // to enter the AssemblyResolve event when searching for resources
-            // in its satellite assemblies. This seems to have been fixed in
-            // .NET Core in the 2.0 servicing branch, so we should not see this
-            // occur but guard against it anyway. If we do see it, exit early
-            // so we don't cause infinite recursion.
-            if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-
-            // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
-            StartupLogger.Debug("Assembly Resolve event received for: {0}. Searching in: {1}", name, ManagedProfilerDirectory);
-            var path = Path.Combine(ManagedProfilerDirectory ?? string.Empty, $"{assemblyName.Name}.dll");
-
-            if (IsDatadogAssembly(path, out var cachedAssembly))
-            {
-                // The file exists in the Home folder...
-                if (cachedAssembly is not null)
-                {
-                    // The assembly is already loaded.
-                    StartupLogger.Debug("Loading from cache. [Path: {0}]", path);
-                    return cachedAssembly;
-                }
-
-                // Only load the main profiler into the default AssemblyLoadContext.
-                // If the NuGet package provides Datadog.Trace or other libraries, loading them is handled in the following two ways:
-                // 1) If the AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
-                //    will load successfully and will not invoke this resolve event.
-                // 2) If the AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
-                //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
-                //    load the originally referenced version.
-                StartupLogger.Debug("Calling DependencyLoadContext.LoadFromAssemblyPath(\"{0}\")", path);
-                var assembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom AssemblyLoadContext
-                SetDatadogAssembly(path, assembly);
-                return assembly;
-            }
-
-            // The file doesn't exist in the Home folder.
-            StartupLogger.Debug("Assembly not found in path: {0}", path);
             return null;
         }
 
-        private static bool IsDatadogAssembly(string path, out Assembly? cachedAssembly)
+        // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
+        StartupLogger.Debug("Assembly Resolve event received for: {0}. Searching in: {1}", name, ManagedProfilerDirectory);
+        var path = Path.Combine(ManagedProfilerDirectory ?? string.Empty, $"{assemblyName.Name}.dll");
+
+        if (IsDatadogAssembly(path, out var cachedAssembly))
         {
-            if (_assemblies is null)
+            // The file exists in the Home folder...
+            if (cachedAssembly is not null)
             {
-                cachedAssembly = null;
-                return false;
+                // The assembly is already loaded.
+                StartupLogger.Debug("Loading from cache. [Path: {0}]", path);
+                return cachedAssembly;
             }
 
-            for (var i = 0; i < _assemblies.Length; i++)
-            {
-                var assembly = _assemblies[i];
-                if (assembly.Path == path)
-                {
-                    cachedAssembly = assembly.Assembly;
-                    return true;
-                }
-            }
+            // Only load the main profiler into the default AssemblyLoadContext.
+            // If the NuGet package provides Datadog.Trace or other libraries, loading them is handled in the following two ways:
+            // 1) If the AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
+            //    will load successfully and will not invoke this resolve event.
+            // 2) If the AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
+            //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
+            //    load the originally referenced version.
+            StartupLogger.Debug("Calling DependencyLoadContext.LoadFromAssemblyPath(\"{0}\")", path);
+            var assembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom AssemblyLoadContext
+            SetDatadogAssembly(path, assembly);
+            return assembly;
+        }
 
+        // The file doesn't exist in the Home folder.
+        StartupLogger.Debug("Assembly not found in path: {0}", path);
+        return null;
+    }
+
+    private static bool IsDatadogAssembly(string path, out Assembly? cachedAssembly)
+    {
+        if (_assemblies is null)
+        {
             cachedAssembly = null;
             return false;
         }
 
-        private static void SetDatadogAssembly(string path, Assembly cachedAssembly)
+        for (var i = 0; i < _assemblies.Length; i++)
         {
-            if (_assemblies is null)
+            var assembly = _assemblies[i];
+            if (assembly.Path == path)
             {
-                return;
-            }
-
-            for (var i = 0; i < _assemblies.Length; i++)
-            {
-                if (_assemblies[i].Path == path)
-                {
-                    _assemblies[i] = new CachedAssembly(path, cachedAssembly);
-                    return;
-                }
+                cachedAssembly = assembly.Assembly;
+                return true;
             }
         }
 
-        private readonly struct CachedAssembly
-        {
-            public readonly string Path;
-            public readonly Assembly? Assembly;
+        cachedAssembly = null;
+        return false;
+    }
 
-            public CachedAssembly(string path, Assembly? assembly)
+    private static void SetDatadogAssembly(string path, Assembly cachedAssembly)
+    {
+        if (_assemblies is null)
+        {
+            return;
+        }
+
+        for (var i = 0; i < _assemblies.Length; i++)
+        {
+            if (_assemblies[i].Path == path)
             {
-                Path = path;
-                Assembly = assembly;
+                _assemblies[i] = new CachedAssembly(path, cachedAssembly);
+                return;
             }
+        }
+    }
+
+    private readonly struct CachedAssembly
+    {
+        public readonly string Path;
+        public readonly Assembly? Assembly;
+
+        public CachedAssembly(string path, Assembly? assembly)
+        {
+            Path = path;
+            Assembly = assembly;
         }
     }
 }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/ManagedProfilerAssemblyResolver.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/ManagedProfilerAssemblyResolver.NetCore.cs
@@ -1,0 +1,164 @@
+// <copyright file="ManagedProfilerAssemblyResolver.NetCore.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Loader
+{
+    // Owns the AppDomain.AssemblyResolve and AssemblyLoadContext.Default.Resolving
+    // callbacks on .NET Core. Kept on a separate class from Startup so the handlers
+    // can be dispatched without forcing Startup's type-initializer to have finished -
+    // the same defense applied to the .NET Framework path. The Framework-specific
+    // configBuilder trigger doesn't exist on .NET Core, but any sync-over-async work
+    // in the Startup..cctor chain whose continuation probes Type.GetType or the ALC
+    // on a ThreadPool thread would hit the same .cctor x sync-over-async hazard.
+    internal static class ManagedProfilerAssemblyResolver
+    {
+        private static readonly AssemblyLoadContext DependencyLoadContext = new ManagedProfilerAssemblyLoadContext();
+
+        private static CachedAssembly[]? _assemblies;
+
+        // Seeded by Startup..cctor before the handlers are subscribed.
+        internal static string? ManagedProfilerDirectory { get; set; }
+
+        internal static void PopulateAssemblyCache(string directory)
+        {
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            // List/Array due to the number of files in the tracer home folder
+            // (7 in netstandard, 2 netcoreapp3.1+)
+            var assemblies = new List<CachedAssembly>();
+            foreach (var file in Directory.EnumerateFiles(directory, "*.dll", SearchOption.TopDirectoryOnly))
+            {
+                assemblies.Add(new CachedAssembly(file, null));
+            }
+
+            _assemblies = [..assemblies];
+            StartupLogger.Debug("Total number of assemblies: {0}", _assemblies.Length);
+        }
+
+        internal static Assembly? OnAssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            return ResolveAssembly(args.Name);
+        }
+
+        internal static Assembly? OnAssemblyLoadContextResolving(AssemblyLoadContext context, AssemblyName assemblyName)
+        {
+            return ResolveAssembly(assemblyName.Name);
+        }
+
+        internal static Assembly? ResolveAssembly(string name)
+        {
+            var assemblyName = new AssemblyName(name);
+
+            // On .NET Framework, having a non-US locale can cause mscorlib
+            // to enter the AssemblyResolve event when searching for resources
+            // in its satellite assemblies. This seems to have been fixed in
+            // .NET Core in the 2.0 servicing branch, so we should not see this
+            // occur but guard against it anyway. If we do see it, exit early
+            // so we don't cause infinite recursion.
+            if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
+            StartupLogger.Debug("Assembly Resolve event received for: {0}. Searching in: {1}", name, ManagedProfilerDirectory);
+            var path = Path.Combine(ManagedProfilerDirectory ?? string.Empty, $"{assemblyName.Name}.dll");
+
+            if (IsDatadogAssembly(path, out var cachedAssembly))
+            {
+                // The file exists in the Home folder...
+                if (cachedAssembly is not null)
+                {
+                    // The assembly is already loaded.
+                    StartupLogger.Debug("Loading from cache. [Path: {0}]", path);
+                    return cachedAssembly;
+                }
+
+                // Only load the main profiler into the default AssemblyLoadContext.
+                // If the NuGet package provides Datadog.Trace or other libraries, loading them is handled in the following two ways:
+                // 1) If the AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
+                //    will load successfully and will not invoke this resolve event.
+                // 2) If the AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
+                //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
+                //    load the originally referenced version.
+                StartupLogger.Debug("Calling DependencyLoadContext.LoadFromAssemblyPath(\"{0}\")", path);
+                var assembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom AssemblyLoadContext
+                SetDatadogAssembly(path, assembly);
+                return assembly;
+            }
+
+            // The file doesn't exist in the Home folder.
+            StartupLogger.Debug("Assembly not found in path: {0}", path);
+            return null;
+        }
+
+        private static bool IsDatadogAssembly(string path, out Assembly? cachedAssembly)
+        {
+            if (_assemblies is null)
+            {
+                cachedAssembly = null;
+                return false;
+            }
+
+            for (var i = 0; i < _assemblies.Length; i++)
+            {
+                var assembly = _assemblies[i];
+                if (assembly.Path == path)
+                {
+                    cachedAssembly = assembly.Assembly;
+                    return true;
+                }
+            }
+
+            cachedAssembly = null;
+            return false;
+        }
+
+        private static void SetDatadogAssembly(string path, Assembly cachedAssembly)
+        {
+            if (_assemblies is null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < _assemblies.Length; i++)
+            {
+                if (_assemblies[i].Path == path)
+                {
+                    _assemblies[i] = new CachedAssembly(path, cachedAssembly);
+                    return;
+                }
+            }
+        }
+
+        private readonly struct CachedAssembly
+        {
+            public readonly string Path;
+            public readonly Assembly? Assembly;
+
+            public CachedAssembly(string path, Assembly? assembly)
+            {
+                Path = path;
+                Assembly = assembly;
+            }
+        }
+    }
+}
+
+#endif

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/ManagedProfilerAssemblyResolver.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/ManagedProfilerAssemblyResolver.NetCore.cs
@@ -52,12 +52,30 @@ internal static class ManagedProfilerAssemblyResolver
 
     internal static Assembly? OnAssemblyResolve(object sender, ResolveEventArgs args)
     {
-        return ResolveAssembly(args.Name);
+        try
+        {
+            return ResolveAssembly(args.Name);
+        }
+        catch (Exception ex)
+        {
+            StartupLogger.Log(ex, "Error resolving assembly: {0}", args.Name);
+        }
+
+        return null;
     }
 
     internal static Assembly? OnAssemblyLoadContextResolving(AssemblyLoadContext context, AssemblyName assemblyName)
     {
-        return ResolveAssembly(assemblyName.Name);
+        try
+        {
+            return ResolveAssembly(assemblyName.Name);
+        }
+        catch (Exception ex)
+        {
+            StartupLogger.Log(ex, "Error resolving assembly: {0}", assemblyName.Name);
+        }
+
+        return null;
     }
 
     internal static Assembly? ResolveAssembly(string name)

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -8,9 +8,7 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Loader
 {
@@ -19,10 +17,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private static readonly System.Runtime.Loader.AssemblyLoadContext DependencyLoadContext = new ManagedProfilerAssemblyLoadContext();
-
-        private static CachedAssembly[]? _assemblies;
-
         internal static string ComputeTfmDirectory(string tracerHomeDirectory)
         {
             var version = Environment.Version;
@@ -46,113 +40,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             var fullPath = Path.Combine(Path.GetFullPath(tracerHomeDirectory), managedLibrariesDirectory);
 
-            if (Directory.Exists(fullPath))
-            {
-                // We use the List/Array approach due to the number of files in the tracer home folder (7 in netstandard, 2 netcoreapp3.1+)
-                var assemblies = new List<CachedAssembly>();
-                foreach (var file in Directory.EnumerateFiles(fullPath, "*.dll", SearchOption.TopDirectoryOnly))
-                {
-                    assemblies.Add(new CachedAssembly(file, null));
-                }
-
-                _assemblies = [..assemblies];
-                StartupLogger.Debug("Total number of assemblies: {0}", _assemblies.Length);
-            }
+            // Populate the resolver's cache. The resolver is a separate type so its handlers
+            // can be dispatched from ThreadPool threads without waiting on Startup..cctor.
+            ManagedProfilerAssemblyResolver.PopulateAssemblyCache(fullPath);
 
             return fullPath;
-        }
-
-        private static Assembly? AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
-        {
-            return ResolveAssembly(args.Name);
-        }
-
-        private static Assembly? ResolveAssembly(string name)
-        {
-            var assemblyName = new AssemblyName(name);
-
-            // On .NET Framework, having a non-US locale can cause mscorlib
-            // to enter the AssemblyResolve event when searching for resources
-            // in its satellite assemblies. This seems to have been fixed in
-            // .NET Core in the 2.0 servicing branch, so we should not see this
-            // occur but guard against it anyway. If we do see it, exit early
-            // so we don't cause infinite recursion.
-            if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-
-            // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
-            StartupLogger.Debug("Assembly Resolve event received for: {0}. Searching in: {1}", name, ManagedProfilerDirectory);
-            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
-
-            if (IsDatadogAssembly(path, out var cachedAssembly))
-            {
-                // The file exists in the Home folder...
-                if (cachedAssembly is not null)
-                {
-                    // The assembly is already loaded.
-                    StartupLogger.Debug("Loading from cache. [Path: {0}]", path);
-                    return cachedAssembly;
-                }
-
-                // Only load the main profiler into the default AssemblyLoadContext.
-                // If the NuGet package provides Datadog.Trace or other libraries, loading them is handled in the following two ways:
-                // 1) If the AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
-                //    will load successfully and will not invoke this resolve event.
-                // 2) If the AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
-                //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
-                //    load the originally referenced version.
-                StartupLogger.Debug("Calling DependencyLoadContext.LoadFromAssemblyPath(\"{0}\")", path);
-                var assembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom AssemblyLoadContext
-                SetDatadogAssembly(path, assembly);
-                return assembly;
-            }
-
-            // The file doesn't exist in the Home folder.
-            StartupLogger.Debug("Assembly not found in path: {0}", path);
-            return null;
-        }
-
-        private static bool IsDatadogAssembly(string path, out Assembly? cachedAssembly)
-        {
-            for (var i = 0; i < _assemblies!.Length; i++)
-            {
-                var assembly = _assemblies[i];
-                if (assembly.Path == path)
-                {
-                    cachedAssembly = assembly.Assembly;
-                    return true;
-                }
-            }
-
-            cachedAssembly = null;
-            return false;
-        }
-
-        private static void SetDatadogAssembly(string path, Assembly cachedAssembly)
-        {
-            for (var i = 0; i < _assemblies!.Length; i++)
-            {
-                if (_assemblies[i].Path == path)
-                {
-                    _assemblies[i] = new CachedAssembly(path, cachedAssembly);
-                    return;
-                }
-            }
-        }
-
-        private readonly struct CachedAssembly
-        {
-            public readonly string Path;
-            public readonly Assembly? Assembly;
-
-            public CachedAssembly(string path, Assembly? assembly)
-            {
-                Path = path;
-                Assembly = assembly;
-            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -80,17 +80,14 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
                 try
                 {
-#if NETFRAMEWORK
-                    // On .NET Framework, route AssemblyResolve through a class other than Startup so
-                    // the handler doesn't require Startup..cctor to have finished. If a configBuilder
-                    // on <appSettings> issues sync-over-async work during Startup..cctor, the async
-                    // continuation may fire AssemblyResolve on a ThreadPool thread; a handler on
-                    // Startup itself would deadlock waiting on Startup..cctor.
+                    // Route AssemblyResolve through a class other than Startup so the handler can
+                    // be dispatched without Startup..cctor having finished. If any sync-over-async
+                    // work during Startup..cctor has a continuation that fires AssemblyResolve on a
+                    // ThreadPool thread, a handler on Startup itself would deadlock waiting on
+                    // Startup..cctor. The observed trigger on .NET Framework is a configBuilder on
+                    // <appSettings>; on .NET Core the same hazard applies to any equivalent pattern.
                     ManagedProfilerAssemblyResolver.ManagedProfilerDirectory = ManagedProfilerDirectory;
                     AppDomain.CurrentDomain.AssemblyResolve += ManagedProfilerAssemblyResolver.OnAssemblyResolve;
-#else
-                    AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve_ManagedProfilerDependencies;
-#endif
                 }
                 catch (Exception ex)
                 {
@@ -100,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 #if NETCOREAPP
                 try
                 {
-                    System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += (_, assemblyName) => ResolveAssembly(assemblyName.Name);
+                    System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += ManagedProfilerAssemblyResolver.OnAssemblyLoadContextResolving;
                 }
                 catch (Exception ex)
                 {
@@ -193,11 +190,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 // We will try to resolve it manually as a last chance.
                 StartupLogger.Log(ex, "Error on assembly load: {0}, Trying to solve it manually...", assemblyString);
 
-#if NETFRAMEWORK
                 var assembly = ManagedProfilerAssemblyResolver.ResolveAssembly(assemblyString);
-#else
-                var assembly = ResolveAssembly(assemblyString);
-#endif
                 if (assembly is not null)
                 {
                     StartupLogger.Log("Assembly '{0}' was resolved manually.", assemblyString);


### PR DESCRIPTION
Follow-up to #8498. No known .NET Core trigger today; defense-in-depth for consistency.

## Summary of changes

Mirror the .NET Framework fix from #8498 on .NET Core. Move the `AppDomain.AssemblyResolve` and `AssemblyLoadContext.Default.Resolving` handlers, plus the assembly cache and `DependencyLoadContext`, off `Startup` onto `ManagedProfilerAssemblyResolver`.

## Reason for change

The mechanism behind #8498 — "invoking a static member requires the declaring type's `.cctor` to have completed" — is runtime-generic; only the trigger (`<appSettings>` configBuilder) was Framework-specific. On .NET Core both `AppDomain.AssemblyResolve` (static method on `Startup`) and `AssemblyLoadContext.Default.Resolving` (lambda compiled to a static method on `Startup`) have the same latent hazard if anything in the `.cctor` chain ever does sync-over-async.

## Implementation details

Same shape as #8498:

- New `ManagedProfilerAssemblyResolver.NetCore.cs` with the handlers, `ResolveAssembly`, `DependencyLoadContext`, cache, and a `PopulateAssemblyCache` entry point.
- `Startup.NetCore.cs` slimmed — `ComputeTfmDirectory` delegates cache population to the resolver.
- `Startup.cs`: `#if NETFRAMEWORK` conditionals removed; both TFMs subscribe through the resolver, and the ALC `Resolving` lambda now points at `OnAssemblyLoadContextResolving`. `LoadAssembly` fallback uses the resolver unconditionally.

Both `OnAssemblyResolve` and `OnAssemblyLoadContextResolving` wrap `ResolveAssembly` in a `try/catch` that logs via `StartupLogger` and returns `null`, matching the .NET Framework resolver. Without this, a throw from `LoadFromAssemblyPath` (e.g. `BadImageFormatException`, `FileLoadException`) would propagate into whoever triggered the resolve — often a credential-chain probe expecting `null` on miss — breaking their fallback logic.

`Startup..cctor` seeds `ManagedProfilerAssemblyResolver.ManagedProfilerDirectory` before subscribing, triggering the resolver's trivial `.cctor` up-front so ThreadPool dispatches don't wait on anything.

## Test coverage

No new tests — the deadlock is theoretical on .NET Core. Existing loader/instrumentation tests exercise the new dispatch path.

## Other details

None.