### PR TITLE
Bump check-azure-pipeline benchmark job timeout from 1h to 2h

### DIFF
--- a/.gitlab/benchmarks/dsm-throughput.yml
+++ b/.gitlab/benchmarks/dsm-throughput.yml
@@ -24,7 +24,7 @@ check_azure_pipeline:
       - build-id.txt
     expire_in: 3 months
   tags: ["arch:amd64"]
-  timeout: 1h
+  timeout: 2h
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       interruptible: false

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -41,7 +41,7 @@ check-azure-pipeline:
     - if: $CI_COMMIT_REF_NAME == "master"
       interruptible: false
     - interruptible: true
-  timeout: 1h
+  timeout: 2h
   artifacts:
     name: "artifacts"
     when: always


### PR DESCRIPTION
## Summary of changes
Raise the `timeout` of the `check-azure-pipeline` job from `1h` to `2h` in:

- `.gitlab/benchmarks/macrobenchmarks.yml`
- `.gitlab/benchmarks/dsm-throughput.yml`
## Reason for change
The `check-azure-pipeline` stage waits on the upstream Azure DevOps pipeline that produces the build under test. That upstream pipeline occasionally exceeds 1h end-to-end, which causes the GitLab benchmarks pipeline to time out and report a failure even though nothing is actually wrong with the benchmarks. Doubling the timeout absorbs this variance and reduces flaky failures on master and PR branches.
## Implementation details

No code changes
## Test coverage

No code changes
## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
