### PR TITLE
Add `Environment.Version` to the banned API list

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -7,6 +7,9 @@ M:System.Environment.GetEnvironmentVariable(System.String);Use EnvironmentHelper
 M:System.Environment.GetEnvironmentVariable(System.String,System.EnvironmentVariableTarget);Use EnvironmentHelpers.GetEnvironmentVariable instead to ensure proper configuration handling
 M:System.Environment.GetEnvironmentVariables();Avoid using this alltogether and get precise env vars through ConfigurationBuilder
 
+# Ban System.Environment.Version - allocates a new Version on every call; use the cached copy instead
+P:System.Environment.Version;Use FrameworkDescription.Instance.RuntimeVersion instead - Environment.Version allocates a new Version object on every call
+
 # Ban JsonConvert.SerializeObject - use JsonHelper in Datadog.Trace.Util.Json instead
 M:Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(System.Object);Use Datadog.Trace.Util.Json.JsonHelper.SerializeObject instead for ArrayPool optimization - new overloads can be added if required
 M:Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(System.Object,Datadog.Trace.Vendors.Newtonsoft.Json.Formatting);Use Datadog.Trace.Util.Json.JsonHelper.SerializeObject instead for ArrayPool optimization - new overloads can be added if required

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -79,7 +79,9 @@ namespace Datadog.Trace
                 osArchitecture: osArchitecture,
                 processArchitecture: processArchitecture,
                 osDescription: osDescription,
+#pragma warning disable RS0030 // FrameworkDescription is the cache for Environment.Version
                 runtimeVersion ?? Environment.Version);
+#pragma warning restore RS0030
         }
 
         public bool IsCoreClr()
@@ -89,7 +91,9 @@ namespace Datadog.Trace
 
         private static void GetNetCoreOrNetFrameworkVersion(out Version version, out string productVersion)
         {
+#pragma warning disable RS0030 // FrameworkDescription is the cache for Environment.Version
             version = Environment.Version;
+#pragma warning restore RS0030
             if (version.Major == 3 || version.Major >= 5)
             {
                 // Environment.Version returns "4.x" in .NET Core 2.x,

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
@@ -46,7 +46,9 @@ namespace Datadog.Trace
                 osArchitecture: osArchitecture,
                 processArchitecture: processArchitecture,
                 osDescription: osDescription,
+#pragma warning disable RS0030 // FrameworkDescription is the cache for Environment.Version
                 runtimeVersion ?? Environment.Version);
+#pragma warning restore RS0030
         }
 
         public bool IsCoreClr()
@@ -94,14 +96,18 @@ namespace Datadog.Trace
                 }
                 else
                 {
+#pragma warning disable RS0030 // FrameworkDescription is the cache for Environment.Version
                     version = Environment.Version;
+#pragma warning restore RS0030
                 }
 
                 return;
             }
 
             // at this point, everything else has failed (this is probably the same as [AssemblyFileVersion] above)
+#pragma warning disable RS0030 // FrameworkDescription is the cache for Environment.Version
             version = Environment.Version;
+#pragma warning restore RS0030
             frameworkVersion = version.ToString();
         }
     }

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -227,7 +227,7 @@ namespace Datadog.Trace
             try
             {
                 // We only need this workaround on .NET 10+ runtimes.
-                if (Environment.Version.Major < 10)
+                if (FrameworkDescription.Instance.RuntimeVersion.Major < 10)
                 {
                     // On .NET <= 9, the runtime provided default termination handlers that result in graceful exit,
                     // so we do not install our own to avoid changing long-standing behavior.


### PR DESCRIPTION
## Summary of changes

Adds `Environment.Version` to the banned list of APIs

## Reason for change

This API allocates a new `Version` instance every time, which is relatively expensive. We have a "cached" instance of the value (which can't change at runtime) in `FrameworkDescription.Instance`, so enforce using that instead

## Implementation details

- Add the API to the banned list
- Add exclusions in `FrameworkDescription`
- Fix (single) offending case

## Test coverage

As long at the existing tests pass, we're good
