### PR TITLE
Disable FMT CONSTEVAL on mac for native builds

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -127,6 +127,11 @@ else()
     add_compile_options(-stdlib=libstdc++)
 endif()
 
+if (ISMACOS)
+    # Apple clang 21 rejects fmt 9.1.0's consteval format-string path in C++20 mode.
+    add_compile_options(-DFMT_CONSTEVAL=)
+endif()
+
 if(ISLINUX)
     add_compile_options(-DLINUX -Wno-pragmas)
 endif()

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -120,6 +120,8 @@ add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
 add_compile_options(-Wno-invalid-noreturn -Wno-macro-redefined)
 if (ISMACOS)
     add_compile_options(-stdlib=libc++ -DMACOS -Wno-pragma-pack -Wno-deprecated-declarations -Wno-deprecated-this-capture)
+    # Apple clang 21 rejects fmt 9.1.0's consteval format-string path in C++20 mode.
+    add_compile_options(-DFMT_CONSTEVAL=)
 elseif(ISLINUX)
     add_compile_options(-stdlib=libstdc++ -DLINUX -Wno-pragmas)
 endif()


### PR DESCRIPTION
## Summary of changes

On the latest version of mac OS (>= 26.4 I think), compiling without this fails with some `error: call to consteval function ... is not a constant expression`

## Reason for change

## Implementation details

## Test coverage

ran it on my machine, with and without, with `git clean -fdx` inbetween

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
