### PR TITLE
Attempt to fix crash in FunctionInfo during ReJit

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -686,6 +686,123 @@ ULONG TypeSignature::GetSignature(PCCOR_SIGNATURE& data) const
 }
 
 // FunctionMethodSignature
+FunctionMethodSignature::FunctionMethodSignature() : pbBase(nullptr), len(0)
+{
+}
+
+FunctionMethodSignature::FunctionMethodSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer) :
+    pbBase(nullptr),
+    len(0)
+{
+    SetSignature(pb, cbBuffer);
+}
+
+FunctionMethodSignature::FunctionMethodSignature(const FunctionMethodSignature& other) :
+    signature(other.signature),
+    pbBase(signature.empty() ? nullptr : signature.data()),
+    len(other.len),
+    numberOfTypeArguments(other.numberOfTypeArguments),
+    numberOfArguments(other.numberOfArguments),
+    returnValue(other.returnValue),
+    params(other.params)
+{
+    RebindTypeSignatureViews();
+}
+
+FunctionMethodSignature::FunctionMethodSignature(FunctionMethodSignature&& other) noexcept :
+    signature(std::move(other.signature)),
+    pbBase(signature.empty() ? nullptr : signature.data()),
+    len(other.len),
+    numberOfTypeArguments(other.numberOfTypeArguments),
+    numberOfArguments(other.numberOfArguments),
+    returnValue(other.returnValue),
+    params(std::move(other.params))
+{
+    RebindTypeSignatureViews();
+    other.pbBase = other.signature.empty() ? nullptr : other.signature.data();
+    other.len = static_cast<unsigned>(other.signature.size());
+    other.numberOfTypeArguments = 0;
+    other.numberOfArguments = 0;
+    other.returnValue = {};
+    other.params.clear();
+    other.RebindTypeSignatureViews();
+}
+
+FunctionMethodSignature& FunctionMethodSignature::operator=(const FunctionMethodSignature& other)
+{
+    if (this == &other)
+    {
+        return *this;
+    }
+
+    signature = other.signature;
+    pbBase = signature.empty() ? nullptr : signature.data();
+    len = other.len;
+    numberOfTypeArguments = other.numberOfTypeArguments;
+    numberOfArguments = other.numberOfArguments;
+    returnValue = other.returnValue;
+    params = other.params;
+    RebindTypeSignatureViews();
+    return *this;
+}
+
+FunctionMethodSignature& FunctionMethodSignature::operator=(FunctionMethodSignature&& other) noexcept
+{
+    if (this == &other)
+    {
+        return *this;
+    }
+
+    signature = std::move(other.signature);
+    pbBase = signature.empty() ? nullptr : signature.data();
+    len = other.len;
+    numberOfTypeArguments = other.numberOfTypeArguments;
+    numberOfArguments = other.numberOfArguments;
+    returnValue = other.returnValue;
+    params = std::move(other.params);
+    RebindTypeSignatureViews();
+
+    other.pbBase = other.signature.empty() ? nullptr : other.signature.data();
+    other.len = static_cast<unsigned>(other.signature.size());
+    other.numberOfTypeArguments = 0;
+    other.numberOfArguments = 0;
+    other.returnValue = {};
+    other.params.clear();
+    other.RebindTypeSignatureViews();
+    return *this;
+}
+
+void FunctionMethodSignature::SetSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer)
+{
+    if (pb == nullptr || cbBuffer == 0)
+    {
+        signature.clear();
+        pbBase = nullptr;
+        len = 0;
+    }
+    else
+    {
+        signature.assign(pb, pb + cbBuffer);
+        pbBase = signature.data();
+        len = static_cast<unsigned>(signature.size());
+    }
+
+    numberOfTypeArguments = 0;
+    numberOfArguments = 0;
+    returnValue = {};
+    params.clear();
+    RebindTypeSignatureViews();
+}
+
+void FunctionMethodSignature::RebindTypeSignatureViews()
+{
+    returnValue.pbBase = pbBase;
+    for (auto& param : params)
+    {
+        param.pbBase = pbBase;
+    }
+}
+
 bool ParseByte(PCCOR_SIGNATURE& pbCur, PCCOR_SIGNATURE pbEnd, unsigned char* pbOut)
 {
     if (pbCur < pbEnd)
@@ -925,9 +1042,18 @@ bool ParseRetType(PCCOR_SIGNATURE& pbCur, PCCOR_SIGNATURE pbEnd)
 
 HRESULT FunctionMethodSignature::TryParse()
 {
+    if (pbBase == nullptr || len == 0)
+    {
+        return E_FAIL;
+    }
+
     PCCOR_SIGNATURE pbCur = pbBase;
     PCCOR_SIGNATURE pbEnd = pbBase + len;
     unsigned char elem_type;
+    ULONG parsedNumberOfTypeArguments = 0;
+    ULONG parsedNumberOfArguments = 0;
+    TypeSignature parsedReturnValue{};
+    std::vector<TypeSignature> parsedParams;
 
     IfFalseRetFAIL(ParseByte(pbCur, pbEnd, &elem_type));
 
@@ -935,19 +1061,19 @@ HRESULT FunctionMethodSignature::TryParse()
     {
         unsigned gen_param_count;
         IfFalseRetFAIL(ParseNumber(pbCur, pbEnd, &gen_param_count));
-        numberOfTypeArguments = gen_param_count;
+        parsedNumberOfTypeArguments = gen_param_count;
     }
 
     unsigned param_count;
     IfFalseRetFAIL(ParseNumber(pbCur, pbEnd, &param_count));
-    numberOfArguments = param_count;
+    parsedNumberOfArguments = param_count;
 
     const PCCOR_SIGNATURE pbRet = pbCur;
 
     IfFalseRetFAIL(ParseRetType(pbCur, pbEnd));
-    returnValue.pbBase = pbBase;
-    returnValue.length = (ULONG) (pbCur - pbRet);
-    returnValue.offset = (ULONG) (pbCur - pbBase - returnValue.length);
+    parsedReturnValue.pbBase = pbBase;
+    parsedReturnValue.length = (ULONG) (pbCur - pbRet);
+    parsedReturnValue.offset = (ULONG) (pbCur - pbBase - parsedReturnValue.length);
 
     auto fEncounteredSentinal = false;
     for (unsigned i = 0; i < param_count; i++)
@@ -971,9 +1097,13 @@ HRESULT FunctionMethodSignature::TryParse()
         argument.length = (ULONG)(pbCur - pbParam);
         argument.offset = (ULONG)(pbCur - pbBase - argument.length);
 
-        params.push_back(argument);
+        parsedParams.push_back(argument);
     }
 
+    numberOfTypeArguments = parsedNumberOfTypeArguments;
+    numberOfArguments = parsedNumberOfArguments;
+    returnValue = parsedReturnValue;
+    params = std::move(parsedParams);
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -1067,6 +1067,7 @@ HRESULT FunctionMethodSignature::TryParse()
     unsigned param_count;
     IfFalseRetFAIL(ParseNumber(pbCur, pbEnd, &param_count));
     parsedNumberOfArguments = param_count;
+    parsedParams.reserve(param_count);
 
     const PCCOR_SIGNATURE pbRet = pbCur;
 

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -5,6 +5,7 @@
 #include <corprof.h>
 #include <functional>
 #include <utility>
+#include <vector>
 
 #include "integration.h"
 
@@ -468,6 +469,8 @@ struct TypeSignature
 struct FunctionMethodSignature
 {
 private:
+    // Parsed TypeSignature entries are views into this owned metadata signature buffer.
+    std::vector<BYTE> signature;
     PCCOR_SIGNATURE pbBase;
     unsigned len;
     ULONG numberOfTypeArguments = 0;
@@ -475,13 +478,16 @@ private:
     TypeSignature returnValue{};
     std::vector<TypeSignature> params;
 
+    void RebindTypeSignatureViews();
+    void SetSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer);
+
 public:
-    FunctionMethodSignature() : pbBase(nullptr), len(0)
-    {
-    }
-    FunctionMethodSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer) : pbBase(pb), len(cbBuffer)
-    {
-    };
+    FunctionMethodSignature();
+    FunctionMethodSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer);
+    FunctionMethodSignature(const FunctionMethodSignature& other);
+    FunctionMethodSignature(FunctionMethodSignature&& other) noexcept;
+    FunctionMethodSignature& operator=(const FunctionMethodSignature& other);
+    FunctionMethodSignature& operator=(FunctionMethodSignature&& other) noexcept;
     ULONG NumberOfTypeArguments() const
     {
         return numberOfTypeArguments;
@@ -516,7 +522,7 @@ public:
         return len == 0;
     }
 
-    std::tuple<PCCOR_SIGNATURE, unsigned> GetFunctionSignatureAndLength()
+    std::tuple<PCCOR_SIGNATURE, unsigned> GetFunctionSignatureAndLength() const
     {
         return {pbBase, len};
     }

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -2135,7 +2135,8 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
 {
     ModuleID module_id = moduleHandler->GetModuleId();
     ModuleMetadata& module_metadata = *moduleHandler->GetModuleMetadata();
-    FunctionInfo* caller = methodHandler->GetFunctionInfo();
+    const auto callerHandle = methodHandler->GetFunctionInfo();
+    FunctionInfo* caller = callerHandle.get();
     DebuggerTokens* debuggerTokens = module_metadata.GetDebuggerTokens();
     mdToken function_token = caller->id;
     TypeSignature retFuncArg = caller->method_signature.GetReturnValue();

--- a/tracer/src/Datadog.Tracer.Native/fault_tolerant_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/fault_tolerant_rewriter.cpp
@@ -51,7 +51,8 @@ HRESULT FaultTolerantRewriter::ApplyKickoffInstrumentation(RejitHandlerModule* m
     m_rejit_handler->EnqueueRequestRejit(requests, promise);
     future.get();
 
-    FunctionInfo* caller = methodHandler->GetFunctionInfo();
+    const auto callerHandle = methodHandler->GetFunctionInfo();
+    FunctionInfo* caller = callerHandle.get();
     int numArgs = caller->method_signature.NumberOfArguments();
     bool isStatic = !(caller->method_signature.CallingConvention() & IMAGE_CEE_CS_CALLCONV_HASTHIS);
     TypeSignature retFuncArg = caller->method_signature.GetReturnValue();
@@ -416,7 +417,8 @@ HRESULT FaultTolerantRewriter::InjectSuccessfulInstrumentation(RejitHandlerModul
     const auto methodId = methodHandler->GetMethodDef();
     const auto instrumentationId = m_methodRewriter->GetInstrumentationId(moduleHandler, methodHandler);
     const auto instrumentingProduct = m_methodRewriter->GetInstrumentingProduct(moduleHandler, methodHandler);
-    FunctionInfo* caller = methodHandler->GetFunctionInfo();
+    const auto callerHandle = methodHandler->GetFunctionInfo();
+    FunctionInfo* caller = callerHandle.get();
     FaultTolerantTokens* faultTolerantTokens = moduleHandler->GetModuleMetadata()->GetFaultTolerantTokens();
     faultTolerantTokens->EnsureCorLibTokens();
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -19,7 +19,7 @@ RejitHandlerModuleMethod::RejitHandlerModuleMethod(mdMethodDef methodDef, RejitH
     m_methodDef(methodDef),
     m_module(module),
     m_pFunctionControl(nullptr),
-    m_functionInfo(std::make_unique<FunctionInfo>(functionInfo)),
+    m_functionInfo(std::make_shared<FunctionInfo>(functionInfo)),
     m_methodRewriter(std::move(methodRewriter))
 {
 }
@@ -34,14 +34,17 @@ RejitHandlerModule* RejitHandlerModuleMethod::GetModule()
     return m_module;
 }
 
-FunctionInfo* RejitHandlerModuleMethod::GetFunctionInfo()
+std::shared_ptr<FunctionInfo> RejitHandlerModuleMethod::GetFunctionInfo()
 {
-    return m_functionInfo.get();
+    std::lock_guard<std::mutex> guard(m_functionInfoLock);
+    return m_functionInfo;
 }
 
 void RejitHandlerModuleMethod::SetFunctionInfo(const FunctionInfo& functionInfo)
 {
-    m_functionInfo = std::make_unique<FunctionInfo>(functionInfo);
+    auto next = std::make_shared<FunctionInfo>(functionInfo);
+    std::lock_guard<std::mutex> guard(m_functionInfoLock);
+    m_functionInfo = std::move(next);
 }
 
 bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId)

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -35,7 +35,11 @@ private:
 protected:
     mdMethodDef m_methodDef;
     ICorProfilerFunctionControl* m_pFunctionControl;
-    std::unique_ptr<FunctionInfo> m_functionInfo;
+    // Stored as shared_ptr so callers can pin the snapshot for the duration of their work even if
+    // SetFunctionInfo races with them. Set swaps in a fresh instance, leaving any in-flight
+    // readers' shared_ptr (and the underlying FunctionInfo) intact until the last reader drops it.
+    std::shared_ptr<FunctionInfo> m_functionInfo;
+    std::mutex m_functionInfoLock;
 
     RejitHandlerModule* m_module;
 
@@ -45,7 +49,7 @@ public:
     mdMethodDef GetMethodDef();
     RejitHandlerModule* GetModule();
 
-    FunctionInfo* GetFunctionInfo();
+    std::shared_ptr<FunctionInfo> GetFunctionInfo();
     void SetFunctionInfo(const FunctionInfo& functionInfo);
 
     bool RequestRejitForInlinersInModule(ModuleID moduleId);

--- a/tracer/src/Datadog.Tracer.Native/tracer_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/tracer_method_rewriter.cpp
@@ -105,7 +105,11 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     ModuleID module_id = moduleHandler->GetModuleId();
     ModuleMetadata& module_metadata = *moduleHandler->GetModuleMetadata();
-    FunctionInfo* caller = methodHandler->GetFunctionInfo();
+    // Pin the FunctionInfo snapshot for the lifetime of this call. SetFunctionInfo on the same
+    // handler can swap in a new instance concurrently; holding the shared_ptr keeps our snapshot
+    // alive even if that happens (or if module/method teardown races with us).
+    const auto callerHandle = methodHandler->GetFunctionInfo();
+    FunctionInfo* caller = callerHandle.get();
     TracerTokens* tracerTokens = module_metadata.GetTracerTokens();
     tracerTokens->SetCorProfilerInfo(m_corProfiler->info_);
     mdToken function_token = caller->id;

--- a/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
@@ -4,6 +4,7 @@
 #include "test_helpers.h"
 #include "../../../shared/src/native-src/pal.h"
 
+#include <tuple>
 #include <vector>
 
 using namespace trace;
@@ -307,6 +308,54 @@ TEST_F(CLRHelperTest, TypeSignatureGetTypeTokName) {
 
     EXPECT_EQ(actual, expected);
   }
+}
+
+TEST_F(CLRHelperTest, FunctionMethodSignatureOwnsSignatureBytesAndRebindsCopiedViews) {
+  COR_SIGNATURE rawSignature[] = {
+      IMAGE_CEE_CS_CALLCONV_DEFAULT,
+      0x01,
+      ELEMENT_TYPE_I4,
+      ELEMENT_TYPE_STRING};
+
+  FunctionMethodSignature original(rawSignature, sizeof(rawSignature));
+  ASSERT_EQ(original.TryParse(), S_OK);
+
+  FunctionMethodSignature copy = original;
+
+  PCCOR_SIGNATURE originalSignature = nullptr;
+  PCCOR_SIGNATURE copySignature = nullptr;
+  auto originalSignatureLength = 0u;
+  auto copySignatureLength = 0u;
+  std::tie(originalSignature, originalSignatureLength) = original.GetFunctionSignatureAndLength();
+  std::tie(copySignature, copySignatureLength) = copy.GetFunctionSignatureAndLength();
+
+  ASSERT_NE(originalSignature, nullptr);
+  ASSERT_NE(copySignature, nullptr);
+  EXPECT_NE(originalSignature, copySignature);
+  EXPECT_EQ(originalSignatureLength, sizeof(rawSignature));
+  EXPECT_EQ(copySignatureLength, sizeof(rawSignature));
+
+  PCCOR_SIGNATURE copyReturnSignature = nullptr;
+  auto copyReturnSignatureLength = copy.GetReturnValue().GetSignature(copyReturnSignature);
+  ASSERT_NE(copyReturnSignature, nullptr);
+  EXPECT_EQ(copyReturnSignature, copySignature + 2);
+  EXPECT_EQ(copyReturnSignatureLength, 1);
+
+  const auto& copyArguments = copy.GetMethodArguments();
+  ASSERT_EQ(copyArguments.size(), 1);
+
+  PCCOR_SIGNATURE copyArgumentSignature = nullptr;
+  auto copyArgumentSignatureLength = copyArguments[0].GetSignature(copyArgumentSignature);
+  ASSERT_NE(copyArgumentSignature, nullptr);
+  EXPECT_EQ(copyArgumentSignature, copySignature + 3);
+  EXPECT_EQ(copyArgumentSignatureLength, 1);
+
+  rawSignature[2] = ELEMENT_TYPE_VOID;
+  rawSignature[3] = ELEMENT_TYPE_OBJECT;
+
+  EXPECT_EQ(std::get<unsigned>(original.GetReturnValue().GetElementTypeAndFlags()), ELEMENT_TYPE_I4);
+  EXPECT_EQ(std::get<unsigned>(copy.GetReturnValue().GetElementTypeAndFlags()), ELEMENT_TYPE_I4);
+  EXPECT_EQ(std::get<unsigned>(copyArguments[0].GetElementTypeAndFlags()), ELEMENT_TYPE_STRING);
 }
 
 TEST_F(CLRHelperTest, FunctionLocalSignatureTryParse) {


### PR DESCRIPTION
## Summary of changes

Fix two lifetime hazards in the native rewriter that can lead to use-after-free crashes when reading `FunctionInfo` during ReJIT.

## Reason for change

Production crash on Linux: `SIGSEGV` inside `__memcpy_avx_unaligned_erms` while formatting an `Logger::Info` line at `tracer_method_rewriter.cpp:785`. The crashing thread was reading `caller->type.name` after a successful `rewriter.Export()`, suggesting the `FunctionInfo` (or its inner signature buffer) was being invalidated mid-rewrite.

Two underlying problems:

1. `RejitHandlerModuleMethod` stored `FunctionInfo` in a `unique_ptr` and handed out raw pointers. `SetFunctionInfo` reseated the `unique_ptr` with no synchronization, so any concurrent reader's pointer could dangle.
2. `FunctionMethodSignature::pbBase` pointed into module metadata, not an owned buffer. After module unload, parsed `TypeSignature` views inside the snapshot would walk freed memory.

## Implementation details

**Snapshot lifetime (`rejit_handler.{h,cpp}`)**
- `m_functionInfo`: `unique_ptr<FunctionInfo>` -> `shared_ptr<FunctionInfo>`, guarded by a new `m_functionInfoLock` mutex.
- `GetFunctionInfo()` returns a copy of the `shared_ptr`; callers pin the snapshot for the duration of their work.
- `SetFunctionInfo()` builds the replacement outside the lock, then atomically swaps under it. In-flight readers are unaffected; the old instance survives until the last share is dropped.
- Rewriter call sites (`tracer_method_rewriter`, `debugger_method_rewriter`, `fault_tolerant_rewriter`) bind a local handle so the raw `caller` pointer remains valid for the whole function.

**Signature ownership (`clr_helpers.{h,cpp}`)**
- `FunctionMethodSignature` now owns a `std::vector<BYTE> signature`; the `(pb, cbBuffer)` constructor deep-copies metadata bytes into it.
- Added copy/move constructors and assignment operators that rebind `pbBase` and every parsed `TypeSignature` view to the owned buffer.
- `TryParse()` writes results to locals and commits only on success; partial parses no longer leave the object inconsistent.

## Test coverage

- New `FunctionMethodSignatureOwnsSignatureBytesAndRebindsCopiedViews` GoogleTest case constructs a signature, copies it, mutates the source bytes, and asserts both original and copy still parse correctly with views pointing into their own buffers.

## Other details
<!-- Fixes #{issue} -->

Generated from `/analyze-crash`.

Sent it through some local reviews, but hopefully it makes sense 😅 

https://app.datadoghq.com/error-tracking/issue/1be45ba2-41be-11f1-a1aa-da7ad0900002


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
