### PR TITLE
Migrate remaining integration tests to CombinatorialOrPairwiseData

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
@@ -27,11 +28,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
         {
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.AwsKinesis
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.Tags["span.kind"] switch
         {
             SpanKinds.Producer => span.IsAwsKinesisOutbound(),
@@ -39,9 +35,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
         };
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitsDsmMetrics(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsDsmMetrics(
+            [PackageVersionData(nameof(PackageVersions.AwsKinesis))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
             SetEnvironmentVariable(ConfigurationKeys.PropagateProcessTags, "0");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/OracleTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/OracleTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -27,18 +28,13 @@ public class OracleTests : TracingIntegrationTest
         SetServiceVersion("1.0.0");
     }
 
-    public static IEnumerable<object[]> GetEnabledConfig()
-    {
-        return from metadataSchemaVersion in new[] { "v0", "v1" }
-               from propagation in new[] { string.Empty, "service", "full" }
-               select new[] { metadataSchemaVersion, propagation };
-    }
-
     [SkippableTheory]
-    [MemberData(nameof(GetEnabledConfig))]
+    [CombinatorialOrPairwiseData]
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "ArmUnsupported")] // the docker image used doesn't work on arm64. It can still be tested on Mac using colima, see https://github.com/abiosoft/colima
-    public async Task SubmitsTraces(string metadataSchemaVersion, string dbmPropagation)
+    public async Task SubmitsTraces(
+        [MetadataSchemaVersionData] string metadataSchemaVersion,
+        [CombinatorialValues("", "service", "full")] string dbmPropagation)
     {
         SetEnvironmentVariable("DD_DBM_PROPAGATION_MODE", dbmPropagation);
         SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
@@ -30,18 +31,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             ConfigureContainers(aerospikeFixture);
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.Aerospike
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsAerospike(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task SubmitTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTraces(
+            [PackageVersionData(nameof(PackageVersions.Aerospike))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -3,15 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Datadog.Trace.Configuration;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
-using FluentAssertions;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -32,35 +28,36 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> TestData
-            => from behaviour in (AgentBehaviour[])Enum.GetValues(typeof(AgentBehaviour))
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new object[] { behaviour, metadataSchemaVersion };
-
         [SkippableTheory]
-        [MemberData(nameof(TestData))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Flaky("Named pipes is flaky", maxRetries: 3)]
-        public Task NamedPipes_SubmitsTraces(AgentBehaviour behaviour, string metadataSchemaVersion)
+        public Task NamedPipes_SubmitsTraces(
+            AgentBehaviour behaviour,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
             return SubmitsTraces(behaviour, TestTransports.WindowsNamedPipe, metadataSchemaVersion);
         }
 
         [SkippableTheory]
-        [MemberData(nameof(TestData))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public Task Tcp_SubmitsTraces(AgentBehaviour behaviour, string metadataSchemaVersion)
+        public Task Tcp_SubmitsTraces(
+            AgentBehaviour behaviour,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
             => SubmitsTraces(behaviour, TestTransports.Tcp, metadataSchemaVersion);
 
 #if NETCOREAPP3_1_OR_GREATER
         [SkippableTheory]
-        [MemberData(nameof(TestData))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public Task Uds_SubmitsTraces(AgentBehaviour behaviour, string metadataSchemaVersion)
+        public Task Uds_SubmitsTraces(
+            AgentBehaviour behaviour,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
             => SubmitsTraces(behaviour, TestTransports.Uds, metadataSchemaVersion);
 #endif
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventHubsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventHubsTests.cs
@@ -27,17 +27,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         {
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.AzureEventHubs
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
-        public static IEnumerable<object[]> GetEnabledConfigWithMessageCount()
-            => from packageVersionArray in PackageVersions.AzureEventHubs
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               from messageCount in new[] { 1, 3 }
-               select new object[] { packageVersionArray[0], metadataSchemaVersion, messageCount };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.Tags["span.kind"] switch
         {
             SpanKinds.Consumer => span.IsAzureEventHubsInbound(metadataSchemaVersion),
@@ -47,9 +36,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         };
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestEventHubsMessageBatchIntegration(string packageVersion, string metadataSchemaVersion)
+        public async Task TestEventHubsMessageBatchIntegration(
+            [PackageVersionData(nameof(PackageVersions.AzureEventHubs))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZUREEVENTHUBS_ENABLED", "true");
@@ -89,9 +80,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfigWithMessageCount))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestEventHubsEnumerableIntegration(string packageVersion, string metadataSchemaVersion, int messageCount)
+        public async Task TestEventHubsEnumerableIntegration(
+            [PackageVersionData(nameof(PackageVersions.AzureEventHubs))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion,
+            [CombinatorialValues(1, 3)] int messageCount)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZUREEVENTHUBS_ENABLED", "true");
@@ -126,9 +120,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestEventHubsMessageBatchIntegrationWithoutBatchLinks(string packageVersion, string metadataSchemaVersion)
+        public async Task TestEventHubsMessageBatchIntegrationWithoutBatchLinks(
+            [PackageVersionData(nameof(PackageVersions.AzureEventHubs))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZUREEVENTHUBS_ENABLED", "true");
@@ -162,9 +158,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfigWithMessageCount))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestEventHubsEnumerableIntegrationWithoutBatchLinks(string packageVersion, string metadataSchemaVersion, int messageCount)
+        public async Task TestEventHubsEnumerableIntegrationWithoutBatchLinks(
+            [PackageVersionData(nameof(PackageVersions.AzureEventHubs))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion,
+            [CombinatorialValues(1, 3)] int messageCount)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZUREEVENTHUBS_ENABLED", "true");
@@ -202,9 +201,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestEventHubsBufferedProducerIntegration(string packageVersion, string metadataSchemaVersion)
+        public async Task TestEventHubsBufferedProducerIntegration(
+            [PackageVersionData(nameof(PackageVersions.AzureEventHubs))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZUREEVENTHUBS_ENABLED", "true");
@@ -244,9 +245,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestEventHubsBufferedProducerIntegrationWithoutBatchLinks(string packageVersion, string metadataSchemaVersion)
+        public async Task TestEventHubsBufferedProducerIntegrationWithoutBatchLinks(
+            [PackageVersionData(nameof(PackageVersions.AzureEventHubs))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZUREEVENTHUBS_ENABLED", "true");
@@ -283,9 +286,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestEventHubsIntegrationDisabled(string packageVersion, string metadataSchemaVersion)
+        public async Task TestEventHubsIntegrationDisabled(
+            [PackageVersionData(nameof(PackageVersions.AzureEventHubs))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZUREEVENTHUBS_ENABLED", "false");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusAPMTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusAPMTests.cs
@@ -32,11 +32,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         {
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.AzureServiceBusAPM
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.Tags["span.kind"] switch
         {
             SpanKinds.Consumer => span.IsAzureServiceBusInboundAPM(metadataSchemaVersion),
@@ -46,9 +41,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         };
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestSendMessagesAsyncIntegration(string packageVersion, string metadataSchemaVersion)
+        public async Task TestSendMessagesAsyncIntegration(
+            [PackageVersionData(nameof(PackageVersions.AzureServiceBusAPM))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZURESERVICEBUS_ENABLED", "true");
@@ -84,9 +81,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestReceiveMessagesAsyncIntegration(string packageVersion, string metadataSchemaVersion)
+        public async Task TestReceiveMessagesAsyncIntegration(
+            [PackageVersionData(nameof(PackageVersions.AzureServiceBusAPM))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZURESERVICEBUS_ENABLED", "true");
@@ -117,9 +116,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestReceiveMessagesAsyncIntegrationMultiple(string packageVersion, string metadataSchemaVersion)
+        public async Task TestReceiveMessagesAsyncIntegrationMultiple(
+            [PackageVersionData(nameof(PackageVersions.AzureServiceBusAPM))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZURESERVICEBUS_ENABLED", "true");
@@ -150,9 +151,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestServiceBusMessageBatchIntegration(string packageVersion, string metadataSchemaVersion)
+        public async Task TestServiceBusMessageBatchIntegration(
+            [PackageVersionData(nameof(PackageVersions.AzureServiceBusAPM))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZURESERVICEBUS_ENABLED", "true");
@@ -209,9 +212,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestServiceBusMessageBatchIntegrationWithoutBatchLinks(string packageVersion, string metadataSchemaVersion)
+        public async Task TestServiceBusMessageBatchIntegrationWithoutBatchLinks(
+            [PackageVersionData(nameof(PackageVersions.AzureServiceBusAPM))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZURESERVICEBUS_ENABLED", "true");
@@ -257,9 +262,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task TestScheduleMessagesAsyncIntegration(string packageVersion, string metadataSchemaVersion)
+        public async Task TestScheduleMessagesAsyncIntegration(
+            [PackageVersionData(nameof(PackageVersions.AzureServiceBusAPM))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("DD_TRACE_AZURESERVICEBUS_ENABLED", "true");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
@@ -28,11 +28,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         {
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.AzureServiceBus
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.Tags["span.kind"] switch
         {
             SpanKinds.Consumer => span.IsAzureServiceBusInbound(metadataSchemaVersion),
@@ -42,10 +37,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         };
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("SkipInCI", "True")] // We are unable to test all the features of Azure Service Bus with an emulator. For now, run only locally with a connection string to a live Azure Service Bus namespace
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.AzureServiceBus))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -27,21 +28,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.CosmosDb
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsCosmosDb(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "LinuxUnsupported")]
         [Trait("Category", "ArmUnsupported")]
         [Trait("SkipInCI", "True")] // Cosmos emulator is too flaky in CI at the moment
-        public async Task SubmitTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTraces(
+            [PackageVersionData(nameof(PackageVersions.CosmosDb))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             var expectedSpanCount = 14;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosVnextTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosVnextTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -30,18 +31,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.CosmosDbVnext
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsCosmosDb(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         // vnext emulator only supports queries on items
-        public async Task SubmitTracesQuery(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTracesQuery(
+            [PackageVersionData(nameof(PackageVersions.CosmosDbVnext))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             var expectedSpanCount = 4;
 
@@ -70,9 +68,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitTracesCRUD(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTracesCRUD(
+            [PackageVersionData(nameof(PackageVersions.CosmosDbVnext))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             var expectedSpanCount = 9;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosVnextTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosVnextTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -30,18 +31,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.CosmosDbVnext
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsCosmosDb(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         // vnext emulator only supports queries on items
-        public async Task SubmitTracesQuery(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTracesQuery(
+            [PackageVersionData(nameof(PackageVersions.CosmosDbVnext))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             var expectedSpanCount = 13;
 
@@ -70,9 +68,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitTracesCRUD(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTracesCRUD(
+            [PackageVersionData(nameof(PackageVersions.CosmosDbVnext))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             var expectedSpanCount = 9;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions.Execution;
@@ -28,18 +29,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.Couchbase3
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsCouchbase(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task SubmitTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTraces(
+            [PackageVersionData(nameof(PackageVersions.Couchbase3))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
@@ -24,18 +25,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.Couchbase
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsCouchbase(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.Couchbase))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
@@ -30,18 +31,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.ElasticSearch5
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsElasticsearchNet(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.ElasticSearch5))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
@@ -30,18 +31,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.ElasticSearch6
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsElasticsearchNet(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.ElasticSearch6))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using VerifyXunit;
@@ -29,17 +30,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.ElasticSearch7
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsElasticsearchNet(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.ElasticSearch7))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GoogleProtobufTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GoogleProtobufTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -27,22 +28,17 @@ public class GoogleProtobufTests : TracingIntegrationTest
     {
     }
 
-    public static IEnumerable<object[]> GetEnabledConfig()
-    {
-        return from metadataSchemaVersion in new[] { "v0", "v1" }
-               from packageVersionArray in PackageVersions.Protobuf
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-    }
-
     public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion)
     {
         return span.IsProtobuf(metadataSchemaVersion);
     }
 
     [SkippableTheory]
-    [MemberData(nameof(GetEnabledConfig))]
+    [CombinatorialOrPairwiseData]
     [Trait("Category", "EndToEnd")]
-    public async Task TagTraces(string packageVersion, string metadataSchemaVersion)
+    public async Task TagTraces(
+        [PackageVersionData(nameof(PackageVersions.Protobuf))] string packageVersion,
+        [MetadataSchemaVersionData] string metadataSchemaVersion)
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
         using var telemetry = this.ConfigureTelemetry();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -44,11 +45,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.Kafka
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) =>
             span.Tags["span.kind"] switch
             {
@@ -58,11 +54,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             };
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
         [Flaky("Kafka SubmitsTraces is flaky", maxRetries: 3)]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.Kafka))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             var topic = $"sample-topic-{TestPrefix}-{packageVersion}".Replace('.', '-');
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -35,17 +36,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.MongoDB
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsMongoDb(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.MongoDB))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
@@ -30,11 +31,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.RabbitMQ
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) =>
             span.Tags["span.kind"] switch
             {
@@ -45,9 +41,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             };
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitTraces(
+            [PackageVersionData(nameof(PackageVersions.RabbitMQ))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
 #if NET6_0_OR_GREATER
             if (packageVersion?.StartsWith("3.") == true)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
@@ -29,17 +30,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.ServiceStackRedis
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsServiceStackRedis(metadataSchemaVersion);
 
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.ServiceStackRedis))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -45,18 +46,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // ReSharper restore InconsistentNaming
         }
 
-        public static IEnumerable<object[]> GetEnabledConfig()
-            => from packageVersionArray in PackageVersions.StackExchangeRedis
-               from metadataSchemaVersion in new[] { "v0", "v1" }
-               select new[] { packageVersionArray[0], metadataSchemaVersion };
-
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsStackExchangeRedis(metadataSchemaVersion);
 
         [Flaky("The PING_REPLICA sometimes invokes the master server instead. We believe it's infrastructure related", maxRetries: 3)]
         [SkippableTheory]
-        [MemberData(nameof(GetEnabledConfig))]
+        [CombinatorialOrPairwiseData]
         [Trait("Category", "EndToEnd")]
-        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(
+            [PackageVersionData(nameof(PackageVersions.StackExchangeRedis))] string packageVersion,
+            [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";


### PR DESCRIPTION
## Summary of changes

Migrates (what I think are) the remaining integration tests to use CombinatorialOrPairwiseData with the goal of speeding up PR CI runs with the hope of not missing regressions

## Reason for change

As we have many tests our CI takes time running them, this aims to reduce some pressure as if a PR meets the criteria for running in Pairwise mode we will swap from combinatorial to pairwise for all of these integrations tests.

This will hopefully reduce times for runs that _likely_ won't modify / impact these tests.

## Implementation details

  One commit per file with the following pattern(s):

  - Drop `GetEnabledConfig()` and the matching `[MemberData(...)]`
    -   Replace with `[CombinatorialOrPairwiseData]`
  - Add Attributes : `[PackageVersionData(nameof(PackageVersions.X))]` and `[MetadataSchemaVersionData]`

Note that some tests needed a few more changes.

## Test coverage

Less!

Same though on non-PR runs or on PR runs that end up on the thorough testing.

## Other details
<!-- Fixes #{issue} -->

I have a planned follow up to reduce the V1 Schema tests that are run in general (the V0/V1 split causes most tests to be doubled for no real benefit as the move to the V1 schema has largely been replaced)

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
