### PR TITLE
Update `UpdateVendors` tool to allow vendoring non-C# code

### DIFF
--- a/shared/src/native-lib/spdlog/include/spdlog/_last_downloaded_source_url.txt
+++ b/shared/src/native-lib/spdlog/include/spdlog/_last_downloaded_source_url.txt
@@ -1,0 +1,1 @@
+https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.zip

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -381,7 +381,7 @@ partial class Build
             var vendorDirectory = Solution.GetProject(Projects.DatadogTrace).Directory / "Vendors";
             var downloadDirectory = TemporaryDirectory / "Downloads";
             EnsureCleanDirectory(downloadDirectory);
-            await UpdateVendorsTool.UpdateVendors(downloadDirectory, vendorDirectory);
+            await UpdateVendorsTool.UpdateVendors(downloadDirectory, RootDirectory, vendorDirectory);
        });
 
     Target UpdateVersion => _ => _

--- a/tracer/build/_build/Honeypot/DependabotFileManager.cs
+++ b/tracer/build/_build/Honeypot/DependabotFileManager.cs
@@ -21,7 +21,7 @@ namespace Honeypot
         {
             var fakeRefs = string.Empty;
 
-            foreach (var dependency in VendoredDependency.All)
+            foreach (var dependency in VendoredDependency.All.Where(x => x.IsNuGetPackage))
             {
                 fakeRefs += $@"{Environment.NewLine}    <!-- https://www.nuget.org/packages/{dependency.LibraryName}/{dependency.Version} -->";
                 fakeRefs += $@"{Environment.NewLine}    <PackageReference Include=""{dependency.LibraryName}"" Version=""{dependency.Version}"" />{Environment.NewLine}";

--- a/tracer/build/_build/UpdateVendors/UpdateVendors.cs
+++ b/tracer/build/_build/UpdateVendors/UpdateVendors.cs
@@ -18,25 +18,29 @@ namespace UpdateVendors
     {
         public static async Task UpdateVendors(
             AbsolutePath downloadDirectory,
-            AbsolutePath vendorDirectory)
+            AbsolutePath rootDirectory,
+            AbsolutePath defaultVendorDirectory)
         {
             foreach (var dependency in VendoredDependency.All)
             {
-                await UpdateVendor(dependency, downloadDirectory, vendorDirectory);
+                await UpdateVendor(dependency, downloadDirectory, rootDirectory, defaultVendorDirectory);
             }
         }
 
-        private static async Task UpdateVendor(VendoredDependency dependency, AbsolutePath downloadDirectory, AbsolutePath vendorDirectory)
+        private static async Task UpdateVendor(VendoredDependency dependency, AbsolutePath downloadDirectory, AbsolutePath rootDirectory, AbsolutePath defaultVendorDirectory)
         {
             var libraryName = dependency.LibraryName;
             var downloadUrl = dependency.DownloadUrl;
             var pathToSrc = dependency.PathToSrc;
 
             Console.WriteLine($"Starting {libraryName} upgrade.");
+            var vendorDirectory = dependency.RelativePathToVendorDirectoryOverride is not null
+                ? rootDirectory / dependency.RelativePathToVendorDirectoryOverride
+                : defaultVendorDirectory;
 
             var zipLocation = Path.Combine(downloadDirectory, $"{libraryName}.zip");
             var extractLocation = Path.Combine(downloadDirectory, $"{libraryName}");
-            var vendorFinalPath = Path.Combine(vendorDirectory, libraryName);
+            var vendorFinalPath = vendorDirectory / libraryName;
             var sourceUrlLocation = Path.Combine(vendorFinalPath, "_last_downloaded_source_url.txt");
 
             // Ensure the url has changed, or don't bother upgrading

--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -426,6 +426,8 @@ namespace UpdateVendors
 
         public RelativePath RelativePathToVendorDirectoryOverride { get; set; }
 
+        public bool IsNuGetPackage { get; set; }
+
         private static void Add(
             string libraryName,
             string version,
@@ -434,7 +436,8 @@ namespace UpdateVendors
             Action<string> transform,
             string[] relativePathsToExclude = null,
             string[] onlyIncludePaths = null,
-            RelativePath relatePathToVendorDirectoryOverride = null)
+            RelativePath relativePathToVendorDirectoryOverride = null,
+            bool isNuGetPackage = true)
         {
             All.Add(new VendoredDependency()
             {
@@ -445,7 +448,8 @@ namespace UpdateVendors
                 Transform = transform,
                 RelativePathsToExclude = relativePathsToExclude ?? Array.Empty<string>(),
                 OnlyIncludeRelativePaths = onlyIncludePaths,
-                RelatePathToVendorDirectoryOverride = relatePathToVendorDirectoryOverride,
+                RelativePathToVendorDirectoryOverride = relativePathToVendorDirectoryOverride,
+                IsNuGetPackage = isNuGetPackage,
             });
         }
 

--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -397,6 +397,15 @@ namespace UpdateVendors
                     "OtlpTraceExporter.cs",
                     "OtlpTraceExporterHelperExtensions.cs"
                 });
+
+            Add(
+                libraryName: "spdlog",
+                version: "1.11.0",
+                downloadUrl: "https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.zip",
+                pathToSrc: new[] {"spdlog-1.11.0", "include", "spdlog"},
+                transform: filePath => { },
+                relativePathToVendorDirectoryOverride: (RelativePath) "shared/src/native-lib/spdlog/include",
+                isNuGetPackage: false);
         }
 
         public static List<VendoredDependency> All { get; set; } = new List<VendoredDependency>();

--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using Nuke.Common.IO;
 
 namespace UpdateVendors
 {
@@ -414,6 +415,8 @@ namespace UpdateVendors
 
         public string[] OnlyIncludeRelativePaths { get; set; }
 
+        public RelativePath RelativePathToVendorDirectoryOverride { get; set; }
+
         private static void Add(
             string libraryName,
             string version,
@@ -421,7 +424,8 @@ namespace UpdateVendors
             string[] pathToSrc,
             Action<string> transform,
             string[] relativePathsToExclude = null,
-            string[] onlyIncludePaths = null)
+            string[] onlyIncludePaths = null,
+            RelativePath relatePathToVendorDirectoryOverride = null)
         {
             All.Add(new VendoredDependency()
             {
@@ -432,6 +436,7 @@ namespace UpdateVendors
                 Transform = transform,
                 RelativePathsToExclude = relativePathsToExclude ?? Array.Empty<string>(),
                 OnlyIncludeRelativePaths = onlyIncludePaths,
+                RelatePathToVendorDirectoryOverride = relatePathToVendorDirectoryOverride,
             });
         }
 


### PR DESCRIPTION
## Summary of changes

- Update the `UpdateVendors` tool to allow outputting to arbitrary directory
- Allow opting-out of "NuGet dependabot honeypot file"
- Add spdlog to the list of vendored deps

## Reason for change

We want to update spdlog. The update was done manually in https://github.com/DataDog/dd-trace-dotnet/pull/4044, but using the existing infrastructure seems preferable.

Note that this PR _doesn't_ bump the dependency, it just sets up the infrastructure to make it easy.

## Implementation details

- Add `RelativePathToVendorDirectoryOverride` to allow vendoring to arbitrary directory
- Add `IsNuGetPackage` to allow opt-out of the NuGet dependabot file
- Add reference for vendored spdlog code

## Test coverage

Ran the tool, and it updated spdlog, but the code was the same

## Other details

We'll bump the spdlog version in a subsequent PR