### PR TITLE
fix(profiler): minor fixes from agent analysis

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -58,10 +58,10 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
-    if (current != nullptr)
+    if (_handler != nullptr)
     {
-        assert(current == handler);
-        return current == handler;
+        assert(_handler == handler);
+        return _handler == handler;
     }
 
     _isHandlerInPlace = SetupSignalHandler();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
@@ -75,7 +75,7 @@ AdaptiveSampler::AdaptiveSampler(
     _samplesPerWindow = samplesPerWindow;
     _budgetLookback = budgetLookback;
 
-    _samplesBudget = samplesPerWindow + (static_cast<int64_t>(budgetLookback) * samplesPerWindow);
+    _samplesBudget.store(samplesPerWindow + (static_cast<int64_t>(budgetLookback) * samplesPerWindow), std::memory_order_relaxed);
     _emaAlpha = ComputeIntervalAlpha(averageLookback);
     _budgetAlpha = ComputeIntervalAlpha(budgetLookback);
 
@@ -97,9 +97,9 @@ bool AdaptiveSampler::Sample()
     auto* counts = _countsRef.load();
     counts->AddTest();
 
-    if (NextDouble() < _probability)
+    if (NextDouble() < _probability.load(std::memory_order_relaxed))
     {
-        return counts->AddSample(_samplesBudget);
+        return counts->AddSample(_samplesBudget.load(std::memory_order_relaxed));
     }
 
     return false;
@@ -161,7 +161,7 @@ void AdaptiveSampler::RollWindow()
     const auto totalCount = counts.TestCount();
     const auto sampledCount = counts.SampleCount();
 
-    _samplesBudget = CalculateBudgetEma(sampledCount);
+    _samplesBudget.store(CalculateBudgetEma(sampledCount), std::memory_order_relaxed);
 
     if (_totalCountRunningAverage == 0 || _emaAlpha <= 0.0)
     {
@@ -174,11 +174,11 @@ void AdaptiveSampler::RollWindow()
 
     if (_totalCountRunningAverage <= 0)
     {
-        _probability = 1;
+        _probability.store(1.0, std::memory_order_relaxed);
     }
     else
     {
-        _probability = std::min(_samplesBudget / _totalCountRunningAverage, 1.0);
+        _probability.store(std::min(_samplesBudget.load(std::memory_order_relaxed) / _totalCountRunningAverage, 1.0), std::memory_order_relaxed);
     }
 
     counts.Reset();
@@ -197,8 +197,8 @@ AdaptiveSampler::State AdaptiveSampler::GetInternalState()
     return State{
         counts->TestCount(),
         counts->SampleCount(),
-        _samplesBudget,
-        _probability,
+        _samplesBudget.load(std::memory_order_relaxed),
+        _probability.load(std::memory_order_relaxed),
         _totalCountRunningAverage};
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.h
@@ -54,8 +54,8 @@ private:
 
     std::atomic<Counts*> _countsRef;
 
-    volatile double _probability = 1;
-    volatile int64_t _samplesBudget;
+    std::atomic<double> _probability{1.0};
+    std::atomic<int64_t> _samplesBudget{0};
 
     double _totalCountRunningAverage;
     double _avgSamples;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -18,6 +18,7 @@
 #include "Sample.h"
 #include "SampleValueTypeProvider.h"
 
+#include <atomic>
 #include <math.h>
 
 using namespace std::chrono_literals;
@@ -192,7 +193,7 @@ void ContentionProvider::AddContentionSample(
 
     // Synchronous case where the current thread is the contended thread
     // (i.e. receiving the contention events directly from ICorProfilerCallback)
-    static uint64_t failureCount = 0;
+    static std::atomic<uint64_t> failureCount{0};
     if ((timestamp == 0ns) && (threadId == -1) && stack.empty())
     {
         auto threadInfo = ManagedThreadInfo::CurrentThreadInfo;
@@ -208,11 +209,9 @@ void ContentionProvider::AddContentionSample(
 
         uint32_t hrCollectStack = E_FAIL;
         const auto result = pStackFramesCollector->CollectStackSample(threadInfo.get(), &hrCollectStack);
-        if ((result->GetFramesCount() == 0) && (failureCount % 1000 == 0))
+        if ((result->GetFramesCount() == 0) && (failureCount.fetch_add(1) % 1000 == 0))
         {
-            // log every 1000 failures
-            failureCount++;
-            Log::Info("Failed to walk ", failureCount, " stacks for sampled contention: ", HResultConverter::ToStringWithCode(hrCollectStack));
+            Log::Info("Failed to walk ", failureCount.load(), " stacks for sampled contention: ", HResultConverter::ToStringWithCode(hrCollectStack));
             return;
         }
 
@@ -229,11 +228,9 @@ void ContentionProvider::AddContentionSample(
     // CLR events are received asynchronously from the Agent
     {
         // avoid the case where the ClrStackWalk event has been missed for the ContentionStart
-        if ((stack.size() == 0) && (failureCount % 1000 == 0))
+        if ((stack.size() == 0) && (failureCount.fetch_add(1) % 1000 == 0))
         {
-            // log every 1000 failures
-            failureCount++;
-            Log::Info("Failed to get ", failureCount, " call stacks for sampled contention");
+            Log::Info("Failed to get ", failureCount.load(), " call stacks for sampled contention");
             return;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
@@ -314,6 +314,10 @@ std::vector<CodeRange> ManagedCodeCache::GetCodeRanges(FunctionID functionId)
     result.reserve(nbCodeInfos);
     for (ULONG32 i = 0; i < nbCodeInfos; i++)
     {
+        if (codeInfos[i].size == 0)
+        {
+            continue;
+        }
         result.emplace_back(
             codeInfos[i].startAddress,
             codeInfos[i].startAddress + codeInfos[i].size - 1,

--- a/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
@@ -5,6 +5,9 @@
 
 #include "gtest/gtest.h"
 
+#include <thread>
+#include <vector>
+
 using namespace std::chrono_literals;
 
 constexpr std::chrono::seconds WindowDuration = 1s;
@@ -119,4 +122,53 @@ TEST(AdaptiveSamplerTest, TestStop)
     sampler.Stop();
 
     ASSERT_FALSE(callbackCalled);
+}
+
+// Regression test: _probability and _samplesBudget were declared `volatile`
+// instead of `std::atomic<>`, making concurrent Sample() / RollWindow() calls
+// a C++ data race (formal UB; TSAN-detectable; torn reads on ARM64).
+//
+// This test runs Sample() from many threads simultaneously while RollWindow()
+// fires repeatedly on a separate thread.  With the volatile code this reliably
+// triggers a TSAN report.  After fixing to std::atomic<> the test is clean.
+TEST(AdaptiveSamplerTest, ConcurrentSampleAndRollWindow_NoDataRace)
+{
+    // Use a manual-roll sampler (windowDuration=0) so we control RollWindow timing.
+    AdaptiveSampler sampler(0ms, 100, 3, 3, nullptr);
+
+    std::atomic<bool> stop{false};
+
+    // Writer thread: continuously rolls the window (updates _probability / _samplesBudget).
+    std::thread writer([&]() {
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            sampler.RollWindow();
+        }
+    });
+
+    // Reader threads: continuously call Sample() (reads _probability / _samplesBudget).
+    const int numReaders = 4;
+    const int callsPerReader = 10000;
+    std::vector<std::thread> readers;
+    readers.reserve(numReaders);
+    for (int i = 0; i < numReaders; ++i)
+    {
+        readers.emplace_back([&]() {
+            for (int j = 0; j < callsPerReader; ++j)
+            {
+                sampler.Sample();
+            }
+        });
+    }
+
+    for (auto& t : readers)
+    {
+        t.join();
+    }
+    stop.store(true);
+    writer.join();
+
+    // The test passes if it completes without crashing or triggering TSAN.
+    // No specific count assertion: sampling is probabilistic.
+    SUCCEED();
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
@@ -246,8 +246,13 @@ TEST_F(ManagedCodeCacheTest, GetFunctionId_BoundaryIPs_CorrectBehavior) {
     EXPECT_FALSE(cache->GetFunctionId(codeStart + codeSize).has_value());
 }
 
-// Test: Zero-sized code range
-TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_HandledGracefully) {
+// Regression: GetCodeRanges used `startAddress + size - 1` without guarding
+// size==0.  For startAddress==0 this gives endAddress==UINTPTR_MAX and the
+// page-insertion loop `for (page=0; page<=UINTPTR_MAX/pageSize; ++page)` runs
+// for billions of iterations, permanently hanging the background worker.
+// For non-zero startAddress the loop silently skips (endPage < startPage) but
+// the degenerate CodeRange still pollutes the sorted range vector.
+TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_DoesNotPolluteCacheNonZeroBase) {
     FunctionID testFuncId = 777;
     uintptr_t codeStart = 0x9000;
     ULONG32 codeSize = 0;
@@ -256,10 +261,29 @@ TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_HandledGracefully) {
     cache->AddFunction(testFuncId);
     WaitForWorkerThread();
 
-    // Should not crash, but may not find the function
-    auto result = cache->GetFunctionId(codeStart);
-    // Result is implementation-dependent, just verify no crash
-    (void)result;
+    // A zero-size range has no valid code; no IP should be reported as managed.
+    EXPECT_FALSE(cache->IsManaged(codeStart))
+        << "IP at startAddress of a size-0 range must not be managed";
+    EXPECT_FALSE(cache->IsManaged(codeStart - 1))
+        << "IP just before startAddress must not be managed";
+    EXPECT_FALSE(cache->IsManaged(codeStart + 0x1000))
+        << "Unrelated IP above a size-0 range must not be managed";
+}
+
+// For startAddress==0 with size==0 the page loop would run from page 0 to
+// ~UINTPTR_MAX/pageSize, hanging the worker forever.  After the fix the worker
+// must complete within the normal wait and IsManaged must return false.
+TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRangeAtAddressZero_WorkerDoesNotHang) {
+    FunctionID testFuncId = 778;
+    uintptr_t codeStart = 0;
+    ULONG32 codeSize = 0;
+
+    SetupMockCodeInfo(testFuncId, codeStart, codeSize);
+    cache->AddFunction(testFuncId);
+
+    // If the worker is stuck this call blocks until the test times out.
+    WaitForWorkerThread(200);
+    EXPECT_FALSE(cache->IsManaged(0x1000));
 }
 
 // Test: Very large code range


### PR DESCRIPTION
## Summary of changes

Four independent bug fixes in the native profiler, each in its own commit.
Found during a static analysis pass on the profiler codebase.

### 1. `AdaptiveSampler`: `volatile` → `std::atomic` (data race)

`_probability` (`double`) and `_samplesBudget` (`int64_t`) were declared `volatile` but written by the timer thread in `RollWindow()` while being read concurrently by `Sample()` on arbitrary CLR threads. C++ `volatile` provides no memory-model guarantees — no happens-before, no atomicity, no ordering. On ARM64 a 64-bit non-atomic store is not guaranteed to be read-consistent across cores. TSAN detects this as a data race.

Fix: replace both fields with `std::atomic<>` using `memory_order_relaxed` (the existing comment acknowledges intentional looseness in window accounting; relaxed atomics preserve that intent while eliminating the formal UB).

New test: `ConcurrentSampleAndRollWindow_NoDataRace` — 4 threads calling `Sample()` while a writer thread calls `RollWindow()` in a tight loop; clean under TSAN with the fix.

### 2. `ProfilerSignalManager`: broken double-checked locking

The inner guard after acquiring the mutex checked the stale pre-lock local `current` instead of re-reading `_handler`:

```cpp
HandlerFn_t current = _handler;   // captured before lock
...
lock.acquire();
if (current != nullptr) return;   // BUG: always nullptr here in the race
```

Two threads that both observe `_handler == nullptr` before the lock race to acquire the mutex sequentially. The second thread's inner check still sees its pre-lock snapshot (`nullptr`) and calls `SetupSignalHandler()` a second time. That second `sigaction()` call saves the profiler's own handler into `_previousAction`; on teardown `UnRegisterHandler()` then restores the profiler handler instead of the original one, creating an infinite signal chain.

Fix: read `_handler` again inside the mutex (`if (_handler != nullptr)`).

### 3. `ContentionProvider`: non-atomic `failureCount` (data race)

`static uint64_t failureCount` was read and incremented concurrently from CLR callback threads (the synchronous `ICorProfilerCallback` path and the async ETW path run on different threads simultaneously). Plain data race.

Fix: `static std::atomic<uint64_t>` with `fetch_add`, making the modulo check and increment a single atomic operation.

### 4. `ManagedCodeCache::GetCodeRanges`: size-0 underflow → worker hang

`GetCodeInfo2` can return a code range with `size == 0`. `GetCodeRanges` computed:

```cpp
endAddress = startAddress + size - 1;  // underflows when size == 0
```

For `startAddress == 0` this gives `endAddress == UINTPTR_MAX`, and the subsequent page-insertion loop iterates from page 0 to `~UINTPTR_MAX / pageSize` — billions of iterations — permanently hanging the background worker thread and starving all `IsManaged()` callers. For non-zero `startAddress` the loop silently skips (endPage < startPage) but the degenerate `CodeRange` still pollutes the sorted range vector.

Fix: skip entries where `size == 0` before constructing the `CodeRange`.

New tests:
- `AddFunction_ZeroSizeRange_DoesNotPolluteCacheNonZeroBase`: verifies `IsManaged` returns false for IPs near a zero-size registration.
- `AddFunction_ZeroSizeRangeAtAddressZero_WorkerDoesNotHang`: verifies the background worker completes within the normal timeout (detects the hang path).

## Reason for change

Correctness: data races (TSAN-detectable, ARM64-relevant), a double-`sigaction` on concurrent startup, and a worker-thread hang on a zero-size JIT code range.

## Test coverage

All four test suites pass on Linux/clang-16: `AdaptiveSamplerTest` (5), `ManagedCodeCacheTest` (14), `ProfilerSignalManagerFixture` (6), `ConfigurationTest` (4) — 29/29.