### PR TITLE
[Dynamic instrumentation] DEBUG-3321 Fix malformed local var sig parsing in PDB reader

### DIFF
--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -215,6 +215,21 @@ namespace Datadog.Trace.Pdb
             return true;
         }
 
+        internal static bool TryDecodeLocalSignature(ref BlobReader blobReader, out ImmutableArray<string> localTypes)
+        {
+            localTypes = default;
+
+            try
+            {
+                localTypes = new SignatureDecoder<string, int>(new TypeProvider(false), default!, 0).DecodeLocalSignature(ref blobReader);
+                return true;
+            }
+            catch (BadImageFormatException)
+            {
+                return false;
+            }
+        }
+
         private int GetLocalVariablesCount(MethodDefinition method)
         {
             var signature = GetLocalSignature(method);
@@ -816,7 +831,12 @@ namespace Datadog.Trace.Pdb
                     return null;
                 }
 
-                var localTypes = signature.Value.DecodeLocalSignature(new TypeProvider(false), 0);
+                BlobReader signatureReader = MetadataReader.GetBlobReader(signature.Value.Signature);
+                if (!TryDecodeLocalSignature(ref signatureReader, out var localTypes))
+                {
+                    return null;
+                }
+
                 localScopes = ImmutableArray.CreateBuilder<LocalScope>();
 
                 foreach (var scopeHandle in PdbReader.GetLocalScopes(methodDefHandle.ToDebugInformationHandle()))

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -192,6 +192,29 @@ namespace Datadog.Trace.Pdb
             return MetadataReader.GetStandaloneSignature(methodBodyBlock.LocalSignature);
         }
 
+        internal static bool TryReadLocalVariablesCount(ref BlobReader blobReader, out int variableCount)
+        {
+            variableCount = 0;
+
+            if (blobReader.RemainingBytes == 0)
+            {
+                return false;
+            }
+
+            if (blobReader.ReadByte() != (byte)SignatureKind.LocalVariables)
+            {
+                return false;
+            }
+
+            if (!blobReader.TryReadCompressedInteger(out variableCount))
+            {
+                variableCount = 0;
+                return false;
+            }
+
+            return true;
+        }
+
         private int GetLocalVariablesCount(MethodDefinition method)
         {
             var signature = GetLocalSignature(method);
@@ -200,12 +223,18 @@ namespace Datadog.Trace.Pdb
                 return 0;
             }
 
-            BlobReader blobReader = MetadataReader.GetBlobReader(signature.Value.Signature);
-
-            if (blobReader.ReadByte() == (byte)SignatureKind.LocalVariables)
+            try
             {
-                int variableCount = blobReader.ReadCompressedInteger();
-                return variableCount;
+                BlobReader blobReader = MetadataReader.GetBlobReader(signature.Value.Signature);
+                if (TryReadLocalVariablesCount(ref blobReader, out var variableCount))
+                {
+                    return variableCount;
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                // Some customer assemblies contain malformed local signatures.
+                // Treat them as "no locals" so the debugger metadata path remains best-effort.
             }
 
             return 0;

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -215,13 +215,13 @@ namespace Datadog.Trace.Pdb
             return true;
         }
 
-        internal static bool TryDecodeLocalSignature(ref BlobReader blobReader, out ImmutableArray<string> localTypes)
+        internal static bool TryDecodeLocalSignature(MetadataReader metadataReader, ref BlobReader blobReader, out ImmutableArray<string> localTypes)
         {
             localTypes = default;
 
             try
             {
-                localTypes = new SignatureDecoder<string, int>(new TypeProvider(false), default!, 0).DecodeLocalSignature(ref blobReader);
+                localTypes = new SignatureDecoder<string, int>(new TypeProvider(false), metadataReader, 0).DecodeLocalSignature(ref blobReader);
                 return true;
             }
             catch (BadImageFormatException)
@@ -832,7 +832,7 @@ namespace Datadog.Trace.Pdb
                 }
 
                 BlobReader signatureReader = MetadataReader.GetBlobReader(signature.Value.Signature);
-                if (!TryDecodeLocalSignature(ref signatureReader, out var localTypes))
+                if (!TryDecodeLocalSignature(MetadataReader, ref signatureReader, out var localTypes))
                 {
                     return null;
                 }

--- a/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.Pdb;
 using FluentAssertions;
 using Xunit;
@@ -55,8 +56,14 @@ public class DatadogMetadataReaderTests
         fixed (byte* ptr = signature)
         {
             var reader = new BlobReader(ptr, signature.Length);
+            using var metadataReader = DatadogMetadataReader.CreatePdbReader(typeof(DatadogMetadataReaderTests).Assembly);
 
-            DatadogMetadataReader.TryDecodeLocalSignature(ref reader, out var localTypes).Should().BeTrue();
+            if (metadataReader is null)
+            {
+                throw new InvalidOperationException("Could not create metadata reader for test assembly.");
+            }
+
+            DatadogMetadataReader.TryDecodeLocalSignature(metadataReader.MetadataReader, ref reader, out var localTypes).Should().BeTrue();
             localTypes.Should().Equal("System.Int32");
         }
     }
@@ -69,8 +76,14 @@ public class DatadogMetadataReaderTests
         fixed (byte* ptr = signature)
         {
             var reader = new BlobReader(ptr, signature.Length);
+            using var metadataReader = DatadogMetadataReader.CreatePdbReader(typeof(DatadogMetadataReaderTests).Assembly);
 
-            DatadogMetadataReader.TryDecodeLocalSignature(ref reader, out var localTypes).Should().BeFalse();
+            if (metadataReader is null)
+            {
+                throw new InvalidOperationException("Could not create metadata reader for test assembly.");
+            }
+
+            DatadogMetadataReader.TryDecodeLocalSignature(metadataReader.MetadataReader, ref reader, out var localTypes).Should().BeFalse();
             localTypes.IsDefault.Should().BeTrue();
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
@@ -46,4 +46,32 @@ public class DatadogMetadataReaderTests
             count.Should().Be(0);
         }
     }
+
+    [Fact]
+    public unsafe void TryDecodeLocalSignature_ValidSignature_ReturnsLocalTypes()
+    {
+        byte[] signature = [(byte)SignatureKind.LocalVariables, 1, 0x08];
+
+        fixed (byte* ptr = signature)
+        {
+            var reader = new BlobReader(ptr, signature.Length);
+
+            DatadogMetadataReader.TryDecodeLocalSignature(ref reader, out var localTypes).Should().BeTrue();
+            localTypes.Should().Equal("System.Int32");
+        }
+    }
+
+    [Fact]
+    public unsafe void TryDecodeLocalSignature_TruncatedAfterCount_ReturnsFalse()
+    {
+        byte[] signature = [(byte)SignatureKind.LocalVariables, 1];
+
+        fixed (byte* ptr = signature)
+        {
+            var reader = new BlobReader(ptr, signature.Length);
+
+            DatadogMetadataReader.TryDecodeLocalSignature(ref reader, out var localTypes).Should().BeFalse();
+            localTypes.IsDefault.Should().BeTrue();
+        }
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
@@ -1,0 +1,49 @@
+// <copyright file="DatadogMetadataReaderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.Pdb;
+using FluentAssertions;
+using Xunit;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Reflection.Metadata;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+#endif
+
+namespace Datadog.Trace.Tests.Pdb;
+
+public class DatadogMetadataReaderTests
+{
+    [Fact]
+    public unsafe void TryReadLocalVariablesCount_ValidSignature_ReturnsCount()
+    {
+        byte[] signature = [(byte)SignatureKind.LocalVariables, 1, 0x08];
+
+        fixed (byte* ptr = signature)
+        {
+            var reader = new BlobReader(ptr, signature.Length);
+
+            DatadogMetadataReader.TryReadLocalVariablesCount(ref reader, out var count).Should().BeTrue();
+            count.Should().Be(1);
+        }
+    }
+
+    [Fact]
+    public unsafe void TryReadLocalVariablesCount_TruncatedSignature_ReturnsFalse()
+    {
+        byte[] signature = [(byte)SignatureKind.LocalVariables];
+
+        fixed (byte* ptr = signature)
+        {
+            var reader = new BlobReader(ptr, signature.Length);
+
+            DatadogMetadataReader.TryReadLocalVariablesCount(ref reader, out var count).Should().BeFalse();
+            count.Should().Be(0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Harden `DatadogMetadataReader` so malformed or truncated local variable signatures are treated as best-effort misses instead of throwing.
Add focused regression tests for both valid and truncated local signatures in DatadogMetadataReaderTests.

## Reason for change

Some customer assemblies appear to contain malformed local variable signature metadata.
In the debugger metadata path, that could surface as Failed to obtain local variable names from PDB with `BadImageFormatException`, even though local names are best-effort metadata.

## Implementation details

The local signature parser now validates the blob shape before reading the compressed local count.
Invalid or truncated signatures now fall back to 0 locals instead of propagating an exception through the debugger local-name lookup flow.

## Test coverage

Added unit coverage for:
a valid local variable signature
a truncated local variable signature
in `DatadogMetadataReaderTests`