### PR TITLE
fix(profiler): five native profiler bug fixes

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -28,7 +28,7 @@ ProfilerSignalManager::~ProfilerSignalManager() noexcept
         _isHandlerInPlace = false;
         sigaction(_signalToSend, &_previousAction, nullptr);
     }
-    _handler = nullptr;
+    _handler.store(nullptr, std::memory_order_release);
 }
 
 ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
@@ -49,7 +49,7 @@ ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
 
 bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 {
-    HandlerFn_t current = _handler;
+    HandlerFn_t current = _handler.load(std::memory_order_acquire);
 
     if (current != nullptr)
     {
@@ -58,7 +58,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
-    current = _handler;
+    current = _handler.load(std::memory_order_acquire);
     if (current != nullptr)
     {
         assert(current == handler);
@@ -69,7 +69,7 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
 
     if (_isHandlerInPlace)
     {
-        _handler = handler;
+        _handler.store(handler, std::memory_order_release);
     }
 
     return _isHandlerInPlace;
@@ -205,7 +205,7 @@ void ProfilerSignalManager::SignalHandler(int signal, siginfo_t* info, void* con
 
 bool ProfilerSignalManager::CallCustomHandler(int32_t signal, siginfo_t* info, void* context)
 {
-    HandlerFn_t handler = _handler;
+    HandlerFn_t handler = _handler.load(std::memory_order_acquire);
     return handler != nullptr && handler(signal, info, context);
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -58,10 +58,10 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
-    if (current != nullptr)
+    if (_handler != nullptr)
     {
-        assert(current == handler);
-        return current == handler;
+        assert(_handler == handler);
+        return _handler == handler;
     }
 
     _isHandlerInPlace = SetupSignalHandler();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -58,10 +58,11 @@ bool ProfilerSignalManager::RegisterHandler(HandlerFn_t handler)
     }
     std::unique_lock<std::mutex> lock(_handlerRegisterMutex);
 
-    if (_handler != nullptr)
+    current = _handler;
+    if (current != nullptr)
     {
-        assert(_handler == handler);
-        return _handler == handler;
+        assert(current == handler);
+        return current == handler;
     }
 
     _isHandlerInPlace = SetupSignalHandler();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -27,7 +27,7 @@ public:
 #ifdef DD_TEST
     void Reset()
     {
-        _handler = nullptr;
+        _handler.store(nullptr, std::memory_order_release);
         sigaction(_signalToSend, &_previousAction, nullptr);
         _isHandlerInPlace = false;
         _canReplaceSignalHandler = true;
@@ -56,7 +56,7 @@ private:
 private:
     bool _canReplaceSignalHandler;
     int32_t _signalToSend;
-    HandlerFn_t _handler;
+    std::atomic<HandlerFn_t> _handler;
     pid_t _processId;
     bool _isHandlerInPlace;
     struct sigaction _previousAction;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
@@ -75,7 +75,7 @@ AdaptiveSampler::AdaptiveSampler(
     _samplesPerWindow = samplesPerWindow;
     _budgetLookback = budgetLookback;
 
-    _samplesBudget = samplesPerWindow + (static_cast<int64_t>(budgetLookback) * samplesPerWindow);
+    _samplesBudget.store(samplesPerWindow + (static_cast<int64_t>(budgetLookback) * samplesPerWindow), std::memory_order_relaxed);
     _emaAlpha = ComputeIntervalAlpha(averageLookback);
     _budgetAlpha = ComputeIntervalAlpha(budgetLookback);
 
@@ -97,9 +97,9 @@ bool AdaptiveSampler::Sample()
     auto* counts = _countsRef.load();
     counts->AddTest();
 
-    if (NextDouble() < _probability)
+    if (NextDouble() < _probability.load(std::memory_order_relaxed))
     {
-        return counts->AddSample(_samplesBudget);
+        return counts->AddSample(_samplesBudget.load(std::memory_order_relaxed));
     }
 
     return false;
@@ -161,7 +161,7 @@ void AdaptiveSampler::RollWindow()
     const auto totalCount = counts.TestCount();
     const auto sampledCount = counts.SampleCount();
 
-    _samplesBudget = CalculateBudgetEma(sampledCount);
+    _samplesBudget.store(CalculateBudgetEma(sampledCount), std::memory_order_relaxed);
 
     if (_totalCountRunningAverage == 0 || _emaAlpha <= 0.0)
     {
@@ -174,11 +174,11 @@ void AdaptiveSampler::RollWindow()
 
     if (_totalCountRunningAverage <= 0)
     {
-        _probability = 1;
+        _probability.store(1.0, std::memory_order_relaxed);
     }
     else
     {
-        _probability = std::min(_samplesBudget / _totalCountRunningAverage, 1.0);
+        _probability.store(std::min(_samplesBudget.load(std::memory_order_relaxed) / _totalCountRunningAverage, 1.0), std::memory_order_relaxed);
     }
 
     counts.Reset();
@@ -197,8 +197,8 @@ AdaptiveSampler::State AdaptiveSampler::GetInternalState()
     return State{
         counts->TestCount(),
         counts->SampleCount(),
-        _samplesBudget,
-        _probability,
+        _samplesBudget.load(std::memory_order_relaxed),
+        _probability.load(std::memory_order_relaxed),
         _totalCountRunningAverage};
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.h
@@ -54,8 +54,8 @@ private:
 
     std::atomic<Counts*> _countsRef;
 
-    volatile double _probability = 1;
-    volatile int64_t _samplesBudget;
+    std::atomic<double> _probability{1.0};
+    std::atomic<int64_t> _samplesBudget{0};
 
     double _totalCountRunningAverage;
     double _avgSamples;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -18,6 +18,7 @@
 #include "Sample.h"
 #include "SampleValueTypeProvider.h"
 
+#include <atomic>
 #include <math.h>
 
 using namespace std::chrono_literals;
@@ -192,7 +193,7 @@ void ContentionProvider::AddContentionSample(
 
     // Synchronous case where the current thread is the contended thread
     // (i.e. receiving the contention events directly from ICorProfilerCallback)
-    static uint64_t failureCount = 0;
+    static std::atomic<uint64_t> failureCount{0};
     if ((timestamp == 0ns) && (threadId == -1) && stack.empty())
     {
         auto threadInfo = ManagedThreadInfo::CurrentThreadInfo;
@@ -208,11 +209,9 @@ void ContentionProvider::AddContentionSample(
 
         uint32_t hrCollectStack = E_FAIL;
         const auto result = pStackFramesCollector->CollectStackSample(threadInfo.get(), &hrCollectStack);
-        if ((result->GetFramesCount() == 0) && (failureCount % 1000 == 0))
+        if ((result->GetFramesCount() == 0) && (failureCount.fetch_add(1) % 1000 == 0))
         {
-            // log every 1000 failures
-            failureCount++;
-            Log::Info("Failed to walk ", failureCount, " stacks for sampled contention: ", HResultConverter::ToStringWithCode(hrCollectStack));
+            Log::Info("Failed to walk ", failureCount.load(), " stacks for sampled contention: ", HResultConverter::ToStringWithCode(hrCollectStack));
             return;
         }
 
@@ -229,11 +228,9 @@ void ContentionProvider::AddContentionSample(
     // CLR events are received asynchronously from the Agent
     {
         // avoid the case where the ClrStackWalk event has been missed for the ContentionStart
-        if ((stack.size() == 0) && (failureCount % 1000 == 0))
+        if ((stack.size() == 0) && (failureCount.fetch_add(1) % 1000 == 0))
         {
-            // log every 1000 failures
-            failureCount++;
-            Log::Info("Failed to get ", failureCount, " call stacks for sampled contention");
+            Log::Info("Failed to get ", failureCount.load(), " call stacks for sampled contention");
             return;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -209,9 +209,12 @@ void ContentionProvider::AddContentionSample(
 
         uint32_t hrCollectStack = E_FAIL;
         const auto result = pStackFramesCollector->CollectStackSample(threadInfo.get(), &hrCollectStack);
-        if ((result->GetFramesCount() == 0) && (failureCount.fetch_add(1) % 1000 == 0))
+        if (result->GetFramesCount() == 0)
         {
-            Log::Info("Failed to walk ", failureCount.load(), " stacks for sampled contention: ", HResultConverter::ToStringWithCode(hrCollectStack));
+            if (failureCount.fetch_add(1) % 1000 == 0)
+            {
+                Log::Info("Failed to walk ", failureCount.load(), " stacks for sampled contention: ", HResultConverter::ToStringWithCode(hrCollectStack));
+            }
             return;
         }
 
@@ -228,9 +231,12 @@ void ContentionProvider::AddContentionSample(
     // CLR events are received asynchronously from the Agent
     {
         // avoid the case where the ClrStackWalk event has been missed for the ContentionStart
-        if ((stack.size() == 0) && (failureCount.fetch_add(1) % 1000 == 0))
+        if (stack.size() == 0)
         {
-            Log::Info("Failed to get ", failureCount.load(), " call stacks for sampled contention");
+            if (failureCount.fetch_add(1) % 1000 == 0)
+            {
+                Log::Info("Failed to get ", failureCount.load(), " call stacks for sampled contention");
+            }
             return;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -2080,7 +2080,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::JITCompilationStarted(FunctionID 
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::JITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
-    if (_managedCodeCache != nullptr)
+    if (_managedCodeCache != nullptr && SUCCEEDED(hrStatus))
     {
         _managedCodeCache->AddFunction(functionId);
     }
@@ -2601,7 +2601,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::GetReJITParameters(ModuleID modul
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
-    if (_managedCodeCache != nullptr)
+    if (_managedCodeCache != nullptr && SUCCEEDED(hrStatus))
     {
         _managedCodeCache->AddFunction(functionId);
     }
@@ -2646,7 +2646,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::DynamicMethodJITCompilationStarte
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::DynamicMethodJITCompilationFinished(FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
-    if (_managedCodeCache != nullptr)
+    if (_managedCodeCache != nullptr && SUCCEEDED(hrStatus))
     {
         _managedCodeCache->AddFunction(functionId);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
@@ -314,6 +314,10 @@ std::vector<CodeRange> ManagedCodeCache::GetCodeRanges(FunctionID functionId)
     result.reserve(nbCodeInfos);
     for (ULONG32 i = 0; i < nbCodeInfos; i++)
     {
+        if (codeInfos[i].size == 0)
+        {
+            continue;
+        }
         result.emplace_back(
             codeInfos[i].startAddress,
             codeInfos[i].startAddress + codeInfos[i].size - 1,

--- a/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
@@ -5,6 +5,9 @@
 
 #include "gtest/gtest.h"
 
+#include <thread>
+#include <vector>
+
 using namespace std::chrono_literals;
 
 constexpr std::chrono::seconds WindowDuration = 1s;
@@ -119,4 +122,53 @@ TEST(AdaptiveSamplerTest, TestStop)
     sampler.Stop();
 
     ASSERT_FALSE(callbackCalled);
+}
+
+// Regression test: _probability and _samplesBudget were declared `volatile`
+// instead of `std::atomic<>`, making concurrent Sample() / RollWindow() calls
+// a C++ data race (formal UB; TSAN-detectable; torn reads on ARM64).
+//
+// This test runs Sample() from many threads simultaneously while RollWindow()
+// fires repeatedly on a separate thread.  With the volatile code this reliably
+// triggers a TSAN report.  After fixing to std::atomic<> the test is clean.
+TEST(AdaptiveSamplerTest, ConcurrentSampleAndRollWindow_NoDataRace)
+{
+    // Use a manual-roll sampler (windowDuration=0) so we control RollWindow timing.
+    AdaptiveSampler sampler(0ms, 100, 3, 3, nullptr);
+
+    std::atomic<bool> stop{false};
+
+    // Writer thread: continuously rolls the window (updates _probability / _samplesBudget).
+    std::thread writer([&]() {
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            sampler.RollWindow();
+        }
+    });
+
+    // Reader threads: continuously call Sample() (reads _probability / _samplesBudget).
+    const int numReaders = 4;
+    const int callsPerReader = 10000;
+    std::vector<std::thread> readers;
+    readers.reserve(numReaders);
+    for (int i = 0; i < numReaders; ++i)
+    {
+        readers.emplace_back([&]() {
+            for (int j = 0; j < callsPerReader; ++j)
+            {
+                sampler.Sample();
+            }
+        });
+    }
+
+    for (auto& t : readers)
+    {
+        t.join();
+    }
+    stop.store(true);
+    writer.join();
+
+    // The test passes if it completes without crashing or triggering TSAN.
+    // No specific count assertion: sampling is probabilistic.
+    SUCCEED();
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
@@ -246,8 +246,13 @@ TEST_F(ManagedCodeCacheTest, GetFunctionId_BoundaryIPs_CorrectBehavior) {
     EXPECT_FALSE(cache->GetFunctionId(codeStart + codeSize).has_value());
 }
 
-// Test: Zero-sized code range
-TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_HandledGracefully) {
+// Regression: GetCodeRanges used `startAddress + size - 1` without guarding
+// size==0.  For startAddress==0 this gives endAddress==UINTPTR_MAX and the
+// page-insertion loop `for (page=0; page<=UINTPTR_MAX/pageSize; ++page)` runs
+// for billions of iterations, permanently hanging the background worker.
+// For non-zero startAddress the loop silently skips (endPage < startPage) but
+// the degenerate CodeRange still pollutes the sorted range vector.
+TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_DoesNotPolluteCacheNonZeroBase) {
     FunctionID testFuncId = 777;
     uintptr_t codeStart = 0x9000;
     ULONG32 codeSize = 0;
@@ -256,10 +261,29 @@ TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_HandledGracefully) {
     cache->AddFunction(testFuncId);
     WaitForWorkerThread();
 
-    // Should not crash, but may not find the function
-    auto result = cache->GetFunctionId(codeStart);
-    // Result is implementation-dependent, just verify no crash
-    (void)result;
+    // A zero-size range has no valid code; no IP should be reported as managed.
+    EXPECT_FALSE(cache->IsManaged(codeStart))
+        << "IP at startAddress of a size-0 range must not be managed";
+    EXPECT_FALSE(cache->IsManaged(codeStart - 1))
+        << "IP just before startAddress must not be managed";
+    EXPECT_FALSE(cache->IsManaged(codeStart + 0x1000))
+        << "Unrelated IP above a size-0 range must not be managed";
+}
+
+// For startAddress==0 with size==0 the page loop would run from page 0 to
+// ~UINTPTR_MAX/pageSize, hanging the worker forever.  After the fix the worker
+// must complete within the normal wait and IsManaged must return false.
+TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRangeAtAddressZero_WorkerDoesNotHang) {
+    FunctionID testFuncId = 778;
+    uintptr_t codeStart = 0;
+    ULONG32 codeSize = 0;
+
+    SetupMockCodeInfo(testFuncId, codeStart, codeSize);
+    cache->AddFunction(testFuncId);
+
+    // If the worker is stuck this call blocks until the test times out.
+    WaitForWorkerThread(200);
+    EXPECT_FALSE(cache->IsManaged(0x1000));
 }
 
 // Test: Very large code range


### PR DESCRIPTION
Five correctness bugs found by static analysis of the native profiler.

**`AdaptiveSampler`: `volatile` → `std::atomic`**
`_probability` and `_samplesBudget` were `volatile` but written by the timer thread and read concurrently by `Sample()`. No memory-model guarantees; TSAN-visible data race, torn reads on ARM64.

**`ProfilerSignalManager`: atomic `_handler` + DCL fix**
`_handler` was a plain pointer read from the signal handler thread (in `CallCustomHandler`) without any lock — a data race. Made `std::atomic<HandlerFn_t>` with acquire/release ordering.
Also fixed the double-checked locking: the inner guard after acquiring the mutex was checking a stale pre-lock local instead of re-reading `_handler`, allowing two racing threads to both call `SetupSignalHandler()` and corrupt `_previousAction`.

**`ContentionProvider`: atomic `failureCount` + always drop empty-stack samples**
`failureCount` was a non-atomic static local incremented from concurrent CLR callback threads. Also: the empty-stack early-return was gated on `failureCount % 1000 == 0`, so 999 out of every 1000 empty-stack failures fell through and emitted a corrupt zero-frame sample. The return is now unconditional; only the log is rate-limited.

**`ManagedCodeCache`: skip zero-size code ranges**
`GetCodeInfo2` entries with `size == 0` produced `endAddress = startAddress - 1` (underflow). For `startAddress == 0` this gives `endAddress = UINTPTR_MAX` and the page-insertion loop runs forever, hanging the background worker. Guard added; JIT callbacks also now check `SUCCEEDED(hrStatus)` before calling `AddFunction`.