### PR TITLE
unify the target to build integration tests across platforms

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1703,7 +1703,7 @@ stages:
 #      displayName: Start test agent
 #      retryCountOnTaskFailure: 3
 
-    - script: tracer\build.cmd CompileTrimmingSamples BuildWindowsIntegrationTests BuildWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+    - script: tracer\build.cmd CompileTrimmingSamples BuildIntegrationTests BuildWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Build integration tests
       retryCountOnTaskFailure: 3
       env:
@@ -2140,7 +2140,7 @@ stages:
         patterns: '**/*-$(targetPlatform).msi'
 
     - script: tracer\build.cmd BuildAspNetIntegrationTests -Framework $(framework)
-      displayName: BuildWindowsIntegrationTests
+      displayName: BuildAspNetIntegrationTests
       retryCountOnTaskFailure: 3
 
     - template: steps/ensure-docker-ready.yml
@@ -2215,8 +2215,8 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/restore-working-directory.yml
 
-    - script: tracer\build.cmd BuildWindowsIntegrationTests  -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
-      displayName: BuildWindowsIntegrationTests
+    - script: tracer\build.cmd BuildIntegrationTests  -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
+      displayName: BuildIntegrationTests
       retryCountOnTaskFailure: 3
 
     - script: tracer\build.cmd RunIntegrationTests -filter FleetInstaller=True -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
@@ -2287,7 +2287,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
+        command: "BuildIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
         apikey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
@@ -2390,7 +2390,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
+        command: "BuildIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
@@ -2512,7 +2512,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --SampleName Samples.Aws.Lambda"
+        command: "BuildIntegrationTests --framework $(publishTargetFramework) --SampleName Samples.Aws.Lambda"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
@@ -2520,7 +2520,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --SampleName Samples.Amazon.Lambda.RuntimeSupport"
+        command: "BuildIntegrationTests --framework $(publishTargetFramework) --SampleName Samples.Amazon.Lambda.RuntimeSupport"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
@@ -3140,7 +3140,7 @@ stages:
           parameters:
             build: true
             baseImage: $(baseImage)
-            command: "BuildLinuxIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
+            command: "BuildIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
 
@@ -3210,7 +3210,7 @@ stages:
           parameters:
             build: true
             baseImage: $(baseImage)
-            command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
+            command: "BuildIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Auto-instrumentation comes from the tracer "monitoring home" deployed separately
 **Quick start:**
 - Build: `./tracer/build.sh` (Linux/macOS) or `.\tracer\build.cmd` (Windows)
 - Unit tests: `./tracer/build.sh BuildAndRunManagedUnitTests`
-- Integration tests: `BuildAndRunLinuxIntegrationTests` / `BuildAndRunWindowsIntegrationTests` / `BuildAndRunOsxIntegrationTests`
+- Integration tests: `BuildAndRunIntegrationTests`
 
 📖 **Load when**: Setting up development environment, running builds, or troubleshooting build issues
 - **`tracer/README.md`** — Complete development setup guide (VS requirements, Docker, Dev Containers, platform-specific build commands, and Nuke targets)

--- a/docs/development/AutomaticInstrumentation.md
+++ b/docs/development/AutomaticInstrumentation.md
@@ -425,7 +425,7 @@ On Windows, we _don't_ typically run multi-api-version tests. There is experimen
 # Build and run the integration tests, building only
 # your sample, and running only your new tests
 # You can choose whichever framework is appropriate
-./tracer/build.ps1 BuildAndRunWindowsIntegrationTests -buildConfiguration Debug -framework net48 -Filter MyNewIntegrationTests -SampleName Samples.MyNewSample
+./tracer/build.ps1 BuildAndRunIntegrationTests -buildConfiguration Debug -framework net48 -Filter MyNewIntegrationTests -SampleName Samples.MyNewSample
 ```
 
 ##### On macOs
@@ -441,7 +441,7 @@ On MacOs, you won't be able to run all tests as some images aren't arm compatibl
 # Build and run the integration tests, building only
 # your sample, and running only your new tests
 # You can choose whichever framework is appropriate
-./tracer/build.sh BuildAndRunOSxIntegrationTests -buildConfiguration Debug -framework net6.0 -Filter MyNewIntegrationTests -SampleName Samples.MyNewSample
+./tracer/build.sh BuildAndRunIntegrationTests -buildConfiguration Debug -framework net6.0 -Filter MyNewIntegrationTests -SampleName Samples.MyNewSample
 ```
 
 #### Testing in CI

--- a/tracer/README.md
+++ b/tracer/README.md
@@ -65,7 +65,7 @@ For example:
 .\build.cmd PackageTracerHome
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-.\build.cmd BuildAndRunWindowsIntegrationTests
+.\build.cmd BuildAndRunIntegrationTests
 ```
 
 ### Dev Containers
@@ -117,12 +117,12 @@ The recommended approach for Linux is to build using Docker. You can use this ap
 ./build_in_docker.sh BuildAndRunManagedUnitTests
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-./build_in_docker.sh BuildAndRunLinuxIntegrationTests
+./build_in_docker.sh BuildAndRunIntegrationTests
 ```
 
 Alternatively, on Windows:
 ```powershell
-./build_in_docker.ps1 BuildTracerHome BuildAndRunLinuxIntegrationTests
+./build_in_docker.ps1 BuildTracerHome BuildAndRunIntegrationTests
 ```
 
 ### macOS
@@ -158,10 +158,10 @@ docker-compose up rabbitmq_osx_arm64
 docker-compose up StartDependencies.OSXARM64
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-./build.sh BuildAndRunOsxIntegrationTests
+./build.sh BuildAndRunIntegrationTests
 
 # Build and run integration tests filtering on one framework, one set of tests and a sample app.
-./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "Datadog.Trace.ClrProfiler.IntegrationTests.RabbitMQTests" --SampleName "Samples.Rabbit"
+./build.sh BuildAndRunIntegrationTests --framework "net6.0" --filter "Datadog.Trace.ClrProfiler.IntegrationTests.RabbitMQTests" --SampleName "Samples.Rabbit"
 
 # Stop IntegrationTests dependencies.
 docker-compose down

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1541,6 +1541,7 @@ partial class Build
         .After(CompileManagedTestHelpers)
         .After(PublishIisSamples)
         .After(BuildRunnerTool)
+        .OnlyWhenStatic(() => IsWin)
         .Requires(() => Framework)
         .Requires(() => MonitoringHomeDirectory != null)
         .Executes(() =>
@@ -1805,7 +1806,7 @@ partial class Build
         .After(CompileIntegrationTests)
         .After(CompileSamples)
         .After(CompileTrimmingSamples)
-        .After(BuildWindowsIntegrationTests)
+        .After(BuildIntegrationTests)
         .After(CompileLinuxOrOsxIntegrationTests)
         .DependsOn(CleanTestLogs)
         .Requires(() => Framework)
@@ -1944,7 +1945,7 @@ partial class Build
         .After(BuildTracerHome)
         .After(CompileIntegrationTests)
         .After(CompileAzureFunctionsSamplesWindows)
-        .After(BuildWindowsIntegrationTests)
+        .After(BuildIntegrationTests)
         .DependsOn(CleanTestLogs)
         .Requires(() => IsWin)
         .Requires(() => Framework)
@@ -2118,6 +2119,7 @@ partial class Build
         .After(CompileManagedSrc)
         .After(CompileManagedTestHelpers)
         .After(BuildRunnerTool)
+        .OnlyWhenStatic(() => IsLinux || IsOsx)
         .Requires(() => MonitoringHomeDirectory != null)
         .Requires(() => Framework)
         .Executes(() =>
@@ -2140,6 +2142,7 @@ partial class Build
         .Unlisted()
         .After(CompileManagedSrc)
         .After(CompileManagedTestHelpers)
+        .OnlyWhenStatic(() => IsLinux)
         .Requires(() => MonitoringHomeDirectory != null)
         .Executes(() =>
         {
@@ -2150,7 +2153,7 @@ partial class Build
         .After(CompileLinuxOrOsxIntegrationTests)
         .DependsOn(CleanTestLogs)
         .Description("Runs the linux dd-dotnet integration tests")
-        .Requires(() => !IsWin)
+        .OnlyWhenStatic(() => IsLinux)
         .Executes(() =>
         {
             var project = Solution.GetProject(Projects.DdTraceIntegrationTests);
@@ -2302,6 +2305,7 @@ partial class Build
        .Description("Copies monitoring-home into the serverless artifacts directory")
        .Unlisted()
        .After(CompileSamples, CompileTrimmingSamples)
+       .OnlyWhenStatic(() => IsLinux || IsOsx)
        .Executes(() =>
         {
             // This is a bit hacky, we can probably improve it once/if we output monitoring home into the BuildArtifactsDirectory too

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1535,7 +1535,7 @@ partial class Build
         .DependsOn(RunProfilerNativeUnitTestsLinux)
         .After(CompileProfilerNativeTests);
 
-    Target CompileIntegrationTests => _ => _
+    Target CompileWindowsIntegrationTests => _ => _
         .Unlisted()
         .After(CompileManagedSrc)
         .After(CompileManagedTestHelpers)
@@ -1803,7 +1803,7 @@ partial class Build
     Target RunIntegrationTests => _ => _
         .Unlisted()
         .After(BuildTracerHome)
-        .After(CompileIntegrationTests)
+        .After(CompileWindowsIntegrationTests)
         .After(CompileSamples)
         .After(CompileTrimmingSamples)
         .After(BuildIntegrationTests)
@@ -1943,7 +1943,7 @@ partial class Build
     Target RunWindowsAzureFunctionsTests => _ => _
         .Unlisted()
         .After(BuildTracerHome)
-        .After(CompileIntegrationTests)
+        .After(CompileWindowsIntegrationTests)
         .After(CompileAzureFunctionsSamplesWindows)
         .After(BuildIntegrationTests)
         .DependsOn(CleanTestLogs)
@@ -1985,7 +1985,7 @@ partial class Build
     Target RunWindowsRegressionTests => _ => _
         .Unlisted()
         .After(BuildTracerHome)
-        .After(CompileIntegrationTests)
+        .After(CompileWindowsIntegrationTests)
         .After(CompileSamples)
         .After(CompileTrimmingSamples)
         .After(BuildNativeLoader)
@@ -2027,7 +2027,7 @@ partial class Build
 
     Target RunWindowsTracerIisIntegrationTests => _ => _
         .After(BuildTracerHome)
-        .After(CompileIntegrationTests)
+        .After(CompileWindowsIntegrationTests)
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
@@ -2070,7 +2070,7 @@ partial class Build
 
     Target RunWindowsMsiIntegrationTests => _ => _
         .After(BuildTracerHome)
-        .After(CompileIntegrationTests)
+        .After(CompileWindowsIntegrationTests)
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2287,7 +2287,6 @@ partial class Build
        .Description("Copies monitoring-home into the serverless artifacts directory")
        .Unlisted()
        .After(CompileSamples, CompileTrimmingSamples)
-       .OnlyWhenStatic(() => IsLinux || IsOsx)
        .Executes(() =>
         {
             // This is a bit hacky, we can probably improve it once/if we output monitoring home into the BuildArtifactsDirectory too

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1553,13 +1553,13 @@ partial class Build
 
             var projects = TracerDirectory
                     .GlobFiles("test/*.IntegrationTests/*.csproj")
-                    .Where(path => !path.Contains(Projects.DebuggerIntegrationTests))
+                    .Where(path => !((string)path).Contains(Projects.DebuggerIntegrationTests))
                     .Where(project => Solution.GetProject(project).TryGetTargetFrameworks()?.Contains(Framework) ?? true);
 
             if (!IsWin)
             {
-                projects = projects.Where(path => !path.Contains(Projects.FleetInstallerTests))
-                                   .Where(path => !path.Contains(Projects.DdDotnetIntegrationTests));
+                projects = projects.Where(path => !((string)path).Contains(Projects.FleetInstallerTests))
+                                   .Where(path => !((string)path).Contains(Projects.DdDotnetIntegrationTests));
             }
 
             DotnetBuild(projects, framework: Framework, noRestore: IsWin);

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1535,30 +1535,37 @@ partial class Build
         .DependsOn(RunProfilerNativeUnitTestsLinux)
         .After(CompileProfilerNativeTests);
 
-    Target CompileWindowsIntegrationTests => _ => _
+    Target CompileIntegrationTests => _ => _
         .Unlisted()
         .After(CompileManagedSrc)
         .After(CompileManagedTestHelpers)
         .After(PublishIisSamples)
         .After(BuildRunnerTool)
-        .OnlyWhenStatic(() => IsWin)
         .Requires(() => Framework)
         .Requires(() => MonitoringHomeDirectory != null)
         .Executes(() =>
         {
             // Compile the dependent samples.
-            if (!Framework.ToString().StartsWith("net4"))
+            if (IsWin && !Framework.ToString().StartsWith("net4"))
             {
                 DotnetBuild(Solution.GetProject(Projects.RazorPages), framework: Framework);
             }
 
             var projects = TracerDirectory
-                    .GlobFiles("test/*.IntegrationTests/*.IntegrationTests.csproj")
-                    .Where(path => !((string)path).Contains(Projects.DebuggerIntegrationTests))
-                    .Where(project => Solution.GetProject(project).GetTargetFrameworks().Contains(Framework))
-                ;
+                    .GlobFiles("test/*.IntegrationTests/*.csproj")
+                    .Where(path => !path.Contains(Projects.DebuggerIntegrationTests))
+                    .Where(project => Solution.GetProject(project).TryGetTargetFrameworks()?.Contains(Framework) ?? true);
 
-            DotnetBuild(projects, framework: Framework);
+            if (!IsWin)
+            {
+                projects = projects.Where(path => !path.Contains(Projects.FleetInstallerTests))
+                                   .Where(path => !path.Contains(Projects.DdDotnetIntegrationTests));
+            }
+
+            DotnetBuild(projects, framework: Framework, noRestore: IsWin);
+
+            IntegrationTestLinuxOrOsxProfilerDirFudge(Projects.ClrProfilerIntegrationTests);
+            IntegrationTestLinuxOrOsxProfilerDirFudge(Projects.AppSecIntegrationTests);
         });
 
     Target CompileSamples => _ => _
@@ -1803,11 +1810,10 @@ partial class Build
     Target RunIntegrationTests => _ => _
         .Unlisted()
         .After(BuildTracerHome)
-        .After(CompileWindowsIntegrationTests)
+        .After(CompileIntegrationTests)
         .After(CompileSamples)
         .After(CompileTrimmingSamples)
         .After(BuildIntegrationTests)
-        .After(CompileLinuxOrOsxIntegrationTests)
         .DependsOn(CleanTestLogs)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
@@ -1943,7 +1949,7 @@ partial class Build
     Target RunWindowsAzureFunctionsTests => _ => _
         .Unlisted()
         .After(BuildTracerHome)
-        .After(CompileWindowsIntegrationTests)
+        .After(CompileIntegrationTests)
         .After(CompileAzureFunctionsSamplesWindows)
         .After(BuildIntegrationTests)
         .DependsOn(CleanTestLogs)
@@ -1985,7 +1991,7 @@ partial class Build
     Target RunWindowsRegressionTests => _ => _
         .Unlisted()
         .After(BuildTracerHome)
-        .After(CompileWindowsIntegrationTests)
+        .After(CompileIntegrationTests)
         .After(CompileSamples)
         .After(CompileTrimmingSamples)
         .After(BuildNativeLoader)
@@ -2027,7 +2033,7 @@ partial class Build
 
     Target RunWindowsTracerIisIntegrationTests => _ => _
         .After(BuildTracerHome)
-        .After(CompileWindowsIntegrationTests)
+        .After(CompileIntegrationTests)
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
@@ -2070,7 +2076,7 @@ partial class Build
 
     Target RunWindowsMsiIntegrationTests => _ => _
         .After(BuildTracerHome)
-        .After(CompileWindowsIntegrationTests)
+        .After(CompileIntegrationTests)
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
@@ -2114,30 +2120,6 @@ partial class Build
             ProjectModelTasks.Initialize();
         });
 
-    Target CompileLinuxOrOsxIntegrationTests => _ => _
-        .Unlisted()
-        .After(CompileManagedSrc)
-        .After(CompileManagedTestHelpers)
-        .After(BuildRunnerTool)
-        .OnlyWhenStatic(() => IsLinux || IsOsx)
-        .Requires(() => MonitoringHomeDirectory != null)
-        .Requires(() => Framework)
-        .Executes(() =>
-        {
-            // Build the actual integration test projects for Any CPU
-            var integrationTestProjects =
-                TracerDirectory
-                   .GlobFiles("test/*.IntegrationTests/*.csproj")
-                   .Where(path => !((string)path).Contains(Projects.DebuggerIntegrationTests))
-                   .Where(path => !((string)path).Contains(Projects.FleetInstallerTests))
-                   .Where(path => !((string)path).Contains(Projects.DdDotnetIntegrationTests));
-
-            DotnetBuild(integrationTestProjects, framework: Framework, noRestore: false);
-
-            IntegrationTestLinuxOrOsxProfilerDirFudge(Projects.ClrProfilerIntegrationTests);
-            IntegrationTestLinuxOrOsxProfilerDirFudge(Projects.AppSecIntegrationTests);
-        });
-
     Target CompileLinuxDdDotnetIntegrationTests => _ => _
         .Unlisted()
         .After(CompileManagedSrc)
@@ -2150,7 +2132,7 @@ partial class Build
         });
 
     Target RunLinuxDdDotnetIntegrationTests => _ => _
-        .After(CompileLinuxOrOsxIntegrationTests)
+        .After(CompileIntegrationTests)
         .DependsOn(CleanTestLogs)
         .Description("Runs the linux dd-dotnet integration tests")
         .OnlyWhenStatic(() => IsLinux)
@@ -2694,6 +2676,11 @@ partial class Build
     // the integration tests need their own copy of the profiler, this achieved through build.props on Windows, but doesn't seem to work under Linux
     private void IntegrationTestLinuxOrOsxProfilerDirFudge(string project)
     {
+        if (!IsLinux && !IsOsx)
+        {
+            return;
+        }
+
         // Not sure if/why this is necessary, and we can't just point to the correct output location
         var src = MonitoringHomeDirectory;
         var testProject = Solution.GetProject(project).Directory;

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1554,7 +1554,7 @@ partial class Build
             var projects = TracerDirectory
                     .GlobFiles("test/*.IntegrationTests/*.csproj")
                     .Where(path => !((string)path).Contains(Projects.DebuggerIntegrationTests))
-                    .Where(project => Solution.GetProject(project).TryGetTargetFrameworks()?.Contains(Framework) ?? true);
+                    .Where(project => Solution.GetProject(project).GetTargetFrameworks().Contains(Framework));
 
             if (!IsWin)
             {

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -297,7 +297,7 @@ partial class Build : NukeBuild
         .Unlisted()
         .Description("Builds the integration tests")
         .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileIntegrationTests)
+        .DependsOn(CompileWindowsIntegrationTests)
         .DependsOn(CompileLinuxOrOsxIntegrationTests)
         .DependsOn(CompileLinuxDdDotnetIntegrationTests)
         .DependsOn(CopyNativeFilesForTests)
@@ -310,14 +310,14 @@ partial class Build : NukeBuild
         .Description("Builds the ASP.NET integration tests for Windows")
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(PublishIisSamples)
-        .DependsOn(CompileIntegrationTests);
+        .DependsOn(CompileWindowsIntegrationTests);
 
     Target BuildWindowsRegressionTests => _ => _
         .Unlisted()
         .Requires(() => IsWin)
         .Description("Builds the regression tests for Windows")
         .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileIntegrationTests);
+        .DependsOn(CompileWindowsIntegrationTests);
 
     Target BuildAndRunIntegrationTests => _ => _
         .Description("Builds and runs the integration tests")
@@ -340,7 +340,7 @@ partial class Build : NukeBuild
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CompileAzureFunctionsSamplesWindows)
         .DependsOn(BuildRunnerTool)
-        .DependsOn(CompileIntegrationTests)
+        .DependsOn(CompileWindowsIntegrationTests)
         .DependsOn(RunWindowsAzureFunctionsTests);
 
     Target BuildAndRunToolArtifactTests => _ => _

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -293,14 +293,16 @@ partial class Build : NukeBuild
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(RunNativeTests);
 
-    Target BuildWindowsIntegrationTests => _ => _
+    Target BuildIntegrationTests => _ => _
         .Unlisted()
-        .Requires(() => IsWin)
-        .Description("Builds the integration tests for Windows")
+        .Description("Builds the integration tests")
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CompileIntegrationTests)
+        .DependsOn(CompileLinuxOrOsxIntegrationTests)
+        .DependsOn(CompileLinuxDdDotnetIntegrationTests)
         .DependsOn(CopyNativeFilesForTests)
-        .DependsOn(BuildRunnerTool);
+        .DependsOn(BuildRunnerTool)
+        .DependsOn(CopyServerlessArtifacts);
 
     Target BuildAspNetIntegrationTests => _ => _
         .Unlisted()
@@ -317,13 +319,13 @@ partial class Build : NukeBuild
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CompileIntegrationTests);
 
-    Target BuildAndRunWindowsIntegrationTests => _ => _
-        .Requires(() => IsWin)
-        .Description("Builds and runs the Windows (non-IIS) integration tests")
-        .DependsOn(BuildWindowsIntegrationTests)
+    Target BuildAndRunIntegrationTests => _ => _
+        .Description("Builds and runs the integration tests")
+        .DependsOn(BuildIntegrationTests)
         .DependsOn(CompileSamples)
         .DependsOn(CompileTrimmingSamples)
-        .DependsOn(RunIntegrationTests);
+        .DependsOn(RunIntegrationTests)
+        .DependsOn(RunLinuxDdDotnetIntegrationTests);
 
     Target BuildAndRunWindowsRegressionTests => _ => _
         .Requires(() => IsWin)
@@ -340,40 +342,6 @@ partial class Build : NukeBuild
         .DependsOn(BuildRunnerTool)
         .DependsOn(CompileIntegrationTests)
         .DependsOn(RunWindowsAzureFunctionsTests);
-
-    Target BuildLinuxIntegrationTests => _ => _
-        .Requires(() => !IsWin)
-        .Description("Builds the linux integration tests")
-        .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileLinuxOrOsxIntegrationTests)
-        .DependsOn(CompileLinuxDdDotnetIntegrationTests)
-        .DependsOn(BuildRunnerTool)
-        .DependsOn(CopyNativeFilesForTests)
-        .DependsOn(CopyServerlessArtifacts);
-
-    Target BuildAndRunLinuxIntegrationTests => _ => _
-        .Requires(() => !IsWin)
-        .Description("Builds and runs the linux integration tests. Requires docker-compose dependencies")
-        .DependsOn(BuildLinuxIntegrationTests)
-        .DependsOn(RunIntegrationTests)
-        .DependsOn(RunLinuxDdDotnetIntegrationTests);
-
-    Target BuildOsxIntegrationTests => _ => _
-        .Requires(() => IsOsx)
-        .Description("Builds the osx integration tests")
-        .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileLinuxOrOsxIntegrationTests)
-        .DependsOn(BuildRunnerTool)
-        .DependsOn(CopyNativeFilesForTests)
-        .DependsOn(CopyServerlessArtifacts);
-
-    Target BuildAndRunOsxIntegrationTests => _ => _
-        .Requires(() => IsOsx)
-        .Description("Builds and runs the osx integration tests. Requires docker-compose dependencies")
-        .DependsOn(BuildOsxIntegrationTests)
-        .DependsOn(CompileSamples)
-        .DependsOn(CompileTrimmingSamples)
-        .DependsOn(RunIntegrationTests);
 
     Target BuildAndRunToolArtifactTests => _ => _
        .Description("Builds and runs the tool artifacts tests")

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -297,8 +297,7 @@ partial class Build : NukeBuild
         .Unlisted()
         .Description("Builds the integration tests")
         .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileWindowsIntegrationTests)
-        .DependsOn(CompileLinuxOrOsxIntegrationTests)
+        .DependsOn(CompileIntegrationTests)
         .DependsOn(CompileLinuxDdDotnetIntegrationTests)
         .DependsOn(CopyNativeFilesForTests)
         .DependsOn(BuildRunnerTool)
@@ -310,14 +309,14 @@ partial class Build : NukeBuild
         .Description("Builds the ASP.NET integration tests for Windows")
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(PublishIisSamples)
-        .DependsOn(CompileWindowsIntegrationTests);
+        .DependsOn(CompileIntegrationTests);
 
     Target BuildWindowsRegressionTests => _ => _
         .Unlisted()
         .Requires(() => IsWin)
         .Description("Builds the regression tests for Windows")
         .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileWindowsIntegrationTests);
+        .DependsOn(CompileIntegrationTests);
 
     Target BuildAndRunIntegrationTests => _ => _
         .Description("Builds and runs the integration tests")
@@ -340,7 +339,7 @@ partial class Build : NukeBuild
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CompileAzureFunctionsSamplesWindows)
         .DependsOn(BuildRunnerTool)
-        .DependsOn(CompileWindowsIntegrationTests)
+        .DependsOn(CompileIntegrationTests)
         .DependsOn(RunWindowsAzureFunctionsTests);
 
     Target BuildAndRunToolArtifactTests => _ => _


### PR DESCRIPTION
## Summary of changes

Remove platform specific "BuildOsxIntegrationTests" etc. in favor of a single one that handles the things to skip internally.

## Reason for change

make instructions simpler, and behavior consistent with the other targets

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
