### PR TITLE
[Dynamic Instrumentation] DEBUG-5104 support case-insensitive line probe source paths

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -415,6 +415,47 @@ namespace Datadog.Trace.Debugger
             public int MatchingTrailingSegments { get; } = matchingTrailingSegments;
         }
 
+        internal readonly struct ClosestPathBySuffixResult
+        {
+            public ClosestPathBySuffixResult(
+                string? exampleSameFileNamePath,
+                int bestMatchingTrailingSegments,
+                int qualifiedMatchCount,
+                int bestQualifiedMatchingTrailingSegments,
+                string? bestQualifiedPath,
+                bool hasAmbiguousBestQualifiedMatch)
+            {
+                ExampleSameFileNamePath = exampleSameFileNamePath;
+                BestMatchingTrailingSegments = bestMatchingTrailingSegments;
+                QualifiedMatchCount = qualifiedMatchCount;
+                BestQualifiedMatchingTrailingSegments = bestQualifiedMatchingTrailingSegments;
+                BestQualifiedPath = bestQualifiedPath;
+                HasAmbiguousBestQualifiedMatch = hasAmbiguousBestQualifiedMatch;
+            }
+
+            public string? ExampleSameFileNamePath { get; }
+
+            public int BestMatchingTrailingSegments { get; }
+
+            public int QualifiedMatchCount { get; }
+
+            public int BestQualifiedMatchingTrailingSegments { get; }
+
+            public string? BestQualifiedPath { get; }
+
+            public bool HasAmbiguousBestQualifiedMatch { get; }
+
+            public bool IsSuccessful => QualifiedMatchCount > 0 && !HasAmbiguousBestQualifiedMatch && BestQualifiedPath is not null;
+
+            public static ClosestPathBySuffixResult NoCandidates() => new(
+                exampleSameFileNamePath: null,
+                bestMatchingTrailingSegments: 0,
+                qualifiedMatchCount: 0,
+                bestQualifiedMatchingTrailingSegments: 0,
+                bestQualifiedPath: null,
+                hasAmbiguousBestQualifiedMatch: false);
+        }
+
         internal sealed class FilePathLookup
         {
             private readonly Trie _trie = new();
@@ -432,6 +473,33 @@ namespace Datadog.Trace.Debugger
                 }
 
                 return Path.DirectorySeparatorChar;
+            }
+
+            private static int CountPathSegments(string path)
+            {
+                if (string.IsNullOrEmpty(path))
+                {
+                    return 0;
+                }
+
+                var pathSpan = path.AsSpan();
+                TrimTrailingSeparators(ref pathSpan);
+                var segmentCount = 0;
+
+                while (!pathSpan.IsEmpty)
+                {
+                    segmentCount++;
+                    var separatorIndex = FindLastSeparatorIndex(pathSpan);
+                    if (separatorIndex < 0)
+                    {
+                        break;
+                    }
+
+                    pathSpan = pathSpan.Slice(0, separatorIndex);
+                    TrimTrailingSeparators(ref pathSpan);
+                }
+
+                return segmentCount;
             }
 
             public void InsertPath(string path)
@@ -469,7 +537,19 @@ namespace Datadog.Trace.Debugger
                 var directoryPathSeparator = _directoryPathSeparator ?? Path.DirectorySeparatorChar;
                 var reversePath = directoryPathSeparator == '\\' ? pathQuery.ReversedBackslashPath : pathQuery.ReversedForwardSlashPath;
                 var match = _trie.GetStringStartingWith(reversePath);
-                return match != null ? GetReversePath(match, directoryPathSeparator, trimTrailingSeparators: false) : null;
+                if (match != null)
+                {
+                    return GetReversePath(match, directoryPathSeparator, trimTrailingSeparators: false);
+                }
+
+                var querySegmentCount = CountPathSegments(pathQuery.Path);
+                if (querySegmentCount == 0)
+                {
+                    return null;
+                }
+
+                var suffixMatch = GetClosestPathBySuffix(pathQuery, querySegmentCount);
+                return suffixMatch.IsSuccessful ? suffixMatch.BestQualifiedPath : null;
             }
 
             public bool TryGetDocumentPathByFileName(string fileName, [NotNullWhen(true)] out string? documentPath)
@@ -558,7 +638,7 @@ namespace Datadog.Trace.Debugger
                     var path1Segment = path1SeparatorIndex >= 0 ? path1Span.Slice(path1SeparatorIndex + 1) : path1Span;
                     var path2Segment = path2SeparatorIndex >= 0 ? path2Span.Slice(path2SeparatorIndex + 1) : path2Span;
 
-                    if (!path1Segment.SequenceEqual(path2Segment))
+                    if (!path1Segment.Equals(path2Segment, StringComparison.OrdinalIgnoreCase))
                     {
                         break;
                     }
@@ -691,37 +771,6 @@ namespace Datadog.Trace.Debugger
                     SameFileNameMatchCount: SameFileNameMatchCount,
                     SameFileNameExamples: SameFileNameExamples);
             }
-        }
-
-        internal sealed class ClosestPathBySuffixResult(
-            string? exampleSameFileNamePath,
-            int bestMatchingTrailingSegments,
-            int qualifiedMatchCount,
-            int bestQualifiedMatchingTrailingSegments,
-            string? bestQualifiedPath,
-            bool hasAmbiguousBestQualifiedMatch)
-        {
-            public string? ExampleSameFileNamePath { get; } = exampleSameFileNamePath;
-
-            public int BestMatchingTrailingSegments { get; } = bestMatchingTrailingSegments;
-
-            public int QualifiedMatchCount { get; } = qualifiedMatchCount;
-
-            public int BestQualifiedMatchingTrailingSegments { get; } = bestQualifiedMatchingTrailingSegments;
-
-            public string? BestQualifiedPath { get; } = bestQualifiedPath;
-
-            public bool HasAmbiguousBestQualifiedMatch { get; } = hasAmbiguousBestQualifiedMatch;
-
-            public bool IsSuccessful => QualifiedMatchCount > 0 && !HasAmbiguousBestQualifiedMatch && BestQualifiedPath is not null;
-
-            public static ClosestPathBySuffixResult NoCandidates() => new(
-                exampleSameFileNamePath: null,
-                bestMatchingTrailingSegments: 0,
-                qualifiedMatchCount: 0,
-                bestQualifiedMatchingTrailingSegments: 0,
-                bestQualifiedPath: null,
-                hasAmbiguousBestQualifiedMatch: false);
         }
 
         private sealed class AssemblyPathMatch(Assembly assembly, string path, LineProbePathMatchType pathMatchType, int? matchingTrailingSegments)

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.Debugger
 
         private static void TrackClosestPathMatch(
             Assembly assembly,
-            ClosestPathBySuffixResult result,
+            in ClosestPathBySuffixResult result,
             bool includeExamplePaths,
             ref int sameFileNameMatchCount,
             ref int bestMatchingTrailingSegments,
@@ -233,7 +233,7 @@ namespace Datadog.Trace.Debugger
                     var closestPathMatch = lookup.GetClosestPathBySuffix(probePathQuery, MinTrailingSegmentsForFallbackMatch);
                     TrackClosestPathMatch(
                         candidateAssembly,
-                        closestPathMatch,
+                        in closestPathMatch,
                         includeDetailedDiagnostics,
                         ref sameFileNameMatchCount,
                         ref bestMatchingTrailingSegments,
@@ -242,7 +242,7 @@ namespace Datadog.Trace.Debugger
 
                     // Only bind when a single global fallback candidate has the best score.
                     // Assemblies with internally ambiguous fallback matches must still participate in that global tie.
-                    bestFallbackMatchSelection.Track(candidateAssembly, closestPathMatch);
+                    bestFallbackMatchSelection.Track(candidateAssembly, in closestPathMatch);
                 }
 
                 if (bestFallbackMatchSelection.BestMatch is { } bestMatch)
@@ -381,7 +381,7 @@ namespace Datadog.Trace.Debugger
 
             public bool HasAmbiguousBestMatch { get; private set; }
 
-            public void Track(Assembly assembly, ClosestPathBySuffixResult result)
+            public void Track(Assembly assembly, in ClosestPathBySuffixResult result)
             {
                 if (result.QualifiedMatchCount == 0)
                 {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
@@ -58,6 +58,18 @@ public class LineProbeResolverTest
         (loc1.MethodToken, loc1.BytecodeOffset).Should().Be((loc2.MethodToken, loc2.BytecodeOffset));
     }
 
+    [Fact]
+    public void ResolvesLineProbeWhenSourceFileCasingDiffers()
+    {
+        var originalSourceFile = _probeDefinition.Where.SourceFile;
+        _probeDefinition.Where.SourceFile = originalSourceFile.ToUpperInvariant();
+
+        var result = _lineProbeResolver.TryResolveLineProbe(_probeDefinition, out var loc);
+
+        result.Status.Should().Be(LiveProbeResolveStatus.Bound);
+        loc.Should().NotBeNull();
+    }
+
     [Theory]
     [InlineData(@"D:\build_agent\yada\yada\src\MyProject\MyFile.cs")]
     [InlineData(@"/usr/opt/build_agent/yada/yada/src/MyProject/MyFile.cs")]
@@ -79,6 +91,19 @@ public class LineProbeResolverTest
     }
 
     [Theory]
+    [InlineData(@"D:\build_agent\yada\yada\src\MyProject\MyFile.cs", @"src\myproject\myfile.cs")]
+    [InlineData(@"/usr/opt/build_agent/yada/yada/controllers/debuggercontroller.cs", @"Controllers/DebuggerController.cs")]
+    [InlineData(@"\\build-agent\share\yada\yada\src\MyProject\MyFile.cs", @"SRC\MYPROJECT\MYFILE.CS")]
+    public void FindPathThatEndsWithIgnoresCaseAndPreservesOriginalPath(string originalPath, string queryPath)
+    {
+        var lookup = new LineProbeResolver.FilePathLookup();
+
+        lookup.InsertPath(originalPath);
+
+        lookup.FindPathThatEndsWith(queryPath).Should().Be(originalPath);
+    }
+
+    [Theory]
     [InlineData(@"D:\build_agent\yada\yada\src\MyProject\MyFile.cs", @"src\MyProject\MyFile.cs\")]
     [InlineData(@"/usr/opt/build_agent/yada/yada/src/MyProject/MyFile.cs", @"src/MyProject/MyFile.cs/")]
     [InlineData(@"\\build-agent\share\yada\yada\src\MyProject\MyFile.cs", @"src\MyProject\MyFile.cs\")]
@@ -89,6 +114,35 @@ public class LineProbeResolverTest
         lookup.InsertPath(originalPath);
 
         lookup.FindPathThatEndsWith(queryPath).Should().Be(originalPath);
+    }
+
+    [Fact]
+    public void FindPathThatEndsWithReturnsNullWhenCaseInsensitiveFallbackIsAmbiguous()
+    {
+        // When the trie misses (e.g., due to case differences) and the case-insensitive fallback
+        // finds multiple candidates with equally good trailing-segment matches, it must return null
+        // rather than arbitrarily binding to one path.
+        var lookup = new LineProbeResolver.FilePathLookup();
+
+        lookup.InsertPath(@"/a/src/Shared/Feature/MyFile.cs");
+        lookup.InsertPath(@"/b/src/Shared/Feature/MyFile.cs");
+
+        lookup.FindPathThatEndsWith(@"src/shared/feature/myfile.cs").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(@"D:\MyFile.cs", @"Source\src\MyProject\MyFile.cs")]
+    [InlineData(@"/_/MyFile.cs", @"Source/src/MyProject/MyFile.cs")]
+    public void FindPathThatEndsWithReturnsNullWhenQueryHasMoreSegmentsThanDocument(string documentPath, string queryPath)
+    {
+        // The fallback inside FindPathThatEndsWith requires the full query (every segment) to match
+        // a trailing suffix of the document. A query with more segments than the document can never
+        // satisfy that and must return null, even when the file name (and other trailing segments) match.
+        var lookup = new LineProbeResolver.FilePathLookup();
+
+        lookup.InsertPath(documentPath);
+
+        lookup.FindPathThatEndsWith(queryPath).Should().BeNull();
     }
 
     [Fact]
@@ -145,16 +199,16 @@ public class LineProbeResolverTest
     }
 
     [Fact]
-    public void FilePathLookupDoesNotFallbackOnCaseOnlyDifference()
+    public void FilePathLookupFallbackMatchesCaseOnlyDifference()
     {
         var lookup = new LineProbeResolver.FilePathLookup();
         const string documentPath = @"/_/src/MyProject/Feature/MyFile.cs";
 
         lookup.InsertPath(documentPath);
 
-        lookup.TryFindClosestPathBySuffix(@"Source/src/MyProject/Feature/myfile.cs", minimumMatchingTrailingSegments: 4, out var match, out var matchingTrailingSegments).Should().BeFalse();
-        match.Should().BeNull();
-        matchingTrailingSegments.Should().Be(0);
+        lookup.TryFindClosestPathBySuffix(@"Source/src/MyProject/Feature/myfile.cs", minimumMatchingTrailingSegments: 4, out var match, out var matchingTrailingSegments).Should().BeTrue();
+        match.Should().Be(documentPath);
+        matchingTrailingSegments.Should().Be(4);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of changes

- Support case-insensitive source path matching for Dynamic Instrumentation line probes.
- Preserve the original PDB document path when resolving matched probes.
- Add focused coverage for case-insensitive exact suffix and fallback path matching.

## Reason for change

- Valid line probes can remain unbound when the configured probe path casing differs from the casing in PDB document paths, e.g. `Controllers/DebuggerController.cs` vs `controllers/debuggercontroller.cs`.

## Implementation details

- Keep the existing trie lookup as the fast path for exact suffix matches.
- On trie miss, use the existing suffix matcher to find a full-query case-insensitive match while preserving ambiguity handling.
- Compare path segments with `StringComparison.OrdinalIgnoreCase`.
- Convert `ClosestPathBySuffixResult` to a readonly struct to avoid adding allocation in this warm probe-resolution path.

## Test coverage

- `LineProbeResolverTest`