### PR TITLE
[SymDB] DEBUG-5382 Add injectable line ranges to method scopes

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Symbols/Model/LineRange.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/Model/LineRange.cs
@@ -1,0 +1,18 @@
+// <copyright file="LineRange.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Debugger.Symbols.Model;
+
+internal record struct LineRange
+{
+    [JsonProperty("start")]
+    internal int Start { get; set; }
+
+    [JsonProperty("end")]
+    internal int End { get; set; }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Scope.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Scope.cs
@@ -28,6 +28,13 @@ internal record struct Scope
     [JsonProperty("end_line")]
     internal int EndLine { get; set; }
 
+    // SymDB uses the existing "injectible" spelling in its cross-language schema.
+    [JsonProperty("has_injectible_lines")]
+    internal bool? HasInjectibleLines { get; set; }
+
+    [JsonProperty("injectible_lines")]
+    internal LineRange[]? InjectibleLines { get; set; }
+
     [JsonProperty("language_specifics")]
     internal LanguageSpecifics? LanguageSpecifics { get; set; }
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -616,6 +616,7 @@ namespace Datadog.Trace.Debugger.Symbols
                 ScopeType = ScopeType.Method,
                 Name = methodName,
                 LanguageSpecifics = methodLanguageSpecifics,
+                HasInjectibleLines = false,
                 Symbols = argsSymbol,
                 Scopes = closureScopes,
                 SourceFile = null,

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
@@ -36,7 +36,9 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
             return false;
         }
 
-        using var memory = DatadogMetadataReader.GetMethodSequencePointsAsMemoryOwner(MetadataTokens.GetToken(methodHandle), false, out var count);
+        // For async methods, the user-facing scope is the kickoff method, but the executable
+        // sequence points often live on the generated MoveNext state machine method.
+        using var memory = DatadogMetadataReader.GetMethodSequencePointsAsMemoryOwner(MetadataTokens.GetToken(methodHandle), true, out var count);
         if (memory == null || count == 0)
         {
             return true;
@@ -47,6 +49,12 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
         methodScope.StartLine = sourcePdbInfo.StartLine;
         methodScope.EndLine = sourcePdbInfo.EndLine;
         methodScope.SourceFile = sourcePdbInfo.Path;
+        methodScope.InjectibleLines = BuildInjectibleLineRanges(sequencePoints);
+        if (methodScope.InjectibleLines is { Length: > 0 })
+        {
+            methodScope.HasInjectibleLines = true;
+        }
+
         if (sourcePdbInfo.EndColumn > 0)
         {
             var ls = new LanguageSpecifics
@@ -64,6 +72,71 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
         var localScopes = GetLocalSymbols(methodHandle, method, sequencePoints, methodScope);
         methodScope.Scopes = ConcatMethodScopes(methodScope.Scopes ?? null, localScopes);
         return true;
+    }
+
+    internal static LineRange[]? BuildInjectibleLineRanges(ReadOnlySpan<DatadogMetadataReader.DatadogSequencePoint> sequencePoints)
+    {
+        if (sequencePoints.IsEmpty)
+        {
+            return null;
+        }
+
+        var lineRanges = ArrayPool<LineRange>.Shared.Rent(sequencePoints.Length);
+        try
+        {
+            var lineRangeCount = 0;
+            ref var firstSequencePoint = ref MemoryMarshal.GetReference(sequencePoints);
+            for (var i = 0; i < sequencePoints.Length; i++)
+            {
+                var sequencePoint = Unsafe.Add(ref firstSequencePoint, i);
+                if (sequencePoint.StartLine <= 0)
+                {
+                    continue;
+                }
+
+                var endLine = sequencePoint.EndLine >= sequencePoint.StartLine ? sequencePoint.EndLine : sequencePoint.StartLine;
+                lineRanges[lineRangeCount] = new LineRange { Start = sequencePoint.StartLine, End = endLine };
+                lineRangeCount++;
+            }
+
+            if (lineRangeCount == 0)
+            {
+                return null;
+            }
+
+            Array.Sort(lineRanges, 0, lineRangeCount, LineRangeComparer.Instance);
+            var mergedLineRangeCount = 0;
+            var currentRange = lineRanges[0];
+
+            for (var i = 1; i < lineRangeCount; i++)
+            {
+                var nextRange = lineRanges[i];
+                if (nextRange.Start <= currentRange.End + 1)
+                {
+                    if (nextRange.End > currentRange.End)
+                    {
+                        currentRange.End = nextRange.End;
+                    }
+
+                    continue;
+                }
+
+                lineRanges[mergedLineRangeCount] = currentRange;
+                mergedLineRangeCount++;
+                currentRange = nextRange;
+            }
+
+            lineRanges[mergedLineRangeCount] = currentRange;
+            mergedLineRangeCount++;
+
+            var mergedRanges = new LineRange[mergedLineRangeCount];
+            Array.Copy(lineRanges, mergedRanges, mergedLineRangeCount);
+            return mergedRanges;
+        }
+        finally
+        {
+            ArrayPool<LineRange>.Shared.Return(lineRanges);
+        }
     }
 
     private SourceLocationInfo GetSourceLocationInfo(ReadOnlySpan<DatadogMetadataReader.DatadogSequencePoint> span)
@@ -476,5 +549,16 @@ internal sealed class SymbolPdbExtractor : SymbolExtractor
         }
 
         return false;
+    }
+
+    private sealed class LineRangeComparer : IComparer<LineRange>
+    {
+        public static readonly LineRangeComparer Instance = new();
+
+        public int Compare(LineRange x, LineRange y)
+        {
+            var startComparison = x.Start.CompareTo(y.Start);
+            return startComparison != 0 ? startComparison : x.End.CompareTo(y.End);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.AsyncMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.AsyncMethod.verified.txt
@@ -14,7 +14,7 @@
           "scope_type": "class",
           "name": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.AsyncMethod",
           "source_file": "tracer\\test\\Datadog.Trace.Tests\\Debugger\\SymbolsTests\\TestSamples\\AsyncMethod.cs",
-          "start_line": 20,
+          "start_line": 15,
           "end_line": 999,
           "language_specifics": {
             "super_classes": [
@@ -27,7 +27,7 @@
               "scope_type": "method",
               "name": "GetTime",
               "source_file": "tracer\\test\\Datadog.Trace.Tests\\Debugger\\SymbolsTests\\TestSamples\\AsyncMethod.cs",
-              "start_line": 20,
+              "start_line": 15,
               "end_line": 999,
               "language_specifics": {
                 "access_modifiers": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedAndNotHoistedLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedAndNotHoistedLocals.verified.txt
@@ -175,8 +175,9 @@
             {
               "scope_type": "method",
               "name": "GetCourseSchedule",
-              "start_line": 0,
-              "end_line": 0,
+              "source_file": "tracer\\test\\Datadog.Trace.Tests\\Debugger\\SymbolsTests\\TestSamples\\HoistedAndNotHoistedLocals.cs",
+              "start_line": 67,
+              "end_line": 999,
               "language_specifics": {
                 "access_modifiers": [
                   "sanitized"
@@ -184,7 +185,9 @@
                 "annotations": [
                   "async"
                 ],
-                "return_type": "System.Threading.Tasks.Task`1<Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+Person>"
+                "return_type": "System.Threading.Tasks.Task`1<Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+Person>",
+                "start_column": 999,
+                "end_column": 999
               },
               "symbols": [
                 {
@@ -239,8 +242,9 @@
             {
               "scope_type": "class",
               "name": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals+Service",
-              "start_line": 0,
-              "end_line": 0,
+              "source_file": "tracer\\test\\Datadog.Trace.Tests\\Debugger\\SymbolsTests\\TestSamples\\HoistedAndNotHoistedLocals.cs",
+              "start_line": 80,
+              "end_line": 999,
               "language_specifics": {
                 "access_modifiers": [
                   "sanitized"
@@ -257,8 +261,9 @@
                 {
                   "scope_type": "method",
                   "name": "BookRoom",
-                  "start_line": 0,
-                  "end_line": 0,
+                  "source_file": "tracer\\test\\Datadog.Trace.Tests\\Debugger\\SymbolsTests\\TestSamples\\HoistedAndNotHoistedLocals.cs",
+                  "start_line": 80,
+                  "end_line": 999,
                   "language_specifics": {
                     "access_modifiers": [
                       "sanitized"
@@ -267,7 +272,9 @@
                       "final virtual",
                       "async"
                     ],
-                    "return_type": "System.Threading.Tasks.Task"
+                    "return_type": "System.Threading.Tasks.Task",
+                    "start_column": 999,
+                    "end_column": 999
                   },
                   "symbols": [
                     {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedLocalsAndArgsInStateMachine.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedLocalsAndArgsInStateMachine.verified.txt
@@ -14,7 +14,7 @@
           "scope_type": "class",
           "name": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine",
           "source_file": "tracer\\test\\Datadog.Trace.Tests\\Debugger\\SymbolsTests\\TestSamples\\HoistedLocalsAndArgsInStateMachine.cs",
-          "start_line": 26,
+          "start_line": 18,
           "end_line": 999,
           "language_specifics": {
             "super_classes": [
@@ -50,8 +50,9 @@
             {
               "scope_type": "method",
               "name": "Init",
-              "start_line": 0,
-              "end_line": 0,
+              "source_file": "tracer\\test\\Datadog.Trace.Tests\\Debugger\\SymbolsTests\\TestSamples\\HoistedLocalsAndArgsInStateMachine.cs",
+              "start_line": 18,
+              "end_line": 999,
               "language_specifics": {
                 "access_modifiers": [
                   "sanitized"
@@ -59,7 +60,9 @@
                 "annotations": [
                   "async"
                 ],
-                "return_type": "System.Threading.Tasks.Task"
+                "return_type": "System.Threading.Tasks.Task",
+                "start_column": 999,
+                "end_column": 999
               },
               "symbols": [
                 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractorTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractorTest.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Debugger.Symbols.Model;
+using Datadog.Trace.Pdb;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using VerifyTests;
@@ -189,6 +190,77 @@ public class SymbolExtractorTest
 #endif
     }
 
+    [Fact]
+    private void BuildInjectibleLineRanges_MergesAndNormalizesSequencePointSpans()
+    {
+        var sequencePoints = new[]
+        {
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 24, EndLine = 25 },
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 20, EndLine = 20 },
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 21, EndLine = 23 },
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 30, EndLine = 30 },
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 32, EndLine = 34 },
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 31, EndLine = 31 },
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 40, EndLine = 39 },
+            new DatadogMetadataReader.DatadogSequencePoint { StartLine = 0, EndLine = 0 },
+        };
+
+        var ranges = SymbolPdbExtractor.BuildInjectibleLineRanges(sequencePoints);
+
+        Assert.Equal(
+            [
+                new LineRange { Start = 20, End = 25 },
+                new LineRange { Start = 30, End = 34 },
+                new LineRange { Start = 40, End = 40 }
+            ],
+            ranges);
+    }
+
+    [SkippableFact]
+    [Trait("Category", "LinuxUnsupported")]
+    private void PdbBackedMethodScopesIncludeInjectibleLines()
+    {
+#if DEBUG
+        throw new SkipException("This test requires RELEASE mode and will always fail in DEBUG mode");
+#elif NETFRAMEWORK
+        throw new SkipException("This test is flaky - The .NET Framework snapshots produced are different in CI and locally");
+#else
+        if (!EnvironmentTools.IsWindows())
+        {
+            throw new SkipException("PDB test only on windows");
+        }
+
+        var type = typeof(TestSamples.AsyncMethod);
+        var assembly = Assembly.GetAssembly(type);
+        Assert.NotNull(assembly);
+
+        var root = GetSymbols(assembly, type.FullName);
+        var classScope = root.Scopes.Single().Scopes.Single();
+        var getTimeMethod = classScope.Scopes.Single(s => s.ScopeType == ScopeType.Method && s.Name == "GetTime");
+
+        Assert.Equal(15, getTimeMethod.StartLine);
+        Assert.Equal(25, getTimeMethod.EndLine);
+        Assert.True(getTimeMethod.HasInjectibleLines);
+        Assert.Equal(
+            [
+                new LineRange { Start = 15, End = 15 },
+                new LineRange { Start = 17, End = 22 },
+                new LineRange { Start = 24, End = 25 }
+            ],
+            getTimeMethod.InjectibleLines);
+        Assert.NotNull(getTimeMethod.Scopes);
+        Assert.Contains(getTimeMethod.Scopes, s => s.ScopeType == ScopeType.Closure);
+
+        var json = JsonConvert.SerializeObject(
+            getTimeMethod,
+            Formatting.None,
+            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+
+        Assert.Contains("\"has_injectible_lines\":true", json);
+        Assert.Contains("\"injectible_lines\":[", json);
+#endif
+    }
+
     private string GetStringToVerify(Root root)
     {
         var assembly = root.Scopes[0];
@@ -231,6 +303,8 @@ public class SymbolExtractorTest
 
             // depends on build optimization
             scope.EndLine = scope.EndLine > 0 ? 999 : 0;
+            scope.HasInjectibleLines = null;
+            scope.InjectibleLines = null;
 
             if (scope.Scopes == null)
             {


### PR DESCRIPTION
## Summary of changes
* Add `has_injectible_lines` and `injectible_lines` to SymDB method scopes.
* Build injectable line ranges from PDB sequence points and merge contiguous executable spans before serializing them.
* Resolve async kickoff methods through generated state machine sequence points so the outer method scope reflects the source lines users actually see.
* Add targeted symbol extractor coverage for injectable-line range generation and exact async-method ranges.
* Update the affected Verify snapshots for async and state-machine-backed samples.

## Reason for change
* Probe placement tooling needs executable source lines so it can avoid repeated trial-and-failure on non-injectable lines.
* Async methods should expose injectable lines on the original method scope, not only on generated closure/state-machine scopes.

## Implementation details
* Keep the existing SymDB schema spelling and introduce a LineRange model for serialized ranges.
* Default method scopes to `has_injectible_lines = false`, then populate ranges when PDB-backed sequence points are available.
* Use async fallback when resolving method sequence points so kickoff methods inherit source information from generated `MoveNext()` sequence points.
* Build ranges by sorting visible sequence points and merging adjacent spans; use pooled intermediate storage so the helper only allocates the final serialized array.
* Snapshot changes are limited to async/state-machine scopes that now resolve to real source lines and columns instead of 0 or closure-only fallback.

## Test coverage
`SymbolsTests.SymbolExtractorTest`