### PR TITLE
Add cursor rule file

### DIFF
--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,6 @@
+---
+description: dd-trace-dotnet project guidelines
+alwaysApply: true
+---
+
+See `AGENTS.md` (repository root) for all project guidelines.


### PR DESCRIPTION
## Summary of changes

Add a single always-applied Cursor rule that points to `AGENTS.md`.

## Reason for change

dd-trace-dotnet has `CLAUDE.md` for Claude Code users but no `.cursor/` configuration, so Cursor users (officially supported; some on the team use it) had no auto-loaded project guidelines. This adds the minimum scaffolding so Cursor loads the same `AGENTS.md` Claude Code already does.

## Implementation details

- One file: `.cursor/rules/agents.mdc` (6 lines: YAML frontmatter + one-line pointer to `AGENTS.md`).
- `alwaysApply: true` so Cursor auto-loads it on every chat.
- No content duplication — `AGENTS.md` remains the single source of truth.

## Test coverage

N/A — config/documentation only.