### PR TITLE
Switch `Activity` handling to use `WeakReference<T>`

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/ActivityListener.cs
+++ b/tracer/src/Datadog.Trace/Activity/ActivityListener.cs
@@ -11,6 +11,7 @@ using System.Reflection.Emit;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Activity.DuckTypes;
+using Datadog.Trace.Activity.Handlers;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
@@ -158,6 +159,9 @@ namespace Datadog.Trace.Activity
                     CreateDiagnosticSourceListenerInstance(diagnosticListenerType);
                 }
 
+                // Kick off the reconciliation sweep that bounds ActivityMappingById growth
+                // when customer code creates Activities without calling Stop.
+                ActivityHandlerCommon.StartReconciliationLoop();
                 return;
             }
 
@@ -192,6 +196,8 @@ namespace Datadog.Trace.Activity
 
         public static void StopListeners()
         {
+            ActivityHandlerCommon.StopReconciliationLoop();
+
             // If there's an activity listener instance we dispose the instance and clear it.
             if (_activityListenerInstance is IDisposable disposableListener)
             {

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -412,7 +412,7 @@ namespace Datadog.Trace.Activity.Handlers
                             }
                         }
 
-                        span.SetTag("is_incomplete", "true");
+                        span.SetTag("closed_reason", "garbage_collected");
 
                         span.Finish();
                         scope.Close();

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Events;
@@ -330,85 +331,14 @@ namespace Datadog.Trace.Activity.Handlers
 
             try
             {
-                var gcCollected = 0;
-                var missedStop = 0;
-                var count = 0;
-                List<ActivityKey>? toRemove = null;
-
-                foreach (var kvp in ActivityMappingById)
-                {
-                    count++;
-                    var activityRef = kvp.Value.Activity;
-                    var scope = kvp.Value.Scope;
-
-                    if (!activityRef.TryGetTarget(out var activityObject))
-                    {
-                        // Activity was GC'd before Stop was called. Close the scope at "now"
-                        // so the span finishes and gets flushed; we don't have a real end time,
-                        // so the duration becomes (now - StartTime) — bounded but possibly inflated.
-                        if (scope?.Span is { } span)
-                        {
-                            span.SetTag("dd.activity.forced_close", "abandoned");
-                            span.Finish();
-                            scope.Close();
-                        }
-
-                        toRemove ??= new List<ActivityKey>();
-                        toRemove.Add(kvp.Key);
-                        gcCollected++;
-                        continue;
-                    }
-
-                    // Activity is still alive. A non-zero Duration on an entry that's still in
-                    // the dictionary means Stop() was called but our listener callback didn't
-                    // handle it - close it using the real end time.
-                    if (activityObject.TryDuckCast<IActivity6>(out var activity6))
-                    {
-                        if (activity6.Duration != TimeSpan.Zero)
-                        {
-                            CloseActivityScope(activity6, scope);
-                            toRemove ??= new List<ActivityKey>();
-                            toRemove.Add(kvp.Key);
-                            missedStop++;
-                        }
-                    }
-                    else if (activityObject.TryDuckCast<IActivity5>(out var activity5))
-                    {
-                        if (activity5.Duration != TimeSpan.Zero)
-                        {
-                            CloseActivityScope(activity5, scope);
-                            toRemove ??= new List<ActivityKey>();
-                            toRemove.Add(kvp.Key);
-                            missedStop++;
-                        }
-                    }
-                    else if (activityObject.TryDuckCast<IActivity>(out var activity4))
-                    {
-                        if (activity4.Duration != TimeSpan.Zero)
-                        {
-                            CloseActivityScope(activity4, scope);
-                            toRemove ??= new List<ActivityKey>();
-                            toRemove.Add(kvp.Key);
-                            missedStop++;
-                        }
-                    }
-                }
-
-                if (toRemove is not null)
-                {
-                    foreach (var key in toRemove)
-                    {
-                        ActivityMappingById.TryRemove(key, out _);
-                    }
-                }
-
-                if (Log.IsEnabled(LogEventLevel.Debug) && (gcCollected > 0 || missedStop > 0))
+                var result = ReconcileSweepCore(ActivityMappingById);
+                if ((result.GcCollected > 0 || result.MissedStop > 0) && Log.IsEnabled(LogEventLevel.Debug))
                 {
                     Log.Debug<int, int, int>(
-                        "ActivityHandlerCommon: reconciliation swept {GcCollected} GC'd activities and {MissedStop} missed-Stop activities; initial dictionary size {Initial}",
-                        gcCollected,
-                        missedStop,
-                        count);
+                        "ActivityHandlerCommon: reconciliation swept {GcCollected} GC'd activities and {MissedStop} missed-Stop activities (iterated {Iterated})",
+                        result.GcCollected,
+                        result.MissedStop,
+                        result.Iterated);
                 }
             }
             catch (Exception ex)
@@ -419,6 +349,71 @@ namespace Datadog.Trace.Activity.Handlers
             {
                 Interlocked.Exchange(ref _sweepInProgress, 0);
             }
+        }
+
+        [TestingAndPrivateOnly]
+        internal static ReconciliationSweepResult ReconcileSweepCore(ConcurrentDictionary<ActivityKey, ActivityMapping> mappings)
+        {
+            var gcCollected = 0;
+            var missedStop = 0;
+            var iterated = 0;
+
+            foreach (var kvp in mappings)
+            {
+                iterated++;
+                var activityRef = kvp.Value.Activity;
+
+                if (!activityRef.TryGetTarget(out var activityObject))
+                {
+                    // Activity was GC'd before Stop was called. Take ownership atomically; if
+                    // another thread already removed this entry, bail without closing.
+                    if (mappings.TryRemove(kvp.Key, out var owned) && owned.Scope is { Span: { } span } scope)
+                    {
+                        span.SetTag("dd.activity.forced_close", "abandoned");
+                        span.Finish();
+                        scope.Close();
+                        gcCollected++;
+                    }
+
+                    continue;
+                }
+
+                // Activity is still alive. A non-zero Duration on an entry that's still in
+                // the dictionary means Stop() was called but our listener callback didn't
+                // handle it — close it using the real end time.
+                if (activityObject.TryDuckCast<IActivity6>(out var activity6))
+                {
+                    if (activity6.Duration != TimeSpan.Zero
+                     && mappings.TryRemove(kvp.Key, out var owned)
+                     && owned.Scope is { } scope)
+                    {
+                        CloseActivityScope(activity6, scope);
+                        missedStop++;
+                    }
+                }
+                else if (activityObject.TryDuckCast<IActivity5>(out var activity5))
+                {
+                    if (activity5.Duration != TimeSpan.Zero
+                     && mappings.TryRemove(kvp.Key, out var owned)
+                     && owned.Scope is { } scope)
+                    {
+                        CloseActivityScope(activity5, scope);
+                        missedStop++;
+                    }
+                }
+                else if (activityObject.TryDuckCast<IActivity>(out var activity4))
+                {
+                    if (activity4.Duration != TimeSpan.Zero
+                     && mappings.TryRemove(kvp.Key, out var owned)
+                     && owned.Scope is { } scope)
+                    {
+                        CloseActivityScope(activity4, scope);
+                        missedStop++;
+                    }
+                }
+            }
+
+            return new ReconciliationSweepResult(gcCollected, missedStop, iterated);
         }
 
         private static void CloseActivityScope<TInner>(TInner activity, Scope scope)
@@ -440,6 +435,20 @@ namespace Datadog.Trace.Activity.Handlers
             span.Finish(activity.StartTimeUtc.Add(activity.Duration));
 
             scope.Close();
+        }
+
+        internal readonly struct ReconciliationSweepResult
+        {
+            public readonly int GcCollected;
+            public readonly int MissedStop;
+            public readonly int Iterated;
+
+            public ReconciliationSweepResult(int gcCollected, int missedStop, int iterated)
+            {
+                GcCollected = gcCollected;
+                MissedStop = missedStop;
+                Iterated = iterated;
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
@@ -23,6 +24,13 @@ namespace Datadog.Trace.Activity.Handlers
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ActivityHandlerCommon));
         internal static readonly ConcurrentDictionary<ActivityKey, ActivityMapping> ActivityMappingById = new();
         private static readonly IntegrationId IntegrationId = IntegrationId.OpenTelemetry;
+
+        // Periodic sweep that handles two reliability cases that the hot-path Stop callback
+        // cannot: 1. Activities the customer abandoned without calling Stop (their WeakReference
+        // target is GC'd); 2. Activities whose Stop fired but our listener callback missed.
+        private static readonly TimeSpan ReconciliationInterval = TimeSpan.FromSeconds(10);
+        private static int _sweepInProgress;
+        private static Timer? _reconciliationTimer;
 
         /// <summary>
         /// Handles when a new Activity is started to map it to a new <see cref="Span"/>/<see cref="Scope"/>.
@@ -200,10 +208,10 @@ namespace Datadog.Trace.Activity.Handlers
                 // Avoid closure allocation if we can
                 activityMapping = ActivityMappingById.GetOrAdd(
                     activityKey.Value,
-                    static (_, details) => new(details.activity.Instance!, CreateScopeFromActivity(details.activity, details.tags, details.parent, details.traceId, details.spanId, details.rawTraceId, details.rawSpanId)),
+                    static (_, details) => new(new(details.activity.Instance!), CreateScopeFromActivity(details.activity, details.tags, details.parent, details.traceId, details.spanId, details.rawTraceId, details.rawSpanId)),
                     (activity, tags, parent, traceId, spanId, rawTraceId, rawSpanId));
 #else
-                activityMapping = ActivityMappingById.GetOrAdd(activityKey.Value, _ => new(activity.Instance!, CreateScopeFromActivity(activity, tags, parent, traceId, spanId, rawTraceId, rawSpanId)));
+                activityMapping = ActivityMappingById.GetOrAdd(activityKey.Value, _ => new(new(activity.Instance!), CreateScopeFromActivity(activity, tags, parent, traceId, spanId, rawTraceId, rawSpanId)));
 #endif
             }
             catch (Exception ex)
@@ -234,142 +242,204 @@ namespace Datadog.Trace.Activity.Handlers
         {
             try
             {
-                if (activity.Instance is not null)
+                if (activity.Instance is null)
                 {
-                    if (IgnoreActivityHandler.ShouldIgnoreByOperationName(activity.OperationName))
-                    {
-                        return;
-                    }
-
-                    // Non-w3c activities will have null trace/span IDs, even though they implement IW3CActivity
-                    ActivityKey key;
-                    if (activity is IW3CActivity w3cActivity
-                     && w3cActivity.TraceId != null!
-                     && w3cActivity.SpanId != null!)
-                    {
-                        key = new(w3cActivity.TraceId, w3cActivity.SpanId);
-                    }
-                    else
-                    {
-                        key = new(activity.Id);
-                    }
-
-                    if (!key.IsValid())
-                    {
-                        // Adding this as a protective measure as Error Tracking identified
-                        // instances where StartActivity had an Activity with null Id, SpanId, TraceId
-                        // In that case we just skip the Activity, so doing the same thing here.
-                        return;
-                    }
-
-                    if (ActivityMappingById.TryRemove(key, out ActivityMapping someValue) && someValue.Scope?.Span is not null)
-                    {
-                        // We have the exact scope associated with the Activity
-                        if (Log.IsEnabled(LogEventLevel.Debug))
-                        {
-                            Log.Debug("DefaultActivityHandler.ActivityStopped: [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
-                        }
-
-                        CloseActivityScope(sourceName, activity, someValue.Scope);
-                        return;
-                    }
+                    Log.Information("DefaultActivityHandler.ActivityStopped: [Missing Activity]");
+                    return;
                 }
 
-                StopActivitySlow(sourceName, activity);
+                if (IgnoreActivityHandler.ShouldIgnoreByOperationName(activity.OperationName))
+                {
+                    return;
+                }
+
+                // Non-w3c activities will have null trace/span IDs, even though they implement IW3CActivity
+                ActivityKey key;
+                if (activity is IW3CActivity w3cActivity
+                 && w3cActivity.TraceId != null!
+                 && w3cActivity.SpanId != null!)
+                {
+                    key = new(w3cActivity.TraceId, w3cActivity.SpanId);
+                }
+                else
+                {
+                    key = new(activity.Id);
+                }
+
+                if (!key.IsValid())
+                {
+                    // Adding this as a protective measure as Error Tracking identified
+                    // instances where StartActivity had an Activity with null Id, SpanId, TraceId
+                    // In that case we just skip the Activity, so doing the same thing here.
+                    return;
+                }
+
+                if (ActivityMappingById.TryRemove(key, out ActivityMapping someValue) && someValue.Scope?.Span is not null)
+                {
+                    // We have the exact scope associated with the Activity
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        Log.Debug("DefaultActivityHandler.ActivityStopped: [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
+                    }
+
+                    CloseActivityScope(activity, someValue.Scope);
+                    return;
+                }
+
+                // No matching entry — either Start was never observed, or the periodic
+                // reconciliation sweep already cleaned this one up. Nothing to do here.
+                if (Log.IsEnabled(LogEventLevel.Information))
+                {
+                    Log.Information("DefaultActivityHandler.ActivityStopped: MISSING SCOPE [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
+                }
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error processing the DefaultActivityHandler.ActivityStopped callback");
             }
+        }
 
-            static void StopActivitySlow<TInner>(string sourceName, TInner activity)
-                where TInner : IActivity
+        internal static void StartReconciliationLoop()
+        {
+            if (Volatile.Read(ref _reconciliationTimer) is not null)
             {
-                // The listener didn't send us the Activity or the scope instance was not found
-                // In this case we are going go through the dictionary to check if we have an activity that
-                // has been closed and then close the associated scope.
-                if (activity.Instance is not null)
-                {
-                    if (Log.IsEnabled(LogEventLevel.Information))
-                    {
-                        Log.Information("DefaultActivityHandler.ActivityStopped: MISSING SCOPE [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity!.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
-                    }
-                }
-                else
-                {
-                    Log.Information($"DefaultActivityHandler.ActivityStopped: [Missing Activity]");
-                }
+                return;
+            }
 
-                List<ActivityKey>? toDelete = null;
+            var timer = new Timer(static _ => RunReconciliationSweep(), state: null, dueTime: ReconciliationInterval, period: ReconciliationInterval);
+            if (Interlocked.CompareExchange(ref _reconciliationTimer, timer, null) is not null)
+            {
+                // Another thread won the race and already started the loop
+                timer.Dispose();
+            }
+        }
+
+        internal static void StopReconciliationLoop()
+        {
+            var timer = Interlocked.Exchange(ref _reconciliationTimer, null);
+            timer?.Dispose();
+        }
+
+        internal static void RunReconciliationSweep()
+        {
+            // Skip if a sweep is already in flight (Timer callbacks can overlap on the threadpool).
+            if (Interlocked.CompareExchange(ref _sweepInProgress, 1, 0) == 1)
+            {
+                return;
+            }
+
+            try
+            {
+                var gcCollected = 0;
+                var missedStop = 0;
+                var count = 0;
+                List<ActivityKey>? toRemove = null;
+
                 foreach (var kvp in ActivityMappingById)
                 {
-                    var activityId = kvp.Key;
-                    var item = kvp.Value;
-                    var activityObject = item.Activity;
-                    var scope = item.Scope;
-                    var hasClosed = false;
+                    count++;
+                    var activityRef = kvp.Value.Activity;
+                    var scope = kvp.Value.Scope;
 
+                    if (!activityRef.TryGetTarget(out var activityObject))
+                    {
+                        // Activity was GC'd before Stop was called. Close the scope at "now"
+                        // so the span finishes and gets flushed; we don't have a real end time,
+                        // so the duration becomes (now - StartTime) — bounded but possibly inflated.
+                        if (scope?.Span is { } span)
+                        {
+                            span.SetTag("dd.activity.forced_close", "abandoned");
+                            span.Finish();
+                            scope.Close();
+                        }
+
+                        toRemove ??= new List<ActivityKey>();
+                        toRemove.Add(kvp.Key);
+                        gcCollected++;
+                        continue;
+                    }
+
+                    // Activity is still alive. A non-zero Duration on an entry that's still in
+                    // the dictionary means Stop() was called but our listener callback didn't
+                    // handle it - close it using the real end time.
                     if (activityObject.TryDuckCast<IActivity6>(out var activity6))
                     {
                         if (activity6.Duration != TimeSpan.Zero)
                         {
-                            CloseActivityScope(sourceName, activity6, scope);
-                            hasClosed = true;
+                            CloseActivityScope(activity6, scope);
+                            toRemove ??= new List<ActivityKey>();
+                            toRemove.Add(kvp.Key);
+                            missedStop++;
                         }
                     }
                     else if (activityObject.TryDuckCast<IActivity5>(out var activity5))
                     {
                         if (activity5.Duration != TimeSpan.Zero)
                         {
-                            CloseActivityScope(sourceName, activity5, scope);
-                            hasClosed = true;
+                            CloseActivityScope(activity5, scope);
+                            toRemove ??= new List<ActivityKey>();
+                            toRemove.Add(kvp.Key);
+                            missedStop++;
                         }
                     }
                     else if (activityObject.TryDuckCast<IActivity>(out var activity4))
                     {
                         if (activity4.Duration != TimeSpan.Zero)
                         {
-                            CloseActivityScope(sourceName, activity4, scope);
-                            hasClosed = true;
+                            CloseActivityScope(activity4, scope);
+                            toRemove ??= new List<ActivityKey>();
+                            toRemove.Add(kvp.Key);
+                            missedStop++;
                         }
                     }
-
-                    if (hasClosed)
-                    {
-                        toDelete ??= new List<ActivityKey>();
-                        toDelete.Add(activityId);
-                    }
                 }
 
-                if (toDelete is not null)
+                if (toRemove is not null)
                 {
-                    foreach (var item in toDelete)
+                    foreach (var key in toRemove)
                     {
-                        ActivityMappingById.TryRemove(item, out _);
+                        ActivityMappingById.TryRemove(key, out _);
                     }
                 }
-            }
 
-            static void CloseActivityScope<TInner>(string sourceName, TInner activity, Scope scope)
-                where TInner : IActivity
+                if (Log.IsEnabled(LogEventLevel.Debug) && (gcCollected > 0 || missedStop > 0))
+                {
+                    Log.Debug<int, int, int>(
+                        "ActivityHandlerCommon: reconciliation swept {GcCollected} GC'd activities and {MissedStop} missed-Stop activities; initial dictionary size {Initial}",
+                        gcCollected,
+                        missedStop,
+                        count);
+                }
+            }
+            catch (Exception ex)
             {
-                var span = scope.Span;
-                OtlpHelpers.UpdateSpanFromActivity(activity, scope.Span);
-
-                // OpenTelemtry SDK / OTLP Fixups
-                // TODO
-                // 3) Add resources to spans
-                // OpenTelemetry SDK resources are added to the span attributes by the configured exporter when OpenTelemetry.BaseExporter<T>.Export is called (e.g. OpenTelemetry.Exporter.ConsoleActivityExporter.Export)
-                // **** Note: The exporter has a ParentProvider field that is populated with the TracerProviderSdk when everything is initially built, so this is technically per instance
-                // **** To reliably get this, we might consider addding a Processor to the TracerProviderBuilder, though not sure where to invoke it
-                // - service.instance.id
-                // - service.name
-                // - service.namespace
-                // - service.version
-                span.Finish(activity.StartTimeUtc.Add(activity.Duration));
-
-                scope.Close();
+                Log.Error(ex, "Error during Activity reconciliation sweep");
             }
+            finally
+            {
+                Interlocked.Exchange(ref _sweepInProgress, 0);
+            }
+        }
+
+        private static void CloseActivityScope<TInner>(TInner activity, Scope scope)
+            where TInner : IActivity
+        {
+            var span = scope.Span;
+            OtlpHelpers.UpdateSpanFromActivity(activity, scope.Span);
+
+            // OpenTelemtry SDK / OTLP Fixups
+            // TODO
+            // 3) Add resources to spans
+            // OpenTelemetry SDK resources are added to the span attributes by the configured exporter when OpenTelemetry.BaseExporter<T>.Export is called (e.g. OpenTelemetry.Exporter.ConsoleActivityExporter.Export)
+            // **** Note: The exporter has a ParentProvider field that is populated with the TracerProviderSdk when everything is initially built, so this is technically per instance
+            // **** To reliably get this, we might consider addding a Processor to the TracerProviderBuilder, though not sure where to invoke it
+            // - service.instance.id
+            // - service.name
+            // - service.namespace
+            // - service.version
+            span.Finish(activity.StartTimeUtc.Add(activity.Duration));
+
+            scope.Close();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -369,7 +369,51 @@ namespace Datadog.Trace.Activity.Handlers
                     // another thread already removed this entry, bail without closing.
                     if (mappings.TryRemove(kvp.Key, out var owned) && owned.Scope is { Span: { } span } scope)
                     {
-                        span.SetTag("dd.activity.forced_close", "abandoned");
+                        // Do some "clean up" of the span, to make sure it has sensible defaults
+                        // Roughly analogous to OtlpHelpers.AgentConvertSpan, but much more basic with extra assumption
+                        if (span.Tags is OpenTelemetryTags tags)
+                        {
+                            if (string.IsNullOrEmpty(tags.SpanKind))
+                            {
+                                tags.SpanKind = SpanKinds.Internal;
+                            }
+
+                            if (string.IsNullOrEmpty(span.OperationName))
+                            {
+                                span.OperationName = OperationNameMapper.GetOperationName(tags);
+                            }
+
+                            if (string.IsNullOrEmpty(tags.OtelStatusCode))
+                            {
+                                tags.OtelStatusCode = "STATUS_CODE_UNSET";
+                            }
+
+                            if (span.ServiceName is null)
+                            {
+                                // this is _Very_ unlikely to be set, as we won't have copied the tags
+                                // across before the Activity was "lost" to GC, but check it just in case
+                                span.SetService(
+                                    span.GetTag("peer.service") switch
+                                    {
+                                        { } peerService when !string.IsNullOrEmpty(peerService) => peerService,
+                                        _ => "OTLPResourceNoServiceName",
+                                    },
+                                    source: null);
+                            }
+
+                            if (string.IsNullOrEmpty(span.ResourceName))
+                            {
+                                span.ResourceName = "ONGOING_ACTIVITY";
+                            }
+
+                            if (string.IsNullOrWhiteSpace(span.Type))
+                            {
+                                span.Type = SpanTypes.Custom;
+                            }
+                        }
+
+                        span.SetTag("is_incomplete", "true");
+
                         span.Finish();
                         scope.Close();
                         gcCollected++;

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -464,7 +464,7 @@ namespace Datadog.Trace.Activity.Handlers
             where TInner : IActivity
         {
             var span = scope.Span;
-            OtlpHelpers.UpdateSpanFromActivity(activity, scope.Span);
+            OtlpHelpers.UpdateSpanFromActivity(activity, span);
 
             // OpenTelemtry SDK / OTLP Fixups
             // TODO

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityMapping.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityMapping.cs
@@ -5,14 +5,21 @@
 
 #nullable enable
 
+using System;
+
 namespace Datadog.Trace.Activity.Handlers
 {
     internal readonly struct ActivityMapping
     {
-        public readonly object Activity;
+        // The Activity is held via a WeakReference so the mapping does not
+        // keep the underlying System.Diagnostics.Activity alive on its own.
+        // If the customer drops all references without calling Stop/Dispose,
+        // GC can reclaim the Activity and the periodic reconciliation sweep
+        // in ActivityHandlerCommon will close the associated Scope.
+        public readonly WeakReference<object> Activity;
         public readonly Scope Scope;
 
-        internal ActivityMapping(object activity, Scope scope)
+        internal ActivityMapping(WeakReference<object> activity, Scope scope)
         {
             Activity = activity;
             Scope = scope;

--- a/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
@@ -24,11 +24,7 @@ namespace Datadog.Trace.Tests.Activity
             await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
 
             var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-            var (key, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
-
-            // Drop the strong reference (held inside AddAbandonedMapping's local frame, now gone)
-            // and force GC until the WeakReference clears.
-            ForceGcUntilCollected(mappings[key].Activity);
+            var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
 
             var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
 
@@ -48,9 +44,7 @@ namespace Datadog.Trace.Tests.Activity
             await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
 
             var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-            var (key, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
-
-            ForceGcUntilCollected(mappings[key].Activity);
+            var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
 
             ActivityHandlerCommon.ReconcileSweepCore(mappings);
 
@@ -77,9 +71,7 @@ namespace Datadog.Trace.Tests.Activity
             await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
 
             var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-            var (key, span) = AddAbandonedMapping(mappings, tracer, "gcd-with-peer-service", presetTags: s => s.SetTag("peer.service", "downstream-api"));
-
-            ForceGcUntilCollected(mappings[key].Activity);
+            var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-with-peer-service", presetTags: s => s.SetTag("peer.service", "downstream-api"));
 
             ActivityHandlerCommon.ReconcileSweepCore(mappings);
 
@@ -97,7 +89,7 @@ namespace Datadog.Trace.Tests.Activity
             var activity = new SD.Activity("missed-stop").Start();
             try
             {
-                var (key, span) = AddMapping(mappings, tracer, activity);
+                var (_, span) = AddMapping(mappings, tracer, activity);
 
                 // Stop sets Duration > 0 — but we never invoke ActivityHandlerCommon.ActivityStopped,
                 // mimicking the case where the listener callback didn't make it through.
@@ -159,11 +151,10 @@ namespace Datadog.Trace.Tests.Activity
 
             var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
 
-            var (gcKey, gcSpan) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
-            ForceGcUntilCollected(mappings[gcKey].Activity);
+            var (_, gcSpan) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
 
             var stoppedActivity = new SD.Activity("missed-stop").Start();
-            var (stoppedKey, stoppedSpan) = AddMapping(mappings, tracer, stoppedActivity);
+            var (_, stoppedSpan) = AddMapping(mappings, tracer, stoppedActivity);
             stoppedActivity.Stop();
 
             var liveActivity = new SD.Activity("live-activity").Start();
@@ -197,33 +188,41 @@ namespace Datadog.Trace.Tests.Activity
             }
         }
 
-        // Constructs a mapping whose Activity has no other live references — the caller never sees
-        // the Activity instance, so the only path keeping it alive is the WeakReference inside the
-        // mapping (which doesn't, by definition).
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        // Constructs a mapping in the "abandoned" state — its Activity reference is already dead,
+        // matching the production scenario where the Activity has been GC'd before the sweep runs.
+        // Uses a deliberately-dead WeakReference rather than relying on real GC timing, which is
+        // flaky in Debug builds where JIT keeps locals alive across method boundaries.
         private static (ActivityKey Key, Span Span) AddAbandonedMapping(
             ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
             Tracer tracer,
-            string operationName,
+            string keyId,
             Action<Span> presetTags = null)
         {
-            var activity = new SD.Activity(operationName);
-            activity.SetIdFormat(SD.ActivityIdFormat.W3C);
-            activity.Start();
-            try
-            {
-                return AddMapping(mappings, tracer, activity, presetTags);
-            }
-            finally
-            {
-                activity.Stop();
-                // Activity.Start() sets Activity.Current (AsyncLocal). Activity.Stop() restores
-                // the previous value, but xunit's async state machine can keep the AsyncLocal
-                // value pinned across the test, preventing GC. Explicitly null it out so the
-                // WeakReference inside the mapping is the only remaining reference.
-                SD.Activity.Current = null;
-                // intentionally do not GC.KeepAlive — we want this collectible
-            }
+            var span = tracer.StartSpan(keyId);
+
+            // Mirror the production behaviour: spans created from Activities use OpenTelemetryTags
+            // so the sweep's fallback logic (which depends on `span.Tags is OpenTelemetryTags`) fires.
+            span.Tags = new OpenTelemetryTags();
+
+            // Null the fields StartSpan populates with tracer defaults so the sweep's `is null/empty`
+            // fallbacks actually fire. In production the GC'd-path fallbacks fire when these fields
+            // haven't been populated by AgentConvertSpan; here we recreate that state explicitly.
+            span.OperationName = null;
+            span.ResourceName = null;
+            span.Type = null;
+#pragma warning disable CS0618
+            span.ServiceName = null;
+#pragma warning restore CS0618
+
+            presetTags?.Invoke(span);
+
+            var scope = tracer.ActivateSpan(span, finishOnClose: false);
+            var key = new ActivityKey(keyId);
+
+            // WeakReference<T>(null) constructs a reference whose TryGetTarget always returns false,
+            // exactly matching the runtime state of a WeakReference whose target has been GC'd.
+            mappings[key] = new ActivityMapping(new WeakReference<object>(null!), scope);
+            return (key, span);
         }
 
         private static (ActivityKey Key, Span Span) AddMapping(
@@ -232,7 +231,7 @@ namespace Datadog.Trace.Tests.Activity
             SD.Activity activity,
             Action<Span> presetTags = null)
         {
-            var span = (Span)tracer.StartSpan(activity.OperationName);
+            var span = tracer.StartSpan(activity.OperationName);
 
             // Mirror the production behaviour: spans created from Activities use OpenTelemetryTags
             // so the sweep's fallback logic (which depends on `span.Tags is OpenTelemetryTags`) fires.
@@ -252,7 +251,7 @@ namespace Datadog.Trace.Tests.Activity
 
             presetTags?.Invoke(span);
 
-            var scope = (Scope)tracer.ActivateSpan(span, finishOnClose: false);
+            var scope = tracer.ActivateSpan(span, finishOnClose: false);
 
             var key = activity.IdFormat == SD.ActivityIdFormat.W3C
                 ? new ActivityKey(activity.TraceId.ToString(), activity.SpanId.ToString())
@@ -260,26 +259,6 @@ namespace Datadog.Trace.Tests.Activity
 
             mappings[key] = new ActivityMapping(new WeakReference<object>(activity), scope);
             return (key, span);
-        }
-
-        private static void ForceGcUntilCollected(WeakReference<object> reference)
-        {
-            for (var attempt = 0; attempt < 10; attempt++)
-            {
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                GC.Collect();
-
-                if (!reference.TryGetTarget(out _))
-                {
-                    return;
-                }
-            }
-
-            // If the runtime stubbornly keeps the Activity alive (e.g. AsyncLocal residue) the test
-            // becomes meaningless rather than failing in a confusing way. Surface that explicitly.
-            throw new InvalidOperationException(
-                "Activity could not be collected after repeated GC attempts; the test environment is keeping it alive.");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Datadog.Trace.Activity.Handlers;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Xunit;
@@ -36,7 +37,54 @@ namespace Datadog.Trace.Tests.Activity
             result.Iterated.Should().Be(1);
             mappings.Should().BeEmpty();
             span.IsFinished.Should().BeTrue();
-            span.GetTag("dd.activity.forced_close").Should().Be("abandoned");
+            span.GetTag("is_incomplete").Should().Be("true");
+        }
+
+        [Fact]
+        public async Task GcdActivity_SetsFallbackValuesOnSpan()
+        {
+            // The Activity is gone, so we can't run the normal OTLP→Datadog conversion. The sweep
+            // applies sensible defaults so the resulting span isn't malformed when it reaches the agent.
+            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+            var (key, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
+
+            ForceGcUntilCollected(mappings[key].Activity);
+
+            ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+            span.IsFinished.Should().BeTrue();
+            span.GetTag("is_incomplete").Should().Be("true");
+
+            // Span-level fallbacks
+            span.OperationName.Should().Be(SpanKinds.Internal); // GetOperationName falls back to lowercased SpanKind
+            span.ServiceName.Should().Be("OTLPResourceNoServiceName");
+            span.ResourceName.Should().Be("ONGOING_ACTIVITY");
+            span.Type.Should().Be(SpanTypes.Custom);
+
+            // Tag-level fallbacks (live on OpenTelemetryTags)
+            var otelTags = (OpenTelemetryTags)span.Tags;
+            otelTags.SpanKind.Should().Be(SpanKinds.Internal);
+            otelTags.OtelStatusCode.Should().Be("STATUS_CODE_UNSET");
+        }
+
+        [Fact]
+        public async Task GcdActivity_UsesPeerServiceAsServiceNameWhenAvailable()
+        {
+            // If a peer.service tag was set on the span before the Activity was lost, prefer that
+            // over the generic OTLPResourceNoServiceName fallback.
+            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+            var (key, span) = AddAbandonedMapping(mappings, tracer, "gcd-with-peer-service", presetTags: s => s.SetTag("peer.service", "downstream-api"));
+
+            ForceGcUntilCollected(mappings[key].Activity);
+
+            ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+            span.IsFinished.Should().BeTrue();
+            span.ServiceName.Should().Be("downstream-api");
         }
 
         [Fact]
@@ -131,7 +179,7 @@ namespace Datadog.Trace.Tests.Activity
                 mappings.Should().HaveCount(1).And.ContainKey(liveKey);
 
                 gcSpan.IsFinished.Should().BeTrue();
-                gcSpan.GetTag("dd.activity.forced_close").Should().Be("abandoned");
+                gcSpan.GetTag("is_incomplete").Should().Be("true");
                 stoppedSpan.IsFinished.Should().BeTrue();
                 liveSpan.IsFinished.Should().BeFalse();
             }
@@ -152,21 +200,28 @@ namespace Datadog.Trace.Tests.Activity
         // Constructs a mapping whose Activity has no other live references — the caller never sees
         // the Activity instance, so the only path keeping it alive is the WeakReference inside the
         // mapping (which doesn't, by definition).
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static (ActivityKey Key, Span Span) AddAbandonedMapping(
             ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
             Tracer tracer,
-            string operationName)
+            string operationName,
+            Action<Span> presetTags = null)
         {
             var activity = new SD.Activity(operationName);
             activity.SetIdFormat(SD.ActivityIdFormat.W3C);
             activity.Start();
             try
             {
-                return AddMapping(mappings, tracer, activity);
+                return AddMapping(mappings, tracer, activity, presetTags);
             }
             finally
             {
                 activity.Stop();
+                // Activity.Start() sets Activity.Current (AsyncLocal). Activity.Stop() restores
+                // the previous value, but xunit's async state machine can keep the AsyncLocal
+                // value pinned across the test, preventing GC. Explicitly null it out so the
+                // WeakReference inside the mapping is the only remaining reference.
+                SD.Activity.Current = null;
                 // intentionally do not GC.KeepAlive — we want this collectible
             }
         }
@@ -174,9 +229,29 @@ namespace Datadog.Trace.Tests.Activity
         private static (ActivityKey Key, Span Span) AddMapping(
             ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
             Tracer tracer,
-            SD.Activity activity)
+            SD.Activity activity,
+            Action<Span> presetTags = null)
         {
             var span = (Span)tracer.StartSpan(activity.OperationName);
+
+            // Mirror the production behaviour: spans created from Activities use OpenTelemetryTags
+            // so the sweep's fallback logic (which depends on `span.Tags is OpenTelemetryTags`) fires.
+            // StartSpan above doesn't set OTel tags, so swap them in by hand.
+            span.Tags = new OpenTelemetryTags();
+
+            // Null out the fields that StartSpan populates with tracer defaults so the sweep's
+            // `is null/empty` fallbacks actually fire. In production the GC'd-path fallbacks fire
+            // when these fields haven't been populated by AgentConvertSpan; here we recreate that
+            // state explicitly.
+            span.OperationName = null;
+            span.ResourceName = null;
+            span.Type = null;
+#pragma warning disable CS0618
+            span.ServiceName = null;
+#pragma warning restore CS0618
+
+            presetTags?.Invoke(span);
+
             var scope = (Scope)tracer.ActivateSpan(span, finishOnClose: false);
 
             var key = activity.IdFormat == SD.ActivityIdFormat.W3C

--- a/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
@@ -1,0 +1,210 @@
+// <copyright file="ReconciliationSweepTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Datadog.Trace.Activity.Handlers;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers.TestTracer;
+using FluentAssertions;
+using Xunit;
+using SD = System.Diagnostics;
+
+namespace Datadog.Trace.Tests.Activity
+{
+    public class ReconciliationSweepTests
+    {
+        [Fact]
+        public async Task GcdActivity_IsClosedAndRemoved()
+        {
+            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+            var (key, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
+
+            // Drop the strong reference (held inside AddAbandonedMapping's local frame, now gone)
+            // and force GC until the WeakReference clears.
+            ForceGcUntilCollected(mappings[key].Activity);
+
+            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+            result.GcCollected.Should().Be(1);
+            result.MissedStop.Should().Be(0);
+            result.Iterated.Should().Be(1);
+            mappings.Should().BeEmpty();
+            span.IsFinished.Should().BeTrue();
+            span.GetTag("dd.activity.forced_close").Should().Be("abandoned");
+        }
+
+        [Fact]
+        public async Task MissedStopActivity_IsClosedWithRealDuration()
+        {
+            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+
+            var activity = new SD.Activity("missed-stop").Start();
+            try
+            {
+                var (key, span) = AddMapping(mappings, tracer, activity);
+
+                // Stop sets Duration > 0 — but we never invoke ActivityHandlerCommon.ActivityStopped,
+                // mimicking the case where the listener callback didn't make it through.
+                activity.Stop();
+                activity.Duration.Should().NotBe(TimeSpan.Zero);
+
+                var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+                result.GcCollected.Should().Be(0);
+                result.MissedStop.Should().Be(1);
+                result.Iterated.Should().Be(1);
+                mappings.Should().BeEmpty();
+                span.IsFinished.Should().BeTrue();
+            }
+            finally
+            {
+                GC.KeepAlive(activity);
+            }
+        }
+
+        [Fact]
+        public async Task LiveUnstoppedActivity_IsLeftAlone()
+        {
+            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+
+            var activity = new SD.Activity("live-activity").Start();
+            try
+            {
+                var (key, span) = AddMapping(mappings, tracer, activity);
+
+                var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+                result.GcCollected.Should().Be(0);
+                result.MissedStop.Should().Be(0);
+                result.Iterated.Should().Be(1);
+                mappings.Should().ContainKey(key);
+                span.IsFinished.Should().BeFalse();
+
+                // Cleanup — finalize manually so the Scope/Span don't leak past the test
+                if (mappings.TryRemove(key, out var owned))
+                {
+                    owned.Scope?.Span.Finish();
+                    owned.Scope?.Close();
+                }
+            }
+            finally
+            {
+                GC.KeepAlive(activity);
+                activity.Stop();
+            }
+        }
+
+        [Fact]
+        public async Task MixedDictionary_HandlesAllCategoriesInOnePass()
+        {
+            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+
+            var (gcKey, gcSpan) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
+            ForceGcUntilCollected(mappings[gcKey].Activity);
+
+            var stoppedActivity = new SD.Activity("missed-stop").Start();
+            var (stoppedKey, stoppedSpan) = AddMapping(mappings, tracer, stoppedActivity);
+            stoppedActivity.Stop();
+
+            var liveActivity = new SD.Activity("live-activity").Start();
+            var (liveKey, liveSpan) = AddMapping(mappings, tracer, liveActivity);
+
+            try
+            {
+                var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+                result.GcCollected.Should().Be(1);
+                result.MissedStop.Should().Be(1);
+                result.Iterated.Should().Be(3);
+                mappings.Should().HaveCount(1).And.ContainKey(liveKey);
+
+                gcSpan.IsFinished.Should().BeTrue();
+                gcSpan.GetTag("dd.activity.forced_close").Should().Be("abandoned");
+                stoppedSpan.IsFinished.Should().BeTrue();
+                liveSpan.IsFinished.Should().BeFalse();
+            }
+            finally
+            {
+                if (mappings.TryRemove(liveKey, out var owned))
+                {
+                    owned.Scope?.Span.Finish();
+                    owned.Scope?.Close();
+                }
+
+                GC.KeepAlive(stoppedActivity);
+                GC.KeepAlive(liveActivity);
+                liveActivity.Stop();
+            }
+        }
+
+        // Constructs a mapping whose Activity has no other live references — the caller never sees
+        // the Activity instance, so the only path keeping it alive is the WeakReference inside the
+        // mapping (which doesn't, by definition).
+        private static (ActivityKey Key, Span Span) AddAbandonedMapping(
+            ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
+            Tracer tracer,
+            string operationName)
+        {
+            var activity = new SD.Activity(operationName);
+            activity.SetIdFormat(SD.ActivityIdFormat.W3C);
+            activity.Start();
+            try
+            {
+                return AddMapping(mappings, tracer, activity);
+            }
+            finally
+            {
+                activity.Stop();
+                // intentionally do not GC.KeepAlive — we want this collectible
+            }
+        }
+
+        private static (ActivityKey Key, Span Span) AddMapping(
+            ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
+            Tracer tracer,
+            SD.Activity activity)
+        {
+            var span = (Span)tracer.StartSpan(activity.OperationName);
+            var scope = (Scope)tracer.ActivateSpan(span, finishOnClose: false);
+
+            var key = activity.IdFormat == SD.ActivityIdFormat.W3C
+                ? new ActivityKey(activity.TraceId.ToString(), activity.SpanId.ToString())
+                : new ActivityKey(activity.Id);
+
+            mappings[key] = new ActivityMapping(new WeakReference<object>(activity), scope);
+            return (key, span);
+        }
+
+        private static void ForceGcUntilCollected(WeakReference<object> reference)
+        {
+            for (var attempt = 0; attempt < 10; attempt++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
+                if (!reference.TryGetTarget(out _))
+                {
+                    return;
+                }
+            }
+
+            // If the runtime stubbornly keeps the Activity alive (e.g. AsyncLocal residue) the test
+            // becomes meaningless rather than failing in a confusing way. Surface that explicitly.
+            throw new InvalidOperationException(
+                "Activity could not be collected after repeated GC attempts; the test environment is keeping it alive.");
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests.Activity
             result.Iterated.Should().Be(1);
             mappings.Should().BeEmpty();
             span.IsFinished.Should().BeTrue();
-            span.GetTag("is_incomplete").Should().Be("true");
+            span.GetTag("closed_reason").Should().Be("garbage_collected");
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Tests.Activity
             ActivityHandlerCommon.ReconcileSweepCore(mappings);
 
             span.IsFinished.Should().BeTrue();
-            span.GetTag("is_incomplete").Should().Be("true");
+            span.GetTag("closed_reason").Should().Be("garbage_collected");
 
             // Span-level fallbacks
             span.OperationName.Should().Be(SpanKinds.Internal); // GetOperationName falls back to lowercased SpanKind
@@ -179,7 +179,7 @@ namespace Datadog.Trace.Tests.Activity
                 mappings.Should().HaveCount(1).And.ContainKey(liveKey);
 
                 gcSpan.IsFinished.Should().BeTrue();
-                gcSpan.GetTag("is_incomplete").Should().Be("true");
+                gcSpan.GetTag("closed_reason").Should().Be("garbage_collected");
                 stoppedSpan.IsFinished.Should().BeTrue();
                 liveSpan.IsFinished.Should().BeFalse();
             }

--- a/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
@@ -14,251 +14,250 @@ using FluentAssertions;
 using Xunit;
 using SD = System.Diagnostics;
 
-namespace Datadog.Trace.Tests.Activity
-{
-    public class ReconciliationSweepTests
-    {
-        [Fact]
-        public async Task GcdActivity_IsClosedAndRemoved()
-        {
-            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+namespace Datadog.Trace.Tests.Activity;
 
-            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-            var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
+public class ReconciliationSweepTests
+{
+    [Fact]
+    public async Task GcdActivity_IsClosedAndRemoved()
+    {
+        await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+        var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+        var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
+
+        var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+        result.GcCollected.Should().Be(1);
+        result.MissedStop.Should().Be(0);
+        result.Iterated.Should().Be(1);
+        mappings.Should().BeEmpty();
+        span.IsFinished.Should().BeTrue();
+        span.GetTag("closed_reason").Should().Be("garbage_collected");
+    }
+
+    [Fact]
+    public async Task GcdActivity_SetsFallbackValuesOnSpan()
+    {
+        // The Activity is gone, so we can't run the normal OTLP→Datadog conversion. The sweep
+        // applies sensible defaults so the resulting span isn't malformed when it reaches the agent.
+        await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+        var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+        var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
+
+        ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+        span.IsFinished.Should().BeTrue();
+        span.GetTag("closed_reason").Should().Be("garbage_collected");
+
+        // Span-level fallbacks
+        span.OperationName.Should().Be(SpanKinds.Internal); // GetOperationName falls back to lowercased SpanKind
+        span.ServiceName.Should().Be("OTLPResourceNoServiceName");
+        span.ResourceName.Should().Be("ONGOING_ACTIVITY");
+        span.Type.Should().Be(SpanTypes.Custom);
+
+        // Tag-level fallbacks (live on OpenTelemetryTags)
+        var otelTags = (OpenTelemetryTags)span.Tags;
+        otelTags.SpanKind.Should().Be(SpanKinds.Internal);
+        otelTags.OtelStatusCode.Should().Be("STATUS_CODE_UNSET");
+    }
+
+    [Fact]
+    public async Task GcdActivity_UsesPeerServiceAsServiceNameWhenAvailable()
+    {
+        // If a peer.service tag was set on the span before the Activity was lost, prefer that
+        // over the generic OTLPResourceNoServiceName fallback.
+        await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+        var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+        var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-with-peer-service", presetTags: s => s.SetTag("peer.service", "downstream-api"));
+
+        ActivityHandlerCommon.ReconcileSweepCore(mappings);
+
+        span.IsFinished.Should().BeTrue();
+        span.ServiceName.Should().Be("downstream-api");
+    }
+
+    [Fact]
+    public async Task MissedStopActivity_IsClosedWithRealDuration()
+    {
+        await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+        var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+
+        var activity = new SD.Activity("missed-stop").Start();
+        try
+        {
+            var (_, span) = AddMapping(mappings, tracer, activity);
+
+            // Stop sets Duration > 0 — but we never invoke ActivityHandlerCommon.ActivityStopped,
+            // mimicking the case where the listener callback didn't make it through.
+            activity.Stop();
+            activity.Duration.Should().NotBe(TimeSpan.Zero);
 
             var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
 
-            result.GcCollected.Should().Be(1);
-            result.MissedStop.Should().Be(0);
+            result.GcCollected.Should().Be(0);
+            result.MissedStop.Should().Be(1);
             result.Iterated.Should().Be(1);
             mappings.Should().BeEmpty();
             span.IsFinished.Should().BeTrue();
-            span.GetTag("closed_reason").Should().Be("garbage_collected");
         }
-
-        [Fact]
-        public async Task GcdActivity_SetsFallbackValuesOnSpan()
+        finally
         {
-            // The Activity is gone, so we can't run the normal OTLP→Datadog conversion. The sweep
-            // applies sensible defaults so the resulting span isn't malformed when it reaches the agent.
-            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
-
-            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-            var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
-
-            ActivityHandlerCommon.ReconcileSweepCore(mappings);
-
-            span.IsFinished.Should().BeTrue();
-            span.GetTag("closed_reason").Should().Be("garbage_collected");
-
-            // Span-level fallbacks
-            span.OperationName.Should().Be(SpanKinds.Internal); // GetOperationName falls back to lowercased SpanKind
-            span.ServiceName.Should().Be("OTLPResourceNoServiceName");
-            span.ResourceName.Should().Be("ONGOING_ACTIVITY");
-            span.Type.Should().Be(SpanTypes.Custom);
-
-            // Tag-level fallbacks (live on OpenTelemetryTags)
-            var otelTags = (OpenTelemetryTags)span.Tags;
-            otelTags.SpanKind.Should().Be(SpanKinds.Internal);
-            otelTags.OtelStatusCode.Should().Be("STATUS_CODE_UNSET");
+            GC.KeepAlive(activity);
         }
+    }
 
-        [Fact]
-        public async Task GcdActivity_UsesPeerServiceAsServiceNameWhenAvailable()
+    [Fact]
+    public async Task LiveUnstoppedActivity_IsLeftAlone()
+    {
+        await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+        var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+
+        var activity = new SD.Activity("live-activity").Start();
+        try
         {
-            // If a peer.service tag was set on the span before the Activity was lost, prefer that
-            // over the generic OTLPResourceNoServiceName fallback.
-            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+            var (key, span) = AddMapping(mappings, tracer, activity);
 
-            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-            var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-with-peer-service", presetTags: s => s.SetTag("peer.service", "downstream-api"));
+            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
 
-            ActivityHandlerCommon.ReconcileSweepCore(mappings);
+            result.GcCollected.Should().Be(0);
+            result.MissedStop.Should().Be(0);
+            result.Iterated.Should().Be(1);
+            mappings.Should().ContainKey(key);
+            span.IsFinished.Should().BeFalse();
 
-            span.IsFinished.Should().BeTrue();
-            span.ServiceName.Should().Be("downstream-api");
-        }
-
-        [Fact]
-        public async Task MissedStopActivity_IsClosedWithRealDuration()
-        {
-            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
-
-            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-
-            var activity = new SD.Activity("missed-stop").Start();
-            try
+            // Cleanup — finalize manually so the Scope/Span don't leak past the test
+            if (mappings.TryRemove(key, out var owned))
             {
-                var (_, span) = AddMapping(mappings, tracer, activity);
-
-                // Stop sets Duration > 0 — but we never invoke ActivityHandlerCommon.ActivityStopped,
-                // mimicking the case where the listener callback didn't make it through.
-                activity.Stop();
-                activity.Duration.Should().NotBe(TimeSpan.Zero);
-
-                var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
-
-                result.GcCollected.Should().Be(0);
-                result.MissedStop.Should().Be(1);
-                result.Iterated.Should().Be(1);
-                mappings.Should().BeEmpty();
-                span.IsFinished.Should().BeTrue();
-            }
-            finally
-            {
-                GC.KeepAlive(activity);
+                owned.Scope?.Span.Finish();
+                owned.Scope?.Close();
             }
         }
-
-        [Fact]
-        public async Task LiveUnstoppedActivity_IsLeftAlone()
+        finally
         {
-            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
-
-            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
-
-            var activity = new SD.Activity("live-activity").Start();
-            try
-            {
-                var (key, span) = AddMapping(mappings, tracer, activity);
-
-                var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
-
-                result.GcCollected.Should().Be(0);
-                result.MissedStop.Should().Be(0);
-                result.Iterated.Should().Be(1);
-                mappings.Should().ContainKey(key);
-                span.IsFinished.Should().BeFalse();
-
-                // Cleanup — finalize manually so the Scope/Span don't leak past the test
-                if (mappings.TryRemove(key, out var owned))
-                {
-                    owned.Scope?.Span.Finish();
-                    owned.Scope?.Close();
-                }
-            }
-            finally
-            {
-                GC.KeepAlive(activity);
-                activity.Stop();
-            }
+            GC.KeepAlive(activity);
+            activity.Stop();
         }
+    }
 
-        [Fact]
-        public async Task MixedDictionary_HandlesAllCategoriesInOnePass()
+    [Fact]
+    public async Task MixedDictionary_HandlesAllCategoriesInOnePass()
+    {
+        await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+        var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+
+        var (_, gcSpan) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
+
+        var stoppedActivity = new SD.Activity("missed-stop").Start();
+        var (_, stoppedSpan) = AddMapping(mappings, tracer, stoppedActivity);
+        stoppedActivity.Stop();
+
+        var liveActivity = new SD.Activity("live-activity").Start();
+        var (liveKey, liveSpan) = AddMapping(mappings, tracer, liveActivity);
+
+        try
         {
-            await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
 
-            var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+            result.GcCollected.Should().Be(1);
+            result.MissedStop.Should().Be(1);
+            result.Iterated.Should().Be(3);
+            mappings.Should().HaveCount(1).And.ContainKey(liveKey);
 
-            var (_, gcSpan) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
-
-            var stoppedActivity = new SD.Activity("missed-stop").Start();
-            var (_, stoppedSpan) = AddMapping(mappings, tracer, stoppedActivity);
-            stoppedActivity.Stop();
-
-            var liveActivity = new SD.Activity("live-activity").Start();
-            var (liveKey, liveSpan) = AddMapping(mappings, tracer, liveActivity);
-
-            try
-            {
-                var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
-
-                result.GcCollected.Should().Be(1);
-                result.MissedStop.Should().Be(1);
-                result.Iterated.Should().Be(3);
-                mappings.Should().HaveCount(1).And.ContainKey(liveKey);
-
-                gcSpan.IsFinished.Should().BeTrue();
-                gcSpan.GetTag("closed_reason").Should().Be("garbage_collected");
-                stoppedSpan.IsFinished.Should().BeTrue();
-                liveSpan.IsFinished.Should().BeFalse();
-            }
-            finally
-            {
-                if (mappings.TryRemove(liveKey, out var owned))
-                {
-                    owned.Scope?.Span.Finish();
-                    owned.Scope?.Close();
-                }
-
-                GC.KeepAlive(stoppedActivity);
-                GC.KeepAlive(liveActivity);
-                liveActivity.Stop();
-            }
+            gcSpan.IsFinished.Should().BeTrue();
+            gcSpan.GetTag("closed_reason").Should().Be("garbage_collected");
+            stoppedSpan.IsFinished.Should().BeTrue();
+            liveSpan.IsFinished.Should().BeFalse();
         }
-
-        // Constructs a mapping in the "abandoned" state — its Activity reference is already dead,
-        // matching the production scenario where the Activity has been GC'd before the sweep runs.
-        // Uses a deliberately-dead WeakReference rather than relying on real GC timing, which is
-        // flaky in Debug builds where JIT keeps locals alive across method boundaries.
-        private static (ActivityKey Key, Span Span) AddAbandonedMapping(
-            ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
-            Tracer tracer,
-            string keyId,
-            Action<Span> presetTags = null)
+        finally
         {
-            var span = tracer.StartSpan(keyId);
+            if (mappings.TryRemove(liveKey, out var owned))
+            {
+                owned.Scope?.Span.Finish();
+                owned.Scope?.Close();
+            }
 
-            // Mirror the production behaviour: spans created from Activities use OpenTelemetryTags
-            // so the sweep's fallback logic (which depends on `span.Tags is OpenTelemetryTags`) fires.
-            span.Tags = new OpenTelemetryTags();
+            GC.KeepAlive(stoppedActivity);
+            GC.KeepAlive(liveActivity);
+            liveActivity.Stop();
+        }
+    }
 
-            // Null the fields StartSpan populates with tracer defaults so the sweep's `is null/empty`
-            // fallbacks actually fire. In production the GC'd-path fallbacks fire when these fields
-            // haven't been populated by AgentConvertSpan; here we recreate that state explicitly.
-            span.OperationName = null;
-            span.ResourceName = null;
-            span.Type = null;
+    // Constructs a mapping in the "abandoned" state — its Activity reference is already dead,
+    // matching the production scenario where the Activity has been GC'd before the sweep runs.
+    // Uses a deliberately-dead WeakReference rather than relying on real GC timing, which is
+    // flaky in Debug builds where JIT keeps locals alive across method boundaries.
+    private static (ActivityKey Key, Span Span) AddAbandonedMapping(
+        ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
+        Tracer tracer,
+        string keyId,
+        Action<Span> presetTags = null)
+    {
+        var span = tracer.StartSpan(keyId);
+
+        // Mirror the production behaviour: spans created from Activities use OpenTelemetryTags
+        // so the sweep's fallback logic (which depends on `span.Tags is OpenTelemetryTags`) fires.
+        span.Tags = new OpenTelemetryTags();
+
+        // Null the fields StartSpan populates with tracer defaults so the sweep's `is null/empty`
+        // fallbacks actually fire. In production the GC'd-path fallbacks fire when these fields
+        // haven't been populated by AgentConvertSpan; here we recreate that state explicitly.
+        span.OperationName = null;
+        span.ResourceName = null;
+        span.Type = null;
 #pragma warning disable CS0618
-            span.ServiceName = null;
+        span.ServiceName = null;
 #pragma warning restore CS0618
 
-            presetTags?.Invoke(span);
+        presetTags?.Invoke(span);
 
-            var scope = tracer.ActivateSpan(span, finishOnClose: false);
-            var key = new ActivityKey(keyId);
+        var scope = tracer.ActivateSpan(span, finishOnClose: false);
+        var key = new ActivityKey(keyId);
 
-            // WeakReference<T>(null) constructs a reference whose TryGetTarget always returns false,
-            // exactly matching the runtime state of a WeakReference whose target has been GC'd.
-            mappings[key] = new ActivityMapping(new WeakReference<object>(null!), scope);
-            return (key, span);
-        }
+        // WeakReference<T>(null) constructs a reference whose TryGetTarget always returns false,
+        // exactly matching the runtime state of a WeakReference whose target has been GC'd.
+        mappings[key] = new ActivityMapping(new WeakReference<object>(null!), scope);
+        return (key, span);
+    }
 
-        private static (ActivityKey Key, Span Span) AddMapping(
-            ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
-            Tracer tracer,
-            SD.Activity activity,
-            Action<Span> presetTags = null)
-        {
-            var span = tracer.StartSpan(activity.OperationName);
+    private static (ActivityKey Key, Span Span) AddMapping(
+        ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
+        Tracer tracer,
+        SD.Activity activity,
+        Action<Span> presetTags = null)
+    {
+        var span = tracer.StartSpan(activity.OperationName);
 
-            // Mirror the production behaviour: spans created from Activities use OpenTelemetryTags
-            // so the sweep's fallback logic (which depends on `span.Tags is OpenTelemetryTags`) fires.
-            // StartSpan above doesn't set OTel tags, so swap them in by hand.
-            span.Tags = new OpenTelemetryTags();
+        // Mirror the production behaviour: spans created from Activities use OpenTelemetryTags
+        // so the sweep's fallback logic (which depends on `span.Tags is OpenTelemetryTags`) fires.
+        // StartSpan above doesn't set OTel tags, so swap them in by hand.
+        span.Tags = new OpenTelemetryTags();
 
-            // Null out the fields that StartSpan populates with tracer defaults so the sweep's
-            // `is null/empty` fallbacks actually fire. In production the GC'd-path fallbacks fire
-            // when these fields haven't been populated by AgentConvertSpan; here we recreate that
-            // state explicitly.
-            span.OperationName = null;
-            span.ResourceName = null;
-            span.Type = null;
+        // Null out the fields that StartSpan populates with tracer defaults so the sweep's
+        // `is null/empty` fallbacks actually fire. In production the GC'd-path fallbacks fire
+        // when these fields haven't been populated by AgentConvertSpan; here we recreate that
+        // state explicitly.
+        span.OperationName = null;
+        span.ResourceName = null;
+        span.Type = null;
 #pragma warning disable CS0618
-            span.ServiceName = null;
+        span.ServiceName = null;
 #pragma warning restore CS0618
 
-            presetTags?.Invoke(span);
+        presetTags?.Invoke(span);
 
-            var scope = tracer.ActivateSpan(span, finishOnClose: false);
+        var scope = tracer.ActivateSpan(span, finishOnClose: false);
 
-            var key = activity.IdFormat == SD.ActivityIdFormat.W3C
-                ? new ActivityKey(activity.TraceId.ToString(), activity.SpanId.ToString())
-                : new ActivityKey(activity.Id);
+        var key = activity.IdFormat == SD.ActivityIdFormat.W3C
+                      ? new ActivityKey(activity.TraceId.ToString(), activity.SpanId.ToString())
+                      : new ActivityKey(activity.Id);
 
-            mappings[key] = new ActivityMapping(new WeakReference<object>(activity), scope);
-            return (key, span);
-        }
+        mappings[key] = new ActivityMapping(new WeakReference<object>(activity), scope);
+        return (key, span);
     }
 }


### PR DESCRIPTION
## Summary of changes

Wraps the reference to `Activity` in our `ActivityHandlerCommon` with a `WeakReference<T>` to avoid leaking them if user's never stop the `Activity`

## Reason for change

We have seen this happening [in practice](https://datadoghq.atlassian.net/browse/APMS-19316), and while it's a coding error, it manifests as a memory leak that's hard to diagnose without taking a memory dump. 

This PR attempts to sidestep the issue by using `WeakReference`, to avoid keeping an `Activity` alive for longer than it otherwise would. It then adds a "reconciliation" process that cleans up and removes any `Activity` object that is no longer reachable, and closes and finishes the corresponding `Span`, so that we don't keep those around for ever (actually the bigger issue WRT memory leaks)

Additionally, we already had an `StopActivitySlow` process which was doing something _similar_, looping through the whole dictionary, trying to find any closed `Activity` instances where the `Span` was still open. This was looping through every item in the dictionary, _Every_ time a span was closed (which in the pathological case would be very slow), so this PR moves that to the reconciliation background task too).

## Implementation details

- Change `ActivityMapping` to use ` WeakReference<object>` for the `Activity` instead of `object`
- On app start, start call `StartReconciliationLoop` to have a process that loops the dictionary to look for missing references _or_ `Activity` instances which are stopped but for which we didn't close the `Span` (_shouldn't_ happen as I understand it)
- When we do need to stop a `Span`, set some basic properties to try to make them "sensible". 
  - Set `SpanKind`, `OperationName`,`OtelStatusCode`, `ServiceName`, `ResourceName`, `Type` if not currently set
  - Add a tag `closed_reason=garbage_collected` to the span, so we/customers can identify spans like this
- Add some logging when we find these cases
  - We could potentially add telemetry, but didn't seem worth it initially, we can always add it later

## Test coverage

- Existing tests ensure that existing behaviour works as expected
- Add tests for the reconciliation loop specifically

Also created a pathological app that creates (and never stops) an `Activity`, and then hammer it in a loop
- Without instrumentation (OTel only), there's no significant increase in memory (expected, ~50MB in my sample)
- Before the fix, constant increase in memory use (I stopped at ~1GB)
- After the fix, memory stabilizes (~150MB)
