### PR TITLE
Revert "[SymDB] DEBUG-5086 SymDB upload enable when DI is disabled"

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -586,8 +586,7 @@ namespace Datadog.Trace.ClrProfiler
 
             if (!debuggerSettings.DynamicInstrumentationEnabled
              && !debuggerSettings.CodeOriginForSpansEnabled
-             && !manager.ExceptionReplaySettings.Enabled
-             && !debuggerSettings.SymbolDatabaseUploadEnabled)
+             && !manager.ExceptionReplaySettings.Enabled)
             {
                 Log.Debug("Debugger products are not enabled");
             }

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
@@ -284,9 +284,10 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                if (!newDebuggerSettings.SymbolDatabaseUploadEnabled)
+                if (!DebuggerSettings.SymbolDatabaseUploadEnabled
+                 || !newDebuggerSettings.DynamicInstrumentationCanBeEnabled)
                 {
-                    // explicitly disabled via local env var
+                    // explicitly disabled via local env var or DI can not be enabled
                     return;
                 }
 
@@ -296,9 +297,15 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                // Initialize the symbol uploader as soon as local settings allow it.
+                if (!newDebuggerSettings.DynamicInstrumentationEnabled
+                 && newDebuggerSettings.DynamicSettings.DynamicInstrumentationEnabled != true)
+                {
+                    return;
+                }
+
+                // Initialize symbol database uploader only if DI is enabled locally or remotely.
                 var tracerManager = TracerManager.Instance;
-                this.SymbolsUploader = DebuggerFactory.CreateSymbolsUploader(tracerManager.DiscoveryService, RcmSubscriptionManager.Instance, () => ServiceName, tracerSettings, newDebuggerSettings, tracerManager.GitMetadataTagsProvider);
+                this.SymbolsUploader = DebuggerFactory.CreateSymbolsUploader(tracerManager.DiscoveryService, RcmSubscriptionManager.Instance, () => ServiceName, tracerSettings, DebuggerSettings, tracerManager.GitMetadataTagsProvider);
                 _ = this.SymbolsUploader.StartFlushingAsync()
                         .ContinueWith(
                              t => Log.Error(t?.Exception, "Failed to initialize symbol uploader"),

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Debugger
             DynamicInstrumentationEnabled = diEnabledResult.WithDefault(false);
             DynamicInstrumentationCanBeEnabled = diEnabledResult.ConfigurationResult is not { IsValid: true, Result: false };
 
-            SymbolDatabaseUploadEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled).AsBool(true);
+            SymbolDatabaseUploadEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled).AsBool(DynamicInstrumentationCanBeEnabled);
 
             MaximumDepthOfMembersToCopy = config
                                          .WithKeys(ConfigurationKeys.Debugger.MaxDepthToSerialize)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
@@ -62,9 +62,7 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, no DI objects should exist
                 memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
                 memoryAssertions.NoObjectsExist<LineProbeResolver>();
-                // The uploader starts early so it can subscribe to SymDB remote config
-                // even while Dynamic Instrumentation is still disabled.
-                memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
+                memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
             },
             remoteConfig: new { dynamic_instrumentation_enabled = true },
             DynamicInstrumentationEnabledLogEntry,
@@ -123,7 +121,6 @@ public class DebuggerManagerDynamicTests : TestHelper
     public async Task DebuggerManager_MultipleProducts_StartDisabled_EnabledViaRemoteConfig()
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.RemoteConfigurationEnabled, "true");
-        SetEnvironmentVariable(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled, string.Empty);
 
         await RunDynamicConfigurationTest(
             false,
@@ -132,11 +129,10 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, no debugger objects should exist
                 memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
                 memoryAssertions.NoObjectsExist<ExceptionAutoInstrumentation.ExceptionReplay>();
+                memoryAssertions.NoObjectsExist<SpanCodeOrigin.SpanCodeOrigin>();
                 memoryAssertions.NoObjectsExist<SnapshotSink>();
                 memoryAssertions.NoObjectsExist<LineProbeResolver>();
-                // The uploader starts early so it can subscribe to SymDB remote config
-                // even while the other debugger products remain disabled.
-                memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
+                memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
             },
             remoteConfig: new
             {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerTests.cs
@@ -45,7 +45,7 @@ public class DebuggerManagerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
-    public async Task DebuggerManager_AllFeaturesByDefault_CreatesOnlyNonDiDebuggerObjects()
+    public async Task DebuggerManager_AllFeaturesByDefault_NoDebuggerObjectsCreated()
     {
         await RunDebuggerManagerTestWithMemoryAssertions(memoryAssertions =>
         {
@@ -53,7 +53,7 @@ public class DebuggerManagerTests : TestHelper
             memoryAssertions.NoObjectsExist<LineProbeResolver>();
             memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
             memoryAssertions.NoObjectsExist<ExceptionAutoInstrumentation.ExceptionReplay>();
-            memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
+            memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
             memoryAssertions.ObjectsExist<SpanCodeOrigin.SpanCodeOrigin>();
         });
     }
@@ -63,7 +63,7 @@ public class DebuggerManagerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
-    public async Task DebuggerManager_DynamicInstrumentationExplicitlyDisabled_DoesNotCreateDynamicInstrumentationObjects()
+    public async Task DebuggerManager_DynamicInstrumentationExplicitlyDisabled_NoDebuggerObjectsCreated()
     {
         // at least one product should be enabled to initialize the debugger manager
         SetEnvironmentVariable(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled, "true");
@@ -73,24 +73,6 @@ public class DebuggerManagerTests : TestHelper
             memoryAssertions.NoObjectsExist<SnapshotSink>();
             memoryAssertions.NoObjectsExist<LineProbeResolver>();
             memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
-        });
-    }
-
-    [SkippableFact]
-    [Trait("Category", "EndToEnd")]
-    [Trait("Category", "ArmUnsupported")]
-    [Trait("RunOnWindows", "True")]
-    [Trait("Category", "LinuxUnsupported")]
-    public async Task DebuggerManager_DynamicInstrumentationExplicitlyDisabled_SymbolDatabaseEnabledByDefault_CreatesSymbolUploader()
-    {
-        SetEnvironmentVariable(ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "false");
-
-        await RunDebuggerManagerTestWithMemoryAssertions(memoryAssertions =>
-        {
-            memoryAssertions.NoObjectsExist<SnapshotSink>();
-            memoryAssertions.NoObjectsExist<LineProbeResolver>();
-            memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
-            memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
         });
     }
 
@@ -141,23 +123,6 @@ public class DebuggerManagerTests : TestHelper
             memoryAssertions.NoObjectsExist<Pdb.DatadogMetadataReader>();
             memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
             memoryAssertions.NoObjectsExist<Symbols.SymbolExtractor>();
-        });
-    }
-
-    [SkippableFact]
-    [Trait("Category", "EndToEnd")]
-    [Trait("Category", "ArmUnsupported")]
-    [Trait("RunOnWindows", "True")]
-    [Trait("Category", "LinuxUnsupported")]
-    public async Task DebuggerManager_SymbolDatabaseUploadEnabled_WithoutDynamicInstrumentation_CreatesSymbolUploader()
-    {
-        SetEnvironmentVariable(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled, "true");
-        SetEnvironmentVariable(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled, "true");
-
-        await RunDebuggerManagerTestWithMemoryAssertions(memoryAssertions =>
-        {
-            memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
-            memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
         });
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -81,23 +81,6 @@ namespace Datadog.Trace.Tests.Debugger
             settings.SymbolDatabaseUploadEnabled.Should().BeTrue();
         }
 
-        [Theory]
-        [InlineData("false")]
-        [InlineData("0")]
-        public void SymbolsEnabled_WhenDynamicInstrumentationExplicitlyDisabled(string enabled)
-        {
-            var settings = new DebuggerSettings(
-                new NameValueConfigurationSource(new()
-                {
-                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, enabled },
-                }),
-                NullConfigurationTelemetry.Instance);
-
-            settings.DynamicInstrumentationEnabled.Should().BeFalse();
-            settings.DynamicInstrumentationCanBeEnabled.Should().BeFalse();
-            settings.SymbolDatabaseUploadEnabled.Should().BeTrue();
-        }
-
         [Fact]
         public void DebuggerSettings_UseSettings()
         {


### PR DESCRIPTION
## Summary of changes

- Reverts #8510.

## Reason for change

- We observed a startup-time performance impact from initializing SymDB independently of Dynamic Instrumentation. We want to investigate that impact before merging this behavior to `master`.

## Implementation details

- Reverted the squash commit `01f5157075e90003af48a52c534dd3e6eceac57b`.

## Other details

- Follow-up performance improvement PR: #8548