### PR TITLE
Fix IAST strings deferred enumerable

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Datadog.Trace.Iast.Dataflow;
 using Datadog.Trace.Iast.Helpers;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -1269,13 +1269,9 @@ public sealed class StringBuilderAspects
 
     private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, char separator, IEnumerable<T>? values, out T[] materializedValues)
     {
-        if (target is null)
-        {
-            throw new NullReferenceException();
-        }
-
         materializedValues = Materialize(values);
-        return target.AppendJoin(separator, materializedValues);
+        // Intentionally throw null ref exception if customer passes in null
+        return target!.AppendJoin(separator, materializedValues);
     }
 
     private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, string separator, IEnumerable<T>? values, out T[] materializedValues)

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -1267,32 +1267,28 @@ public sealed class StringBuilderAspects
         return result;
     }
 
-    private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, char separator, IEnumerable<T>? values, out T[] materializedValues)
+    private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, char separator, IEnumerable<T>? values, out IReadOnlyCollection<T>? materializedValues)
     {
         materializedValues = Materialize(values);
         // Intentionally throw null ref exception if customer passes in null
-        return target!.AppendJoin(separator, materializedValues);
+        return target!.AppendJoin(separator, materializedValues!);
     }
 
-    private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, string separator, IEnumerable<T>? values, out T[] materializedValues)
+    private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, string separator, IEnumerable<T>? values, out IReadOnlyCollection<T>? materializedValues)
     {
-        if (target is null)
-        {
-            throw new NullReferenceException();
-        }
-
         materializedValues = Materialize(values);
-        return target.AppendJoin(separator, materializedValues);
+        // Intentionally throw null ref exception if customer passes in null
+        return target!.AppendJoin(separator, materializedValues!);
     }
 
-    private static T[] Materialize<T>(IEnumerable<T>? values)
+    private static IReadOnlyCollection<T>? Materialize<T>(IEnumerable<T>? values)
     {
         if (values is null)
         {
-            throw new ArgumentNullException(nameof(values));
+            return null;
         }
 
-        return values as T[] ?? values.ToArray();
+        return values as IReadOnlyCollection<T> ?? values.ToList();
     }
 
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Datadog.Trace.Iast.Dataflow;
 using Datadog.Trace.Iast.Propagation;
@@ -1231,10 +1232,10 @@ public sealed class StringBuilderAspects
     [AspectMethodReplaceFromVersion("3.2.0", "System.Text.StringBuilder::AppendJoin(System.Char,System.Collections.Generic.IEnumerable`1<!!0>)")]
     public static StringBuilder AppendJoin<T>(StringBuilder? target, char separator, IEnumerable<T>? values)
     {
-        var result = target!.AppendJoin(separator, values!);
+        var result = AppendJoinAndMaterialize(target, separator, values, out var materializedValues);
         try
         {
-            StringBuilderModuleImpl.FullTaintIfAnyTaintedEnumerable(target, null, values);
+            StringBuilderModuleImpl.FullTaintIfAnyTaintedEnumerable(result, null, materializedValues);
         }
         catch (Exception ex)
         {
@@ -1253,10 +1254,10 @@ public sealed class StringBuilderAspects
     [AspectMethodReplaceFromVersion("3.2.0", "System.Text.StringBuilder::AppendJoin(System.String,System.Collections.Generic.IEnumerable`1<!!0>)")]
     public static StringBuilder AppendJoin<T>(StringBuilder? target, string separator, IEnumerable<T>? values)
     {
-        var result = target!.AppendJoin(separator, values!);
+        var result = AppendJoinAndMaterialize(target, separator, values, out var materializedValues);
         try
         {
-            StringBuilderModuleImpl.FullTaintIfAnyTaintedEnumerable(target, separator, values);
+            StringBuilderModuleImpl.FullTaintIfAnyTaintedEnumerable(result, separator, materializedValues);
         }
         catch (Exception ex)
         {
@@ -1264,6 +1265,38 @@ public sealed class StringBuilderAspects
         }
 
         return result;
+    }
+
+    private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, char separator, IEnumerable<T>? values, out T[] materializedValues)
+    {
+        if (target is null)
+        {
+            throw new NullReferenceException();
+        }
+
+        materializedValues = Materialize(values);
+        return target.AppendJoin(separator, materializedValues);
+    }
+
+    private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, string separator, IEnumerable<T>? values, out T[] materializedValues)
+    {
+        if (target is null)
+        {
+            throw new NullReferenceException();
+        }
+
+        materializedValues = Materialize(values);
+        return target.AppendJoin(separator, materializedValues);
+    }
+
+    private static T[] Materialize<T>(IEnumerable<T>? values)
+    {
+        if (values is null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        return values as T[] ?? values.ToArray();
     }
 
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Datadog.Trace.Iast.Dataflow;
+using Datadog.Trace.Iast.Helpers;
 using Datadog.Trace.Iast.Propagation;
 using Datadog.Trace.Logging;
 
@@ -1269,26 +1270,16 @@ public sealed class StringBuilderAspects
 
     private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, char separator, IEnumerable<T>? values, out IReadOnlyCollection<T>? materializedValues)
     {
-        materializedValues = Materialize(values);
-        // Intentionally throw null ref exception if customer passes in null
+        materializedValues = values.Materialize();
+        // Intentionally throw null ref / argument null exception if customer passes in null
         return target!.AppendJoin(separator, materializedValues!);
     }
 
     private static StringBuilder AppendJoinAndMaterialize<T>(StringBuilder? target, string separator, IEnumerable<T>? values, out IReadOnlyCollection<T>? materializedValues)
     {
-        materializedValues = Materialize(values);
-        // Intentionally throw null ref exception if customer passes in null
+        materializedValues = values.Materialize();
+        // Intentionally throw null ref / argument null exception if customer passes in null
         return target!.AppendJoin(separator, materializedValues!);
-    }
-
-    private static IReadOnlyCollection<T>? Materialize<T>(IEnumerable<T>? values)
-    {
-        if (values is null)
-        {
-            return null;
-        }
-
-        return values as IReadOnlyCollection<T> ?? values.ToList();
     }
 
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -477,10 +477,10 @@ public sealed class StringAspects
     [AspectMethodReplace("System.String::Concat(System.Collections.Generic.IEnumerable`1<System.String>)")]
     public static string Concat(IEnumerable<string> values)
     {
-        var result = string.Concat(values);
+        var result = ConcatAndMaterialize(values, out var materializedValues);
         try
         {
-            return StringModuleImpl.OnStringConcat(values, result);
+            return StringModuleImpl.OnStringConcat(materializedValues, result);
         }
         catch (Exception ex)
         {
@@ -499,10 +499,10 @@ public sealed class StringAspects
     [AspectMethodReplaceFromVersion("3.2.0", "System.String::Concat(System.Collections.Generic.IEnumerable`1<!!0>)")]
     public static string Concat<T>(IEnumerable<T> values)
     {
-        var result = string.Concat(values);
+        var result = ConcatAndMaterialize(values, out var materializedValues);
         try
         {
-            return StringModuleImpl.OnStringConcat(values, result);
+            return StringModuleImpl.OnStringConcat(materializedValues, result);
         }
         catch (Exception ex)
         {
@@ -510,6 +510,12 @@ public sealed class StringAspects
         }
 
         return result;
+    }
+
+    private static string ConcatAndMaterialize<T>(IEnumerable<T> values, out T[] materializedValues)
+    {
+        materializedValues = Materialize(values);
+        return string.Concat((IEnumerable<T>)materializedValues);
     }
 
 #if NET6_0_OR_GREATER
@@ -733,10 +739,10 @@ public sealed class StringAspects
     [AspectMethodReplaceFromVersion("3.2.0", "System.String::Join(System.Char,System.Collections.Generic.IEnumerable`1<!!0>)")]
     public static string Join<T>(char separator, IEnumerable<T> values)
     {
-        var result = string.Join(separator, values);
+        var result = JoinAndMaterialize(separator, values, out var materializedValues);
         try
         {
-            return OnStringJoin(result, separator, values);
+            return OnStringJoin(result, separator, materializedValues);
         }
         catch (Exception ex)
         {
@@ -757,10 +763,10 @@ public sealed class StringAspects
     [AspectMethodReplaceFromVersion("3.2.0", "System.String::Join(System.String,System.Collections.Generic.IEnumerable`1<!!0>)")]
     public static string Join<T>(string separator, IEnumerable<T> values)
     {
-        var result = string.Join(separator, values);
+        var result = JoinAndMaterialize(separator, values, out var materializedValues);
         try
         {
-            return OnStringJoin(result, separator, values);
+            return OnStringJoin(result, separator, materializedValues);
         }
         catch (Exception ex)
         {
@@ -823,10 +829,10 @@ public sealed class StringAspects
     [AspectMethodReplace("System.String::Join(System.String,System.Collections.Generic.IEnumerable`1<System.String>)")]
     public static string JoinString(string separator, IEnumerable<string> values)
     {
-        var result = string.Join(separator, values);
+        var result = JoinAndMaterialize(separator, values, out var materializedValues);
         try
         {
-            return OnStringJoin(result, separator, values);
+            return OnStringJoin(result, separator, materializedValues);
         }
         catch (Exception ex)
         {
@@ -834,6 +840,28 @@ public sealed class StringAspects
         }
 
         return result;
+    }
+
+    private static string JoinAndMaterialize<T>(char separator, IEnumerable<T> values, out T[] materializedValues)
+    {
+        materializedValues = Materialize(values);
+        return string.Join(separator, materializedValues);
+    }
+
+    private static string JoinAndMaterialize<T>(string separator, IEnumerable<T> values, out T[] materializedValues)
+    {
+        materializedValues = Materialize(values);
+        return string.Join(separator, materializedValues);
+    }
+
+    private static T[] Materialize<T>(IEnumerable<T> values)
+    {
+        if (values is null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        return values as T[] ?? values.ToArray();
     }
 
 #if NET6_0_OR_GREATER

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -842,11 +842,14 @@ public sealed class StringAspects
         return result;
     }
 
+#if NETCOREAPP
     private static string JoinAndMaterialize<T>(char separator, IEnumerable<T> values, out T[] materializedValues)
     {
         materializedValues = Materialize(values);
         return string.Join(separator, materializedValues);
     }
+
+#endif
 
     private static string JoinAndMaterialize<T>(string separator, IEnumerable<T> values, out T[] materializedValues)
     {

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -861,7 +861,7 @@ public sealed class StringAspects
     {
         if (values is null)
         {
-            throw new ArgumentNullException(nameof(values));
+            return null;
         }
 
         return values as T[] ?? values.ToArray();

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -512,10 +512,10 @@ public sealed class StringAspects
         return result;
     }
 
-    private static string ConcatAndMaterialize<T>(IEnumerable<T> values, out T[] materializedValues)
+    private static string ConcatAndMaterialize<T>(IEnumerable<T> values, out IReadOnlyCollection<T> materializedValues)
     {
         materializedValues = Materialize(values);
-        return string.Concat((IEnumerable<T>)materializedValues);
+        return string.Concat(materializedValues);
     }
 
 #if NET6_0_OR_GREATER
@@ -843,7 +843,7 @@ public sealed class StringAspects
     }
 
 #if NETCOREAPP
-    private static string JoinAndMaterialize<T>(char separator, IEnumerable<T> values, out T[] materializedValues)
+    private static string JoinAndMaterialize<T>(char separator, IEnumerable<T> values, out IReadOnlyCollection<T> materializedValues)
     {
         materializedValues = Materialize(values);
         return string.Join(separator, materializedValues);
@@ -851,20 +851,20 @@ public sealed class StringAspects
 
 #endif
 
-    private static string JoinAndMaterialize<T>(string separator, IEnumerable<T> values, out T[] materializedValues)
+    private static string JoinAndMaterialize<T>(string separator, IEnumerable<T> values, out IReadOnlyCollection<T> materializedValues)
     {
         materializedValues = Materialize(values);
         return string.Join(separator, materializedValues);
     }
 
-    private static T[] Materialize<T>(IEnumerable<T> values)
+    private static IReadOnlyCollection<T> Materialize<T>(IEnumerable<T> values)
     {
         if (values is null)
         {
             return null;
         }
 
-        return values as T[] ?? values.ToArray();
+        return values as IReadOnlyCollection<T> ?? values.ToList();
     }
 
 #if NET6_0_OR_GREATER

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/StringAspects.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Datadog.Trace.Iast.Dataflow;
+using Datadog.Trace.Iast.Helpers;
 using Datadog.Trace.Iast.Propagation;
 using Datadog.Trace.Logging;
 using static Datadog.Trace.Iast.Propagation.StringModuleImpl;
@@ -514,7 +515,7 @@ public sealed class StringAspects
 
     private static string ConcatAndMaterialize<T>(IEnumerable<T> values, out IReadOnlyCollection<T> materializedValues)
     {
-        materializedValues = Materialize(values);
+        materializedValues = values.Materialize();
         return string.Concat(materializedValues);
     }
 
@@ -845,7 +846,7 @@ public sealed class StringAspects
 #if NETCOREAPP
     private static string JoinAndMaterialize<T>(char separator, IEnumerable<T> values, out IReadOnlyCollection<T> materializedValues)
     {
-        materializedValues = Materialize(values);
+        materializedValues = values.Materialize();
         return string.Join(separator, materializedValues);
     }
 
@@ -853,18 +854,8 @@ public sealed class StringAspects
 
     private static string JoinAndMaterialize<T>(string separator, IEnumerable<T> values, out IReadOnlyCollection<T> materializedValues)
     {
-        materializedValues = Materialize(values);
+        materializedValues = values.Materialize();
         return string.Join(separator, materializedValues);
-    }
-
-    private static IReadOnlyCollection<T> Materialize<T>(IEnumerable<T> values)
-    {
-        if (values is null)
-        {
-            return null;
-        }
-
-        return values as IReadOnlyCollection<T> ?? values.ToList();
     }
 
 #if NET6_0_OR_GREATER

--- a/tracer/src/Datadog.Trace/Iast/Helpers/EnumerableExtensions.cs
+++ b/tracer/src/Datadog.Trace/Iast/Helpers/EnumerableExtensions.cs
@@ -1,0 +1,24 @@
+// <copyright file="EnumerableExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Datadog.Trace.Iast.Helpers;
+
+internal static class EnumerableExtensions
+{
+    public static IReadOnlyCollection<T>? Materialize<T>(this IEnumerable<T>? values)
+    {
+        if (values is null)
+        {
+            return null;
+        }
+
+        return values as IReadOnlyCollection<T> ?? values.ToList();
+    }
+}

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/StringConcatTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/StringConcatTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -78,6 +79,42 @@ public class StringConcatTests : InstrumentationTestsBase
         var testString5 = AddTaintedString("+-*/{}");
 
         FormatTainted(System.String.Concat(new List<string> { testString1, testString2, testString3, testString4, testString5 })).Should().Be(":+-01-+::+-abc-+::+-ABCD-+::+-.,;:?-+::+-+-*/{}-+:");
+    }
+
+    [Fact]
+    public void GivenDeferredStringEnumerable_WhenCallingConcat_EnumerableIsOnlyEnumeratedOnce()
+    {
+        const int elementCount = 3;
+        var sideEffectInvocations = 0;
+        var values = Enumerable.Range(0, elementCount).Select(i =>
+        {
+            sideEffectInvocations++;
+            return i == 0 ? TaintedString : $"value{i}";
+        });
+
+        var result = System.String.Concat(values);
+
+        Assert.Equal("TaintedStringvalue1value2", result);
+        Assert.Equal(elementCount, sideEffectInvocations);
+        Assert.Equal(":+-TaintedString-+:value1value2", FormatTainted(result));
+    }
+
+    [Fact]
+    public void GivenDeferredGenericEnumerable_WhenCallingConcat_EnumerableIsOnlyEnumeratedOnce()
+    {
+        const int elementCount = 3;
+        var sideEffectInvocations = 0;
+        var values = Enumerable.Range(0, elementCount).Select<int, object>(i =>
+        {
+            sideEffectInvocations++;
+            return i == 0 ? TaintedObject : $"value{i}";
+        });
+
+        var result = System.String.Concat(values);
+
+        Assert.Equal("TaintedObjectvalue1value2", result);
+        Assert.Equal(elementCount, sideEffectInvocations);
+        Assert.Equal(":+-TaintedObject-+:value1value2", FormatTainted(result));
     }
 
     [Fact]
@@ -708,4 +745,3 @@ public class StringConcatTests : InstrumentationTestsBase
         System.String.Concat(obj).Should().BeEmpty();
     }
 }
-

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/StringJoinTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/String/StringJoinTests.cs
@@ -83,6 +83,39 @@ public class StringJoinTests : InstrumentationTestsBase
     }
 
     [Fact]
+    public void GivenDeferredStringEnumerable_WhenCallingJoin_EnumerableIsOnlyEnumeratedOnce()
+    {
+        const int elementCount = 3;
+        var sideEffectInvocations = 0;
+        var values = Enumerable.Range(0, elementCount).Select(i =>
+        {
+            sideEffectInvocations++;
+            return i == 0 ? TaintedString : $"value{i}";
+        });
+
+        var result = System.String.Join("|", values);
+
+        Assert.Equal("TaintedString|value1|value2", result);
+        Assert.Equal(elementCount, sideEffectInvocations);
+        Assert.Equal(":+-TaintedString-+:|value1|value2", FormatTainted(result));
+    }
+
+    [Fact]
+    public void GivenNullEnumerable_WhenCallingJoin_ThrowsArgumentNullExceptionForValues()
+    {
+        var stringEnumerableException = Assert.Throws<ArgumentNullException>(() => System.String.Join("|", (IEnumerable<string>)null));
+        Assert.Equal("values", stringEnumerableException.ParamName);
+
+        var genericEnumerableException = Assert.Throws<ArgumentNullException>(() => System.String.Join<object>("|", (IEnumerable<object>)null));
+        Assert.Equal("values", genericEnumerableException.ParamName);
+
+#if NETCOREAPP3_1_OR_GREATER
+        var charSeparatorException = Assert.Throws<ArgumentNullException>(() => System.String.Join('|', (IEnumerable<string>)null));
+        Assert.Equal("values", charSeparatorException.ParamName);
+#endif
+    }
+
+    [Fact]
     public void GivenATaintedObject_WhenCallingJoinWithStringArrayAndIndex_ResultIsTainted()
     {
         AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", System.String.Join(",", new string[] { taintedValue, taintedValue2 }, 0, 1), () => System.String.Join(",", new string[] { taintedValue, taintedValue2 }, 0, 1));

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/StringBuilder/StringBuilderAppendJoin.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Propagation/StringBuilder/StringBuilderAppendJoin.cs
@@ -1,5 +1,6 @@
 #if NETCOREAPP3_1_OR_GREATER
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Samples.InstrumentedTests.Iast.Propagation.StringBuilder;
@@ -214,6 +215,24 @@ public class StringBuilderAppendJoin : InstrumentationTestsBase
             () => new System.Text.StringBuilder().AppendJoin(_taintedValue, new List<object> { _untaintedString, _untaintedString }));
     }
 
+    [Fact]
+    public void GivenDeferredEnumerable_WhenCallingAppendJoinWithStringSeparator_EnumerableIsOnlyEnumeratedOnce()
+    {
+        const int elementCount = 3;
+        var sideEffectInvocations = 0;
+        var values = Enumerable.Range(0, elementCount).Select<int, object>(i =>
+        {
+            sideEffectInvocations++;
+            return i == 0 ? _taintedValue : $"value{i}";
+        });
+
+        var result = new System.Text.StringBuilder().AppendJoin(".", values);
+
+        Assert.Equal("tainted.value1.value2", result.ToString());
+        Assert.Equal(elementCount, sideEffectInvocations);
+        Assert.Equal(":+-tainted.value1.value2-+:", FormatTainted(result));
+    }
+
     // System.Text.StringBuilder::AppendJoin(System.Char,System.Char[])
 
     [Fact]
@@ -354,6 +373,24 @@ public class StringBuilderAppendJoin : InstrumentationTestsBase
         AssertTaintedFormatWithOriginalCallCheck(":+-test3.4-+:",
             GetTaintedStringBuilder("test").AppendJoin('.', new List<int> { 3, 4 }),
             () => GetTaintedStringBuilder("test").AppendJoin('.', new List<int> { 3, 4 }));
+    }
+
+    [Fact]
+    public void GivenDeferredEnumerable_WhenCallingAppendJoinWithCharSeparator_EnumerableIsOnlyEnumeratedOnce()
+    {
+        const int elementCount = 3;
+        var sideEffectInvocations = 0;
+        var values = Enumerable.Range(0, elementCount).Select<int, object>(i =>
+        {
+            sideEffectInvocations++;
+            return i == 0 ? _taintedValue : $"value{i}";
+        });
+
+        var result = new System.Text.StringBuilder().AppendJoin('.', values);
+
+        Assert.Equal("tainted.value1.value2", result.ToString());
+        Assert.Equal(elementCount, sideEffectInvocations);
+        Assert.Equal(":+-tainted.value1.value2-+:", FormatTainted(result));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of changes

- Materialize deferred enumerable inputs once in IAST aspects for `string.Join`, `string.Concat`, and `StringBuilder.AppendJoin`.
- Reuse the materialized values for both the original framework call and IAST taint propagation.
- Add regression coverage for deferred enumerable inputs to ensure they are not enumerated more than once.

## Reason for change

IAST propagation was re-enumerating deferred `IEnumerable<T>` inputs after the original .NET API had already consumed them.
For deferred sequences with side effects, this changed application behavior.

We got case where when using SqlKata/Npgsql, the second enumeration duplicated query compiler side effects and misaligned SQL bindings.

## Implementation details

- Added materialization helpers that preserve null argument behavior and avoid extra allocation when the input is already an array.
- Updated affected enumerable overloads to call the framework API with the materialized array.
- Passed the same materialized array into IAST propagation, preventing IAST from re-running user iterator code.
- Kept array overloads unchanged because arrays are already stable, materialized inputs.

## Test coverage

- Added deferred enumerable regression tests for `string.Join`, `string.Concat`, and `StringBuilder.AppendJoin`.
- Verified each affected enumerable is evaluated exactly once.

---
https://datadoghq.atlassian.net/browse/APPSEC-63121