### PR TITLE
Retry microbenchmarks on non-compliant CPUs

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -51,7 +51,7 @@ check-azure-pipeline:
     expire_in: 3 months
   variables:
     # Set this for quickly testing benchmarking workflows.
-    HARDCODED_BUILD_ID: ""
+    HARDCODED_BUILD_ID: "200925"
   script:
     - |
       if [[ -n "$HARDCODED_BUILD_ID" ]]; then

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -51,7 +51,7 @@ check-azure-pipeline:
     expire_in: 3 months
   variables:
     # Set this for quickly testing benchmarking workflows.
-    HARDCODED_BUILD_ID: "200925"
+    HARDCODED_BUILD_ID: "200907"
   script:
     - |
       if [[ -n "$HARDCODED_BUILD_ID" ]]; then

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -51,7 +51,7 @@ check-azure-pipeline:
     expire_in: 3 months
   variables:
     # Set this for quickly testing benchmarking workflows.
-    HARDCODED_BUILD_ID: "200907"
+    HARDCODED_BUILD_ID: ""
   script:
     - |
       if [[ -n "$HARDCODED_BUILD_ID" ]]; then

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -538,7 +538,7 @@ profiler_cpu_timer_create-arm64:
   stage: benchmarks-win
   needs: ["check-azure-pipeline"]
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dd-trace-dotnet-macro
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts

--- a/.gitlab/benchmarks/microbenchmarks/infrastructure/instance.yml
+++ b/.gitlab/benchmarks/microbenchmarks/infrastructure/instance.yml
@@ -10,6 +10,8 @@
 
 name: &provision_name "dd-trace-dotnet-microbenchmarks"
 
+target_cpu: "8259CL"
+
 init_environment:
   # S3 bucket for benchmark results
   BP_INFRA_ARTIFACTS_BUCKET_NAME: "windows-benchmarking-results-us-east-1"
@@ -21,20 +23,9 @@ tags:
   Name: *provision_name
 
 provision_steps:
-  - check_cpu_model
   - fetch_baseline_metadata
   - run_benchmarks
   - upload_results
-
-check_cpu_model:
-  remote_command: |
-    $ErrorActionPreference = "Stop"
-    $cpuModel = (Get-WmiObject -Class Win32_Processor).Name
-    if ($cpuModel -notlike "*8259CL CPU*") {
-        Write-Error "CPU model is not Intel(R) Xeon(R) Platinum 8259CL: $cpuModel"
-        exit 1
-    }
-    Write-Output "CPU model verified: Intel(R) Xeon(R) Platinum 8259CL"
 
 fetch_baseline_metadata:
   populate_env: true


### PR DESCRIPTION
## Summary of changes

Use bp-infra `target_cpu` field for CPU validation with automatic retry on mismatch.

## Reason for change

Fix flaky microbenchmarks CI caused by m5.metal CPU lottery (8259CL vs 8175M).

## Implementation details

- Add `target_cpu: "8259CL"` to provision file
- Remove manual `check_cpu_model` step (bp-infra handles this internally now)

## Test coverage

Testing microbenchmarks: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1656268778
   - Successful auto CPU check: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1656268778#L284

Testing macrobenchmarks: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1656650126
   - Successful auto CPU check: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1656650126#L168

## Other details

Depends on https://github.com/DataDog/benchmarking-platform-tools/pull/232