### PR TITLE
Don't run benchmark trigger on tag pushes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -259,6 +259,10 @@ microbenchmarks:
     include: .gitlab/benchmarks/microbenchmarks.yml
     strategy: depend
   allow_failure: true
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: never
+    - when: always
 
 dsm_throughput:
   stage: benchmarks


### PR DESCRIPTION
## Summary of changes

Don't run the microbenchmark trigger on tag pushes

## Reason for change

We don't need to run these on tag pushes (as the code hasn't changed) and we already exclude running them in microbenchmarks.yml anyway

## Implementation details

Add exclude for commit tag pushes

## Test coverage

We can't really test it unfortunately

## Other details

Note that we use `except:` in other places, but `rules:` is apparently the recommended approach