### PR TITLE
[Azure Functions] Update Datadog.Serverless.Compat version to 1.4.0

### DIFF
--- a/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
+++ b/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Datadog.Trace.Annotations\Datadog.Trace.Annotations.csproj" />
 
     <!-- Use PrivateAssets="none" to stop excluding content files by default -->
-    <PackageReference Include="Datadog.Serverless.Compat" Version="1.2.0" PrivateAssets="none" />
+    <PackageReference Include="Datadog.Serverless.Compat" Version="1.4.0" PrivateAssets="none" />
 
     <!-- managed assemblies -->
     <None Include="$(SourcePath)/net6.0/Datadog.Trace.dll" Pack="true" Visible="false" PackagePath="contentFiles/any/any/datadog/net6.0/">


### PR DESCRIPTION
## Summary of changes
Update Datadog.Serverless.Compat to [v1.4.0](https://github.com/DataDog/datadog-serverless-compat-dotnet/releases/tag/v1.4.0) for Datadog.AzureFunctions.
## Reason for change
New Serverless Compatibility Layer package available.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
