### PR TITLE
Reapply "[SymDB] DEBUG-5086 SymDB upload enable when DI is disabled"

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -586,7 +586,8 @@ namespace Datadog.Trace.ClrProfiler
 
             if (!debuggerSettings.DynamicInstrumentationEnabled
              && !debuggerSettings.CodeOriginForSpansEnabled
-             && !manager.ExceptionReplaySettings.Enabled)
+             && !manager.ExceptionReplaySettings.Enabled
+             && !debuggerSettings.SymbolDatabaseUploadEnabled)
             {
                 Log.Debug("Debugger products are not enabled");
             }

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
@@ -284,10 +284,9 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                if (!DebuggerSettings.SymbolDatabaseUploadEnabled
-                 || !newDebuggerSettings.DynamicInstrumentationCanBeEnabled)
+                if (!newDebuggerSettings.SymbolDatabaseUploadEnabled)
                 {
-                    // explicitly disabled via local env var or DI can not be enabled
+                    // explicitly disabled via local env var
                     return;
                 }
 
@@ -297,15 +296,9 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                if (!newDebuggerSettings.DynamicInstrumentationEnabled
-                 && newDebuggerSettings.DynamicSettings.DynamicInstrumentationEnabled != true)
-                {
-                    return;
-                }
-
-                // Initialize symbol database uploader only if DI is enabled locally or remotely.
+                // Initialize the symbol uploader as soon as local settings allow it.
                 var tracerManager = TracerManager.Instance;
-                this.SymbolsUploader = DebuggerFactory.CreateSymbolsUploader(tracerManager.DiscoveryService, RcmSubscriptionManager.Instance, () => ServiceName, tracerSettings, DebuggerSettings, tracerManager.GitMetadataTagsProvider);
+                this.SymbolsUploader = DebuggerFactory.CreateSymbolsUploader(tracerManager.DiscoveryService, RcmSubscriptionManager.Instance, () => ServiceName, tracerSettings, newDebuggerSettings, tracerManager.GitMetadataTagsProvider);
                 _ = this.SymbolsUploader.StartFlushingAsync()
                         .ContinueWith(
                              t => Log.Error(t?.Exception, "Failed to initialize symbol uploader"),

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Debugger
             DynamicInstrumentationEnabled = diEnabledResult.WithDefault(false);
             DynamicInstrumentationCanBeEnabled = diEnabledResult.ConfigurationResult is not { IsValid: true, Result: false };
 
-            SymbolDatabaseUploadEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled).AsBool(DynamicInstrumentationCanBeEnabled);
+            SymbolDatabaseUploadEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled).AsBool(true);
 
             MaximumDepthOfMembersToCopy = config
                                          .WithKeys(ConfigurationKeys.Debugger.MaxDepthToSerialize)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerDynamicTests.cs
@@ -62,7 +62,9 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, no DI objects should exist
                 memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
                 memoryAssertions.NoObjectsExist<LineProbeResolver>();
-                memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
+                // The uploader starts early so it can subscribe to SymDB remote config
+                // even while Dynamic Instrumentation is still disabled.
+                memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
             },
             remoteConfig: new { dynamic_instrumentation_enabled = true },
             DynamicInstrumentationEnabledLogEntry,
@@ -121,6 +123,7 @@ public class DebuggerManagerDynamicTests : TestHelper
     public async Task DebuggerManager_MultipleProducts_StartDisabled_EnabledViaRemoteConfig()
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.RemoteConfigurationEnabled, "true");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled, string.Empty);
 
         await RunDynamicConfigurationTest(
             false,
@@ -129,10 +132,11 @@ public class DebuggerManagerDynamicTests : TestHelper
                 // Initially, no debugger objects should exist
                 memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
                 memoryAssertions.NoObjectsExist<ExceptionAutoInstrumentation.ExceptionReplay>();
-                memoryAssertions.NoObjectsExist<SpanCodeOrigin.SpanCodeOrigin>();
                 memoryAssertions.NoObjectsExist<SnapshotSink>();
                 memoryAssertions.NoObjectsExist<LineProbeResolver>();
-                memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
+                // The uploader starts early so it can subscribe to SymDB remote config
+                // even while the other debugger products remain disabled.
+                memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
             },
             remoteConfig: new
             {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerManagerTests.cs
@@ -45,7 +45,7 @@ public class DebuggerManagerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
-    public async Task DebuggerManager_AllFeaturesByDefault_NoDebuggerObjectsCreated()
+    public async Task DebuggerManager_AllFeaturesByDefault_CreatesOnlyNonDiDebuggerObjects()
     {
         await RunDebuggerManagerTestWithMemoryAssertions(memoryAssertions =>
         {
@@ -53,7 +53,7 @@ public class DebuggerManagerTests : TestHelper
             memoryAssertions.NoObjectsExist<LineProbeResolver>();
             memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
             memoryAssertions.NoObjectsExist<ExceptionAutoInstrumentation.ExceptionReplay>();
-            memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
+            memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
             memoryAssertions.ObjectsExist<SpanCodeOrigin.SpanCodeOrigin>();
         });
     }
@@ -63,7 +63,7 @@ public class DebuggerManagerTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
     [Trait("Category", "LinuxUnsupported")]
-    public async Task DebuggerManager_DynamicInstrumentationExplicitlyDisabled_NoDebuggerObjectsCreated()
+    public async Task DebuggerManager_DynamicInstrumentationExplicitlyDisabled_DoesNotCreateDynamicInstrumentationObjects()
     {
         // at least one product should be enabled to initialize the debugger manager
         SetEnvironmentVariable(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled, "true");
@@ -73,6 +73,24 @@ public class DebuggerManagerTests : TestHelper
             memoryAssertions.NoObjectsExist<SnapshotSink>();
             memoryAssertions.NoObjectsExist<LineProbeResolver>();
             memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
+        });
+    }
+
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "ArmUnsupported")]
+    [Trait("RunOnWindows", "True")]
+    [Trait("Category", "LinuxUnsupported")]
+    public async Task DebuggerManager_DynamicInstrumentationExplicitlyDisabled_SymbolDatabaseEnabledByDefault_CreatesSymbolUploader()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "false");
+
+        await RunDebuggerManagerTestWithMemoryAssertions(memoryAssertions =>
+        {
+            memoryAssertions.NoObjectsExist<SnapshotSink>();
+            memoryAssertions.NoObjectsExist<LineProbeResolver>();
+            memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
+            memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
         });
     }
 
@@ -123,6 +141,23 @@ public class DebuggerManagerTests : TestHelper
             memoryAssertions.NoObjectsExist<Pdb.DatadogMetadataReader>();
             memoryAssertions.NoObjectsExist<Symbols.SymbolsUploader>();
             memoryAssertions.NoObjectsExist<Symbols.SymbolExtractor>();
+        });
+    }
+
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "ArmUnsupported")]
+    [Trait("RunOnWindows", "True")]
+    [Trait("Category", "LinuxUnsupported")]
+    public async Task DebuggerManager_SymbolDatabaseUploadEnabled_WithoutDynamicInstrumentation_CreatesSymbolUploader()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.CodeOriginForSpansEnabled, "true");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled, "true");
+
+        await RunDebuggerManagerTestWithMemoryAssertions(memoryAssertions =>
+        {
+            memoryAssertions.NoObjectsExist<DynamicInstrumentation>();
+            memoryAssertions.ObjectsExist<Symbols.SymbolsUploader>();
         });
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -81,6 +81,23 @@ namespace Datadog.Trace.Tests.Debugger
             settings.SymbolDatabaseUploadEnabled.Should().BeTrue();
         }
 
+        [Theory]
+        [InlineData("false")]
+        [InlineData("0")]
+        public void SymbolsEnabled_WhenDynamicInstrumentationExplicitlyDisabled(string enabled)
+        {
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, enabled },
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            settings.DynamicInstrumentationEnabled.Should().BeFalse();
+            settings.DynamicInstrumentationCanBeEnabled.Should().BeFalse();
+            settings.SymbolDatabaseUploadEnabled.Should().BeTrue();
+        }
+
         [Fact]
         public void DebuggerSettings_UseSettings()
         {


### PR DESCRIPTION
## Summary of changes

- Reapplies #8510, which was previously reverted by #8550.
- Restores the change so `Datadog.Trace` enables SymDB upload independently of Dynamic Instrumentation being enabled.

## Reason for change

- We want SymDB to upload symbols even when DI is disabled (DEBUG-5086).
- The original PR #8510 was reverted in #8550 because of an observed startup-time impact when SymDB was initialized independently of DI.

## Implementation details

- Pure revert of revert commit `587c0655017587728bfd90fbc842bf448491af07` (#8550).
- Restores the original logic from #8510 in `Instrumentation.cs`, `DebuggerManager.cs`, `DebuggerSettings.cs`, and the corresponding unit tests in `DebuggerManagerTests`, `DebuggerManagerDynamicTests`, and `DebuggerSettingsTests`.
- No additional changes on top of the original #8510.

## Test coverage

- No new tests added beyond what was restored from #8510 (those tests are reapplied as-is).
- Tests not run locally for this revert-of-revert; relying on CI.

## Other details

- The startup-time concern that motivated #8550 is being addressed in the open follow-up #8548 ("[SymDB] Defer SymDB startup work until remote enablement"). This PR should not be merged with #8548 lands (or the perf concern is otherwise resolved), otherwise we will reintroduce the regression that triggered the original revert.
<!-- Fixes DEBUG-5086 -->