### PR TITLE
[Dynamic Instrumentation] Skip arg/local when byref-like check fails

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -105,6 +105,9 @@ HRESULT DebuggerMethodRewriter::WriteCallsToLogArgOrLocal(
         {
             Logger::Warn("DebuggerRewriter: Failed to determine if ", isArgs ? "argument" : "local", " index = ", argOrLocalIndex,
                          " is By-Ref like.");
+            // We couldn't reliably determine whether this value is byref-like.
+            // Do not instrument it. Instrumenting byref-like values can lead to runtime failures.
+            continue;
         }
         else if (isTypeIsByRefLike)
         {


### PR DESCRIPTION
## Summary of changes

- In `DebuggerMethodRewriter::WriteCallsToLogArgOrLocal`, when `IsTypeByRefLike` returns a failure HRESULT, skip instrumentation for that argument/local instead of falling through.

## Reason for change

- If `IsTypeByRefLike` fails (e.g. metadata cannot be resolved), the rewriter previously continued and emitted `LogArg`/`LogLocal` calls for the value. If the value happened to be byref-like, this can produce invalid IL or runtime failures (`InvalidProgramException`, crashes when reading the byref).
- Treating the failure conservatively avoids those failures; we already skip when the type is confirmed byref-like.

## Implementation details

- Add a `continue;` in the `FAILED(hr)` branch with a comment explaining the conservative behavior. No other changes.

## Test coverage

- No new tests in this PR; covered by existing debugger integration tests that exercise IL rewriting.
- Did not run tests locally.

## Other details
<!-- Fixes #{issue} -->