### PR TITLE
[Debugger] Harden SnapshotPruner fallback handling

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
@@ -50,6 +50,11 @@ namespace DatadogDebugger.Util
 
         public static string Prune(string snapshot, int maxTargetedSize, int minLevel)
         {
+            if (snapshot is null)
+            {
+                return snapshot;
+            }
+
             var delta = Encoding.UTF8.GetByteCount(snapshot) - maxTargetedSize;
             if (delta <= 0)
             {
@@ -63,6 +68,12 @@ namespace DatadogDebugger.Util
             foreach (var leaf in leaves)
             {
                 sortedLeaves.Add(leaf);
+            }
+
+            if (sortedLeaves.Count == 0)
+            {
+                // Nothing to prune (could be invalid JSON, or it doesn't contain any objects deep enough)
+                return snapshot;
             }
 
             var total = 0;
@@ -100,6 +111,22 @@ namespace DatadogDebugger.Util
             }
 
             var prunedNodes = nodes.Values.OrderBy(n => n.Start).ToList();
+            if (prunedNodes.Count == 0)
+            {
+                return snapshot;
+            }
+
+            // Defensive bounds checks - Node.Start/End are char indices, not byte indices
+            // If these are out of bounds for any reason, abort pruning and return original snapshot.
+            for (var i = 0; i < prunedNodes.Count; i++)
+            {
+                var n = prunedNodes[i];
+                if (n.Start < 0 || n.End < n.Start || n.End >= snapshot.Length)
+                {
+                    return snapshot;
+                }
+            }
+
             var sb = StringBuilderCache.Acquire();
             sb.Append(snapshot, 0, prunedNodes[0].Start);
             for (var i = 1; i < prunedNodes.Count; i++)
@@ -107,12 +134,18 @@ namespace DatadogDebugger.Util
                 sb.Append(Pruned);
                 var nextSegmentStart = prunedNodes[i - 1].End + 1;
                 var nextSegmentLength = prunedNodes[i].Start - nextSegmentStart;
+                if (nextSegmentStart < 0 || nextSegmentStart > snapshot.Length || nextSegmentLength < 0 || (nextSegmentStart + nextSegmentLength) > snapshot.Length)
+                {
+                    // Malformed segment boundaries - abort pruning
+                    return snapshot;
+                }
+
                 sb.Append(snapshot, nextSegmentStart, nextSegmentLength);
             }
 
             sb.Append(Pruned);
             var lastSegmentStart = prunedNodes[prunedNodes.Count - 1].End + 1;
-            if (lastSegmentStart < Encoding.UTF8.GetByteCount(snapshot))
+            if (lastSegmentStart < snapshot.Length)
             {
                 sb.Append(snapshot, lastSegmentStart, snapshot.Length - lastSegmentStart);
             }
@@ -197,7 +230,7 @@ namespace DatadogDebugger.Util
             switch (c)
             {
                 case '"':
-                    if (pruner._strMatchIdx == Encoding.UTF8.GetByteCount(pruner._matchingString))
+                    if (pruner._strMatchIdx == pruner._matchingString.Length)
                     {
                         return NotCapturedAction();
                     }

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
@@ -131,15 +131,16 @@ namespace DatadogDebugger.Util
             sb.Append(snapshot, 0, prunedNodes[0].Start);
             for (var i = 1; i < prunedNodes.Count; i++)
             {
-                sb.Append(Pruned);
                 var nextSegmentStart = prunedNodes[i - 1].End + 1;
                 var nextSegmentLength = prunedNodes[i].Start - nextSegmentStart;
                 if (nextSegmentStart < 0 || nextSegmentStart > snapshot.Length || nextSegmentLength < 0 || (nextSegmentStart + nextSegmentLength) > snapshot.Length)
                 {
                     // Malformed segment boundaries - abort pruning
+                    StringBuilderCache.Release(sb);
                     return snapshot;
                 }
 
+                sb.Append(Pruned);
                 sb.Append(snapshot, nextSegmentStart, nextSegmentLength);
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
@@ -117,30 +117,36 @@ namespace DatadogDebugger.Util
             }
 
             var sb = StringBuilderCache.Acquire();
-            sb.Append(snapshot, 0, prunedNodes[0].Start);
-            for (var i = 1; i < prunedNodes.Count; i++)
+            try
             {
-                var nextSegmentStart = prunedNodes[i - 1].End + 1;
-                var nextSegmentLength = prunedNodes[i].Start - nextSegmentStart;
-                if (nextSegmentStart < 0 || nextSegmentStart > snapshot.Length || nextSegmentLength < 0 || (nextSegmentStart + nextSegmentLength) > snapshot.Length)
+                sb.Append(snapshot, 0, prunedNodes[0].Start);
+                for (var i = 1; i < prunedNodes.Count; i++)
                 {
-                    // Malformed segment boundaries - abort pruning
-                    StringBuilderCache.Release(sb);
-                    return snapshot;
+                    var nextSegmentStart = prunedNodes[i - 1].End + 1;
+                    var nextSegmentLength = prunedNodes[i].Start - nextSegmentStart;
+                    if (nextSegmentStart < 0 || nextSegmentStart > snapshot.Length || nextSegmentLength < 0 || (nextSegmentStart + nextSegmentLength) > snapshot.Length)
+                    {
+                        // Malformed segment boundaries - abort pruning
+                        return snapshot;
+                    }
+
+                    sb.Append(Pruned);
+                    sb.Append(snapshot, nextSegmentStart, nextSegmentLength);
                 }
 
                 sb.Append(Pruned);
-                sb.Append(snapshot, nextSegmentStart, nextSegmentLength);
-            }
+                var lastSegmentStart = prunedNodes[prunedNodes.Count - 1].End + 1;
+                if (lastSegmentStart < snapshot.Length)
+                {
+                    sb.Append(snapshot, lastSegmentStart, snapshot.Length - lastSegmentStart);
+                }
 
-            sb.Append(Pruned);
-            var lastSegmentStart = prunedNodes[prunedNodes.Count - 1].End + 1;
-            if (lastSegmentStart < snapshot.Length)
+                return sb.ToString();
+            }
+            finally
             {
-                sb.Append(snapshot, lastSegmentStart, snapshot.Length - lastSegmentStart);
+                StringBuilderCache.Release(sb);
             }
-
-            return StringBuilderCache.GetStringAndRelease(sb);
         }
 
         private IEnumerable<Node> GetLeaves(int minLevel)

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
@@ -116,17 +116,6 @@ namespace DatadogDebugger.Util
                 return snapshot;
             }
 
-            // Defensive bounds checks - Node.Start/End are char indices, not byte indices
-            // If these are out of bounds for any reason, abort pruning and return original snapshot.
-            for (var i = 0; i < prunedNodes.Count; i++)
-            {
-                var n = prunedNodes[i];
-                if (n.Start < 0 || n.End < n.Start || n.End >= snapshot.Length)
-                {
-                    return snapshot;
-                }
-            }
-
             var sb = StringBuilderCache.Acquire();
             sb.Append(snapshot, 0, prunedNodes[0].Start);
             for (var i = 1; i < prunedNodes.Count; i++)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.TestHelpers;
+using DatadogDebugger.Util;
 using Newtonsoft.Json.Linq;
 using VerifyXunit;
 using Xunit;
@@ -26,6 +27,33 @@ namespace Datadog.Trace.Tests.Debugger
             var slicer = GetSlicer(3, snapshot.Length + 1);
             var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
             Assert.Equal(snapshot, modifiedSnapshot);
+        }
+
+        [Fact]
+        public void NullSnapshot_ReturnsNull()
+        {
+            var modifiedSnapshot = SnapshotPruner.Prune(null, 0, 0);
+            Assert.Null(modifiedSnapshot);
+        }
+
+        [Fact]
+        public void InvalidJsonWithNoLeaves_ReturnsOriginalSnapshot()
+        {
+            var snapshot = "{\"debugger\":{\"snapshot\":{\"captures\":{";
+            var modifiedSnapshot = SnapshotPruner.Prune(snapshot, 1, 1);
+            Assert.Equal(snapshot, modifiedSnapshot);
+        }
+
+        [Fact]
+        public void SnapshotWithNonAsciiCharacters_PrunesUsingCharIndexes()
+        {
+            var snapshot = "{\"debugger\":{\"snapshot\":{\"captures\":{\"message\":\"é\",\"value\":{\"notCapturedReason\":\"depth\",\"type\":\"String\",\"value\":\"é\"}}}}}";
+
+            var modifiedSnapshot = SnapshotPruner.Prune(snapshot, 1, 4);
+
+            var captures = JObject.Parse(modifiedSnapshot).SelectToken("debugger.snapshot.captures");
+            Assert.Equal("é", captures["message"].Value<string>());
+            Assert.Contains("\"pruned\":true", modifiedSnapshot);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

- Harden `SnapshotPruner.Prune` so known fallback cases return the original snapshot instead of throwing.
- Handle `null` input and snapshots that produce no pruneable leaves.
- Use `snapshot.Length` / `_matchingString.Length` for checks that operate on char indexes.
- Add focused regression tests for fallback behavior and non-ASCII snapshot content.

## Reason for change

`SnapshotPruner` works with char indexes into the snapshot string, so checks that compare against those indexes should use string length, not UTF-8 byte length.

Returning the original snapshot is preferable for known no-op fallback cases, because the caller already treats pruning failures as non-fatal and falls back to the original payload.

## Implementation details

- Invalid or shallow input that produces no pruneable nodes now returns the original snapshot directly.
- The successful pruned output shape is unchanged.
- The `_matchingString` comparison now uses `.Length` for consistency with char-based parsing.

## Test coverage

- Added focused unit coverage for:
  - `null` snapshot input returning `null`
  - invalid/no-leaf JSON returning the original snapshot
  - non-ASCII snapshot pruning using char indexes while preserving valid JSON output