### PR TITLE
[Debugger] Treat Nullable<T> as safe for snapshot ToString

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -193,8 +193,10 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal static bool IsSafeToCallToString(Type type)
         {
-            return TypeExtensions.IsSimple(type) ||
-                   AllowedTypesSafeToCallToString.Contains(type) ||
+            var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
+
+            return TypeExtensions.IsSimple(effectiveType) ||
+                   AllowedTypesSafeToCallToString.Contains(effectiveType) ||
                    IsSupportedCollection(type);
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -191,8 +191,13 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal static Redaction Instance => _instnace;
 
-        internal static bool IsSafeToCallToString(Type type)
+        internal static bool IsSafeToCallToString(Type? type)
         {
+            if (type is null)
+            {
+                return false;
+            }
+
             var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
 
             return TypeExtensions.IsSimple(effectiveType) ||

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -903,8 +903,8 @@ namespace Datadog.Trace.Tests.Debugger
             where T : IComparable<T>
         {
         }
-		
-		private class HashtableHolder
+
+        private class HashtableHolder
         {
             private readonly Hashtable dictionary = new()
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -514,6 +514,31 @@ namespace Datadog.Trace.Tests.Debugger
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
         }
 
+        [Fact]
+        public void ProbeExpressionParser_NonGenericDictionaryDump_AllowsNullValues()
+        {
+            var scopeMembers = CreateScopeMembers();
+            var holder = new HashtableHolder();
+            scopeMembers.AddMember(new ScopeMember("HashtableHolderLocal", typeof(HashtableHolder), holder, ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "ref": "HashtableHolderLocal"
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<string>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Equal("{[hello, ], }", result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
         private async Task Test(string expressionTestFilePath)
         {
             // Arrange
@@ -877,6 +902,14 @@ namespace Datadog.Trace.Tests.Debugger
         internal class RecursiveGenericConstraintTarget<T>
             where T : IComparable<T>
         {
+        }
+		
+		private class HashtableHolder
+        {
+            private readonly Hashtable dictionary = new()
+            {
+                { "hello", null },
+            };
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -173,6 +173,29 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void SpecialType_NullableSafeToStringTypes_DoNotRecurseIntoFields()
+        {
+            var expectedDate = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var expectedDuration = TimeSpan.FromSeconds(3);
+            var snapshot = JObject.Parse(SnapshotHelper.GenerateSnapshot(new NullableSafeToStringHolder(), prettify: false));
+
+            var dateToken = snapshot.SelectToken("debugger.snapshot.captures.return.locals.local0.fields.Date");
+            Assert.NotNull(dateToken);
+            Assert.Equal("Nullable`1", dateToken["type"]?.Value<string>());
+            Assert.Equal(expectedDate.ToString(), dateToken["value"]?.Value<string>());
+            Assert.Null(dateToken["fields"]);
+
+            var durationToken = snapshot.SelectToken("debugger.snapshot.captures.return.locals.local0.fields.Duration");
+            Assert.NotNull(durationToken);
+            Assert.Equal("Nullable`1", durationToken["type"]?.Value<string>());
+            Assert.Equal(expectedDuration.ToString(), durationToken["value"]?.Value<string>());
+            Assert.Null(durationToken["fields"]);
+
+            Assert.Equal("Bar", snapshot.SelectToken("logger.name")?.Value<string>());
+            Assert.Equal("Foo", snapshot.SelectToken("logger.method")?.Value<string>());
+        }
+
+        [Fact]
         public async Task SpecialType_LazyUninitialized()
         {
             await ValidateSingleValue(new Lazy<int>(() => Math.Max(1, 2)));
@@ -1218,6 +1241,13 @@ namespace Datadog.Trace.Tests.Debugger
             private readonly int _numField998 = 998;
             private readonly int _numField999 = 999;
             private readonly int _numField1000 = 1000;
+        }
+
+        private class NullableSafeToStringHolder
+        {
+            public DateTime? Date { get; } = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            public TimeSpan? Duration { get; } = TimeSpan.FromSeconds(3);
         }
 
         private class CollectionAtMaxDepth

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
@@ -15,14 +15,26 @@ namespace Datadog.Trace.Tests.Debugger
 {
     public class SupportedTypesServiceTests
     {
-        private static readonly object[] Objects = { 3, DateTime.MinValue, TimeSpan.FromSeconds(3), DateTimeOffset.MinValue, Guid.Empty, "Hello", new int?(5), new DateTime?(DateTime.MinValue), ConsoleColor.Blue };
+        private static readonly Type[] Types =
+        {
+            typeof(int),
+            typeof(DateTime),
+            typeof(TimeSpan),
+            typeof(DateTimeOffset),
+            typeof(Guid),
+            typeof(string),
+            typeof(int?),
+            typeof(DateTime?),
+            typeof(TimeSpan?),
+            typeof(DateTimeOffset?),
+            typeof(ConsoleColor)
+        };
 
         [Fact]
         public void TestCanCallToString()
         {
-            foreach (var obj in Objects)
+            foreach (var type in Types)
             {
-                var type = obj.GetType();
                 Redaction.IsSafeToCallToString(type).Should().BeTrue($"Type {type} should be safe to call ToString on");
             }
         }


### PR DESCRIPTION
## Summary of changes

- `Redaction.IsSafeToCallToString` now unwraps `Nullable<T>` before checking `IsSimple`/the allow-list of types that are safe to `ToString`.
- Preserve the existing null-tolerant behavior of `IsSafeToCallToString` so expression dumping fallback paths can still pass a null `Type`.
- Update `SupportedTypesServiceTests` to test `Type` values directly and cover `int?`, `DateTime?`, `TimeSpan?`, `DateTimeOffset?`.
- Add snapshot and expression-dump regression coverage for nullable safe-to-`ToString` values and non-generic dictionary null values.

## Reason for change

- `DateTime?`/`TimeSpan?`/etc. were treated as complex objects, so snapshot serialization recursed into `Nullable<T>` internals instead of rendering the underlying value via `ToString`.
- The previous test used boxed nullable values, which masks the issue because `GetType()` returns the underlying type rather than `Nullable<T>`.
- `IsSafeToCallToString` is also used by expression dumping, where existing callers can pass a null `Type` for null dictionary values; that fallback behavior must be preserved.

## Implementation details

- `Nullable.GetUnderlyingType` is only called after a null check.
- `IsSupportedCollection(type)` is still passed the original type so collection detection is unchanged.

## Test coverage

- Added unit tests in `SupportedTypesServiceTests`, `DebuggerSnapshotCreatorTests`, and `DebuggerExpressionLanguageTests`.