### PR TITLE
[Debugger] Handle open generic types in probe expressions

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -839,6 +839,7 @@
       <type fullname="System.Reflection.EventInfo" />
       <type fullname="System.Reflection.FieldAttributes" />
       <type fullname="System.Reflection.FieldInfo" />
+      <type fullname="System.Reflection.GenericParameterAttributes" />
       <type fullname="System.Reflection.ICustomAttributeProvider" />
       <type fullname="System.Reflection.IntrospectionExtensions" />
       <type fullname="System.Reflection.LocalVariableInfo" />

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -81,7 +81,21 @@ internal sealed partial class ProbeExpressionParser<T>
         }
         catch (Exception e)
         {
-            AddError($"{left?.ToString() ?? "N/A"} {operand} {right?.ToString() ?? "N/A"}", e.Message);
+            var error = e.Message;
+            if (e is InvalidOperationException)
+            {
+                if ((left?.Type?.IsValueType == true && right?.Type?.IsValueType == false)
+                 || (right?.Type?.IsValueType == true && left?.Type?.IsValueType == false))
+                {
+                    error = "A reference type cannot be compared to a not nullable value type.";
+                    if (right is ConstantExpression { Value: null } || left is ConstantExpression { Value: null })
+                    {
+                        error += " Did you mean to compare do 'default' instead of 'null'?";
+                    }
+                }
+            }
+
+            AddError($"{left?.ToString() ?? "N/A"} {operand} {right?.ToString() ?? "N/A"}", error);
             return ReturnDefaultValueExpression();
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -90,7 +90,7 @@ internal sealed partial class ProbeExpressionParser<T>
                     error = "A reference type cannot be compared to a not nullable value type.";
                     if (right is ConstantExpression { Value: null } || left is ConstantExpression { Value: null })
                     {
-                        error += " Did you mean to compare do 'default' instead of 'null'?";
+                        error += " Did you mean to compare to 'default' instead of 'null'?";
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -84,8 +84,8 @@ internal sealed partial class ProbeExpressionParser<T>
             var error = e.Message;
             if (e is InvalidOperationException)
             {
-                if ((IsValueType(left) && IsReferenceType(right))
-                 || (IsValueType(right) && IsReferenceType(left)))
+                if ((IsNonNullableValueType(left) && IsReferenceType(right))
+                 || (IsNonNullableValueType(right) && IsReferenceType(left)))
                 {
                     error = "A reference type cannot be compared to a not nullable value type.";
                     if (right is ConstantExpression { Value: null } || left is ConstantExpression { Value: null })
@@ -131,7 +131,7 @@ internal sealed partial class ProbeExpressionParser<T>
             return operand == "==" ? Expression.Equal(left, right) : Expression.NotEqual(left, right);
         }
 
-        static bool IsValueType(Expression expression) => expression is not null && expression.Type.IsValueType;
+        static bool IsNonNullableValueType(Expression expression) => expression is not null && expression.Type.IsValueType && Nullable.GetUnderlyingType(expression.Type) is null;
 
         static bool IsReferenceType(Expression expression) => expression is not null && !expression.Type.IsValueType;
     }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -84,8 +84,8 @@ internal sealed partial class ProbeExpressionParser<T>
             var error = e.Message;
             if (e is InvalidOperationException)
             {
-                if ((left?.Type?.IsValueType == true && right?.Type?.IsValueType == false)
-                 || (right?.Type?.IsValueType == true && left?.Type?.IsValueType == false))
+                if ((IsValueType(left) && IsReferenceType(right))
+                 || (IsValueType(right) && IsReferenceType(left)))
                 {
                     error = "A reference type cannot be compared to a not nullable value type.";
                     if (right is ConstantExpression { Value: null } || left is ConstantExpression { Value: null })
@@ -130,6 +130,10 @@ internal sealed partial class ProbeExpressionParser<T>
 
             return operand == "==" ? Expression.Equal(left, right) : Expression.NotEqual(left, right);
         }
+
+        static bool IsValueType(Expression expression) => expression is not null && expression.Type.IsValueType;
+
+        static bool IsReferenceType(Expression expression) => expression is not null && !expression.Type.IsValueType;
     }
 
     private void NumericImplicitConversion(ref Expression left, ref Expression right)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -139,6 +139,11 @@ internal partial class ProbeExpressionParser<T>
 
     private static Type CloseOpenGenericType(Type type)
     {
+        return CloseOpenGenericType(type, new List<Type>());
+    }
+
+    private static Type CloseOpenGenericType(Type type, List<Type> visitedGenericParameters)
+    {
         if (!type.ContainsGenericParameters)
         {
             return type;
@@ -146,12 +151,12 @@ internal partial class ProbeExpressionParser<T>
 
         if (type.IsGenericParameter)
         {
-            return CloseGenericParameter(type);
+            return CloseGenericParameter(type, visitedGenericParameters);
         }
 
         if (type.HasElementType)
         {
-            var elementType = CloseOpenGenericType(type.GetElementType());
+            var elementType = CloseOpenGenericType(type.GetElementType(), visitedGenericParameters);
             if (type.IsArray)
             {
                 var rank = type.GetArrayRank();
@@ -175,7 +180,7 @@ internal partial class ProbeExpressionParser<T>
             var concreteTypes = new Type[genericArguments.Length];
             for (int i = 0; i < genericArguments.Length; i++)
             {
-                concreteTypes[i] = CloseOpenGenericType(genericArguments[i]);
+                concreteTypes[i] = CloseOpenGenericType(genericArguments[i], visitedGenericParameters);
             }
 
             try
@@ -191,32 +196,45 @@ internal partial class ProbeExpressionParser<T>
         throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains generic parameters that cannot be safely closed.");
     }
 
-    private static Type CloseGenericParameter(Type type)
+    private static Type CloseGenericParameter(Type type, List<Type> visitedGenericParameters)
     {
-        var attributes = type.GenericParameterAttributes;
-        if ((attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+        if (visitedGenericParameters.Contains(type))
         {
-            throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains a generic value type parameter.");
+            throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains recursive generic parameter constraints.");
         }
 
-        var constraints = type.GetGenericParameterConstraints();
-        if (constraints.Length == 1)
+        visitedGenericParameters.Add(type);
+        try
         {
-            var constraint = CloseOpenGenericType(constraints[0]);
-            if (constraint.IsValueType)
+            var attributes = type.GenericParameterAttributes;
+            if ((attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
             {
                 throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains a generic value type parameter.");
             }
 
-            return constraint;
-        }
+            var constraints = type.GetGenericParameterConstraints();
+            if (constraints.Length == 1)
+            {
+                var constraint = CloseOpenGenericType(constraints[0], visitedGenericParameters);
+                if (constraint.IsValueType)
+                {
+                    throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains a generic value type parameter.");
+                }
 
-        if (constraints.Length > 1)
+                return constraint;
+            }
+
+            if (constraints.Length > 1)
+            {
+                throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains generic parameters with multiple constraints.");
+            }
+
+            return typeof(object);
+        }
+        finally
         {
-            throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains generic parameters with multiple constraints.");
+            visitedGenericParameters.RemoveAt(visitedGenericParameters.Count - 1);
         }
-
-        return typeof(object);
     }
 
     private static string FormatTypeName(Type type)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -137,6 +137,93 @@ internal partial class ProbeExpressionParser<T>
                        Expression.Constant(NumberFormatInfo.CurrentInfo));
     }
 
+    private static Type CloseOpenGenericType(Type type)
+    {
+        if (!type.ContainsGenericParameters)
+        {
+            return type;
+        }
+
+        if (type.IsGenericParameter)
+        {
+            return CloseGenericParameter(type);
+        }
+
+        if (type.HasElementType)
+        {
+            var elementType = CloseOpenGenericType(type.GetElementType());
+            if (type.IsArray)
+            {
+                var rank = type.GetArrayRank();
+                return rank == 1 ? elementType.MakeArrayType() : elementType.MakeArrayType(rank);
+            }
+
+            if (type.IsByRef)
+            {
+                return elementType.MakeByRefType();
+            }
+
+            if (type.IsPointer)
+            {
+                return elementType.MakePointerType();
+            }
+        }
+
+        if (type.IsGenericType)
+        {
+            var genericArguments = type.GetGenericArguments();
+            var concreteTypes = new Type[genericArguments.Length];
+            for (int i = 0; i < genericArguments.Length; i++)
+            {
+                concreteTypes[i] = CloseOpenGenericType(genericArguments[i]);
+            }
+
+            try
+            {
+                return type.GetGenericTypeDefinition().MakeGenericType(concreteTypes);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains generic parameters that cannot be safely closed.", ex);
+            }
+        }
+
+        throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains generic parameters that cannot be safely closed.");
+    }
+
+    private static Type CloseGenericParameter(Type type)
+    {
+        var attributes = type.GenericParameterAttributes;
+        if ((attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+        {
+            throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains a generic value type parameter.");
+        }
+
+        var constraints = type.GetGenericParameterConstraints();
+        if (constraints.Length == 1)
+        {
+            var constraint = CloseOpenGenericType(constraints[0]);
+            if (constraint.IsValueType)
+            {
+                throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains a generic value type parameter.");
+            }
+
+            return constraint;
+        }
+
+        if (constraints.Length > 1)
+        {
+            throw new InvalidOperationException($"Could not evaluate expression for type {FormatTypeName(type)} because it contains generic parameters with multiple constraints.");
+        }
+
+        return typeof(object);
+    }
+
+    private static string FormatTypeName(Type type)
+    {
+        return type.FullName ?? type.Name;
+    }
+
     private Expression IsInstanceOf(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         var value = ParseTree(reader, parameters, itParameter);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq.Expressions;
-using Datadog.Trace.ClrProfiler.AutoInstrumentation.IbmMq;
 using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Logging;
@@ -544,6 +543,7 @@ internal partial class ProbeExpressionParser<T>
         var argsOrLocals = methodScopeMembers.Members;
         var @this = methodScopeMembers.InvocationTarget;
         var thisType = thisTypeOverride;
+
         if (string.IsNullOrEmpty(expressionJson) || argsOrLocals == null || thisType == null)
         {
             var ex = new ArgumentException("Method has been called with an invalid argument");
@@ -616,6 +616,33 @@ internal partial class ProbeExpressionParser<T>
     private ParameterExpression AddParameterAndVariable(ScopeMember scopeMember, Type type, string name, List<Expression> expressions, List<ParameterExpression> scopeMembers)
     {
         var parameterExpression = Expression.Parameter(scopeMember.GetType());
+        if (type.IsGenericTypeDefinition)
+        {
+            var genericArguments = type.GetGenericArguments();
+            Type[] concreteTypes = new Type[genericArguments.Length];
+            bool succeeded = true;
+            for (int i = 0; i < genericArguments.Length; i++)
+            {
+                if (genericArguments[i].IsValueType)
+                {
+                    succeeded = false;
+                    break;
+                }
+                else
+                {
+                    // For reference types, we can use object
+                    concreteTypes[i] = typeof(object);
+                }
+            }
+
+            if (!succeeded)
+            {
+                throw new InvalidOperationException($"Could not evaluate expression for type {type.FullName ?? type.Name} because it is a generic type definition.");
+            }
+
+            type = type.MakeGenericType(concreteTypes);
+        }
+
         var variable = Expression.Variable(type, name);
         var valueField = Expression.Field(parameterExpression, "Value");
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -522,6 +522,11 @@ internal partial class ProbeExpressionParser<T>
             // If declared type is Int32 but actual value is Int64, using declared type
             // would cause InvalidCastException when the lambda is executed.
             var runtimeType = argOrLocal.Value?.GetType() ?? argOrLocal.Type;
+            if (runtimeType.ContainsGenericParameters)
+            {
+                runtimeType = CloseOpenGenericType(runtimeType);
+            }
+
             var variable = Expression.Variable(runtimeType, argOrLocal.Name);
             scopeMembers.Add(variable);
 
@@ -616,31 +621,9 @@ internal partial class ProbeExpressionParser<T>
     private ParameterExpression AddParameterAndVariable(ScopeMember scopeMember, Type type, string name, List<Expression> expressions, List<ParameterExpression> scopeMembers)
     {
         var parameterExpression = Expression.Parameter(scopeMember.GetType());
-        if (type.IsGenericTypeDefinition)
+        if (type.ContainsGenericParameters)
         {
-            var genericArguments = type.GetGenericArguments();
-            Type[] concreteTypes = new Type[genericArguments.Length];
-            bool succeeded = true;
-            for (int i = 0; i < genericArguments.Length; i++)
-            {
-                if (genericArguments[i].IsValueType)
-                {
-                    succeeded = false;
-                    break;
-                }
-                else
-                {
-                    // For reference types, we can use object
-                    concreteTypes[i] = typeof(object);
-                }
-            }
-
-            if (!succeeded)
-            {
-                throw new InvalidOperationException($"Could not evaluate expression for type {type.FullName ?? type.Name} because it is a generic type definition.");
-            }
-
-            type = type.MakeGenericType(concreteTypes);
+            type = CloseOpenGenericType(scopeMember.Value?.GetType() ?? type);
         }
 
         var variable = Expression.Variable(type, name);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -217,6 +217,136 @@ namespace Datadog.Trace.Tests.Debugger
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
         }
 
+        [Fact]
+        public void ProbeExpressionParser_OpenGenericReferenceTypeParameter_CanCompileExpression()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.InvocationTarget = new ScopeMember("this", typeof(GenericReferenceTypeTarget<>), new GenericReferenceTypeTarget<string>(), ScopeMemberKind.This);
+
+            const string json = """
+                                {
+                                  "ref": "this"
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers, typeof(GenericReferenceTypeTarget<>));
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.IsType<GenericReferenceTypeTarget<string>>(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_ConstructedOpenGenericReferenceTypeParameter_CanCompileExpression()
+        {
+            var scopeMembers = CreateScopeMembers();
+            var collection = new List<string> { "value" };
+            var openCollectionType = typeof(GenericReferenceTypeTarget<>).GetProperty(nameof(GenericReferenceTypeTarget<string>.Collection)).PropertyType;
+            scopeMembers.Return = new ScopeMember("return", openCollectionType, collection, ScopeMemberKind.Return);
+
+            const string json = """
+                                {
+                                  "ref": "@return"
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Same(collection, result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_NullConstructedOpenGenericArgument_CanCompileExpression()
+        {
+            var scopeMembers = CreateScopeMembers();
+            var openCollectionType = typeof(GenericReferenceTypeTarget<>).GetProperty(nameof(GenericReferenceTypeTarget<string>.Collection)).PropertyType;
+            scopeMembers.AddMember(new ScopeMember("OpenCollectionArg", openCollectionType, null, ScopeMemberKind.Argument));
+
+            const string json = """
+                                {
+                                  "eq": [
+                                    { "ref": "OpenCollectionArg" },
+                                    null
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_OpenGenericValueTypeParameter_ReturnsEvaluationError()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.InvocationTarget = new ScopeMember("this", typeof(GenericValueTypeTarget<>), null, ScopeMemberKind.This);
+
+            const string json = """
+                                {
+                                  "ref": "this"
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers, typeof(GenericValueTypeTarget<>));
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Null(result);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Contains("generic value type parameter", error.Message);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_ValueTypeReferenceTypeComparison_ReturnsFriendlyError()
+        {
+            var scopeMembers = CreateScopeMembers();
+
+            const string json = """
+                                {
+                                  "gt": [
+                                    { "ref": "IntLocal" },
+                                    "value"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Equal("A reference type cannot be compared to a not nullable value type.", error.Message);
+        }
+
         [Theory]
         [InlineData("""
                     {
@@ -653,6 +783,17 @@ namespace Datadog.Trace.Tests.Debugger
                 private string _childPrivateMember = "Hello from child private member";
 #pragma warning restore CS0414 // Field is assigned but its value is never used
             }
+        }
+
+        internal class GenericReferenceTypeTarget<T>
+            where T : class
+        {
+            public IEnumerable<T> Collection { get; set; }
+        }
+
+        internal class GenericValueTypeTarget<T>
+            where T : struct
+        {
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -347,6 +347,59 @@ namespace Datadog.Trace.Tests.Debugger
             Assert.Equal("A reference type cannot be compared to a not nullable value type.", error.Message);
         }
 
+        [Fact]
+        public void ProbeExpressionParser_NullableValueTypeComparedToNull_DoesNotThrow()
+        {
+            var scopeMembers = CreateScopeMembers();
+
+            const string json = """
+                                {
+                                  "eq": [
+                                    { "ref": "NullableNullValueLocal" },
+                                    null
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_NullableValueTypeReferenceTypeComparison_KeepsOriginalError()
+        {
+            var scopeMembers = CreateScopeMembers();
+
+            const string json = """
+                                {
+                                  "eq": [
+                                    { "ref": "NullableNullValueLocal" },
+                                    "value"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Contains("The binary operator Equal is not defined for the types", error.Message);
+        }
+
         [Theory]
         [InlineData("""
                     {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -321,6 +321,31 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_RecursiveGenericConstraint_ReturnsEvaluationError()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.InvocationTarget = new ScopeMember("this", typeof(RecursiveGenericConstraintTarget<>), null, ScopeMemberKind.This);
+
+            const string json = """
+                                {
+                                  "ref": "this"
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers, typeof(RecursiveGenericConstraintTarget<>));
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Null(result);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Contains("recursive generic parameter constraints", error.Message);
+        }
+
+        [Fact]
         public void ProbeExpressionParser_ValueTypeReferenceTypeComparison_ReturnsFriendlyError()
         {
             var scopeMembers = CreateScopeMembers();
@@ -846,6 +871,11 @@ namespace Datadog.Trace.Tests.Debugger
 
         internal class GenericValueTypeTarget<T>
             where T : struct
+        {
+        }
+
+        internal class RecursiveGenericConstraintTarget<T>
+            where T : IComparable<T>
         {
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CompareStringAndInt.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CompareStringAndInt.verified.txt
@@ -60,4 +60,4 @@ Expression: (
 }
 Result: True
 Errors:
-EvaluationError { Expression = this.String > this.IntNumber, Message = The binary operator GreaterThan is not defined for the types 'System.String' and 'System.Int32'. }
+EvaluationError { Expression = this.String > this.IntNumber, Message = A reference type cannot be compared to a not nullable value type. }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrueString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrueString.verified.txt
@@ -49,4 +49,4 @@ Expression: (
 }
 Result: True
 Errors:
-EvaluationError { Expression = BooleanValue == "true", Message = The binary operator Equal is not defined for the types 'System.Boolean' and 'System.String'. }
+EvaluationError { Expression = BooleanValue == "true", Message = A reference type cannot be compared to a not nullable value type. }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanStringChar.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanStringChar.verified.txt
@@ -60,4 +60,4 @@ Expression: (
 }
 Result: True
 Errors:
-EvaluationError { Expression = this.String > this.Char, Message = The binary operator GreaterThan is not defined for the types 'System.String' and 'System.Char'. }
+EvaluationError { Expression = this.String > this.Char, Message = A reference type cannot be compared to a not nullable value type. }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
@@ -47,4 +47,4 @@ Expression: (
 }
 Result: True
 Errors:
-EvaluationError { Expression = "SomeLocal" > 2, Message = The binary operator GreaterThan is not defined for the types 'System.String' and 'System.Int32'. }
+EvaluationError { Expression = "SomeLocal" > 2, Message = A reference type cannot be compared to a not nullable value type. }


### PR DESCRIPTION
## Summary of changes

- `ProbeExpressionParser` now closes open generic scope member types during expression compilation, including constructed open generics such as `IEnumerable<T>`, by substituting safe reference-type generic parameters.
- Generic value-type parameters are rejected with a clear evaluation error when there is no concrete runtime type to use.
- Binary comparisons between reference types and non-nullable value types now surface a friendly evaluation error.
- Updated expression-language Verify snapshots for the intentional error message change.

## Reason for change

- Probe expression evaluation can receive declared types that still contain unresolved generic parameters, such as `IEnumerable<T>` from generic methods/types. Passing those types to expression-tree construction can produce opaque failures.
- Invalid reference/value-type comparisons previously surfaced raw `InvalidOperationException` messages instead of actionable debugger evaluation errors.

## Implementation details

- Open generic types are normalized only during expression compilation/cache miss. The compiled delegate hot path does not repeat the reflection/type-closing work.
- If a concrete runtime type is available, it is used. Otherwise, unresolved reference-type parameters are substituted with `object`, while value-type generic parameters are rejected because there is no safe substitute.

## Test coverage

- Added focused `DebuggerExpressionLanguageTests` for open generic definitions, constructed open generics, null constructed-open generic arguments, value-type generic rejection, and friendly comparison errors.
- Updated affected Verify snapshots.