### PR TITLE
[Debugger] Reuse singleton no-op symbol uploader

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Symbols/NoOpSymbolUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/NoOpSymbolUploader.cs
@@ -11,6 +11,8 @@ namespace Datadog.Trace.Debugger.Symbols
 {
     internal sealed class NoOpSymbolUploader : IDebuggerUploader
     {
+        public static readonly NoOpSymbolUploader Instance = new();
+
         public Task StartFlushingAsync()
         {
             return Task.CompletedTask;

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/NoOpSymbolUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/NoOpSymbolUploader.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Debugger.Symbols
 {
     internal sealed class NoOpSymbolUploader : IDebuggerUploader
     {
-        public static readonly NoOpSymbolUploader Instance = new();
+        internal static readonly NoOpSymbolUploader Instance = new();
 
         public Task StartFlushingAsync()
         {

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -126,13 +126,13 @@ namespace Datadog.Trace.Debugger.Symbols
             if (!settings.SymbolDatabaseUploadEnabled)
             {
                 Log.Information("Symbol database uploading is disabled. To enable it, please set {EnvironmentVariable} environment variable to 'true'.", ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabled);
-                return new NoOpSymbolUploader();
+                return NoOpSymbolUploader.Instance;
             }
 
             if (!ThirdPartyModules.IsValid)
             {
                 Log.Warning("Third party modules load has failed. Disabling Symbol Uploader.");
-                return new NoOpSymbolUploader();
+                return NoOpSymbolUploader.Instance;
             }
 
             // TODO: we need to be able to update the tracer settings dynamically


### PR DESCRIPTION
## Summary of changes

- Add a shared `NoOpSymbolUploader.Instance`.
- Return the shared no-op uploader from `SymbolsUploader.Create` when symbol database upload is disabled or third-party module loading failed.

## Reason for change

- `NoOpSymbolUploader` is stateless, so callers do not need distinct instances for disabled symbol upload paths.
- This keeps the disabled/fallback behavior unchanged while simplifying object ownership.

## Implementation details

- The singleton instance is `internal static readonly` and only exposes the existing no-op behavior: `StartFlushingAsync()` returns `Task.CompletedTask`, and `Dispose()` does nothing.
- No logging, configuration, snapshot, or symbol upload output shape changes are intended.

## Test coverage

- No dedicated test needed.

