### PR TITLE
[Debugger Tests] Surface sample exit diagnostics during /stop cleanup

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerSampleProcessHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/DebuggerSampleProcessHelperTests.cs
@@ -1,0 +1,85 @@
+// <copyright file="DebuggerSampleProcessHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Debugger.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Debugger.IntegrationTests
+{
+    public class DebuggerSampleProcessHelperTests
+    {
+        [Fact]
+        public async Task StopSample_WhenProcessAlreadyExitedWithNonZeroExitCode_SurfacesExitDetails()
+        {
+            const int ExitCode = 42;
+            const string ExpectedStandardOutput = "expected stdout";
+            const string ExpectedErrorOutput = "expected stderr";
+
+            using var process = StartProcessThatExits(ExitCode, ExpectedStandardOutput, ExpectedErrorOutput);
+            process.WaitForExit(10_000).Should().BeTrue();
+
+            var output = new CapturingTestOutputHelper();
+            using var helper = new DebuggerSampleProcessHelper("http://127.0.0.1:1/", process, output);
+            var completedTask = await Task.WhenAny(helper.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            completedTask.Should().Be(helper.Task);
+
+            var exception = await Assert.ThrowsAsync<ExitCodeException>(() => helper.StopSample());
+
+            exception.Message.Should().Contain($"actual exit code: {ExitCode}");
+            output.Output.Should().Contain($"Process already exited with code {ExitCode}");
+            output.Output.Should().Contain(ExpectedStandardOutput);
+            output.Output.Should().Contain(ExpectedErrorOutput);
+        }
+
+        private static Process StartProcessThatExits(int exitCode, string standardOutput, string errorOutput)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                startInfo.FileName = "cmd.exe";
+                startInfo.Arguments = $"/C \"echo {standardOutput} & echo {errorOutput} 1>&2 & exit /b {exitCode}\"";
+            }
+            else
+            {
+                startInfo.FileName = "/bin/sh";
+                startInfo.Arguments = $"-c \"printf '%s\\n' '{standardOutput}'; printf '%s\\n' '{errorOutput}' >&2; exit {exitCode}\"";
+            }
+
+            return Process.Start(startInfo);
+        }
+
+        private class CapturingTestOutputHelper : ITestOutputHelper
+        {
+            private readonly StringBuilder _output = new();
+
+            public string Output => _output.ToString();
+
+            public void WriteLine(string message)
+            {
+                _output.AppendLine(message);
+            }
+
+            public void WriteLine(string format, params object[] args)
+            {
+                _output.AppendLine(string.Format(format, args));
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerSampleProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerSampleProcessHelper.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit.Abstractions;
@@ -30,7 +32,36 @@ namespace Datadog.Trace.Debugger.IntegrationTests.Helpers
 
         internal async Task StopSample()
         {
-            using var httpWebResponse = await WebRequest.CreateHttp(_stopUrl).GetResponseAsync();
+            // The sample process may have already exited (e.g., crash or early termination).
+            // In that case, calling /stop will fail with connection refused, masking the real cause.
+            if (Process.HasExited)
+            {
+                _output.WriteLine($"[DebuggerSampleProcessHelper] Process already exited with code {Process.ExitCode} (0x{Process.ExitCode:X}). Skipping /stop request.");
+                _output.WriteLine($"[DebuggerSampleProcessHelper] Standard output:\n{StandardOutput}");
+                _output.WriteLine($"[DebuggerSampleProcessHelper] Error output:\n{ErrorOutput}");
+                ExitCodeException.ThrowIfNonZero(Process.ExitCode);
+                return;
+            }
+
+            try
+            {
+                using var httpWebResponse = await WebRequest.CreateHttp(_stopUrl).GetResponseAsync();
+            }
+            catch (WebException ex) when (ex.InnerException is HttpRequestException or SocketException)
+            {
+                // If the process exited between the HasExited check and the /stop request, surface exit details.
+                if (Process.HasExited)
+                {
+                    _output.WriteLine($"[DebuggerSampleProcessHelper] /stop request failed because the process already exited with code {Process.ExitCode} (0x{Process.ExitCode:X}).");
+                    _output.WriteLine($"[DebuggerSampleProcessHelper] Standard output:\n{StandardOutput}");
+                    _output.WriteLine($"[DebuggerSampleProcessHelper] Error output:\n{ErrorOutput}");
+                    ExitCodeException.ThrowIfNonZero(Process.ExitCode);
+                    return;
+                }
+
+                throw;
+            }
+
             var timeout = 10_000;
             var isExited = Process.WaitForExit(timeout);
 


### PR DESCRIPTION
## Summary of changes

- `DebuggerSampleProcessHelper.StopSample` now surfaces the actual sample-process exit code, stdout, and stderr when the process exits before or during the `/stop` HTTP call.
- Pre-checks `Process.HasExited` before issuing `/stop`, then uses `ExitCodeException.ThrowIfNonZero` so crashes fail with the real process exit information.
- Handles `/stop` transport failures caused by `HttpRequestException` or `SocketException`; if the process exited mid-request, the same diagnostics are logged and the exit code is surfaced.
- Adds focused coverage for the already-exited non-zero sample-process path.

## Reason for change

- When a debugger sample crashes, the test can currently fail with a generic connection error from `/stop`, hiding the real exit code and sample output.
- Surfacing the process diagnostics makes native crashes and managed throws in debugger integration tests much faster to triage.

## Implementation details

- Test-only helper change. No production code changes.
- The exception filter is intentionally narrow: only transport-style `/stop` failures are translated, and only when the process has exited.
- Other failures, such as timeouts or failures while the process is still alive, continue to be rethrown unchanged.

## Test coverage

- Added `DebuggerSampleProcessHelperTests.StopSample_WhenProcessAlreadyExitedWithNonZeroExitCode_SurfacesExitDetails`.
