### PR TITLE
[Debugger] Fix flaky DI probe file test

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -49,6 +49,8 @@ namespace Datadog.Trace.Debugger
         private readonly DebuggerSettings _settings;
         private readonly object _instanceLock = new();
         private int _disposeState;
+        private int _initializationState;
+        private Task? _initializationTask;
 
         internal DynamicInstrumentation(
             DebuggerSettings settings,
@@ -88,17 +90,30 @@ namespace Datadog.Trace.Debugger
 
         public bool IsDisposed => Volatile.Read(ref _disposeState) != 0;
 
-        public bool IsInitialized { get; private set; }
+        public bool IsInitialized => Volatile.Read(ref _initializationState) == 2;
 
         internal void Initialize()
         {
-            if (!_settings.DynamicInstrumentationEnabled)
+            if (!_settings.DynamicInstrumentationEnabled || IsInitialized)
             {
                 return;
             }
 
-            _ = InitializeAsync();
+            if (Interlocked.CompareExchange(ref _initializationState, 1, 0) != 0)
+            {
+                return;
+            }
+
+            _initializationTask = InitializeAsync();
         }
+
+        /// <summary>
+        /// Returns the task representing in-flight initialization (or a completed
+        /// task if <see cref="Initialize"/> has not been called yet). DI enablement
+        /// is serialized by the owning initialization flow, so callers are expected
+        /// to request this task after invoking <see cref="Initialize"/>.
+        /// </summary>
+        internal Task GetInitializationTask() => _initializationTask ?? Task.CompletedTask;
 
         private async Task InitializeAsync()
         {
@@ -161,7 +176,7 @@ namespace Datadog.Trace.Debugger
 
             AppDomain.CurrentDomain.AssemblyLoad += CheckUnboundProbes;
             StartBackgroundProcess();
-            IsInitialized = true;
+            Volatile.Write(ref _initializationState, 2);
         }
 
         private void StartBackgroundProcess()

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Debugger
 
         internal void Initialize()
         {
-            if (!_settings.DynamicInstrumentationEnabled || IsInitialized)
+            if (!_settings.DynamicInstrumentationEnabled || IsDisposed)
             {
                 return;
             }
@@ -165,11 +165,15 @@ namespace Datadog.Trace.Debugger
             {
                 Log.Error(e, "Dynamic Instrumentation initialization failed");
             }
+            finally
+            {
+                Interlocked.CompareExchange(ref _initializationState, 0, 1);
+            }
         }
 
         private void StartRuntimeIfNeeded()
         {
-            if (IsInitialized)
+            if (IsInitialized || IsDisposed)
             {
                 return;
             }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -61,6 +61,47 @@ public class DynamicInstrumentationTests
     }
 
     [Fact]
+    public async Task DynamicInstrumentationEnabled_FailedInitializationCanRetry()
+    {
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+            NullConfigurationTelemetry.Instance);
+
+        var discoveryService = new DiscoveryServiceFailsOnceMock();
+        var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();
+        var lineProbeResolver = new LineProbeResolverMock();
+        var snapshotUploader = new SnapshotUploaderMock();
+        var logUploader = new LogUploaderMock();
+        var diagnosticsUploader = new UploaderMock();
+        var probeStatusPoller = new ProbeStatusPollerMock();
+        var updater = ConfigurationUpdater.Create("env", "version", 0);
+
+        var debugger = new DynamicInstrumentation(settings, discoveryService, rcmSubscriptionManagerMock, lineProbeResolver, snapshotUploader, logUploader, diagnosticsUploader, probeStatusPoller, updater, NoOpStatsd.Instance);
+        try
+        {
+            debugger.Initialize();
+            await debugger.GetInitializationTask();
+
+            debugger.IsInitialized.Should().BeFalse("the first discovery subscription attempt fails");
+            discoveryService.SubscribeCount.Should().Be(1);
+
+            debugger.Initialize();
+            await debugger.GetInitializationTask();
+
+            discoveryService.SubscribeCount.Should().Be(2);
+            debugger.IsInitialized.Should().BeTrue("the failed initialization attempt should not block a later retry");
+            probeStatusPoller.Called.Should().BeTrue();
+            snapshotUploader.Called.Should().BeTrue();
+            diagnosticsUploader.Called.Should().BeTrue();
+            rcmSubscriptionManagerMock.ProductKeys.Contains(RcmProducts.LiveDebugging).Should().BeTrue();
+        }
+        finally
+        {
+            debugger.Dispose();
+        }
+    }
+
+    [Fact]
     public void DynamicInstrumentationDisabled_ServicesNotCalled()
     {
         var settings = DebuggerSettings.FromSource(
@@ -646,6 +687,48 @@ public class DynamicInstrumentationTests
         public void SubscribeToChanges(Action<AgentConfiguration> callback)
         {
             Called = true;
+            callback(
+                new AgentConfiguration(
+                    configurationEndpoint: "configurationEndpoint",
+                    debuggerEndpoint: "debuggerEndpoint",
+                    debuggerV2Endpoint: "debuggerV2Endpoint",
+                    diagnosticsEndpoint: "diagnosticsEndpoint",
+                    symbolDbEndpoint: "symbolDbEndpoint",
+                    agentVersion: "agentVersion",
+                    statsEndpoint: "traceStatsEndpoint",
+                    dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
+                    eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
+                    telemetryProxyEndpoint: "telemetryProxyEndpoint",
+                    tracerFlareEndpoint: "tracerFlareEndpoint",
+                    containerTagsHash: "containerTagsHash",
+                    clientDropP0: false,
+                    spanMetaStructs: true,
+                    spanEvents: true));
+        }
+
+        public void RemoveSubscription(Action<AgentConfiguration> callback)
+        {
+        }
+
+        public void SetCurrentConfigStateHash(string configStateHash)
+        {
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+    }
+
+    private class DiscoveryServiceFailsOnceMock : IDiscoveryService
+    {
+        internal int SubscribeCount { get; private set; }
+
+        public void SubscribeToChanges(Action<AgentConfiguration> callback)
+        {
+            SubscribeCount++;
+            if (SubscribeCount == 1)
+            {
+                throw new InvalidOperationException("Simulated discovery subscription failure");
+            }
+
             callback(
                 new AgentConfiguration(
                     configurationEndpoint: "configurationEndpoint",

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -111,9 +111,15 @@ public class DynamicInstrumentationTests
     public class ProbeFileLoadingTests : IDisposable
     {
         private readonly List<string> _tempFiles = new();
+        private readonly List<DynamicInstrumentation> _debuggers = new();
 
         public void Dispose()
         {
+            foreach (var debugger in _debuggers)
+            {
+                debugger.Dispose();
+            }
+
             // Clean up temp files
             foreach (var file in _tempFiles)
             {
@@ -219,7 +225,7 @@ public class DynamicInstrumentationTests
             var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
             debugger.Initialize();
 
-            await WaitUntilAsync(() => GetCurrentConfiguration(debugger).LogProbes.Any(probe => probe.Id == "applied-file-probe"));
+            await debugger.GetInitializationTask();
 
             lineProbeResolver.Called.Should().BeTrue("file probes should be applied to the owning DynamicInstrumentation instance");
             probeStatusPoller.Called.Should().BeTrue("applying a file probe should update probe statuses");
@@ -461,7 +467,6 @@ public class DynamicInstrumentationTests
 
             debugger.IsInitialized.Should().BeTrue("file probes should not wait for the RCM availability timeout");
             GetFileProbes(debugger).Should().NotBeNull();
-            debugger.Dispose();
         }
 
         private static ProbeConfiguration? GetFileProbes(DynamicInstrumentation debugger)
@@ -508,7 +513,7 @@ public class DynamicInstrumentationTests
             var diagnosticsUploader = new UploaderMock();
             probeStatusPoller ??= new ProbeStatusPollerMock();
 
-            return new DynamicInstrumentation(
+            var debugger = new DynamicInstrumentation(
                 settings,
                 discoveryService ?? new DiscoveryServiceMock(),
                 rcmSubscriptionManagerMock,
@@ -519,6 +524,8 @@ public class DynamicInstrumentationTests
                 probeStatusPoller,
                 ConfigurationUpdater.Create("env", "version", 0),
                 global::Datadog.Trace.DogStatsd.NoOpStatsd.Instance);
+            _debuggers.Add(debugger);
+            return debugger;
         }
     }
 


### PR DESCRIPTION
## Summary of changes

- Fixes a flaky Dynamic Instrumentation probe-file unit test by awaiting DI initialization before asserting probe application side effects.
- Tracks DI initialization with a task/state latch so tests can deterministically wait for initialization completion.
- Disposes `DynamicInstrumentation` instances created by probe-file tests to avoid leaking assembly-load callbacks between tests.

## Reason for change

- `ProbeFile_ValidProbe_AppliesInstrumentation` can fail under CI load because `Initialize()` starts async initialization and returns before file probes are fully applied.
- The failed assertion observed on master was `probeStatusPoller.Called == false`, indicating the test raced probe application.

## Implementation details

- Adds an internal `GetInitializationTask()` helper backed by the same initialization state pattern used in the snapshot exploration branch.
- Uses `Interlocked.CompareExchange` to ensure initialization is only started once, and `Volatile.Read/Write` to publish and observe initialized state.
- Updates the flaky test to await initialization completion instead of polling only for current configuration state.

## Test coverage

- `ProbeFileLoadingTests.ProbeFile_ValidProbe_AppliesInstrumentation`