### PR TITLE
Add a fixed cutoff for the activity handler reconcilliation loop for OTel

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -30,6 +30,12 @@ namespace Datadog.Trace.Activity.Handlers
         // cannot: 1. Activities the customer abandoned without calling Stop (their WeakReference
         // target is GC'd); 2. Activities whose Stop fired but our listener callback missed.
         private static readonly TimeSpan ReconciliationInterval = TimeSpan.FromSeconds(10);
+
+        // Activity.Stop() sets Duration before our listener callback runs. The sweep can race
+        // that callback, so we only treat a stopped activity as "missed" once it's been stopped
+        // long enough that an in-flight listener would have completed.
+        private static readonly TimeSpan MissedStopGracePeriod = TimeSpan.FromMinutes(1);
+
         private static int _sweepInProgress;
         private static Timer? _reconciliationTimer;
 
@@ -331,7 +337,9 @@ namespace Datadog.Trace.Activity.Handlers
 
             try
             {
-                var result = ReconcileSweepCore(ActivityMappingById);
+                // Activities whose end time is at or after missedStopCutoff are considered "still
+                // in the grace period" and skipped — the listener callback may still be in flight.
+                var result = ReconcileSweepCore(ActivityMappingById, missedStopCutoff: DateTime.UtcNow - MissedStopGracePeriod);
                 if ((result.GcCollected > 0 || result.MissedStop > 0) && Log.IsEnabled(LogEventLevel.Debug))
                 {
                     Log.Debug<int, int, int>(
@@ -352,7 +360,9 @@ namespace Datadog.Trace.Activity.Handlers
         }
 
         [TestingAndPrivateOnly]
-        internal static ReconciliationSweepResult ReconcileSweepCore(ConcurrentDictionary<ActivityKey, ActivityMapping> mappings)
+        internal static ReconciliationSweepResult ReconcileSweepCore(
+            ConcurrentDictionary<ActivityKey, ActivityMapping> mappings,
+            DateTime missedStopCutoff)
         {
             var gcCollected = 0;
             var missedStop = 0;
@@ -423,11 +433,14 @@ namespace Datadog.Trace.Activity.Handlers
                 }
 
                 // Activity is still alive. A non-zero Duration on an entry that's still in
-                // the dictionary means Stop() was called but our listener callback didn't
-                // handle it — close it using the real end time.
+                // the dictionary means Stop() was called but our listener callback hasn't
+                // processed it yet. Skip if it stopped inside the grace window — the
+                // listener may still be in flight, and closing here would double-close the
+                // scope. Past the grace window, close it using the real end time.
                 if (activityObject.TryDuckCast<IActivity6>(out var activity6))
                 {
                     if (activity6.Duration != TimeSpan.Zero
+                     && activity6.StartTimeUtc.Add(activity6.Duration) < missedStopCutoff
                      && mappings.TryRemove(kvp.Key, out var owned)
                      && owned.Scope is { } scope)
                     {
@@ -438,6 +451,7 @@ namespace Datadog.Trace.Activity.Handlers
                 else if (activityObject.TryDuckCast<IActivity5>(out var activity5))
                 {
                     if (activity5.Duration != TimeSpan.Zero
+                     && activity5.StartTimeUtc.Add(activity5.Duration) < missedStopCutoff
                      && mappings.TryRemove(kvp.Key, out var owned)
                      && owned.Scope is { } scope)
                     {
@@ -448,6 +462,7 @@ namespace Datadog.Trace.Activity.Handlers
                 else if (activityObject.TryDuckCast<IActivity>(out var activity4))
                 {
                     if (activity4.Duration != TimeSpan.Zero
+                     && activity4.StartTimeUtc.Add(activity4.Duration) < missedStopCutoff
                      && mappings.TryRemove(kvp.Key, out var owned)
                      && owned.Scope is { } scope)
                     {

--- a/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Activity/ReconciliationSweepTests.cs
@@ -26,7 +26,7 @@ public class ReconciliationSweepTests
         var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
         var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
 
-        var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+        var result = ActivityHandlerCommon.ReconcileSweepCore(mappings, missedStopCutoff: DateTime.MaxValue);
 
         result.GcCollected.Should().Be(1);
         result.MissedStop.Should().Be(0);
@@ -46,7 +46,7 @@ public class ReconciliationSweepTests
         var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
         var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-activity");
 
-        ActivityHandlerCommon.ReconcileSweepCore(mappings);
+        ActivityHandlerCommon.ReconcileSweepCore(mappings, missedStopCutoff: DateTime.MaxValue);
 
         span.IsFinished.Should().BeTrue();
         span.GetTag("closed_reason").Should().Be("garbage_collected");
@@ -73,7 +73,7 @@ public class ReconciliationSweepTests
         var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
         var (_, span) = AddAbandonedMapping(mappings, tracer, "gcd-with-peer-service", presetTags: s => s.SetTag("peer.service", "downstream-api"));
 
-        ActivityHandlerCommon.ReconcileSweepCore(mappings);
+        ActivityHandlerCommon.ReconcileSweepCore(mappings, missedStopCutoff: DateTime.MaxValue);
 
         span.IsFinished.Should().BeTrue();
         span.ServiceName.Should().Be("downstream-api");
@@ -96,13 +96,54 @@ public class ReconciliationSweepTests
             activity.Stop();
             activity.Duration.Should().NotBe(TimeSpan.Zero);
 
-            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings, missedStopCutoff: DateTime.MaxValue);
 
             result.GcCollected.Should().Be(0);
             result.MissedStop.Should().Be(1);
             result.Iterated.Should().Be(1);
             mappings.Should().BeEmpty();
             span.IsFinished.Should().BeTrue();
+        }
+        finally
+        {
+            GC.KeepAlive(activity);
+        }
+    }
+
+    [Fact]
+    public async Task RecentlyStoppedActivity_IsSkippedDuringGracePeriod()
+    {
+        // The sweep races the OS Stop() listener callback. Stop() sets Duration before our
+        // callback runs, so a just-stopped activity will look "missed" even though the
+        // callback is in flight. With a cutoff before the activity's end time, the sweep
+        // should leave the entry alone.
+        await using var tracer = TracerHelper.CreateWithFakeAgent(new TracerSettings());
+
+        var mappings = new ConcurrentDictionary<ActivityKey, ActivityMapping>();
+
+        var activity = new SD.Activity("recently-stopped").Start();
+        try
+        {
+            var (key, span) = AddMapping(mappings, tracer, activity);
+            activity.Stop();
+            activity.Duration.Should().NotBe(TimeSpan.Zero);
+
+            // DateTime.MinValue is unconditionally before any real activity end time, so the
+            // grace-period check `endTime < cutoff` is always false — the entry is skipped.
+            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings, missedStopCutoff: DateTime.MinValue);
+
+            result.GcCollected.Should().Be(0);
+            result.MissedStop.Should().Be(0);
+            result.Iterated.Should().Be(1);
+            mappings.Should().ContainKey(key);
+            span.IsFinished.Should().BeFalse();
+
+            // Cleanup
+            if (mappings.TryRemove(key, out var owned))
+            {
+                owned.Scope?.Span.Finish();
+                owned.Scope?.Close();
+            }
         }
         finally
         {
@@ -122,7 +163,10 @@ public class ReconciliationSweepTests
         {
             var (key, span) = AddMapping(mappings, tracer, activity);
 
-            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+            // The activity is live (Duration == 0), so the missed-stop check short-circuits
+            // before the cutoff is consulted. MaxValue makes the test's intent explicit:
+            // "even with the most permissive cutoff, a live activity is left alone".
+            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings, missedStopCutoff: DateTime.MaxValue);
 
             result.GcCollected.Should().Be(0);
             result.MissedStop.Should().Be(0);
@@ -162,7 +206,7 @@ public class ReconciliationSweepTests
 
         try
         {
-            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings);
+            var result = ActivityHandlerCommon.ReconcileSweepCore(mappings, missedStopCutoff: DateTime.MaxValue);
 
             result.GcCollected.Should().Be(1);
             result.MissedStop.Should().Be(1);


### PR DESCRIPTION
## Summary of changes

Don't auto-close closed-`Activity` related `Scope` which have been closed for < 1 minute

## Reason for change

In #8549, we moved the "CloseActivitySlow" reconciliation step when an `Activity` is closed but we somehow "missed" the `StopActivity()` call into a background job. We don't have a known mechanism for how that would happen today, and so this seemed reasonable.

There's a non-ideal aspect to this in terms of `AsyncLocal<T>` and execution context flow, in that we're  now closing the `Scope` from a background task, that's _off_ the original `async` context that created it. This will theoretically mean that the `ActiveScope` flow doesn't work correctly (needs confirming, but it's plausible).

This is _mostly_ "OK" given we don't have a known mechanism where we would hit this path _however_, we also introduced a race condition, where a given `Activity` is closed, and is in the _process_ of calling `StopActivity`, when our background loop executes. In that case we preemptively close it from the background thread.

## Implementation details

As a workaround, this PR simply adds a 1 minute cutoff before we start closing the associated `Scope`, on the basis that this _should_ be plenty of time for our inline handler to run if it's going to. This isn't ideal, as it's somewhat of a hacky workaround, but then, so is the CloseActivitySlow process anyway 😅 

The other option is that we move the reconciliation _back_ into the hot path, but that doesn't seem worth the trade off to me, especially as we consider this to be an unknown edge case anyway, and it's more there for safety than anything else.

## Test coverage

Added a test to confirm that a "freshly" closed `Activity` is ignored, and it's only an "old" closed `Activity` that gets swept

## Other details

Related to https://datadoghq.atlassian.net/browse/APMS-19316.

