### PR TITLE
[Profiler] Ensure valid json format for information json

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
@@ -840,8 +840,6 @@ std::string ProfileExporter::GetInfoJson(std::string& runtimeId) const
     {
         return "";
     }
-    auto sectionCount = metadata.size();
-    auto currentSection = 0;
 
     // the json schema is supposed to send sections under the systemInfo element
     std::stringstream builder;
@@ -849,8 +847,9 @@ std::string ProfileExporter::GetInfoJson(std::string& runtimeId) const
         AppendProfilerInfo(builder, runtimeId);
     builder << ",";
         AppendGcConfig(builder);
-    builder << ",";
-        AppendEnvVars(builder);
+
+    // There might not be any env var so deal with the ',' in AppendEnvVars
+    AppendEnvVars(builder, metadata);
     builder << "}";
 
     return builder.str();
@@ -915,47 +914,25 @@ void ProfileExporter::AppendValueList(const tags& kvp, std::stringstream& builde
     }
 }
 
-bool ProfileExporter::AppendEnvVars(std::stringstream& builder) const
+void ProfileExporter::AppendEnvVars(std::stringstream& builder, const IMetadataProvider::metadata_t& metadata) const
 {
-    auto const& metadata = _metadataProvider->Get();
-    if (metadata.empty())
-    {
-        return false;
-    }
-
-    bool firstSection = true;
     for (auto const& [section, kvp] : metadata)
     {
         if (section == MetadataProvider::SectionEnvVars)
         {
-            if (!firstSection)
-            {
-                builder << ", ";
-            }
+            builder << ", ";
             ElementStart(builder, "System Properties");
             AppendValueList(kvp, builder);
             ElementEnd(builder);
-            firstSection = false;
         }
         else if (section == MetadataProvider::SectionOverrides)
         {
-            if (!firstSection)
-            {
-                builder << ", ";
-            }
+            builder << ", ";
             ElementStart(builder, "System Overrides");
             AppendValueList(kvp, builder);
             ElementEnd(builder);
-            firstSection = false;
-        }
-        else
-        {
-            // skip Runtime Settings and others
-            continue;
         }
     }
-
-    return true;
 }
 
 void ProfileExporter::AppendGcConfig(std::stringstream& builder) const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "IExporter.h"
+#include "IMetadataProvider.h"
 #include "IUpscaleProvider.h"
 #include "MetricsRegistry.h"
 #include "Sample.h"
@@ -24,7 +25,6 @@ class IRuntimeInfo;
 class IEnabledProfilers;
 class IAllocationsRecorder;
 class IProcessSamplesProvider;
-class IMetadataProvider;
 class IConfiguration;
 class IRuntimeInfo;
 class ISsiManager;
@@ -115,10 +115,9 @@ private:
     std::list<std::shared_ptr<Sample>> GetProcessSamples();
     std::optional<ProfileInfoScope> GetInfo(const std::string& runtimeId);
     std::string GetMetadataJson() const;
-    std::string GetInfoJson(std::string& runtimeId) const;
     void AppendProfilerInfo(std::stringstream& builder, std::string& runtimeId) const;
     void AppendValueList(const tags& kvp, std::stringstream& builder) const;
-    bool AppendEnvVars(std::stringstream& builder) const;
+    void AppendEnvVars(std::stringstream& builder, const IMetadataProvider::metadata_t& metadata) const;
     void AppendGcConfig(std::stringstream& builder) const;
 
     inline void ElementStart(std::stringstream& builder, const std::string& name) const
@@ -176,4 +175,5 @@ private:
 
 public: // for tests
     static std::string GetEnabledProfilers(IEnabledProfilers* enabledProfilers);
+    std::string GetInfoJson(std::string& runtimeId) const;
 };

--- a/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfo/ApplicationInfoTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfo/ApplicationInfoTest.cs
@@ -77,6 +77,54 @@ namespace Datadog.Profiler.IntegrationTests.ApplicationInfo
             infos.Select(x => x.ToJsonString()).Should().OnlyContain(x => x != "{}");
         }
 
+        [TestAppFact("Samples.Computer01")]
+        public void CheckInfoJsonContainsEnvVarsAndOverrides(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: "--scenario 1", enableProfiler: true);
+
+            runner.Environment.SetVariable(EnvironmentVariables.SsiDeployed, "tracer");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(runner.XUnitLogger);
+
+            var infoJsons = new List<JsonNode>();
+
+            agent.ProfilerRequestReceived += (_, ctx) =>
+            {
+                var info = ExtractJsonField(GetRequestText(ctx.Value.Request), "info");
+                if (info is not null)
+                {
+                    infoJsons.Add(info);
+                }
+            };
+
+            runner.Run(agent);
+
+            agent.NbCallsOnProfilingEndpoint.Should().BeGreaterThan(0);
+            infoJsons.Should().NotBeEmpty();
+
+            var lastInfo = infoJsons.Last();
+
+            lastInfo["profiler"].Should().NotBeNull();
+            lastInfo["profiler"]["version"].Should().NotBeNull();
+            lastInfo["profiler"]["ssi"].Should().NotBeNull();
+            lastInfo["profiler"]["activation"].Should().NotBeNull();
+            lastInfo["profiler"]["runtime"].Should().NotBeNull();
+            lastInfo["GC Config"].Should().NotBeNull();
+            lastInfo["GC Config"]["GC Mode"].Should().NotBeNull();
+
+            // DD_PROFILING_UPLOAD_PERIOD is always set by the test framework (SectionEnvVars)
+            lastInfo["System Properties"].Should().NotBeNull();
+            lastInfo["System Properties"]["DD_PROFILING_UPLOAD_PERIOD"].Should().NotBeNull();
+
+            // DD_PROFILING_ENABLED is set to "1" when enableProfiler: true (SectionOverrides)
+            lastInfo["System Overrides"].Should().NotBeNull();
+            lastInfo["System Overrides"]["DD_PROFILING_ENABLED"].Should().NotBeNull();
+
+            // no trailing comma in the raw JSON
+            var rawJson = lastInfo.ToJsonString();
+            rawJson.Should().NotContain(",}");
+        }
+
         private static (string ServiceName, string Environment, string Version) ExtractServiceFromProfilerRequest(HttpListenerRequest request)
         {
             var text = GetRequestText(request);
@@ -111,57 +159,49 @@ namespace Datadog.Profiler.IntegrationTests.ApplicationInfo
         private static JsonNode ExtractMetadataFromProfilerRequest(HttpListenerRequest request)
         {
             var text = GetRequestText(request);
+            return ExtractJsonField(text, "internal") ?? JsonNode.Parse("{}");
+        }
 
-            /*
-             we want to extract the "tags_profiler" attribute from the http body. The format is as followed:
-             {
-                 "internal": <METADATA>,
-                 "start":"<START DATE>",
-                 "end":"<END DATE>",
-                 "attachments":["<ATTACHMENT1>", "<ATTACHMENT2>"],
-                 "tags_profiler":"<PROFILER TAGS>",
-                 "family":"<FAMILY>",
-                 "version":"4"
-             }
-             <METADATA> json string
-             */
-
-            var offset = text.IndexOf("\"internal\":");
+        private static JsonNode ExtractJsonField(string text, string fieldName)
+        {
+            var marker = $"\"{fieldName}\":";
+            var offset = text.IndexOf(marker);
             if (offset == -1)
             {
-                return JsonNode.Parse(string.Empty);
+                return null;
             }
 
-            offset += 11; // move after ':';
+            offset += marker.Length;
 
-            // skip whitespaces if any
-            while (text[offset] == ' ')
+            while (offset < text.Length && text[offset] == ' ')
             {
                 offset++;
             }
 
-            // next character must be the open-curly braces
-            if (text[offset] != '{')
+            if (offset >= text.Length || text[offset] != '{')
             {
-                return JsonNode.Parse(string.Empty);
+                return null;
             }
 
             var start = offset;
             var end = start + 1;
-
-            var nbCurlyBraces = 1;
-            var curlyBraces = new[] { '{', '}' };
-            while (nbCurlyBraces != 0)
+            var depth = 1;
+            var braces = new[] { '{', '}' };
+            while (depth != 0)
             {
-                int current = text.IndexOfAny(curlyBraces, end);
-                if (text[current] == '{')
+                int current = text.IndexOfAny(braces, end);
+                if (current == -1)
                 {
-                    nbCurlyBraces++;
+                    return null;
                 }
 
-                if (text[current] == '}')
+                if (text[current] == '{')
                 {
-                    nbCurlyBraces--;
+                    depth++;
+                }
+                else
+                {
+                    depth--;
                 }
 
                 end = current + 1;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
@@ -10,6 +10,7 @@
 
 #include "FakeSamples.h"
 #include "IMetadataProvider.h"
+#include "MetadataProvider.h"
 #include "MetricsRegistry.h"
 #include "ProfilerMockedInterface.h"
 #include "RuntimeInfoHelper.h"
@@ -804,4 +805,245 @@ TEST(ProfileExporterTest, CheckAllocationIsEnabledWhenHeapIsEnabled)
 
     ASSERT_TRUE(tag.find("allocations") != std::string::npos);
     ASSERT_TRUE(tag.find("heap") != std::string::npos);
+}
+
+// ----- GetInfoJson tests -----
+
+struct InfoJsonTestComponents
+{
+    std::unique_ptr<IConfiguration> configuration;
+    MockConfiguration* mockConfiguration = nullptr;
+    MockApplicationStore applicationStore;
+    std::unique_ptr<RuntimeInfoHelper> runtimeInfoHelper;
+    std::unique_ptr<EnabledProfilers> enabledProfilers;
+    MetricsRegistry metricsRegistry;
+    std::unique_ptr<IMetadataProvider> metadataProvider;
+    MockMetadataProvider* mockMetadataProvider = nullptr;
+    std::unique_ptr<ISsiManager> ssiManager;
+    MockSsiManager* mockSsiManager = nullptr;
+    MockGcSettingsProvider gcSettingsProvider;
+
+    fs::path pprofDir;
+    std::string agentUrl = "http://localhost:8126";
+    std::string host = "localhost";
+    std::vector<std::pair<std::string, std::string>> tags;
+};
+
+std::unique_ptr<InfoJsonTestComponents> CreateInfoJsonTestComponents(bool withSsiManager, bool withMetadataProvider)
+{
+    auto c = std::make_unique<InfoJsonTestComponents>();
+
+    auto [config, mockConfig] = CreateConfiguration();
+    c->configuration = std::move(config);
+    c->mockConfiguration = &mockConfig;
+
+    EXPECT_CALL(mockConfig, GetProfilesOutputDirectory()).WillRepeatedly(ReturnRef(c->pprofDir));
+    EXPECT_CALL(mockConfig, GetAgentUrl()).WillRepeatedly(ReturnRef(c->agentUrl));
+    EXPECT_CALL(mockConfig, GetHostname()).WillRepeatedly(ReturnRef(c->host));
+    EXPECT_CALL(mockConfig, IsAgentless()).WillRepeatedly(Return(false));
+    EXPECT_CALL(mockConfig, GetUserTags()).WillRepeatedly(ReturnRef(c->tags));
+
+    EXPECT_CALL(mockConfig, IsWallTimeProfilingEnabled()).WillRepeatedly(Return(true));
+    EXPECT_CALL(mockConfig, IsCpuProfilingEnabled()).WillRepeatedly(Return(false));
+    EXPECT_CALL(mockConfig, IsExceptionProfilingEnabled()).WillRepeatedly(Return(false));
+    EXPECT_CALL(mockConfig, IsGcThreadsCpuTimeEnabled()).WillRepeatedly(Return(false));
+    EXPECT_CALL(mockConfig, IsThreadLifetimeEnabled()).WillRepeatedly(Return(false));
+    EXPECT_CALL(mockConfig, GetEnablementStatus()).WillRepeatedly(Return(EnablementStatus::Auto));
+
+    c->runtimeInfoHelper = std::make_unique<RuntimeInfoHelper>(4, 8, true);
+    c->enabledProfilers = std::make_unique<EnabledProfilers>(c->configuration.get(), false, false);
+
+    if (withSsiManager)
+    {
+        auto [ssi, mockSsi] = CreateSsiManager();
+        c->ssiManager = std::move(ssi);
+        c->mockSsiManager = &mockSsi;
+        EXPECT_CALL(mockSsi, GetDeploymentMode()).WillRepeatedly(Return(DeploymentMode::SingleStepInstrumentation));
+    }
+
+    if (withMetadataProvider)
+    {
+        auto [mp, mockMp] = CreateMetadataProvider();
+        c->metadataProvider = std::move(mp);
+        c->mockMetadataProvider = &mockMp;
+    }
+
+    EXPECT_CALL(c->gcSettingsProvider, GetMode()).WillRepeatedly(Return(GCMode::Workstation));
+
+    return c;
+}
+
+std::unique_ptr<ProfileExporter> CreateExporterForInfoJsonTest(InfoJsonTestComponents& c)
+{
+    std::vector<SampleValueType> sampleTypeDefinitions({{"walltime", "nanoseconds"}});
+    auto exporter = std::make_unique<ProfileExporter>(
+        std::move(sampleTypeDefinitions),
+        c.mockConfiguration,
+        &c.applicationStore,
+        c.runtimeInfoHelper->GetRuntimeInfo(),
+        c.enabledProfilers.get(),
+        c.metricsRegistry,
+        c.metadataProvider.get(),
+        c.ssiManager.get(),
+        nullptr,
+        nullptr);
+    exporter->RegisterGcSettingsProvider(&c.gcSettingsProvider);
+    return exporter;
+}
+
+void AssertValidInfoJsonStructure(const std::string& json)
+{
+    ASSERT_FALSE(json.empty());
+    ASSERT_EQ(json.front(), '{');
+    ASSERT_EQ(json.back(), '}');
+    ASSERT_EQ(json.find(",}"), std::string::npos) << "Trailing comma found in: " << json;
+    ASSERT_EQ(json.find(",,"), std::string::npos) << "Double comma found in: " << json;
+    ASSERT_NE(json.find("\"profiler\""), std::string::npos) << "Missing profiler section in: " << json;
+    ASSERT_NE(json.find("\"GC Config\""), std::string::npos) << "Missing GC Config section in: " << json;
+}
+
+TEST(ProfileExporterTest, InfoJsonIsEmptyWhenNoSsiManager)
+{
+    auto c = CreateInfoJsonTestComponents(false, false);
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    ASSERT_TRUE(result.empty());
+}
+
+TEST(ProfileExporterTest, InfoJsonIsEmptyWhenMetadataIsEmpty)
+{
+    auto c = CreateInfoJsonTestComponents(true, true);
+
+    IMetadataProvider::metadata_t emptyMetadata;
+    EXPECT_CALL(*c->mockMetadataProvider, Get()).WillRepeatedly(ReturnRef(emptyMetadata));
+
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    ASSERT_TRUE(result.empty());
+}
+
+TEST(ProfileExporterTest, InfoJsonHasNoTrailingCommaWhenNoEnvVarsSection)
+{
+    auto c = CreateInfoJsonTestComponents(true, true);
+
+    IMetadataProvider::metadata_t metadata = {
+        {"Unknown Section", {{"key1", "value1"}}}
+    };
+    EXPECT_CALL(*c->mockMetadataProvider, Get()).WillRepeatedly(ReturnRef(metadata));
+
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    AssertValidInfoJsonStructure(result);
+    ASSERT_EQ(result.find("\"System Properties\""), std::string::npos);
+    ASSERT_EQ(result.find("\"System Overrides\""), std::string::npos);
+}
+
+TEST(ProfileExporterTest, InfoJsonHasNoTrailingCommaWhenOnlyRuntimeSettings)
+{
+    auto c = CreateInfoJsonTestComponents(true, true);
+
+    IMetadataProvider::metadata_t metadata = {
+        {MetadataProvider::SectionRuntimeSettings, {{"Start Time", "2026-05-05T17:18:21Z"}}}
+    };
+    EXPECT_CALL(*c->mockMetadataProvider, Get()).WillRepeatedly(ReturnRef(metadata));
+
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    AssertValidInfoJsonStructure(result);
+    ASSERT_EQ(result.find("\"System Properties\""), std::string::npos);
+    ASSERT_EQ(result.find("\"System Overrides\""), std::string::npos);
+    ASSERT_EQ(result.find("\"Runtime Settings\""), std::string::npos) << "Runtime Settings should not appear in info JSON";
+}
+
+TEST(ProfileExporterTest, InfoJsonContainsSystemPropertiesWhenEnvVarsExist)
+{
+    auto c = CreateInfoJsonTestComponents(true, true);
+
+    IMetadataProvider::metadata_t metadata = {
+        {MetadataProvider::SectionEnvVars, {{"DD_TRACE_DEBUG", "1"}}}
+    };
+    EXPECT_CALL(*c->mockMetadataProvider, Get()).WillRepeatedly(ReturnRef(metadata));
+
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    AssertValidInfoJsonStructure(result);
+    ASSERT_NE(result.find("\"System Properties\""), std::string::npos);
+    ASSERT_NE(result.find("\"DD_TRACE_DEBUG\""), std::string::npos);
+}
+
+TEST(ProfileExporterTest, InfoJsonContainsSystemOverridesWhenOverridesExist)
+{
+    auto c = CreateInfoJsonTestComponents(true, true);
+
+    IMetadataProvider::metadata_t metadata = {
+        {MetadataProvider::SectionOverrides, {{"DD_PROFILING_ENABLED", "true"}}}
+    };
+    EXPECT_CALL(*c->mockMetadataProvider, Get()).WillRepeatedly(ReturnRef(metadata));
+
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    AssertValidInfoJsonStructure(result);
+    ASSERT_NE(result.find("\"System Overrides\""), std::string::npos);
+    ASSERT_NE(result.find("\"DD_PROFILING_ENABLED\""), std::string::npos);
+}
+
+TEST(ProfileExporterTest, InfoJsonContainsBothSectionsWhenBothExist)
+{
+    auto c = CreateInfoJsonTestComponents(true, true);
+
+    IMetadataProvider::metadata_t metadata = {
+        {MetadataProvider::SectionEnvVars, {{"DD_TRACE_DEBUG", "1"}}},
+        {MetadataProvider::SectionOverrides, {{"DD_PROFILING_ENABLED", "true"}}}
+    };
+    EXPECT_CALL(*c->mockMetadataProvider, Get()).WillRepeatedly(ReturnRef(metadata));
+
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    AssertValidInfoJsonStructure(result);
+    ASSERT_NE(result.find("\"System Properties\""), std::string::npos);
+    ASSERT_NE(result.find("\"System Overrides\""), std::string::npos);
+
+    auto propsPos = result.find("\"System Properties\"");
+    auto overridesPos = result.find("\"System Overrides\"");
+    ASSERT_LT(propsPos, overridesPos) << "System Properties should appear before System Overrides";
+}
+
+TEST(ProfileExporterTest, InfoJsonHandlesEmptyKeyValueList)
+{
+    auto c = CreateInfoJsonTestComponents(true, true);
+
+    IMetadataProvider::metadata_t metadata = {
+        {MetadataProvider::SectionEnvVars, {}}
+    };
+    EXPECT_CALL(*c->mockMetadataProvider, Get()).WillRepeatedly(ReturnRef(metadata));
+
+    auto exporter = CreateExporterForInfoJsonTest(*c);
+
+    std::string runtimeId = "test-rid";
+    auto result = exporter->GetInfoJson(runtimeId);
+
+    AssertValidInfoJsonStructure(result);
+    ASSERT_NE(result.find("\"System Properties\": {}"), std::string::npos)
+        << "Expected empty System Properties object in: " << result;
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
@@ -38,6 +38,13 @@ std::tuple<std::unique_ptr<ISsiManager>, MockSsiManager&> CreateSsiManager()
     return {std::move(manager), *managerPtr};
 }
 
+std::tuple<std::unique_ptr<IMetadataProvider>, MockMetadataProvider&> CreateMetadataProvider()
+{
+    std::unique_ptr<IMetadataProvider> provider = std::make_unique<MockMetadataProvider>();
+    auto providerPtr = static_cast<MockMetadataProvider*>(provider.get());
+    return {std::move(provider), *providerPtr};
+}
+
 std::vector<std::pair<std::string, std::string>> CreateCallstack(int depth)
 {
     std::vector<std::pair<std::string, std::string>> result;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -14,6 +14,7 @@
 #include "IContentionListener.h"
 #include "IExporter.h"
 #include "IGcSettingsProvider.h"
+#include "IMetadataProvider.h"
 #include "IMetricsSender.h"
 #include "IRuntimeIdStore.h"
 #include "ISamplesCollector.h"
@@ -144,6 +145,20 @@ public:
     MOCK_METHOD(void, ProcessEnd, (), (override));
     MOCK_METHOD(SkipProfileHeuristicType, GetSkipProfileHeuristic, (), (const override));
     MOCK_METHOD(DeploymentMode, GetDeploymentMode, (), (const override));
+};
+
+class MockMetadataProvider : public IMetadataProvider
+{
+public:
+    MOCK_METHOD(void, Initialize, (), (override));
+    MOCK_METHOD(void, Add, (std::string const&, std::string const&, std::string const&), (override));
+    MOCK_METHOD(IMetadataProvider::metadata_t const&, Get, (), (override));
+};
+
+class MockGcSettingsProvider : public IGcSettingsProvider
+{
+public:
+    MOCK_METHOD(GCMode, GetMode, (), (override));
 };
 
 class MockMetricsSender : public IMetricsSender
@@ -277,6 +292,7 @@ std::tuple<std::shared_ptr<ISamplesProvider>, MockSampleProvider&> CreateSamples
 std::tuple<std::unique_ptr<IExporter>, MockExporter&> CreateExporter();
 std::tuple<std::unique_ptr<ISamplesCollector>, MockSamplesCollector&> CreateSamplesCollector();
 std::tuple<std::unique_ptr<ISsiManager>, MockSsiManager&> CreateSsiManager();
+std::tuple<std::unique_ptr<IMetadataProvider>, MockMetadataProvider&> CreateMetadataProvider();
 
 std::shared_ptr<Sample> CreateSample(std::string_view runtimeId, const std::vector<std::pair<std::string, std::string>>& callstack, const std::vector<std::pair<std::string, std::string>>& labels, std::int64_t value);
 


### PR DESCRIPTION
## Summary of changes
Fix possible invalid Json generation

## Reason for change
Invalid Json would fail the profile sending

## Implementation details
Handle empty cases

## Test coverage
New tests have been added

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
