### PR TITLE
[Profiler] Add guard-rails when creating a profile

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
@@ -18,11 +18,21 @@ using namespace std::chrono_literals;
 
 libdatadog::profile_unique_ptr CreateProfile(std::vector<SampleValueType> const& valueTypes, std::string const& periodType, std::string const& periodUnit);
 
-Profile::Profile(IConfiguration* configuration, std::vector<SampleValueType> const& valueTypes, std::string const& periodType, std::string const& periodUnit, std::string applicationName) :
-    _applicationName{std::move(applicationName)},
-    _addTimestampOnSample{configuration->IsTimestampsAsLabelEnabled()}
+std::unique_ptr<Profile> Profile::Create(IConfiguration* configuration, std::vector<SampleValueType> const& valueTypes, std::string const& periodType, std::string const& periodUnit, std::string applicationName)
 {
-    _impl = CreateProfile(valueTypes, periodType, periodUnit);
+    auto impl = CreateProfile(valueTypes, periodType, periodUnit);
+    if (impl == nullptr)
+    {
+        return nullptr;
+    }
+    return std::unique_ptr<Profile>(new Profile(std::move(impl), std::move(applicationName), configuration->IsTimestampsAsLabelEnabled()));
+}
+
+Profile::Profile(profile_unique_ptr impl, std::string applicationName, bool addTimestampOnSample) :
+    _impl{std::move(impl)},
+    _applicationName{std::move(applicationName)},
+    _addTimestampOnSample{addTimestampOnSample}
+{
 }
 
 Profile::~Profile() = default;
@@ -188,6 +198,12 @@ libdatadog::Success Profile::AddUpscalingRulePoisson(std::vector<std::uintptr_t>
 
 libdatadog::profile_unique_ptr CreateProfile(std::vector<SampleValueType> const& valueTypes, std::string const& periodType, std::string const& periodUnit)
 {
+    if (valueTypes.empty())
+    {
+        Log::Error("Cannot create profile: no sample value types defined. Ensure at least one profiler provider is enabled.");
+        return nullptr;
+    }
+
     std::vector<ddog_prof_SampleType> samplesTypes;
     samplesTypes.reserve(valueTypes.size());
 
@@ -216,9 +232,15 @@ libdatadog::profile_unique_ptr CreateProfile(std::vector<SampleValueType> const&
     period.sample_type = periodSampleType;
     period.value = 1;
 
+    Log::Debug("Creating libdatadog profile with ", samplesTypes.size(), " sample type(s), slice ptr=", (void*)sample_types.ptr, ", len=", sample_types.len);
+
     auto res = ddog_prof_Profile_new(sample_types, &period);
     if (res.tag == DDOG_PROF_PROFILE_NEW_RESULT_ERR)
     {
+        auto error = libdatadog::make_error(res.err);
+        Log::Error("ddog_prof_Profile_new failed: ", error.message(),
+                   " (sample_types count=", samplesTypes.size(),
+                   ", period=", periodType, "/", periodUnit, ")");
         return nullptr;
     }
     return std::make_unique<ProfileImpl>(res.ok);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.h
@@ -23,7 +23,7 @@ struct ProfileImpl;
 class Profile
 {
 public:
-    Profile(IConfiguration* configuration, std::vector<SampleValueType> const& valueTypes, std::string const& periodType, std::string const& periodUnit, std::string applicationName);
+    static std::unique_ptr<Profile> Create(IConfiguration* configuration, std::vector<SampleValueType> const& valueTypes, std::string const& periodType, std::string const& periodUnit, std::string applicationName);
     ~Profile();
 
     Profile(Profile const&) = delete;
@@ -37,8 +37,10 @@ public:
     std::string const& GetApplicationName() const;
 
 private:
-    friend class Exporter;
     std::unique_ptr<ProfileImpl> _impl;
+    Profile(std::unique_ptr<ProfileImpl> impl, std::string applicationName, bool addTimestampOnSample);
+
+    friend class Exporter;
     std::string _applicationName;
     bool _addTimestampOnSample;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
@@ -162,7 +162,7 @@ std::unique_ptr<libdatadog::Exporter> ProfileExporter::CreateExporter(IConfigura
 
 std::unique_ptr<libdatadog::Profile> ProfileExporter::CreateProfile(std::string serviceName)
 {
-    return std::make_unique<libdatadog::Profile>(_configuration, _sampleTypeDefinitions, ProfilePeriodType, ProfilePeriodUnit, std::move(serviceName));
+    return libdatadog::Profile::Create(_configuration, _sampleTypeDefinitions, ProfilePeriodType, ProfilePeriodUnit, std::move(serviceName));
 }
 
 void ProfileExporter::RegisterUpscaleProvider(IUpscaleProvider* provider)
@@ -400,6 +400,14 @@ void ProfileExporter::Add(std::shared_ptr<Sample> const& sample)
     {
         auto applicationInfo = _applicationStore->GetApplicationInfo(std::string(sample->GetRuntimeId()));
         profileInfoScope.profileInfo.profile = CreateProfile(applicationInfo.ServiceName);
+        if (profileInfoScope.profileInfo.profile == nullptr)
+        {
+            Log::Error("Failed to create profile for service '", applicationInfo.ServiceName,
+                       "' (runtime id: ", sample->GetRuntimeId(),
+                       ", sample type definitions: ", _sampleTypeDefinitions.size(),
+                       "). Sample will be dropped.");
+            return;
+        }
     }
     auto* profile = profileInfoScope.profileInfo.profile.get();
     Add(profile, sample);
@@ -437,6 +445,14 @@ void ProfileExporter::SetEndpoint(const std::string& runtimeId, uint64_t traceId
     {
         auto applicationInfo = _applicationStore->GetApplicationInfo(runtimeId);
         profileInfoScope.profileInfo.profile = CreateProfile(applicationInfo.ServiceName);
+        if (profileInfoScope.profileInfo.profile == nullptr)
+        {
+            Log::Error("Failed to create profile for service '", applicationInfo.ServiceName,
+                       "' (runtime id: ", runtimeId,
+                       ", sample type definitions: ", _sampleTypeDefinitions.size(),
+                       ") while setting endpoint. Endpoint will not be set.");
+            return;
+        }
     }
 
     auto* profile = profileInfoScope.profileInfo.profile.get();

--- a/profiler/test/Datadog.Profiler.Native.Tests/ExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ExporterTest.cpp
@@ -13,9 +13,9 @@
 
 namespace libdatadog {
 
-Profile CreateEmptyProfile(std::unique_ptr<IConfiguration> const& configuration)
+std::unique_ptr<Profile> CreateEmptyProfile(std::unique_ptr<IConfiguration> const& configuration)
 {
-    return Profile(configuration.get(), {{"cpu", "nanosecond"}}, "RealTime", "Nanoseconds", "my app");
+    return Profile::Create(configuration.get(), {{"cpu", "nanosecond"}}, "RealTime", "Nanoseconds", "my app");
 }
 
 TEST(ExporterTest, EnsureCrashOnDebug)
@@ -103,7 +103,7 @@ TEST(ExporterTest, CheckFileCreatedWithFileExporter)
     auto profile = CreateEmptyProfile(configuration);
 
     auto tags = Tags();
-    ASSERT_NO_FATAL_FAILURE(exporter->Send(&profile, std::move(tags), {}, std::string(), std::string(), std::string())) << "sending the profile crashed";
+    ASSERT_NO_FATAL_FAILURE(exporter->Send(profile.get(), std::move(tags), {}, std::string(), std::string(), std::string())) << "sending the profile crashed";
 
     ASSERT_FALSE(fs::is_empty(outputFolder));
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
@@ -805,3 +805,60 @@ TEST(ProfileExporterTest, CheckAllocationIsEnabledWhenHeapIsEnabled)
     ASSERT_TRUE(tag.find("allocations") != std::string::npos);
     ASSERT_TRUE(tag.find("heap") != std::string::npos);
 }
+
+TEST(ProfileExporterTest, CheckNoCrashWhenProfileCreationFails)
+{
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+
+    fs::path pprofTempDir;
+    EXPECT_CALL(mockConfiguration, GetProfilesOutputDirectory()).WillRepeatedly(ReturnRef(pprofTempDir));
+
+    std::string agentUrl;
+    EXPECT_CALL(mockConfiguration, GetAgentUrl()).Times(1).WillOnce(ReturnRef(agentUrl));
+
+#if _WINDOWS
+    std::string namedPipeName;
+    EXPECT_CALL(mockConfiguration, GetNamedPipeName()).Times(1).WillOnce(ReturnRef(namedPipeName));
+#endif
+
+    std::string agentHost = "localhost";
+    EXPECT_CALL(mockConfiguration, GetAgentHost()).Times(1).WillOnce(ReturnRef(agentHost));
+    int agentPort = 8126;
+    EXPECT_CALL(mockConfiguration, GetAgentPort()).Times(1).WillOnce(Return(agentPort));
+    std::string host = "localhost";
+    EXPECT_CALL(mockConfiguration, GetHostname()).Times(1).WillOnce(ReturnRef(host));
+    EXPECT_CALL(mockConfiguration, IsAgentless()).Times(1).WillOnce(Return(false));
+
+    std::vector<std::pair<std::string, std::string>> tags;
+    EXPECT_CALL(mockConfiguration, GetUserTags()).Times(1).WillOnce(ReturnRef(tags));
+
+    auto applicationStore = MockApplicationStore();
+
+    std::string runtimeId = "MyRid";
+    ApplicationInfo applicationInfo{"MyApp", "myenv", "1.0.2"};
+    EXPECT_CALL(applicationStore, GetApplicationInfo(runtimeId)).WillRepeatedly(Return(applicationInfo));
+
+    RuntimeInfoHelper helper(6, 0, false);
+    IRuntimeInfo* runtimeInfo = helper.GetRuntimeInfo();
+    EnabledProfilers enabledProfilers(configuration.get(), false, false);
+
+    // Empty sample type definitions will cause Profile::Create to return nullptr
+    std::vector<SampleValueType> sampleTypeDefinitions;
+
+    MetricsRegistry metricsRegistry;
+    IAllocationsRecorder* allocRecorder = nullptr;
+    IMetadataProvider* metadataProvider = nullptr;
+    ISsiManager* ssiManager = nullptr;
+    IHeapSnapshotManager* heapSnapshotManager = nullptr;
+    auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo,
+                                    &enabledProfilers, metricsRegistry, metadataProvider, ssiManager, allocRecorder, heapSnapshotManager);
+
+    auto callstack = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}});
+    auto labels = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}};
+    auto sample = CreateSample(runtimeId, callstack, labels, 42);
+
+    ASSERT_NO_FATAL_FAILURE(exporter.Add(sample)) << "Adding a sample when profile creation fails must not crash";
+
+    auto exported = exporter.Export();
+    ASSERT_FALSE(exported) << "Export must return false when profile creation failed";
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfileTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfileTest.cpp
@@ -8,30 +8,34 @@
 
 namespace libdatadog {
 
-Profile CreateProfile(std::unique_ptr<IConfiguration> const& configuration)
+std::unique_ptr<Profile> CreateProfile(std::unique_ptr<IConfiguration> const& configuration)
 {
-    return Profile(configuration.get(), {{"cpu", "nanosecond"}}, "RealTime", "Nanoseconds", "my app");
+    auto p = Profile::Create(configuration.get(), {{"cpu", "nanosecond"}}, "RealTime", "Nanoseconds", "my app");
+    EXPECT_NE(p, nullptr);
+    return p;
 }
 
 TEST(ProfileTest, CheckProfileName)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto p = CreateProfile(configuration);
+    ASSERT_NE(p, nullptr);
 
-    ASSERT_EQ("my app", p.GetApplicationName());
+    ASSERT_EQ("my app", p->GetApplicationName());
 }
 
 TEST(ProfileTest, AddSample)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto p = CreateProfile(configuration);
+    ASSERT_NE(p, nullptr);
 
     Sample::ValuesCount = 1;
     auto s = std::make_shared<Sample>(1ns, "1", 2);
     s->AddFrame({"", "", "", 1});
     s->AddFrame({"", "", "", 2});
     s->AddValue(42, 0);
-    auto success = p.Add(s);
+    auto success = p->Add(s);
     ASSERT_TRUE(success) << success.message();
 }
 
@@ -39,9 +43,10 @@ TEST(ProfileTest, AddUpscalingRule)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto p = CreateProfile(configuration);
+    ASSERT_NE(p, nullptr);
 
     std::vector<SampleValueTypeProvider::Offset> offsets = {0};
-    auto success = p.AddUpscalingRuleProportional(offsets, "my_label", "my_group", 2, 10);
+    auto success = p->AddUpscalingRuleProportional(offsets, "my_label", "my_group", 2, 10);
     ASSERT_TRUE(success) << success.message();
 }
 
@@ -49,23 +54,25 @@ TEST(ProfileTest, SetEndpoint)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto p = CreateProfile(configuration);
+    ASSERT_NE(p, nullptr);
 
-    EXPECT_NO_THROW(p.SetEndpoint(42, "my_endpoint"));
+    EXPECT_NO_THROW(p->SetEndpoint(42, "my_endpoint"));
 }
 
 TEST(ProfileTest, AddEndpointCount)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto p = CreateProfile(configuration);
+    ASSERT_NE(p, nullptr);
 
-    EXPECT_NO_THROW(p.AddEndpointCount("my_endpoint", 1));
+    EXPECT_NO_THROW(p->AddEndpointCount("my_endpoint", 1));
 }
 
-// Test is mainly meant for memory leak detection (unit tests are run with ASAN)
 TEST(ProfileTest, EnsureAddFailIfWrongNumberOfValues)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto p = CreateProfile(configuration);
+    ASSERT_NE(p, nullptr);
 
     // change number of values to fail the Add
     Sample::ValuesCount = 2;
@@ -73,7 +80,7 @@ TEST(ProfileTest, EnsureAddFailIfWrongNumberOfValues)
     s->AddFrame({"", "", "", 1});
     s->AddFrame({"", "", "", 2});
     s->AddValue(42, 0);
-    auto success = p.Add(s);
+    auto success = p->Add(s);
     ASSERT_FALSE(success);
 }
 
@@ -82,9 +89,18 @@ TEST(ProfileTest, EnsureAddUpscalingRuleFailIfMissingFields)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto p = CreateProfile(configuration);
+    ASSERT_NE(p, nullptr);
+
     std::vector<SampleValueTypeProvider::Offset> offsets;
-    auto success = p.AddUpscalingRuleProportional(offsets, "", "", 0, 0);
+    auto success = p->AddUpscalingRuleProportional(offsets, "", "", 0, 0);
     ASSERT_FALSE(success) << success.message();
+}
+
+TEST(ProfileTest, CreateProfileReturnsNullOnEmptyValueTypes)
+{
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+    auto p = Profile::Create(configuration.get(), {}, "RealTime", "Nanoseconds", "my app");
+    ASSERT_EQ(p, nullptr);
 }
 
 } // namespace libdatadog


### PR DESCRIPTION
## Summary of changes

Add guards to prevent crashing if failed at creating a FFI profile

## Reason for change

This is to make the code safer.

## Implementation details

- Make public the static `Profile::Create` factory method and private the ctor
- Check if value types and ffi calls succeed to return nullptr or a valid `Profile` instance

## Test coverage
- Added unit tests for failing case.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
