### PR TITLE
[Debugger] Fix ConcurrentAdaptiveCache.GetOrAdd race that returned stale value

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Caching/ConcurrentAdaptiveCache.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Caching/ConcurrentAdaptiveCache.cs
@@ -244,7 +244,10 @@ namespace Datadog.Trace.Debugger.Caching
             {
                 if (_cache.TryGetValue(key, out var item))
                 {
-                    return value;
+                    item.UpdateAccess(_timeProvider.UtcNow);
+                    Interlocked.Increment(ref _hits);
+                    _evictionPolicy.Access(key);
+                    return item.Value;
                 }
 
                 value = valueFactory(key);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/CacheTests/ConcurrentAdaptiveCacheTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/CacheTests/ConcurrentAdaptiveCacheTests.cs
@@ -50,6 +50,19 @@ namespace Datadog.Trace.Tests.Debugger.CacheTests
         }
 
         [Fact]
+        public void GetOrAdd_Should_Return_Item_Found_By_Write_Lock_Double_Check()
+        {
+            // Simulate the race window deterministically instead of relying on thread scheduling.
+            var comparer = new FirstLookupMissComparer();
+            using var cache = new ConcurrentAdaptiveCache<string, int?>(capacity: 10, comparer: comparer);
+            cache.Add(42, keys: "target");
+
+            var result = cache.GetOrAdd("target", _ => null);
+
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
         public void Cache_Should_Evict_Items_When_Capacity_Is_Reached()
         {
             using var cache = new ConcurrentAdaptiveCache<int, string>(capacity: 3, evictionPolicyKind: EvictionPolicy.Lru);
@@ -554,6 +567,29 @@ namespace Datadog.Trace.Tests.Debugger.CacheTests
 
             Assert.Equal(CacheState.Error, cache.State);
             Assert.Throws<InvalidCacheStateException>(() => cache.Add(1, keys: "test"));
+        }
+
+        private sealed class FirstLookupMissComparer : IEqualityComparer<string>
+        {
+            private const string TargetKey = "target";
+            private int _shouldMissTargetLookup = 1;
+
+            public bool Equals(string x, string y)
+            {
+                if (x == TargetKey &&
+                    y == TargetKey &&
+                    Interlocked.Exchange(ref _shouldMissTargetLookup, 0) == 1)
+                {
+                    return false;
+                }
+
+                return string.Equals(x, y, StringComparison.Ordinal);
+            }
+
+            public int GetHashCode(string obj)
+            {
+                return 0;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Fix `ConcurrentAdaptiveCache.GetOrAdd` returning a stale local value (default/null) when another thread populated the entry between the initial `TryGet` miss and the write-lock acquisition.
- Make the write-lock double-check branch consistent with the read-hit path: update `LastAccessed`, increment hit count, notify the eviction policy, and return the cached value.
- Add a deterministic regression test in `ConcurrentAdaptiveCacheTests` that exercises the double-check branch via a custom comparer.

## Reason for change

- Concurrent callers of `ConcurrentAdaptiveCache.GetOrAdd` could observe `default(T)` (or `null` for reference/nullable values) for a key that was already populated, causing incorrect cached results in debugger redaction, span code origin, and other consumers of this cache.
- LRU/LFU access counters and hit metrics were not updated when the double-check found the entry, leading to skewed eviction and hit-rate metrics under contention.

## Implementation details

- In `ConcurrentAdaptiveCache.GetOrAdd`, when the inner `_cache.TryGetValue(key, out var item)` succeeds under the write lock, return `item.Value` and call `item.UpdateAccess(...)`, `Interlocked.Increment(ref _hits)`, and `_evictionPolicy.Access(key)`.
- Mirrors the existing `TryGet` hit path so cache metadata (last accessed time, access count, eviction policy ordering, hit count) is consistent regardless of which path produced the hit.
- No public API change. The eviction policy is invoked under the cache write lock, matching the existing call pattern in `Add`/`AddOrUpdate`.

## Test coverage

`ConcurrentAdaptiveCacheTests`