### PR TITLE
[Test] Validate new Timeit converter for DSM throughput benchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -329,6 +329,10 @@ dsm_throughput:
     include: .gitlab/benchmarks/dsm-throughput.yml
   allow_failure: true
   rules:
+    # Auto-run on the timeit-converter validation branch so we don't have
+    # to manually click play on every push. Revert before merging.
+    - if: '$CI_COMMIT_BRANCH == "rob/dsm-throughput-timeit-validation"'
+      when: always
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"'
       when: always
     - if: '$CI_PIPELINE_SOURCE == "schedule" && $BENCHMARK_RUN == "true"'

--- a/.gitlab/benchmarks/dsm-throughput.yml
+++ b/.gitlab/benchmarks/dsm-throughput.yml
@@ -44,7 +44,11 @@ dsm_throughput:
     # - GITHUB_ORG_INTERNAL: GitHub org for internal repos
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/${GITLAB_GROUP}/".insteadOf "https://github.com/DataDog/"
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/${GITLAB_GROUP}/".insteadOf "https://github.com/${GITHUB_ORG_INTERNAL}/"
-    - git clone --branch dd-trace-dotnet/data-streams-monitoring https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/${GITLAB_GROUP}/benchmarking-platform platform && cd platform
+    # NOTE: Pointing at rob.carlan/dd-trace-dotnet/data-streams-monitoring-timeit
+    # to validate the new Timeit converter end-to-end before the corresponding
+    # benchmarking-platform-tools PR (rob.carlan/timeit-converter) is merged.
+    # Restore to dd-trace-dotnet/data-streams-monitoring before merging this PR.
+    - git clone --branch rob.carlan/dd-trace-dotnet/data-streams-monitoring-timeit https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/${GITLAB_GROUP}/benchmarking-platform platform && cd platform
     - ./steps/setup-sut.sh
     - bp-runner bp-runner.yml --debug
   artifacts:


### PR DESCRIPTION
## Summary

> [!NOTE]
> **Do not merge.** This PR exists only to drive a CI run that validates the new
> `Timeit` converter on the [benchmarking-platform-tools] side end-to-end before
> opening the real converter PR.

- Points `.gitlab/benchmarks/dsm-throughput.yml` at the temporary
  `rob.carlan/dd-trace-dotnet/data-streams-monitoring-timeit` branch on
  benchmarking-platform.
- That branch adds a `convert-to-common-format` step to `bp-runner.yml` which
  runs `bp-analyzer convert --framework=Timeit ...` against each per-experiment
  `dotnet timeit --json-exporter` artifact and emits
  `candidate-<experiment>.converted.json` under `$ARTIFACTS_DIR`.
- `upload_to_bp_api` then uploads those to the BP UI (project
  `dd-trace-dotnet-dsm`).


See artefacts with candidate*.converted.json here:
https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1669099904/artifacts/browse/artifacts/

## Related branches

| Repo | Branch | Purpose |
| --- | --- | --- |
| benchmarking-platform-tools | [`rob.carlan/timeit-converter`](https://github.com/DataDog/benchmarking-platform-tools/tree/rob.carlan/timeit-converter) | New `Timeit` converter + tests |
| benchmarking-platform | [`rob.carlan/dd-trace-dotnet/data-streams-monitoring-timeit`](https://github.com/DataDog/benchmarking-platform/tree/rob.carlan/dd-trace-dotnet/data-streams-monitoring-timeit) | bp-runner step that runs the converter |
| dd-trace-dotnet | this PR | wires the bp branch into CI |
