### PR TITLE
[Code Origin] Reduce endpoint detector allocations

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -179,13 +179,8 @@
       <type fullname="System.Collections.Immutable.ImmutableArray`1" />
       <type fullname="System.Collections.Immutable.ImmutableArray`1/Builder" />
       <type fullname="System.Collections.Immutable.ImmutableArray`1/Enumerator" />
-      <type fullname="System.Collections.Immutable.ImmutableDictionary" />
-      <type fullname="System.Collections.Immutable.ImmutableDictionary`2" />
-      <type fullname="System.Collections.Immutable.ImmutableDictionary`2/Builder" />
       <type fullname="System.Collections.Immutable.ImmutableHashSet" />
       <type fullname="System.Collections.Immutable.ImmutableHashSet`1" />
-      <type fullname="System.Collections.Immutable.ImmutableHashSet`1/Builder" />
-      <type fullname="System.Collections.Immutable.ImmutableHashSet`1/Enumerator" />
    </assembly>
    <assembly fullname="System.Collections.NonGeneric">
       <type fullname="System.Collections.Queue" />
@@ -564,6 +559,7 @@
       <type fullname="System.Reflection.Metadata.MetadataReader" />
       <type fullname="System.Reflection.Metadata.MetadataReaderOptions" />
       <type fullname="System.Reflection.Metadata.MetadataReaderProvider" />
+      <type fullname="System.Reflection.Metadata.MetadataStringComparer" />
       <type fullname="System.Reflection.Metadata.MetadataStringDecoder" />
       <type fullname="System.Reflection.Metadata.MethodBodyBlock" />
       <type fullname="System.Reflection.Metadata.MethodDebugInformation" />

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -67,7 +67,17 @@ internal static class EndpointDetector
             ThrowHelper.ThrowArgumentNullException(nameof(datadogMetadataReader));
         }
 
-        var metadataReader = datadogMetadataReader.MetadataReader;
+        GetEndpointMethodTokens(datadogMetadataReader.MetadataReader, ref consumer);
+    }
+
+    internal static void GetEndpointMethodTokens<TConsumer>(MetadataReader metadataReader, ref TConsumer consumer)
+        where TConsumer : struct, IEndpointMethodTokenConsumer
+    {
+        if (metadataReader is null)
+        {
+            ThrowHelper.ThrowArgumentNullException(nameof(metadataReader));
+        }
+
         foreach (var typeHandle in metadataReader.TypeDefinitions)
         {
             var typeDef = metadataReader.GetTypeDefinition(typeHandle);

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -6,10 +6,7 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Pdb;
 
 #if NETCOREAPP
@@ -24,49 +21,52 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin;
 
 internal static class EndpointDetector
 {
-    private static readonly HashSet<string> ControllerAttributes =
-    [
-        "Microsoft.AspNetCore.Mvc.ApiControllerAttribute",
-        "Microsoft.AspNetCore.Mvc.ControllerAttribute",
-        "Microsoft.AspNetCore.Mvc.RouteAttribute"
-    ];
+    private const TypeAttributes InvalidTypeAttributes = TypeAttributes.Interface | TypeAttributes.Abstract;
+    private const MethodAttributes PublicMethodAttributes = MethodAttributes.Public;
+    private const MethodAttributes InvalidMethodAttributes = MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName;
+    private const string MvcNamespace = "Microsoft.AspNetCore.Mvc";
+    private const string MvcRoutingNamespace = "Microsoft.AspNetCore.Mvc.Routing";
+    private const string RazorPagesNamespace = "Microsoft.AspNetCore.Mvc.RazorPages";
+    private const string SignalRNamespace = "Microsoft.AspNetCore.SignalR";
+    private const string CompilerServicesNamespace = "System.Runtime.CompilerServices";
 
-    private static readonly HashSet<string> ControllerBaseNames =
-    [
-        "Microsoft.AspNetCore.Mvc.Controller",
-        "Microsoft.AspNetCore.Mvc.ControllerBase"
-    ];
+    private enum EndpointTypeKind
+    {
+        None,
+        Controller,
+        PageModel,
+        SignalRHub,
+        CompilerGenerated
+    }
 
-    private static readonly HashSet<string> ActionAttributes =
-    [
-        "Microsoft.AspNetCore.Mvc.HttpGetAttribute",
-        "Microsoft.AspNetCore.Mvc.HttpPostAttribute",
-        "Microsoft.AspNetCore.Mvc.HttpPutAttribute",
-        "Microsoft.AspNetCore.Mvc.HttpDeleteAttribute",
-        "Microsoft.AspNetCore.Mvc.HttpPatchAttribute",
-        "Microsoft.AspNetCore.Mvc.HttpHeadAttribute",
-        "Microsoft.AspNetCore.Mvc.HttpOptionsAttribute",
-        "Microsoft.AspNetCore.Mvc.Routing.HttpMethodAttribute"
-    ];
+    private enum KnownNameSet
+    {
+        ControllerAttribute,
+        ActionAttribute,
+        NoHandlerAttribute,
+        CompilerGeneratedAttribute
+    }
 
-    private static readonly HashSet<string> SignalRHubBaseNames =
-    [
-        "Microsoft.AspNetCore.SignalR.Hub",
-        "Microsoft.AspNetCore.SignalR.Hub`1"
-    ];
+    private enum KnownBaseTypeSet
+    {
+        Controller,
+        PageModel,
+        SignalRHub
+    }
 
-    private static readonly HashSet<string> PageModelBaseNames = ["Microsoft.AspNetCore.Mvc.RazorPages.PageModel"];
+    internal interface IEndpointMethodTokenConsumer
+    {
+        void OnEndpointMethodToken(int token);
+    }
 
-    private static readonly HashSet<string> NoHandlerAttributes = ["Microsoft.AspNetCore.Mvc.RazorPages.NonHandlerAttribute"];
-
-    internal static ImmutableHashSet<int> GetEndpointMethodTokens(DatadogMetadataReader datadogMetadataReader)
+    internal static void GetEndpointMethodTokens<TConsumer>(DatadogMetadataReader datadogMetadataReader, ref TConsumer consumer)
+        where TConsumer : struct, IEndpointMethodTokenConsumer
     {
         if (datadogMetadataReader is null)
         {
             ThrowHelper.ThrowArgumentNullException(nameof(datadogMetadataReader));
         }
 
-        var builder = ImmutableHashSet.CreateBuilder<int>();
         var metadataReader = datadogMetadataReader.MetadataReader;
         foreach (var typeHandle in metadataReader.TypeDefinitions)
         {
@@ -77,25 +77,10 @@ internal static class EndpointDetector
                 continue;
             }
 
-            bool isPageModel = false;
-            bool isSignalRHub = false;
-            bool isCompilerGeneratedType = false;
-            var isController = IsInheritFromTypesOrHasAttribute(typeDef, metadataReader, ControllerAttributes, ControllerBaseNames);
-            if (!isController)
+            var endpointType = ClassifyType(typeDef, metadataReader);
+            if (endpointType == EndpointTypeKind.None)
             {
-                isPageModel = IsInheritFromTypes(typeDef, metadataReader, PageModelBaseNames);
-                if (!isPageModel)
-                {
-                    isSignalRHub = IsInheritFromTypes(typeDef, metadataReader, SignalRHubBaseNames);
-                    if (!isSignalRHub)
-                    {
-                        isCompilerGeneratedType = datadogMetadataReader.IsCompilerGeneratedAttributeDefinedOnType(MetadataTokens.GetToken(typeHandle));
-                        if (!isCompilerGeneratedType)
-                        {
-                            continue;
-                        }
-                    }
-                }
+                continue;
             }
 
             foreach (var methodHandle in typeDef.GetMethods())
@@ -107,64 +92,78 @@ internal static class EndpointDetector
                     continue;
                 }
 
-                if (isController && HasAttributeFromSet(methodDef.GetCustomAttributes(), metadataReader, ActionAttributes))
+                if (endpointType == EndpointTypeKind.Controller && HasAttributeFromSet(methodDef.GetCustomAttributes(), metadataReader, KnownNameSet.ActionAttribute))
                 {
-                    builder.Add(metadataReader.GetToken(methodHandle));
+                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
                     continue;
                 }
 
-                if (isPageModel && IsPageModelHandler(methodDef, metadataReader))
+                if (endpointType == EndpointTypeKind.PageModel && IsPageModelHandler(methodDef, metadataReader))
                 {
-                    builder.Add(metadataReader.GetToken(methodHandle));
+                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
                     continue;
                 }
 
-                if (isSignalRHub)
+                if (endpointType == EndpointTypeKind.SignalRHub)
                 {
-                    builder.Add(metadataReader.GetToken(methodHandle));
+                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
                     continue;
                 }
 
                 // minimal API endpoints
-                if (isCompilerGeneratedType && MightBeEndpoint(methodDef, metadataReader))
+                if (endpointType == EndpointTypeKind.CompilerGenerated && MightBeEndpoint(methodDef, metadataReader))
                 {
-                    builder.Add(metadataReader.GetToken(methodHandle));
+                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
                 }
             }
         }
+    }
 
-        return builder.ToImmutable();
+    private static void AddEndpointToken<TConsumer>(ref TConsumer consumer, MetadataReader metadataReader, MethodDefinitionHandle methodHandle)
+        where TConsumer : struct, IEndpointMethodTokenConsumer
+    {
+        consumer.OnEndpointMethodToken(metadataReader.GetToken(methodHandle));
     }
 
     private static bool IsValidTypeKind(TypeDefinition typeDef)
     {
-        var attributes = typeDef.Attributes;
-        return (attributes & TypeAttributes.Interface) == 0 &&
-               (attributes & TypeAttributes.Abstract) == 0;
+        return (typeDef.Attributes & InvalidTypeAttributes) == 0;
     }
 
     private static bool IsValidMethod(MethodDefinition methodDef)
     {
         var attributes = methodDef.Attributes;
-        return (attributes & MethodAttributes.Public) != 0 &&
-               (attributes & MethodAttributes.Static) == 0;
+        return (attributes & PublicMethodAttributes) != 0 &&
+               (attributes & InvalidMethodAttributes) == 0;
     }
 
-    private static bool IsInheritFromTypesOrHasAttribute(TypeDefinition typeDef, MetadataReader reader, HashSet<string> attributesNames, HashSet<string> baseTypeNames)
+    private static EndpointTypeKind ClassifyType(TypeDefinition typeDef, MetadataReader reader)
     {
-        if (HasAttributeFromSet(typeDef.GetCustomAttributes(), reader, attributesNames))
+        var typeAttributes = typeDef.GetCustomAttributes();
+        if (HasAttributeFromSet(typeAttributes, reader, KnownNameSet.ControllerAttribute))
         {
-            return true;
+            return EndpointTypeKind.Controller;
         }
 
+        var fallbackType = EndpointTypeKind.None;
+        var isCompilerGenerated = HasAttributeFromSet(typeAttributes, reader, KnownNameSet.CompilerGeneratedAttribute);
         var baseTypeHandle = typeDef.BaseType;
         while (!baseTypeHandle.IsNil)
         {
-            if (TryGetBaseTypeInfo(baseTypeHandle, reader, out var baseTypeName, out var nextBaseTypeHandle))
+            if (BaseTypeMatchesAny(baseTypeHandle, reader, KnownBaseTypeSet.Controller))
             {
-                if (baseTypeNames.Contains(baseTypeName))
+                return EndpointTypeKind.Controller;
+            }
+
+            if (fallbackType == EndpointTypeKind.None)
+            {
+                if (BaseTypeMatchesAny(baseTypeHandle, reader, KnownBaseTypeSet.PageModel))
                 {
-                    return true;
+                    fallbackType = EndpointTypeKind.PageModel;
+                }
+                else if (BaseTypeMatchesAny(baseTypeHandle, reader, KnownBaseTypeSet.SignalRHub))
+                {
+                    fallbackType = EndpointTypeKind.SignalRHub;
                 }
             }
 
@@ -174,172 +173,248 @@ internal static class EndpointDetector
             }
 
             var baseType = reader.GetTypeDefinition((TypeDefinitionHandle)baseTypeHandle);
-            if (HasAttributeFromSet(baseType.GetCustomAttributes(), reader, attributesNames))
+            if (HasAttributeFromSet(baseType.GetCustomAttributes(), reader, KnownNameSet.ControllerAttribute))
             {
-                return true;
+                return EndpointTypeKind.Controller;
             }
 
-            baseTypeHandle = nextBaseTypeHandle;
+            baseTypeHandle = baseType.BaseType;
         }
 
-        return false;
-    }
-
-    private static bool HasAttributeFromSet(CustomAttributeHandleCollection attributes, MetadataReader reader, HashSet<string> attributeNames)
-    {
-        foreach (var attributeHandle in attributes)
+        if (fallbackType != EndpointTypeKind.None)
         {
-            string fullName;
-            var attribute = reader.GetCustomAttribute(attributeHandle);
-            switch (attribute.Constructor.Kind)
-            {
-                case HandleKind.MemberReference:
-                    {
-                        var ctor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
-                        switch (ctor.Parent.Kind)
-                        {
-                            case HandleKind.TypeReference:
-                                var tr = reader.GetTypeReference((TypeReferenceHandle)ctor.Parent);
-                                fullName = GetFullTypeName(tr.Namespace, tr.Name, reader);
-                                break;
-
-                            case HandleKind.TypeDefinition:
-                                var td = reader.GetTypeDefinition((TypeDefinitionHandle)ctor.Parent);
-                                fullName = GetFullTypeName(td.Namespace, td.Name, reader);
-                                break;
-
-                            default:
-                                continue;
-                        }
-
-                        break;
-                    }
-
-                case HandleKind.MethodDefinition:
-                    {
-                        var ctor = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
-                        var td = reader.GetTypeDefinition(ctor.GetDeclaringType());
-                        fullName = GetFullTypeName(td.Namespace, td.Name, reader);
-                        break;
-                    }
-
-                default:
-                    continue;
-            }
-
-            if (attributeNames.Contains(fullName))
-            {
-                return true;
-            }
+            return fallbackType;
         }
 
-        return false;
+        return isCompilerGenerated ? EndpointTypeKind.CompilerGenerated : EndpointTypeKind.None;
     }
 
-    private static bool IsInheritFromTypes(TypeDefinition typeDef, MetadataReader reader, HashSet<string> baseTypeNames)
+    private static bool HasAttributeFromSet(CustomAttributeHandleCollection attributes, MetadataReader reader, KnownNameSet nameSet)
     {
-        var baseTypeHandle = typeDef.BaseType;
-        while (!baseTypeHandle.IsNil)
-        {
-            if (TryGetBaseTypeInfo(baseTypeHandle, reader, out var baseTypeName, out var nextBaseTypeHandle))
-            {
-                var indexOfTypeArg = baseTypeName.IndexOf('<');
-                if (indexOfTypeArg > 0)
-                {
-                    baseTypeName = baseTypeName.Substring(0, indexOfTypeArg);
-                }
-
-                if (baseTypeNames.Contains(baseTypeName))
-                {
-                    return true;
-                }
-            }
-
-            if (baseTypeHandle.Kind != HandleKind.TypeDefinition)
-            {
-                break;
-            }
-
-            baseTypeHandle = nextBaseTypeHandle;
-        }
-
-        return false;
-    }
-
-    private static bool IsPageModelHandler(MethodDefinition methodDef, MetadataReader reader)
-    {
-        // First check if the method has [NonHandler] attribute
-        if (HasAttributeFromSet(methodDef.GetCustomAttributes(), reader, NoHandlerAttributes))
+        if (attributes.Count == 0)
         {
             return false;
         }
 
-        var name = reader.GetString(methodDef.Name);
-        // https://learn.microsoft.com/en-us/dotnet/api/system.web.mvc.httpverbs
-        return name.StartsWith("On", StringComparison.Ordinal) &&
-               (name.Equals("OnGet", StringComparison.Ordinal) ||
-                name.Equals("OnGetAsync", StringComparison.Ordinal) ||
-                name.Equals("OnPost", StringComparison.Ordinal) ||
-                name.Equals("OnPostAsync", StringComparison.Ordinal) ||
-                name.Equals("OnPut", StringComparison.Ordinal) ||
-                name.Equals("OnPutAsync", StringComparison.Ordinal) ||
-                name.Equals("OnDelete", StringComparison.Ordinal) ||
-                name.Equals("OnDeleteAsync", StringComparison.Ordinal) ||
-                name.Equals("OnHead", StringComparison.Ordinal) ||
-                name.Equals("OnHeadAsync", StringComparison.Ordinal) ||
-                name.Equals("OnPatch", StringComparison.Ordinal) ||
-                name.Equals("OnPatchAsync", StringComparison.Ordinal) ||
-                name.Equals("OnOptions", StringComparison.Ordinal) ||
-                name.Equals("OnOptionsAsync", StringComparison.Ordinal));
-    }
-
-    private static bool MightBeEndpoint(MethodDefinition methodDef, MetadataReader reader)
-    {
-        var name = reader.GetString(methodDef.Name);
-        if (name.StartsWith("<", StringComparison.Ordinal))
+        foreach (var attributeHandle in attributes)
         {
-            return true;
+            var attribute = reader.GetCustomAttribute(attributeHandle);
+            if (!TryGetAttributeTypeName(attribute, reader, out var namespaceHandle, out var nameHandle))
+            {
+                continue;
+            }
+
+            if (NameMatches(reader, namespaceHandle, nameHandle, nameSet))
+            {
+                return true;
+            }
         }
 
         return false;
     }
 
-    private static bool TryGetBaseTypeInfo(EntityHandle typeHandle, MetadataReader reader, [NotNullWhen(true)] out string? baseTypeName, out EntityHandle baseType)
+    private static bool TryGetAttributeTypeName(CustomAttribute attribute, MetadataReader reader, out StringHandle namespaceHandle, out StringHandle nameHandle)
+    {
+        namespaceHandle = default;
+        nameHandle = default;
+
+        if (attribute.Constructor.IsNil)
+        {
+            return false;
+        }
+
+        switch (attribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+                {
+                    var ctor = reader.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+                    return TryGetTypeName(ctor.Parent, reader, out namespaceHandle, out nameHandle);
+                }
+
+            case HandleKind.MethodDefinition:
+                {
+                    var ctor = reader.GetMethodDefinition((MethodDefinitionHandle)attribute.Constructor);
+                    var declaringType = ctor.GetDeclaringType();
+                    if (declaringType.IsNil)
+                    {
+                        return false;
+                    }
+
+                    var typeDef = reader.GetTypeDefinition(declaringType);
+                    namespaceHandle = typeDef.Namespace;
+                    nameHandle = typeDef.Name;
+                    return !nameHandle.IsNil;
+                }
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool IsPageModelHandler(MethodDefinition methodDef, MetadataReader reader)
+    {
+        var name = methodDef.Name;
+        var comparer = reader.StringComparer;
+
+        // Razor Pages handler method conventions:
+        // https://learn.microsoft.com/en-us/aspnet/core/razor-pages/?view=aspnetcore-8.0#handler-methods
+        if (!comparer.StartsWith(name, "On"))
+        {
+            return false;
+        }
+
+        if (!IsKnownPageModelHandlerName(reader, name))
+        {
+            return false;
+        }
+
+        return !HasAttributeFromSet(methodDef.GetCustomAttributes(), reader, KnownNameSet.NoHandlerAttribute);
+    }
+
+    private static bool MightBeEndpoint(MethodDefinition methodDef, MetadataReader reader)
+    {
+        return reader.StringComparer.StartsWith(methodDef.Name, "<");
+    }
+
+    private static bool BaseTypeMatchesAny(EntityHandle typeHandle, MetadataReader reader, KnownBaseTypeSet baseTypeSet)
     {
         switch (typeHandle.Kind)
         {
             case HandleKind.TypeDefinition:
+            case HandleKind.TypeReference:
+                return TryGetTypeName(typeHandle, reader, out var namespaceHandle, out var nameHandle) &&
+                       BaseTypeNameMatches(reader, namespaceHandle, nameHandle, baseTypeSet);
+
+            case HandleKind.TypeSpecification:
+                return TypeSpecMatchesByOuterName((TypeSpecificationHandle)typeHandle, reader, baseTypeSet);
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TypeSpecMatchesByOuterName(TypeSpecificationHandle typeHandle, MetadataReader reader, KnownBaseTypeSet baseTypeSet)
+    {
+        var typeSpec = reader.GetTypeSpecification(typeHandle);
+        var blobReader = reader.GetBlobReader(typeSpec.Signature);
+
+        if (blobReader.ReadCompressedInteger() != (int)SignatureTypeCode.GenericTypeInstance)
+        {
+            return false;
+        }
+
+        var rawTypeKind = blobReader.ReadCompressedInteger();
+        if (rawTypeKind != (int)SignatureTypeKind.Class &&
+            rawTypeKind != (int)SignatureTypeKind.ValueType)
+        {
+            return false;
+        }
+
+        var outerTypeHandle = blobReader.ReadTypeHandle();
+        return TryGetTypeName(outerTypeHandle, reader, out var namespaceHandle, out var nameHandle) &&
+               BaseTypeNameMatches(reader, namespaceHandle, nameHandle, baseTypeSet);
+    }
+
+    private static bool TryGetTypeName(EntityHandle typeHandle, MetadataReader reader, out StringHandle namespaceHandle, out StringHandle nameHandle)
+    {
+        namespaceHandle = default;
+        nameHandle = default;
+
+        switch (typeHandle.Kind)
+        {
+            case HandleKind.TypeDefinition:
                 var typeDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeHandle);
-                baseTypeName = GetFullTypeName(typeDef.Namespace, typeDef.Name, reader);
-                baseType = typeDef.BaseType;
-                break;
+                namespaceHandle = typeDef.Namespace;
+                nameHandle = typeDef.Name;
+                return !nameHandle.IsNil;
 
             case HandleKind.TypeReference:
                 var typeRef = reader.GetTypeReference((TypeReferenceHandle)typeHandle);
-                baseTypeName = GetFullTypeName(typeRef.Namespace, typeRef.Name, reader);
-                baseType = default;
-                break;
-
-            case HandleKind.TypeSpecification:
-                baseTypeName = ((TypeSpecificationHandle)typeHandle).FullName(reader);
-                baseType = default;
-                break;
+                namespaceHandle = typeRef.Namespace;
+                nameHandle = typeRef.Name;
+                return !nameHandle.IsNil;
 
             default:
-                baseTypeName = null;
-                baseType = default;
-                break;
+                return false;
         }
-
-        return !string.IsNullOrEmpty(baseTypeName);
     }
 
-    private static string GetFullTypeName(StringHandle namespaceHandle, StringHandle nameHandle, MetadataReader reader)
+    private static bool IsKnownPageModelHandlerName(MetadataReader reader, StringHandle name)
     {
-        var nameSpace = reader.GetString(namespaceHandle);
-        var name = reader.GetString(nameHandle);
-        return $"{nameSpace}.{name}";
+        var comparer = reader.StringComparer;
+        return comparer.Equals(name, "OnGet") ||
+               comparer.Equals(name, "OnGetAsync") ||
+               comparer.Equals(name, "OnPost") ||
+               comparer.Equals(name, "OnPostAsync") ||
+               comparer.Equals(name, "OnPut") ||
+               comparer.Equals(name, "OnPutAsync") ||
+               comparer.Equals(name, "OnDelete") ||
+               comparer.Equals(name, "OnDeleteAsync") ||
+               comparer.Equals(name, "OnHead") ||
+               comparer.Equals(name, "OnHeadAsync") ||
+               comparer.Equals(name, "OnPatch") ||
+               comparer.Equals(name, "OnPatchAsync") ||
+               comparer.Equals(name, "OnOptions") ||
+               comparer.Equals(name, "OnOptionsAsync");
     }
 
-    private sealed record Entity(string Name, EntityHandle Handle);
+    private static bool NameMatches(MetadataReader reader, StringHandle namespaceHandle, StringHandle nameHandle, KnownNameSet nameSet)
+    {
+        var comparer = reader.StringComparer;
+        switch (nameSet)
+        {
+            case KnownNameSet.ControllerAttribute:
+                return comparer.Equals(namespaceHandle, MvcNamespace) &&
+                       (comparer.Equals(nameHandle, "ApiControllerAttribute") ||
+                        comparer.Equals(nameHandle, "ControllerAttribute") ||
+                        comparer.Equals(nameHandle, "RouteAttribute"));
+
+            case KnownNameSet.ActionAttribute:
+                return (comparer.Equals(namespaceHandle, MvcNamespace) &&
+                        (comparer.Equals(nameHandle, "HttpGetAttribute") ||
+                         comparer.Equals(nameHandle, "HttpPostAttribute") ||
+                         comparer.Equals(nameHandle, "HttpPutAttribute") ||
+                         comparer.Equals(nameHandle, "HttpDeleteAttribute") ||
+                         comparer.Equals(nameHandle, "HttpPatchAttribute") ||
+                         comparer.Equals(nameHandle, "HttpHeadAttribute") ||
+                         comparer.Equals(nameHandle, "HttpOptionsAttribute"))) ||
+                       (comparer.Equals(namespaceHandle, MvcRoutingNamespace) &&
+                        comparer.Equals(nameHandle, "HttpMethodAttribute"));
+
+            case KnownNameSet.NoHandlerAttribute:
+                return comparer.Equals(namespaceHandle, RazorPagesNamespace) &&
+                       comparer.Equals(nameHandle, "NonHandlerAttribute");
+
+            case KnownNameSet.CompilerGeneratedAttribute:
+                return comparer.Equals(namespaceHandle, CompilerServicesNamespace) &&
+                       comparer.Equals(nameHandle, "CompilerGeneratedAttribute");
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool BaseTypeNameMatches(MetadataReader reader, StringHandle namespaceHandle, StringHandle nameHandle, KnownBaseTypeSet baseTypeSet)
+    {
+        var comparer = reader.StringComparer;
+        switch (baseTypeSet)
+        {
+            case KnownBaseTypeSet.Controller:
+                return comparer.Equals(namespaceHandle, MvcNamespace) &&
+                       (comparer.Equals(nameHandle, "Controller") ||
+                        comparer.Equals(nameHandle, "ControllerBase"));
+
+            case KnownBaseTypeSet.PageModel:
+                return comparer.Equals(namespaceHandle, RazorPagesNamespace) &&
+                       comparer.Equals(nameHandle, "PageModel");
+
+            case KnownBaseTypeSet.SignalRHub:
+                return comparer.Equals(namespaceHandle, SignalRNamespace) &&
+                       (comparer.Equals(nameHandle, "Hub") ||
+                        comparer.Equals(nameHandle, "Hub`1"));
+
+            default:
+                return false;
+        }
+    }
 }

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -104,35 +104,29 @@ internal static class EndpointDetector
 
                 if (endpointType == EndpointTypeKind.Controller && HasAttributeFromSet(methodDef.GetCustomAttributes(), metadataReader, KnownNameSet.ActionAttribute))
                 {
-                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
+                    consumer.OnEndpointMethodToken(metadataReader.GetToken(methodHandle));
                     continue;
                 }
 
                 if (endpointType == EndpointTypeKind.PageModel && IsPageModelHandler(methodDef, metadataReader))
                 {
-                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
+                    consumer.OnEndpointMethodToken(metadataReader.GetToken(methodHandle));
                     continue;
                 }
 
                 if (endpointType == EndpointTypeKind.SignalRHub)
                 {
-                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
+                    consumer.OnEndpointMethodToken(metadataReader.GetToken(methodHandle));
                     continue;
                 }
 
                 // minimal API endpoints
                 if (endpointType == EndpointTypeKind.CompilerGenerated && MightBeEndpoint(methodDef, metadataReader))
                 {
-                    AddEndpointToken(ref consumer, metadataReader, methodHandle);
+                    consumer.OnEndpointMethodToken(metadataReader.GetToken(methodHandle));
                 }
             }
         }
-    }
-
-    private static void AddEndpointToken<TConsumer>(ref TConsumer consumer, MetadataReader metadataReader, MethodDefinitionHandle methodHandle)
-        where TConsumer : struct, IEndpointMethodTokenConsumer
-    {
-        consumer.OnEndpointMethodToken(metadataReader.GetToken(methodHandle));
     }
 
     private static bool IsValidTypeKind(TypeDefinition typeDef)

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -185,50 +186,13 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
                     try
                     {
-                        var endpointMethodTokens = EndpointDetector.GetEndpointMethodTokens(reader);
-
                         // Build dictionary of sequence points for ALL detected endpoint methods in one pass
-                        // This avoids reopening the PDB file on subsequent endpoint calls
-                        var builder = ImmutableDictionary.CreateBuilder<int, CachedSequencePoint?>();
+                        // This avoids reopening the PDB file on subsequent endpoint calls.
+                        var sequencePoints = new Dictionary<int, CachedSequencePoint>();
+                        var consumer = new SequencePointTokenConsumer(reader, sequencePoints, asm);
+                        EndpointDetector.GetEndpointMethodTokens(reader, ref consumer);
 
-                        foreach (var token in endpointMethodTokens)
-                        {
-                            try
-                            {
-                                var sequencePoint = reader.GetMethodSourceLocation(token);
-                                if (sequencePoint is { } sp)
-                                {
-                                    // If we don't have a source URL, the sequence point isn't useful for code origin tags
-                                    // (line/column without a file doesn't provide actionable info).
-                                    if (StringUtil.IsNullOrEmpty(sp.URL))
-                                    {
-                                        builder.Add(token, null);
-                                        continue;
-                                    }
-
-                                    // Precompute string representations once during per-assembly cache population (stored per endpoint token)
-                                    // to avoid per-span allocations (ToString()) for line/column.
-                                    builder.Add(
-                                        token,
-                                        new CachedSequencePoint(
-                                            sp.URL,
-                                            sp.StartLine.ToString(CultureInfo.InvariantCulture),
-                                            sp.StartColumn.ToString(CultureInfo.InvariantCulture)));
-                                }
-                                else
-                                {
-                                    builder.Add(token, null);
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex, "Failed to get sequence point for method token {Token} in assembly {AssemblyName}", property0: token, asm.FullName);
-                                // Add null to dictionary to avoid retrying on every call
-                                builder.Add(token, null);
-                            }
-                        }
-
-                        return new AssemblyPdbInfo(builder.ToImmutable());
+                        return new AssemblyPdbInfo(sequencePoints);
                     }
                     catch (Exception ex)
                     {
@@ -248,7 +212,9 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                 return null;
             }
 
-            return pdbInfo?.MethodSequencePoints.GetValueOrDefault<CachedSequencePoint?>(metadataToken);
+            return pdbInfo is not null && pdbInfo.MethodSequencePoints.TryGetValue(metadataToken, out var sequencePoint)
+                       ? sequencePoint
+                       : null;
         }
 
         private void AddExitSpanTags(Span span)
@@ -353,9 +319,53 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
         private readonly record struct CachedSequencePoint(string Url, string Line, string Column);
 
-        private sealed class AssemblyPdbInfo(ImmutableDictionary<int, CachedSequencePoint?> sequencePoints)
+        private readonly struct SequencePointTokenConsumer : EndpointDetector.IEndpointMethodTokenConsumer
         {
-            public ImmutableDictionary<int, CachedSequencePoint?> MethodSequencePoints { get; } = sequencePoints;
+            private readonly DatadogMetadataReader _reader;
+            private readonly Dictionary<int, CachedSequencePoint> _sequencePoints;
+            private readonly Assembly _assembly;
+
+            public SequencePointTokenConsumer(DatadogMetadataReader reader, Dictionary<int, CachedSequencePoint> sequencePoints, Assembly assembly)
+            {
+                _reader = reader;
+                _sequencePoints = sequencePoints;
+                _assembly = assembly;
+            }
+
+            public void OnEndpointMethodToken(int token)
+            {
+                try
+                {
+                    var sequencePoint = _reader.GetMethodSourceLocation(token);
+                    if (sequencePoint is { } sp)
+                    {
+                        // If we don't have a source URL, the sequence point isn't useful for code origin tags
+                        // (line/column without a file doesn't provide actionable info).
+                        if (StringUtil.IsNullOrEmpty(sp.URL))
+                        {
+                            return;
+                        }
+
+                        // Precompute string representations once during per-assembly cache population (stored per endpoint token)
+                        // to avoid per-span allocations (ToString()) for line/column.
+                        _sequencePoints.Add(
+                            token,
+                            new CachedSequencePoint(
+                                sp.URL,
+                                sp.StartLine.ToString(CultureInfo.InvariantCulture),
+                                sp.StartColumn.ToString(CultureInfo.InvariantCulture)));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to get sequence point for method token {Token} in assembly {AssemblyName}", property0: token, _assembly.FullName);
+                }
+            }
+        }
+
+        private sealed class AssemblyPdbInfo(Dictionary<int, CachedSequencePoint> sequencePoints)
+        {
+            public Dictionary<int, CachedSequencePoint> MethodSequencePoints { get; } = sequencePoints;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -212,7 +212,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                 return null;
             }
 
-            return pdbInfo is not null && pdbInfo.MethodSequencePoints.TryGetValue(metadataToken, out var sequencePoint)
+            return pdbInfo is not null && pdbInfo.TryGetSequencePoint(metadataToken, out var sequencePoint)
                        ? sequencePoint
                        : null;
         }
@@ -365,7 +365,12 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
         private sealed class AssemblyPdbInfo(Dictionary<int, CachedSequencePoint> sequencePoints)
         {
-            public Dictionary<int, CachedSequencePoint> MethodSequencePoints { get; } = sequencePoints;
+            private readonly Dictionary<int, CachedSequencePoint> _sequencePoints = sequencePoints;
+
+            public bool TryGetSequencePoint(int token, out CachedSequencePoint sequencePoint)
+            {
+                return _sequencePoints.TryGetValue(token, out sequencePoint);
+            }
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -176,7 +176,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
 
             var pdbInfo = _assemblyPdbCache.GetOrAdd(
                 assembly,
-                asm =>
+                static asm =>
                 {
                     using var reader = DatadogMetadataReader.CreatePdbReader(asm);
                     if (reader is not { IsPdbExist: true })

--- a/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Datadog.Trace.Debugger.SpanCodeOrigin;
-using Datadog.Trace.Pdb;
 using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,6 +17,14 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+#else
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Metadata;
+using Datadog.Trace.VendoredMicrosoftCode.System.Reflection.PortableExecutable;
+#endif
 
 namespace Datadog.Trace.Tests.Debugger
 {
@@ -32,7 +39,7 @@ namespace Datadog.Trace.Tests.Debugger
         {
             _output = output;
             _assemblyPath = CreateTestAssembly();
-            _assembly = Assembly.LoadFile(_assemblyPath);
+            _assembly = Assembly.Load(File.ReadAllBytes(_assemblyPath));
         }
 
         public void Dispose()
@@ -53,11 +60,8 @@ namespace Datadog.Trace.Tests.Debugger
         [Fact]
         public void GetEndpointMethodTokens_FindsAllEndpoints()
         {
-            // Arrange
-            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
-
             // Act
-            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+            var endpointTokens = GetEndpointMethodTokens(_assemblyPath);
 
             // Create a mapping of method tokens to more friendly names for debugging
             var tokenToMethodMap = new Dictionary<int, string>();
@@ -150,11 +154,8 @@ namespace Datadog.Trace.Tests.Debugger
         [Fact]
         public void GetEndpointMethodTokens_DoesNotDetectNonEndpoints()
         {
-            // Arrange
-            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
-
             // Act
-            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+            var endpointTokens = GetEndpointMethodTokens(_assemblyPath);
 
             // Create a list of methods that should NOT be endpoints
             var nonEndpointTokens = new List<int>();
@@ -236,11 +237,8 @@ namespace Datadog.Trace.Tests.Debugger
         [Fact]
         public void GetEndpointMethodTokens_DetectsInheritedCustomControllerAttribute()
         {
-            // Arrange
-            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
-
             // Act
-            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+            var endpointTokens = GetEndpointMethodTokens(_assemblyPath);
 
             // Assert: the leaf controller carries no attribute itself; the chain-walk must find
             // [ApiController] on CustomApiBaseController to recognize InheritedAttributeController.
@@ -256,11 +254,8 @@ namespace Datadog.Trace.Tests.Debugger
         [Fact]
         public void GetEndpointMethodTokens_DetectsGenericSignalRHubBaseType()
         {
-            // Arrange
-            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
-
             // Act
-            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+            var endpointTokens = GetEndpointMethodTokens(_assemblyPath);
 
             // Assert: TestGenericHub : Hub<string> drives the TypeSpecification path through
             // BaseTypeMatcher. The open-generic Hub`1 candidate must match the decoded
@@ -277,11 +272,8 @@ namespace Datadog.Trace.Tests.Debugger
         [Fact]
         public void GetEndpointMethodTokens_DoesNotDetectHubNestedInsideGenericArgument()
         {
-            // Arrange
-            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
-
             // Act
-            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+            var endpointTokens = GetEndpointMethodTokens(_assemblyPath);
 
             // Assert: NestedGenericHubInheritor's immediate base is SomeWrapper<Hub<string>>.
             // Hub appears only as a nested generic argument, so the type must NOT be
@@ -301,14 +293,16 @@ namespace Datadog.Trace.Tests.Debugger
         {
             // Arrange
             var assemblyPath = CreateAssemblyWithoutEndpoints();
-            var assembly = Assembly.LoadFile(assemblyPath);
 
             try
             {
-                using (var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(assembly))
+                using (var assemblyStream = File.OpenRead(assemblyPath))
+                using (var peReader = new PEReader(assemblyStream, PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage))
                 {
+                    var metadataReader = peReader.GetMetadataReader();
+
                     // Act
-                    var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+                    var endpointTokens = GetEndpointMethodTokens(metadataReader);
 
                     // Assert
                     endpointTokens.Should().BeEmpty();
@@ -330,11 +324,18 @@ namespace Datadog.Trace.Tests.Debugger
             }
         }
 
-        private static IReadOnlyList<int> GetEndpointMethodTokens(DatadogMetadataReader reader)
+        private static IReadOnlyList<int> GetEndpointMethodTokens(MetadataReader reader)
         {
             var consumer = new ListEndpointTokenConsumer(new List<int>());
             EndpointDetector.GetEndpointMethodTokens(reader, ref consumer);
             return consumer.Tokens;
+        }
+
+        private static IReadOnlyList<int> GetEndpointMethodTokens(string assemblyPath)
+        {
+            using var assemblyStream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(assemblyStream, PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage);
+            return GetEndpointMethodTokens(peReader.GetMetadataReader());
         }
 
         private void LogEndpointDetails(IReadOnlyList<int> endpointTokens, Dictionary<int, string> tokenToMethodMap, HashSet<int> expectedEndpoints)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
@@ -19,12 +19,6 @@ using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
 
-#if NETCOREAPP3_1_OR_GREATER
-using System.Collections.Immutable;
-#else
-using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
-#endif
-
 namespace Datadog.Trace.Tests.Debugger
 {
     public class EndpointDetectorTests : IDisposable
@@ -60,10 +54,10 @@ namespace Datadog.Trace.Tests.Debugger
         public void GetEndpointMethodTokens_FindsAllEndpoints()
         {
             // Arrange
-            var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
+            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
 
             // Act
-            var endpointTokens = EndpointDetector.GetEndpointMethodTokens(datadogMetadataReader);
+            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
 
             // Create a mapping of method tokens to more friendly names for debugging
             var tokenToMethodMap = new Dictionary<int, string>();
@@ -95,6 +89,12 @@ namespace Datadog.Trace.Tests.Debugger
                         isExpectedEndpoint = true;
                     }
 
+                    // Leaf controller that inherits [ApiController] through a custom base type
+                    else if (type.Name == "InheritedAttributeController" && method.Name == "Get")
+                    {
+                        isExpectedEndpoint = true;
+                    }
+
                     // Controller with HTTP methods
                     else if (type.Name == "HttpMethodController" &&
                             method.Name is "Get" or "Post" or "Put" or "Delete" or "Patch" or "Head" or "Options" or "Custom")
@@ -102,10 +102,10 @@ namespace Datadog.Trace.Tests.Debugger
                         isExpectedEndpoint = true;
                     }
 
-                    // PageModel handlers
+                    // PageModel handlers (OnGetWithNonHandlerAttribute is excluded by the list
+                    // pattern itself - it's covered by the negative-case test, not here).
                     else if (type.Name == "TestPageModel" &&
-                            method.Name is "OnGet" or "OnGetAsync" or "OnPost" or "OnPostAsync" or "OnPut" or "OnPutAsync" or "OnDelete" or "OnDeleteAsync" or "OnHead" or "OnHeadAsync" or "OnPatch" or "OnPatchAsync" or "OnOptions" or "OnOptionsAsync" &&
-                            method.Name != "OnGetWithNonHandlerAttribute")
+                            method.Name is "OnGet" or "OnGetAsync" or "OnPost" or "OnPostAsync" or "OnPut" or "OnPutAsync" or "OnDelete" or "OnDeleteAsync" or "OnHead" or "OnHeadAsync" or "OnPatch" or "OnPatchAsync" or "OnOptions" or "OnOptionsAsync")
                     {
                         isExpectedEndpoint = true;
                     }
@@ -137,17 +137,24 @@ namespace Datadog.Trace.Tests.Debugger
             // Log and assert
             LogEndpointDetails(endpointTokens, tokenToMethodMap, expectedEndpoints);
 
-            endpointTokens.Count.Should().BeGreaterThanOrEqualTo(expectedEndpoints.Count, "The EndpointDetector should find all controller, page handler, and SignalR hub methods");
+            // Each expected endpoint must be detected. We don't assert exact equality because the
+            // intentionally-fuzzy minimal-API path can produce additional compiler-generated lambda hits.
+            endpointTokens.Should().Contain(expectedEndpoints, "The EndpointDetector should find every controller action, page handler, SignalR hub method, and inherited-attribute controller endpoint");
+
+            // Soft upper bound: the minimal-API fuzzy path is allowed to over-detect a handful of
+            // compiler-generated lambdas, but a runaway result set (e.g. every public instance method
+            // on a compiler-generated type) would indicate a regression in the classification logic.
+            endpointTokens.Count.Should().BeLessThan(expectedEndpoints.Count + 25, "the minimal-API fuzzy detection must not blow up the result set");
         }
 
         [Fact]
         public void GetEndpointMethodTokens_DoesNotDetectNonEndpoints()
         {
             // Arrange
-            var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
+            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
 
             // Act
-            var endpointTokens = EndpointDetector.GetEndpointMethodTokens(datadogMetadataReader);
+            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
 
             // Create a list of methods that should NOT be endpoints
             var nonEndpointTokens = new List<int>();
@@ -226,7 +233,111 @@ namespace Datadog.Trace.Tests.Debugger
             nonEndpointTokens.Should().NotContain(token => endpointTokens.Contains(token), "Non-endpoints should not be detected as endpoints");
         }
 
-        private void LogEndpointDetails(ImmutableHashSet<int> endpointTokens, Dictionary<int, string> tokenToMethodMap, HashSet<int> expectedEndpoints)
+        [Fact]
+        public void GetEndpointMethodTokens_DetectsInheritedCustomControllerAttribute()
+        {
+            // Arrange
+            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
+
+            // Act
+            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+
+            // Assert: the leaf controller carries no attribute itself; the chain-walk must find
+            // [ApiController] on CustomApiBaseController to recognize InheritedAttributeController.
+            var leafController = _assembly.GetType("EndpointDetectorTestNamespace.InheritedAttributeController");
+            leafController.Should().NotBeNull();
+
+            var getMethod = leafController.GetMethod("Get");
+            getMethod.Should().NotBeNull();
+
+            endpointTokens.Should().Contain(getMethod.MetadataToken, "the inherited [ApiController] on the base type must be discovered by the chain walk");
+        }
+
+        [Fact]
+        public void GetEndpointMethodTokens_DetectsGenericSignalRHubBaseType()
+        {
+            // Arrange
+            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
+
+            // Act
+            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+
+            // Assert: TestGenericHub : Hub<string> drives the TypeSpecification path through
+            // BaseTypeMatcher. The open-generic Hub`1 candidate must match the decoded
+            // signature even though the immediate base is a TypeSpec, not a TypeReference.
+            var hubType = _assembly.GetType("EndpointDetectorTestNamespace.TestGenericHub");
+            hubType.Should().NotBeNull();
+
+            var sendMethod = hubType.GetMethod("Send");
+            sendMethod.Should().NotBeNull();
+
+            endpointTokens.Should().Contain(sendMethod.MetadataToken, "Hub<T> base must resolve through TypeSpecification + ISignatureTypeProvider");
+        }
+
+        [Fact]
+        public void GetEndpointMethodTokens_DoesNotDetectHubNestedInsideGenericArgument()
+        {
+            // Arrange
+            using var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(_assembly);
+
+            // Act
+            var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+
+            // Assert: NestedGenericHubInheritor's immediate base is SomeWrapper<Hub<string>>.
+            // Hub appears only as a nested generic argument, so the type must NOT be
+            // classified as a Hub. This locks in BaseTypeMatcher.GetGenericInstantiation
+            // returning genericType (the outer match) rather than propagating type-arg matches.
+            var nestedType = _assembly.GetType("EndpointDetectorTestNamespace.NestedGenericHubInheritor");
+            nestedType.Should().NotBeNull();
+
+            var notEndpointMethod = nestedType.GetMethod("ShouldNotBeEndpoint");
+            notEndpointMethod.Should().NotBeNull();
+
+            endpointTokens.Should().NotContain(notEndpointMethod.MetadataToken, "Hub appearing only as a nested generic argument must not promote the leaf type to an endpoint");
+        }
+
+        [Fact]
+        public void GetEndpointMethodTokens_ReturnsEmptyCollectionForAssemblyWithoutEndpoints()
+        {
+            // Arrange
+            var assemblyPath = CreateAssemblyWithoutEndpoints();
+            var assembly = Assembly.LoadFile(assemblyPath);
+
+            try
+            {
+                using (var datadogMetadataReader = DatadogMetadataReader.CreatePdbReader(assembly))
+                {
+                    // Act
+                    var endpointTokens = GetEndpointMethodTokens(datadogMetadataReader);
+
+                    // Assert
+                    endpointTokens.Should().BeEmpty();
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(assemblyPath))
+                    {
+                        File.Delete(assemblyPath);
+                    }
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+
+        private static IReadOnlyList<int> GetEndpointMethodTokens(DatadogMetadataReader reader)
+        {
+            var consumer = new ListEndpointTokenConsumer(new List<int>());
+            EndpointDetector.GetEndpointMethodTokens(reader, ref consumer);
+            return consumer.Tokens;
+        }
+
+        private void LogEndpointDetails(IReadOnlyList<int> endpointTokens, Dictionary<int, string> tokenToMethodMap, HashSet<int> expectedEndpoints)
         {
             // Log expected endpoints (using the HashSet to avoid duplicates)
             _output.WriteLine($"\nExpected {expectedEndpoints.Count} endpoints:");
@@ -284,6 +395,32 @@ namespace Datadog.Trace.Tests.Debugger
                               .Select(d => $"{d.Id}: {d.GetMessage()}"));
 
                 throw new InvalidOperationException($"Failed to create test assembly: {errors}");
+            }
+
+            return assemblyPath;
+        }
+
+        private string CreateAssemblyWithoutEndpoints()
+        {
+            var compilation = CSharpCompilation.Create(
+                $"{TestAssemblyName}NoEndpoints",
+                syntaxTrees: new[] { CSharpSyntaxTree.ParseText(GetAssemblyWithoutEndpointsCode()) },
+                references: GetMetadataReferences(),
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var uniqueId = Guid.NewGuid().ToString("N").Substring(0, 8);
+            var assemblyPath = Path.Combine(Path.GetTempPath(), $"{TestAssemblyName}_NoEndpoints_{uniqueId}.dll");
+
+            EmitResult emitResult = compilation.Emit(assemblyPath);
+            if (!emitResult.Success)
+            {
+                string errors = string.Join(
+                    Environment.NewLine,
+                    emitResult.Diagnostics
+                              .Where(d => d.Severity == DiagnosticSeverity.Error)
+                              .Select(d => $"{d.Id}: {d.GetMessage()}"));
+
+                throw new InvalidOperationException($"Failed to create no-endpoints test assembly: {errors}");
             }
 
             return assemblyPath;
@@ -454,6 +591,17 @@ namespace EndpointDetectorTestNamespace
         public object Get() => null;
     }
 
+    // Custom base controller decorated with [ApiController] - leaf inherits the attribute through the base chain.
+    [Microsoft.AspNetCore.Mvc.ApiControllerAttribute]
+    public class CustomApiBaseController { }
+
+    // Leaf controller with no attribute that inherits [ApiController] from CustomApiBaseController.
+    public class InheritedAttributeController : CustomApiBaseController
+    {
+        [Microsoft.AspNetCore.Mvc.HttpGet]
+        public object Get() => null;
+    }
+
     // Controller with various HTTP method attributes
     public class HttpMethodController : Microsoft.AspNetCore.Mvc.ControllerBase
     {
@@ -522,6 +670,16 @@ namespace EndpointDetectorTestNamespace
         public void Receive() { }
     }
 
+    // Generic non-hub wrapper used to test nested-generic detection semantics.
+    public class SomeWrapper<T> { }
+
+    // Leaf type whose immediate base is SomeWrapper<Hub<string>>. Hub appears only as a
+    // nested generic argument; the detector must NOT classify the leaf as a Hub.
+    public class NestedGenericHubInheritor : SomeWrapper<Microsoft.AspNetCore.SignalR.Hub<string>>
+    {
+        public void ShouldNotBeEndpoint() { }
+    }
+
     // Abstract controller - should be ignored
     [Microsoft.AspNetCore.Mvc.ApiControllerAttribute]
     public abstract class AbstractController
@@ -578,6 +736,54 @@ namespace EndpointDetectorTestNamespace
         }
     }
 }");
+        }
+
+        private SourceText GetAssemblyWithoutEndpointsCode()
+        {
+            return SourceText.From(@"
+using System;
+
+namespace EndpointDetectorNoEndpoints
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class DebuggerStepThroughAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class NullableContextAttribute : Attribute
+    {
+        public NullableContextAttribute(byte flag) { }
+    }
+
+    [DebuggerStepThrough]
+    [NullableContext(1)]
+    public class PlainService
+    {
+        [DebuggerStepThrough]
+        public object Get() => null;
+
+        public object Post() => null;
+    }
+
+    public class PlainControllerNameOnly
+    {
+        public object Get() => null;
+    }
+}");
+        }
+
+        private struct ListEndpointTokenConsumer : EndpointDetector.IEndpointMethodTokenConsumer
+        {
+            internal ListEndpointTokenConsumer(List<int> tokens)
+            {
+                Tokens = tokens;
+            }
+
+            internal List<int> Tokens { get; }
+
+            public void OnEndpointMethodToken(int token)
+            {
+                Tokens.Add(token);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Reduces allocations and CPU cost in `EndpointDetector` by avoiding metadata string materialization, removing matcher objects/arrays, and using direct metadata handle comparisons.
- Classifies endpoint types with a single base-type walk instead of repeated controller/PageModel/SignalR checks.
- Avoids unnecessary Razor Pages attribute scans by checking handler-shaped method names first.
- Filters special-name methods so property/event accessors are not treated as endpoint candidates.
- Reduces span code-origin sequence-point cache churn by storing only useful PDB entries in a mutable dictionary.

## Reason for change

- Span code origin endpoint detection runs in customer processes during per-assembly PDB cache population, so avoidable allocation and metadata work directly affect first-request latency and GC pressure.
- The previous detector path could allocate heavily by materializing metadata strings and building intermediate endpoint collections.

## Implementation details

- Replaced generic `MetadataName[]` matching with specialized namespace/name predicates using `MetadataReader.StringComparer`.
- Reworked type classification to prefer controller matches while collecting PageModel/SignalR fallback matches during one base-chain walk.
- Kept endpoint enumeration as a struct-consumer API to avoid intermediate collections on the production path.
- Switched `SpanCodeOrigin` endpoint cache storage from `ImmutableDictionary<int, CachedSequencePoint?>` with null entries to `Dictionary<int, CachedSequencePoint>` containing only usable sequence points.
- BenchmarkDotNet results (`net8.0`, Release, short job, 3 iterations):

| Scenario | Before `DetectEndpointMethodTokens` | After `DetectEndpointMethodTokens` |
|---|---:|---:|
| MixedSmall | 8.97 us / 17,720 B | 2.35 us / 0 B |
| NoEndpointsLarge | 128.99 us / 236,680 B | 35.63 us / 0 B |
| ManyPlainTypes | 162.26 us / 319,528 B | 27.63 us / 0 B |
| DeepInheritance | 7.25 ms / 18.82 MB | 1.19 ms / 0 B |
| RazorPagesManyHelpers | 340.61 us / 359,896 B | 132.52 us / 0 B |
| SignalRWithAccessors | 371.42 us / 303,256 B | 46.04 us / 0 B |
| TypeSpecGenericBases | 467.43 us / 1.37 MB | 56.13 us / 0 B |

- Cold probe example: `DeepInheritance` first-call mean allocation dropped from ~18.82 MB to ~1 KB.

Benchmark scenarios:
- `MixedSmall`: realistic small mix of controllers, Razor Pages, SignalR, and generic hubs.
- `NoEndpointsLarge` / `ManyPlainTypes`: large non-endpoint assemblies to measure fast rejection and attribute scan cost.
- `DeepInheritance`: long base-class chains to stress base-type walking.
- `RazorPagesManyHelpers`: PageModels with many helper methods to stress handler filtering.
- `SignalRWithAccessors`: hubs with methods plus property/event accessors to validate special-name filtering.
- `TypeSpecGenericBases`: generic base types like `Hub<T>` and nested wrappers to stress TypeSpecification parsing.


## Test coverage

- `EndpointDetectorTests`