### PR TITLE
Debugger: add upload metadata fields to SymDB upload event message

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
@@ -110,7 +110,7 @@ internal sealed class DebuggerFactory
 
     internal static IDebuggerUploader CreateSymbolsUploader(IDiscoveryService discoveryService, Func<string> serviceNameProvider, TracerSettings tracerSettings, DebuggerSettings settings, IGitMetadataTagsProvider gitMetadataTagsProvider)
     {
-        var symbolBatchApi = DebuggerUploadApiFactory.CreateSymbolsUploadApi(GetApiFactory(tracerSettings, true), discoveryService, gitMetadataTagsProvider, serviceNameProvider, settings.SymbolDatabaseCompressionEnabled);
+        var symbolBatchApi = DebuggerUploadApiFactory.CreateSymbolsUploadApi(GetApiFactory(tracerSettings, true), discoveryService, gitMetadataTagsProvider, settings.SymbolDatabaseCompressionEnabled);
         var symbolsUploader = SymbolsUploader.Create(symbolBatchApi, discoveryService, tracerSettings, settings, serviceNameProvider);
         return symbolsUploader;
     }

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Root.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Root.cs
@@ -4,6 +4,7 @@
 // </copyright>
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
@@ -42,5 +43,16 @@ namespace Datadog.Trace.Debugger.Symbols.Model
 
         [JsonProperty("scopes")]
         internal IReadOnlyList<Scope>? Scopes { get; set; }
+
+        // upload_id/batch_num/final use snake_case to match the rest of the
+        // attachment scope schema (scope_type, source_file, etc.).
+        [JsonProperty("upload_id")]
+        internal Guid? UploadId { get; set; }
+
+        [JsonProperty("batch_num")]
+        internal long? BatchNum { get; set; }
+
+        [JsonProperty("final")]
+        internal bool? Final { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -39,15 +39,22 @@ namespace Datadog.Trace.Debugger.Symbols
         private readonly ImmutableHashSet<string> _symDb3rdPartyExcludes;
         private readonly long _thresholdInBytes;
         private readonly TaskCompletionSource<bool> _processExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly IBatchUploadApi _api;
+        private readonly ISymbolUploadApi _api;
         private readonly object _disposeLock = new();
         private readonly IDiscoveryService _discoveryService;
+
+        // The (uploadId, batchNum) pair groups all batches uploaded by this
+        // uploader instance. The same values are stamped into both the
+        // attachment Root and the EvP event metadata so the backend can
+        // match them up.
+        private readonly Guid _symdbUploadId = Guid.NewGuid();
         private volatile bool _disposed;
         private byte[]? _payload;
         private volatile string? _symDbEndpoint;
+        private long _symdbBatchNum;
 
         private SymbolsUploader(
-            IBatchUploadApi api,
+            ISymbolUploadApi api,
             IDiscoveryService discoveryService,
             DebuggerSettings settings,
             TracerSettings tracerSettings,
@@ -95,7 +102,7 @@ namespace Datadog.Trace.Debugger.Symbols
             }
         }
 
-        public static IDebuggerUploader Create(IBatchUploadApi api, IDiscoveryService discoveryService, TracerSettings tracerSettings, DebuggerSettings settings, Func<string> serviceNameProvider)
+        public static IDebuggerUploader Create(ISymbolUploadApi api, IDiscoveryService discoveryService, TracerSettings tracerSettings, DebuggerSettings settings, Func<string> serviceNameProvider)
         {
             if (!settings.SymbolDatabaseUploadEnabled)
             {
@@ -241,26 +248,25 @@ namespace Datadog.Trace.Debugger.Symbols
 
         private async Task UploadClasses(Root root, IEnumerable<Model.Scope> classes)
         {
-            var rootAsString = JsonHelper.SerializeObject(root);
-            if (!TryBuildPrefixAndSuffix(rootAsString, out var prefix, out var suffix))
-            {
-                // this should not happen unless Root/Scope JSON shape changes
-                Log.Warning("Unable to find insertion point for class scopes in SymDB payload");
-                return;
-            }
-
-            var prefixLength = prefix.Length;
-            var builder = StringBuilderCache.Acquire(prefixLength + (int)_thresholdInBytes + suffix.Length + 16);
-            builder.Append(prefix);
+            // The payload builder is used for the whole upload: each batch
+            // starts by appending a fresh prefix (with a per-batch batch_num),
+            // class scopes are appended directly into it, and on flush we
+            // append ']' + suffix and send.
+            var payloadBuilder = StringBuilderCache.Acquire((int)_thresholdInBytes + 256);
 
             var serializer = JsonSerializer.Create(_jsonSerializerSettings);
             using var pooledWriter = new Utf8CountingPooledTextWriter();
 
-            var accumulatedBytes = 0;
-            var hasAnyClass = false;
-
             try
             {
+                if (!TryStartBatch(root, payloadBuilder, out var suffix, out var batchNum))
+                {
+                    return;
+                }
+
+                var accumulatedBytes = 0;
+                var hasAnyClass = false;
+
                 foreach (var classSymbol in classes)
                 {
                     if (classSymbol == default)
@@ -269,18 +275,24 @@ namespace Datadog.Trace.Debugger.Symbols
                     }
 
                     // Try to serialize and append the class
-                    if (!TrySerializeClass(classSymbol, builder, hasAnyClass, serializer, pooledWriter, accumulatedBytes, out var newByteCount))
+                    if (!TrySerializeClass(classSymbol, payloadBuilder, hasAnyClass, serializer, pooledWriter, accumulatedBytes, out var newByteCount))
                     {
                         // If we couldn't append because it would exceed capacity,
                         // upload current batch first
                         bool succeeded = false;
                         if (hasAnyClass)
                         {
-                            await Upload(builder, prefixLength, suffix).ConfigureAwait(false);
+                            await Flush(payloadBuilder, suffix, batchNum).ConfigureAwait(false);
+                            payloadBuilder.Length = 0;
                             accumulatedBytes = 0;
                             hasAnyClass = false;
-                            // Try again with empty builder
-                            succeeded = TrySerializeClass(classSymbol, builder, hasAnyClass, serializer, pooledWriter, accumulatedBytes, out newByteCount);
+                            if (!TryStartBatch(root, payloadBuilder, out suffix, out batchNum))
+                            {
+                                return;
+                            }
+
+                            // Try again with empty scopes in the new batch
+                            succeeded = TrySerializeClass(classSymbol, payloadBuilder, hasAnyClass, serializer, pooledWriter, accumulatedBytes, out newByteCount);
                         }
 
                         if (!succeeded)
@@ -298,27 +310,49 @@ namespace Datadog.Trace.Debugger.Symbols
                 // Upload any remaining data
                 if (hasAnyClass)
                 {
-                    await Upload(builder, prefixLength, suffix).ConfigureAwait(false);
+                    await Flush(payloadBuilder, suffix, batchNum).ConfigureAwait(false);
                 }
             }
             finally
             {
-                if (builder != null)
-                {
-                    StringBuilderCache.Release(builder);
-                }
+                StringBuilderCache.Release(payloadBuilder);
             }
         }
 
-        private async Task Upload(StringBuilder builder, int prefixLength, string suffix)
+        private bool TryStartBatch(Root root, StringBuilder builder, out string suffix, out long batchNum)
+        {
+            batchNum = Interlocked.Increment(ref _symdbBatchNum);
+            root.UploadId = _symdbUploadId;
+            root.BatchNum = batchNum;
+            root.Final = false;
+            var rootAsString = JsonHelper.SerializeObject(root);
+            if (!TryBuildPrefixAndSuffix(rootAsString, out var prefix, out suffix))
+            {
+                // this should not happen unless Root/Scope JSON shape changes
+                Log.Warning("Unable to find insertion point for class scopes in SymDB payload");
+                return false;
+            }
+
+            builder.Append(prefix);
+            return true;
+        }
+
+        private async Task Flush(StringBuilder builder, string suffix, long batchNum)
         {
             builder.Append(']');
             builder.Append(suffix);
-            await SendSymbol(builder.ToString()).ConfigureAwait(false);
-            builder.Length = prefixLength;
+            var metadata = new SymDbUploadMetadata(
+                Service: _serviceName.Value,
+                Version: _serviceVersion,
+                UploadId: _symdbUploadId,
+                BatchNum: batchNum,
+                // Always false: the .NET tracer continuously uploads new code as
+                // assemblies get loaded; there is no defined end-of-upload point.
+                Final: false);
+            await SendSymbol(builder.ToString(), metadata).ConfigureAwait(false);
         }
 
-        private async Task<bool> SendSymbol(string symbol)
+        private async Task<bool> SendSymbol(string symbol, SymDbUploadMetadata metadata)
         {
             var count = Encoding.UTF8.GetByteCount(symbol);
             if (_payload == null || count > _payload.Length)
@@ -329,7 +363,9 @@ namespace Datadog.Trace.Debugger.Symbols
             Encoding.UTF8.GetBytes(symbol, 0, symbol.Length, _payload, 0);
             try
             {
-                return await _api.SendBatchAsync(new ArraySegment<byte>(_payload, 0, count)).ConfigureAwait(false);
+                return await _api
+                    .SendBatchAsync(new ArraySegment<byte>(_payload, 0, count), metadata)
+                    .ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiFactory.cs
@@ -28,9 +28,9 @@ namespace Datadog.Trace.Debugger.Upload
             return DiagnosticsUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
         }
 
-        internal static IBatchUploadApi CreateSymbolsUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider, Func<string> serviceNameProvider, bool enableCompression)
+        internal static ISymbolUploadApi CreateSymbolsUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider, bool enableCompression)
         {
-            return SymbolUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider, serviceNameProvider, enableCompression);
+            return SymbolUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider, enableCompression);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/ISymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/ISymbolUploadApi.cs
@@ -1,0 +1,16 @@
+// <copyright file="ISymbolUploadApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Debugger.Upload
+{
+    internal interface ISymbolUploadApi : IBatchUploadApi
+    {
+        Task<bool> SendBatchAsync(ArraySegment<byte> symbols, SymDbUploadMetadata metadata);
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymDbUploadMetadata.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymDbUploadMetadata.cs
@@ -1,0 +1,17 @@
+// <copyright file="SymDbUploadMetadata.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+
+namespace Datadog.Trace.Debugger.Upload
+{
+    internal readonly record struct SymDbUploadMetadata(
+        string Service,
+        string? Version,
+        Guid UploadId,
+        long BatchNum,
+        bool Final);
+}

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -7,7 +7,6 @@
 using System;
 using System.IO;
 using System.IO.Compression;
-using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
@@ -21,7 +20,7 @@ using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Debugger.Upload
 {
-    internal sealed class SymbolUploadApi : DebuggerUploadApiBase
+    internal sealed class SymbolUploadApi : DebuggerUploadApiBase, ISymbolUploadApi
     {
         private const int MaxRetries = 3;
         private const int StartingSleepDuration = 3;
@@ -29,19 +28,19 @@ namespace Datadog.Trace.Debugger.Upload
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SymbolUploadApi>();
 
         private readonly IApiRequestFactory _apiRequestFactory;
-        private readonly Lazy<ArraySegment<byte>> _eventMetadata;
+        private readonly string _runtimeId;
         private readonly bool _enableCompression;
 
         private SymbolUploadApi(
             IApiRequestFactory apiRequestFactory,
             IDiscoveryService discoveryService,
             IGitMetadataTagsProvider gitMetadataTagsProvider,
-            Lazy<ArraySegment<byte>> eventMetadata,
+            string runtimeId,
             bool enableCompression)
             : base(apiRequestFactory, gitMetadataTagsProvider)
         {
             _apiRequestFactory = apiRequestFactory;
-            _eventMetadata = eventMetadata;
+            _runtimeId = runtimeId;
             _enableCompression = enableCompression;
             discoveryService.SubscribeToChanges(c =>
             {
@@ -50,25 +49,24 @@ namespace Datadog.Trace.Debugger.Upload
             });
         }
 
-        internal static IBatchUploadApi Create(
+        internal static ISymbolUploadApi Create(
             IApiRequestFactory apiRequestFactory,
             IDiscoveryService discoveryService,
             IGitMetadataTagsProvider gitMetadataTagsProvider,
-            Func<string> serviceNameProvider,
             bool enableCompression)
         {
-            ArraySegment<byte> GetEventMetadataAsArraySegment()
-            {
-                // Capture service name on first use, and keep it fixed for the lifetime of this API instance
-                var serviceName = serviceNameProvider();
-                return CreateEventMetadata(serviceName, Tracer.RuntimeId);
-            }
-
-            var eventMetadata = new Lazy<ArraySegment<byte>>(GetEventMetadataAsArraySegment, LazyThreadSafetyMode.ExecutionAndPublication);
-            return new SymbolUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, eventMetadata, enableCompression);
+            return new SymbolUploadApi(
+                apiRequestFactory,
+                discoveryService,
+                gitMetadataTagsProvider,
+                Tracer.RuntimeId,
+                enableCompression);
         }
 
-        internal static ArraySegment<byte> CreateEventMetadata(string serviceName, string runtimeId)
+        internal static ArraySegment<byte> CreateEventMetadata(
+            SymDbUploadMetadata metadata,
+            string runtimeId,
+            int attachmentSize)
         {
             const int bufferSize = 256;
             using var stream = new MemoryStream(capacity: bufferSize);
@@ -83,13 +81,31 @@ namespace Datadog.Trace.Debugger.Upload
                 jsonWriter.WriteValue(DebuggerTags.DDSource);
 
                 jsonWriter.WritePropertyName("service");
-                jsonWriter.WriteValue(serviceName);
+                jsonWriter.WriteValue(metadata.Service);
+
+                jsonWriter.WritePropertyName("version");
+                jsonWriter.WriteValue(metadata.Version);
+
+                jsonWriter.WritePropertyName("language");
+                jsonWriter.WriteValue("dotnet");
 
                 jsonWriter.WritePropertyName("runtimeId");
                 jsonWriter.WriteValue(runtimeId);
 
                 jsonWriter.WritePropertyName("type");
                 jsonWriter.WriteValue(DebuggerTags.DebuggerType.SymDb);
+
+                jsonWriter.WritePropertyName("uploadId");
+                jsonWriter.WriteValue(metadata.UploadId.ToString());
+
+                jsonWriter.WritePropertyName("batchNum");
+                jsonWriter.WriteValue(metadata.BatchNum);
+
+                jsonWriter.WritePropertyName("final");
+                jsonWriter.WriteValue(metadata.Final);
+
+                jsonWriter.WritePropertyName("attachmentSize");
+                jsonWriter.WriteValue(attachmentSize);
 
                 jsonWriter.WriteEndObject();
                 jsonWriter.Flush();
@@ -101,7 +117,17 @@ namespace Datadog.Trace.Debugger.Upload
                        : new ArraySegment<byte>(stream.ToArray());
         }
 
-        public override async Task<bool> SendBatchAsync(ArraySegment<byte> symbols)
+        public override Task<bool> SendBatchAsync(ArraySegment<byte> symbols)
+        {
+            // SymbolsUploader is the only caller and uses the typed overload
+            // below (so that metadata matches what's stamped into the
+            // attachment Root). The IBatchUploadApi.SendBatchAsync method is
+            // retained for interface compatibility only.
+            throw new NotSupportedException(
+                "Use SendBatchAsync(symbols, metadata) for SymDB uploads.");
+        }
+
+        public async Task<bool> SendBatchAsync(ArraySegment<byte> symbols, SymDbUploadMetadata metadata)
         {
             if (symbols.Array == null || symbols.Count == 0)
             {
@@ -121,10 +147,12 @@ namespace Datadog.Trace.Debugger.Upload
             var sleepDuration = StartingSleepDuration;
 
             MultipartFormItem symbolsItem;
+            ArraySegment<byte> attachmentBytes;
 
             if (!_enableCompression)
             {
-                symbolsItem = new MultipartFormItem("file", MimeTypes.Json, "file.json", symbols);
+                attachmentBytes = symbols;
+                symbolsItem = new MultipartFormItem("file", MimeTypes.Json, "file.json", attachmentBytes);
             }
             else
             {
@@ -134,10 +162,15 @@ namespace Datadog.Trace.Debugger.Upload
                     return false;
                 }
 
-                symbolsItem = new MultipartFormItem("file", MimeTypes.Gzip, "file.gz", compressedSymbols.Value);
+                attachmentBytes = compressedSymbols.Value;
+                symbolsItem = new MultipartFormItem("file", MimeTypes.Gzip, "file.gz", attachmentBytes);
             }
 
-            var items = new[] { symbolsItem, new MultipartFormItem("event", MimeTypes.Json, "event.json", _eventMetadata.Value) };
+            var eventMetadata = CreateEventMetadata(
+                metadata,
+                _runtimeId,
+                attachmentBytes.Count);
+            var items = new[] { symbolsItem, new MultipartFormItem("event", MimeTypes.Json, "event.json", eventMetadata) };
 
             while (retries < MaxRetries)
             {

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -88,7 +88,7 @@ namespace Datadog.Trace.Debugger.Upload
                 jsonWriter.WritePropertyName("runtimeId");
                 jsonWriter.WriteValue(runtimeId);
 
-                jsonWriter.WritePropertyName("debugger.type");
+                jsonWriter.WritePropertyName("type");
                 jsonWriter.WriteValue(DebuggerTags.DebuggerType.SymDb);
 
                 jsonWriter.WriteEndObject();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -5,10 +5,10 @@
 
 #nullable enable
 
-using System.Collections.Generic;
+using System;
 using System.Text;
 using Datadog.Trace.Debugger.Upload;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Debugger.SymbolsTests;
@@ -16,21 +16,36 @@ namespace Datadog.Trace.Tests.Debugger.SymbolsTests;
 public class SymbolUploadApiTests
 {
     [Fact]
-    public void EventMetadata_IsValidJson_AndDebuggerTypeIsQuoted()
+    public void EventMetadata_IsValidJson_AndContainsAllFields()
     {
         // Include quotes to ensure proper JSON escaping/quoting
         const string serviceName = "test\"service";
+        const string version = "1.0.0";
         const string runtimeId = "runtime-id";
+        var uploadId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        const long batchNum = 7;
+        const int attachmentSize = 12345;
 
-        var bytes = SymbolUploadApi.CreateEventMetadata(serviceName, runtimeId);
+        var metadata = new SymDbUploadMetadata(
+            Service: serviceName,
+            Version: version,
+            UploadId: uploadId,
+            BatchNum: batchNum,
+            Final: false);
+        var bytes = SymbolUploadApi.CreateEventMetadata(metadata, runtimeId, attachmentSize);
         var json = Encoding.UTF8.GetString(bytes.Array!, bytes.Offset, bytes.Count);
 
-        var dict = JsonConvert.DeserializeObject<Dictionary<string, object?>>(json);
+        var jobj = JObject.Parse(json);
 
-        Assert.NotNull(dict);
-        Assert.Equal("dd_debugger", dict!["ddsource"]);
-        Assert.Equal(serviceName, dict["service"]);
-        Assert.Equal(runtimeId, dict["runtimeId"]);
-        Assert.Equal("symdb", dict["type"]);
+        Assert.Equal("dd_debugger", (string?)jobj["ddsource"]);
+        Assert.Equal(serviceName, (string?)jobj["service"]);
+        Assert.Equal(version, (string?)jobj["version"]);
+        Assert.Equal("dotnet", (string?)jobj["language"]);
+        Assert.Equal(runtimeId, (string?)jobj["runtimeId"]);
+        Assert.Equal("symdb", (string?)jobj["type"]);
+        Assert.Equal(uploadId.ToString(), (string?)jobj["uploadId"]);
+        Assert.Equal(batchNum, (long?)jobj["batchNum"]);
+        Assert.Equal(false, (bool?)jobj["final"]);
+        Assert.Equal(attachmentSize, (int?)jobj["attachmentSize"]);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -31,6 +31,6 @@ public class SymbolUploadApiTests
         Assert.Equal("dd_debugger", dict!["ddsource"]);
         Assert.Equal(serviceName, dict["service"]);
         Assert.Equal(runtimeId, dict["runtimeId"]);
-        Assert.Equal("symdb", dict["debugger.type"]);
+        Assert.Equal("symdb", dict["type"]);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
@@ -150,11 +150,17 @@ public class SymbolUploaderTest
         return (root, scopes);
     }
 
-    private class MockBatchUploadApi : IBatchUploadApi
+    private class MockBatchUploadApi : ISymbolUploadApi
     {
         public List<byte[]> Segments { get; } = new();
 
         public Task<bool> SendBatchAsync(ArraySegment<byte> symbols)
+        {
+            Segments.Add(symbols.ToArray());
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> SendBatchAsync(ArraySegment<byte> symbols, SymDbUploadMetadata metadata)
         {
             Segments.Add(symbols.ToArray());
             return Task.FromResult(true);


### PR DESCRIPTION
Add the following fields to the SymDB upload event message that
accompanies each multipart upload (camelCase, matching the rest of
the EvP event schema):

- "version" (top-level): the service version
- "language" (top-level): "dotnet"
- "uploadId" (top-level): a UUID generated once per SymbolsUploader
  instance, shared by all batches uploaded by the instance
- "batchNum" (top-level): 1-indexed counter incremented per upload
- "final" (top-level): always false; the .NET tracer continuously
  uploads new code as assemblies get loaded, so there is no defined
  end-of-upload point
- "attachmentSize" (top-level): size in bytes of the (compressed)
  attachment payload

Also add the same metadata to the gzipped attachment Root
(snake_case to match the rest of the attachment scope schema):

- "upload_id"
- "batch_num"
- "final"

uploadId/batchNum are computed in SymbolsUploader once per batch
(rebuilding the JSON prefix per batch) and threaded into
SymbolUploadApi.SendBatchAsync so both the attachment and the event
JSON carry the same values. SymbolUploadApi no longer tracks its own
batch counter.

Some of these fields are new, to be used by the backend in the future.
Others duplicate info that was already included in the attachment; by
duplicating some metadata out of the SymDB attachment body into the EvP
event body, the backend can populate per-attachment bookkeeping without
downloading the attachment.