### PR TITLE
[Code Origin] Improve ASP.NET Core code origin endpoint detection

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/EndpointDetector.cs
@@ -375,13 +375,15 @@ internal static class EndpointDetector
 
             case KnownNameSet.ActionAttribute:
                 return (comparer.Equals(namespaceHandle, MvcNamespace) &&
-                        (comparer.Equals(nameHandle, "HttpGetAttribute") ||
+                        (comparer.Equals(nameHandle, "AcceptVerbsAttribute") ||
+                         comparer.Equals(nameHandle, "HttpGetAttribute") ||
                          comparer.Equals(nameHandle, "HttpPostAttribute") ||
                          comparer.Equals(nameHandle, "HttpPutAttribute") ||
                          comparer.Equals(nameHandle, "HttpDeleteAttribute") ||
                          comparer.Equals(nameHandle, "HttpPatchAttribute") ||
                          comparer.Equals(nameHandle, "HttpHeadAttribute") ||
-                         comparer.Equals(nameHandle, "HttpOptionsAttribute"))) ||
+                         comparer.Equals(nameHandle, "HttpOptionsAttribute") ||
+                         comparer.Equals(nameHandle, "RouteAttribute"))) ||
                        (comparer.Equals(namespaceHandle, MvcRoutingNamespace) &&
                         comparer.Equals(nameHandle, "HttpMethodAttribute"));
 

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -92,6 +92,11 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             AddEntrySpanTags(span, type, method);
         }
 
+        internal bool HasCodeOrigin(Span? span)
+        {
+            return span?.GetTag(_tags.Type) != null;
+        }
+
         private void AddEntrySpanTags(Span span, Type type, MethodInfo method)
         {
             try

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -444,8 +444,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnRoutingEndpointMatched(object arg)
         {
-            if (!_tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId) ||
-                !_tracer.Settings.RouteTemplateResourceNamesEnabled)
+            if (!_tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 return;
             }
@@ -454,14 +453,10 @@ namespace Datadog.Trace.DiagnosticListeners
              && typedArg.HttpContext is { } httpContext
              && httpContext.Items[AspNetCoreHttpRequestHandler.HttpContextTrackingKey] is AspNetCoreHttpRequestHandler.RequestTrackingFeature { RootScope.Span: { } rootSpan } trackingFeature)
             {
-                if (rootSpan.Tags is not AspNetCoreEndpointTags tags)
-                {
-                    // customer is using legacy resource names
-                    return;
-                }
-
+                var routeTemplateResourceNamesEnabled = _tracer.Settings.RouteTemplateResourceNamesEnabled;
                 var isFirstExecution = trackingFeature.IsFirstPipelineExecution;
-                if (isFirstExecution)
+                // Only modify tracking feature if _not_ using legacy feature names
+                if (isFirstExecution && routeTemplateResourceNamesEnabled)
                 {
                     trackingFeature.IsUsingEndpointRouting = true;
                     trackingFeature.IsFirstPipelineExecution = false;
@@ -512,22 +507,28 @@ namespace Datadog.Trace.DiagnosticListeners
                     return;
                 }
 
-                if (CurrentCodeOrigin is { Settings.CodeOriginForSpansEnabled: true })
+                var codeOrigin = CurrentCodeOrigin;
+                var isCodeOriginEnabled = codeOrigin is { Settings.CodeOriginForSpansEnabled: true };
+
+                if (isCodeOriginEnabled &&
+                    AspNetCoreEndpointCodeOrigin.TryGetTypeAndMethod(routeEndpoint.Value, out var endpointType, out var endpointMethod))
                 {
-                    var method = routeEndpoint?.RequestDelegate?.Method;
-                    if (method != null)
-                    {
-                        CurrentCodeOrigin?.SetCodeOriginForEntrySpan(rootSpan, routeEndpoint?.RequestDelegate?.Target?.GetType() ?? method.DeclaringType, method);
-                    }
-                    else if (routeEndpoint?.RequestDelegate?.TryDuckCast<Target>(out var target) == true && target is { Handler: { } handler })
-                    {
-                        Log.Debug("RouteEndpoint?.RequestDelegate?.Method is null. Extracting code origin from RouteEndpoint.RequestDelegate.Target.Handler {Handler}", handler);
-                        CurrentCodeOrigin?.SetCodeOriginForEntrySpan(rootSpan, handler.Target?.GetType(), handler.Method);
-                    }
-                    else
-                    {
-                        Log.Debug("RouteEndpoint?.RequestDelegate?.Method is null and could not extract handler from RouteEndpoint.RequestDelegate.Target");
-                    }
+                    codeOrigin.SetCodeOriginForEntrySpan(rootSpan, endpointType, endpointMethod);
+                }
+                else if (isCodeOriginEnabled)
+                {
+                    Log.Debug("Could not extract type and method for endpoint code origin. Endpoint: {EndpointDisplayName}", routeEndpoint.Value.DisplayName);
+                }
+
+                if (!routeTemplateResourceNamesEnabled)
+                {
+                    return;
+                }
+
+                if (rootSpan.Tags is not AspNetCoreEndpointTags tags)
+                {
+                    // customer is using legacy resource names
+                    return;
                 }
 
                 if (isFirstExecution)
@@ -621,20 +622,20 @@ namespace Datadog.Trace.DiagnosticListeners
                     }
                 }
 
+                if (isCodeOriginEnabled)
+                {
+                    if (TryGetTypeAndMethod(typedArg, out var type, out var method))
+                    {
+                        CurrentCodeOrigin?.SetCodeOriginForEntrySpan(rootSpan, type, method);
+                    }
+                    else
+                    {
+                        Log.Debug("Could not extract type and method from {ActionDescriptor}", typedArg.ActionDescriptor?.DisplayName);
+                    }
+                }
+
                 if (span is not null)
                 {
-                    if (isCodeOriginEnabled)
-                    {
-                        if (TryGetTypeAndMethod(typedArg, out var type, out var method))
-                        {
-                            CurrentCodeOrigin?.SetCodeOriginForEntrySpan(rootSpan, type, method);
-                        }
-                        else
-                        {
-                            Log.Debug("Could not extract type and method from {ActionDescriptor}", typedArg.ActionDescriptor?.DisplayName);
-                        }
-                    }
-
                     _security.CheckPathParamsFromAction(httpContext, span, typedArg.ActionDescriptor?.Parameters, typedArg.RouteData.Values);
                 }
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -593,7 +593,8 @@ namespace Datadog.Trace.DiagnosticListeners
             var integrationEnabled = _tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId);
             var appsecEnabled = _security.AppsecEnabled;
             var iastEnabled = _iast.Settings.Enabled;
-            var isCodeOriginEnabled = CurrentCodeOrigin is { Settings.CodeOriginForSpansEnabled: true };
+            var codeOrigin = CurrentCodeOrigin;
+            var isCodeOriginEnabled = codeOrigin is { Settings.CodeOriginForSpansEnabled: true };
 
             if (!integrationEnabled && !appsecEnabled && !iastEnabled && !isCodeOriginEnabled)
             {
@@ -622,11 +623,11 @@ namespace Datadog.Trace.DiagnosticListeners
                     }
                 }
 
-                if (isCodeOriginEnabled)
+                if (isCodeOriginEnabled && !codeOrigin.HasCodeOrigin(rootSpan))
                 {
                     if (TryGetTypeAndMethod(typedArg, out var type, out var method))
                     {
-                        CurrentCodeOrigin?.SetCodeOriginForEntrySpan(rootSpan, type, method);
+                        codeOrigin.SetCodeOriginForEntrySpan(rootSpan, type, method);
                     }
                     else
                     {

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreEndpointCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreEndpointCodeOrigin.cs
@@ -1,0 +1,69 @@
+// <copyright file="AspNetCoreEndpointCodeOrigin.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.DiagnosticListeners;
+
+internal static class AspNetCoreEndpointCodeOrigin
+{
+    internal static bool TryGetTypeAndMethod(RouteEndpoint routeEndpoint, [NotNullWhen(true)] out Type? type, [NotNullWhen(true)] out MethodInfo? method)
+    {
+        type = null;
+        method = null;
+
+        // Fast path: use RequestDelegate.Method and prefer the delegate target type if available.
+        var requestDelegate = routeEndpoint.RequestDelegate;
+        var delegateMethod = requestDelegate?.Method;
+        if (delegateMethod is not null)
+        {
+            var candidate = requestDelegate?.Target?.GetType() ?? delegateMethod.DeclaringType ?? delegateMethod.ReflectedType;
+            if (candidate is not null)
+            {
+                type = candidate;
+                method = delegateMethod;
+                return true;
+            }
+        }
+
+        // Fallback: minimal API/internal shapes (RequestDelegate.Target.handler)
+        if (requestDelegate?.Target is { } requestDelegateTarget &&
+            TryGetHandlerFromRequestDelegateTarget(requestDelegateTarget, out var handler) &&
+            handler.Method is { } handlerMethod)
+        {
+            var candidate = handler.Target?.GetType() ?? handlerMethod.DeclaringType ?? handlerMethod.ReflectedType;
+            if (candidate is not null)
+            {
+                type = candidate;
+                method = handlerMethod;
+                return true;
+            }
+        }
+
+        // We can consider adding additional fallbacks here
+        // (e.g., endpoint metadata scan and/or a carefully bounded reflection-based fallback).
+
+        return false;
+    }
+
+    private static bool TryGetHandlerFromRequestDelegateTarget(object requestDelegateTarget, [NotNullWhen(true)] out Delegate? handler)
+    {
+        handler = null;
+
+        // Common shape: field "handler"
+        if (requestDelegateTarget.TryDuckCast<Target>(out var target) && target.Handler is { } h1)
+        {
+            handler = h1;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreEndpointCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreEndpointCodeOrigin.cs
@@ -35,7 +35,8 @@ internal static class AspNetCoreEndpointCodeOrigin
 
         // Fallback: minimal API/internal shapes (RequestDelegate.Target.handler)
         if (requestDelegate?.Target is { } requestDelegateTarget &&
-            TryGetHandlerFromRequestDelegateTarget(requestDelegateTarget, out var handler) &&
+            requestDelegateTarget.TryDuckCast<Target>(out var target) &&
+            target.Handler is { } handler &&
             handler.Method is { } handlerMethod)
         {
             var candidate = handler.Target?.GetType() ?? handlerMethod.DeclaringType ?? handlerMethod.ReflectedType;
@@ -49,20 +50,6 @@ internal static class AspNetCoreEndpointCodeOrigin
 
         // We can consider adding additional fallbacks here
         // (e.g., endpoint metadata scan and/or a carefully bounded reflection-based fallback).
-
-        return false;
-    }
-
-    private static bool TryGetHandlerFromRequestDelegateTarget(object requestDelegateTarget, [NotNullWhen(true)] out Delegate? handler)
-    {
-        handler = null;
-
-        // Common shape: field "handler"
-        if (requestDelegateTarget.TryDuckCast<Target>(out var target) && target.Handler is { } h1)
-        {
-            handler = h1;
-            return true;
-        }
 
         return false;
     }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/SingleSpanAspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/SingleSpanAspNetCoreDiagnosticObserver.cs
@@ -233,19 +233,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 if (CurrentCodeOrigin is { Settings.CodeOriginForSpansEnabled: true } codeOrigin)
                 {
-                    var method = routeEndpoint.Value.RequestDelegate?.Method;
-                    if (method != null)
+                    if (AspNetCoreEndpointCodeOrigin.TryGetTypeAndMethod(routeEndpoint.Value, out var type, out var method))
                     {
-                        codeOrigin.SetCodeOriginForEntrySpan(rootSpan, routeEndpoint.Value.RequestDelegate?.Target?.GetType() ?? method.DeclaringType, method);
-                    }
-                    else if (routeEndpoint.Value.RequestDelegate?.TryDuckCast<Target>(out var target) == true && target is { Handler: { } handler })
-                    {
-                        Log.Debug("RouteEndpoint?.RequestDelegate?.Method is null. Extracting code origin from RouteEndpoint.RequestDelegate.Target.Handler {Handler}", handler);
-                        codeOrigin.SetCodeOriginForEntrySpan(rootSpan, handler.Target?.GetType(), handler.Method);
+                        codeOrigin.SetCodeOriginForEntrySpan(rootSpan, type, method);
                     }
                     else
                     {
-                        Log.Debug("RouteEndpoint?.RequestDelegate?.Method is null and could not extract handler from RouteEndpoint.RequestDelegate.Target");
+                        Log.Debug("Could not extract type and method for endpoint code origin. Endpoint: {EndpointDisplayName}", routeEndpoint.Value.DisplayName);
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/SingleSpanAspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/SingleSpanAspNetCoreDiagnosticObserver.cs
@@ -288,7 +288,8 @@ namespace Datadog.Trace.DiagnosticListeners
         {
             var appsecEnabled = _security.AppsecEnabled;
             var iastEnabled = _iast.Settings.Enabled;
-            var isCodeOriginEnabled = CurrentCodeOrigin is { Settings.CodeOriginForSpansEnabled: true };
+            var codeOrigin = CurrentCodeOrigin;
+            var isCodeOriginEnabled = codeOrigin is { Settings.CodeOriginForSpansEnabled: true };
 
             if (!appsecEnabled && !iastEnabled && !isCodeOriginEnabled)
             {
@@ -299,11 +300,11 @@ namespace Datadog.Trace.DiagnosticListeners
              && typedArg.HttpContext is { } httpContext
              && httpContext.Items[AspNetCoreHttpRequestHandler.HttpContextTrackingKey] is AspNetCoreHttpRequestHandler.SingleSpanRequestTrackingFeature { RootScope.Span: { } rootSpan })
             {
-                if (isCodeOriginEnabled)
+                if (isCodeOriginEnabled && !codeOrigin!.HasCodeOrigin(rootSpan))
                 {
                     if (AspNetCoreDiagnosticObserver.TryGetTypeAndMethod(typedArg, out var type, out var method))
                     {
-                        CurrentCodeOrigin!.SetCodeOriginForEntrySpan(rootSpan, type, method);
+                        codeOrigin.SetCodeOriginForEntrySpan(rootSpan, type, method);
                     }
                     else
                     {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/EndpointDetectorTests.cs
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Tests.Debugger
 
                     // Controller with HTTP methods
                     else if (type.Name == "HttpMethodController" &&
-                            method.Name is "Get" or "Post" or "Put" or "Delete" or "Patch" or "Head" or "Options" or "Custom")
+                            method.Name is "Get" or "Post" or "Put" or "Delete" or "Patch" or "Head" or "Options" or "Custom" or "AcceptVerbs" or "RouteOnly")
                     {
                         isExpectedEndpoint = true;
                     }
@@ -249,6 +249,24 @@ namespace Datadog.Trace.Tests.Debugger
             getMethod.Should().NotBeNull();
 
             endpointTokens.Should().Contain(getMethod.MetadataToken, "the inherited [ApiController] on the base type must be discovered by the chain walk");
+        }
+
+        [Theory]
+        [InlineData("AcceptVerbs")]
+        [InlineData("RouteOnly")]
+        public void GetEndpointMethodTokens_DetectsAdditionalMvcActionAttributes(string methodName)
+        {
+            // Act
+            var endpointTokens = GetEndpointMethodTokens(_assemblyPath);
+
+            // Assert
+            var controller = _assembly.GetType("EndpointDetectorTestNamespace.HttpMethodController");
+            controller.Should().NotBeNull();
+
+            var method = controller.GetMethod(methodName);
+            method.Should().NotBeNull();
+
+            endpointTokens.Should().Contain(method.MetadataToken, "[AcceptVerbs] and method-level [Route] should identify MVC controller actions");
         }
 
         [Fact]
@@ -459,6 +477,12 @@ namespace Microsoft.AspNetCore.Mvc
     }
 
     [AttributeUsage(AttributeTargets.Method)]
+    public class AcceptVerbsAttribute : Attribute
+    {
+        public AcceptVerbsAttribute(params string[] verbs) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
     public class HttpGetAttribute : Attribute 
     {
         public HttpGetAttribute() { }
@@ -629,6 +653,12 @@ namespace EndpointDetectorTestNamespace
 
         [Microsoft.AspNetCore.Mvc.Routing.HttpMethodAttribute]
         public object Custom() => null;
+
+        [Microsoft.AspNetCore.Mvc.AcceptVerbs(""GET"", ""POST"")]
+        public object AcceptVerbs() => null;
+
+        [Microsoft.AspNetCore.Mvc.Route(""route-only"")]
+        public object RouteOnly() => null;
     }
 
     // PageModel with handler methods

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SpanCodeOriginTests.cs
@@ -90,6 +90,22 @@ namespace Datadog.Trace.Tests.Debugger
             }
 
             [Fact]
+            public void HasCodeOrigin_ReturnsWhetherSpanHasCodeOriginTags()
+            {
+                // Arrange
+                SpanCodeOrigin spanCodeOrigin = CreateSpanCodeOrigin();
+                var span = CreateSpan();
+
+                // Act / Assert
+                spanCodeOrigin.HasCodeOrigin(null).Should().BeFalse();
+                spanCodeOrigin.HasCodeOrigin(span).Should().BeFalse();
+
+                span.SetTag($"{CodeOriginTag}.type", "existing");
+
+                spanCodeOrigin.HasCodeOrigin(span).Should().BeTrue();
+            }
+
+            [Fact]
             public void SetCodeOriginForEntrySpan_WithValidInputs_ShouldSetCorrectTags()
             {
                 // Arrange

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -109,6 +109,71 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
 
 #if NET6_0_OR_GREATER
         [Fact]
+        public void AspNetCoreEndpointCodeOrigin_ExtractsTypeAndMethodFromRequestDelegate()
+        {
+            // Arrange
+            var target = new EndpointHandlerTarget();
+            var expectedMethod = typeof(EndpointHandlerTarget).GetMethod(nameof(EndpointHandlerTarget.Handle));
+            var routeEndpoint = new RouteEndpoint
+            {
+                RequestDelegate = new Datadog.Trace.DiagnosticListeners.RequestDelegate
+                {
+                    Method = expectedMethod,
+                    Target = target
+                }
+            };
+
+            // Act
+            var success = AspNetCoreEndpointCodeOrigin.TryGetTypeAndMethod(routeEndpoint, out var type, out var method);
+
+            // Assert
+            success.Should().BeTrue();
+            type.Should().Be(typeof(EndpointHandlerTarget));
+            method.Should().BeSameAs(expectedMethod);
+        }
+
+        [Fact]
+        public void AspNetCoreEndpointCodeOrigin_ExtractsTypeAndMethodFromRequestDelegateTargetHandler()
+        {
+            // Arrange
+            var handlerTarget = new EndpointHandlerTarget();
+            var expectedMethod = typeof(EndpointHandlerTarget).GetMethod(nameof(EndpointHandlerTarget.Handle));
+            var routeEndpoint = new RouteEndpoint
+            {
+                RequestDelegate = new Datadog.Trace.DiagnosticListeners.RequestDelegate
+                {
+                    Target = new RequestDelegateTarget(handlerTarget.Handle)
+                }
+            };
+
+            // Act
+            var success = AspNetCoreEndpointCodeOrigin.TryGetTypeAndMethod(routeEndpoint, out var type, out var method);
+
+            // Assert
+            success.Should().BeTrue();
+            type.Should().Be(typeof(EndpointHandlerTarget));
+            method.Should().BeSameAs(expectedMethod);
+        }
+
+        [Fact]
+        public void AspNetCoreEndpointCodeOrigin_ReturnsFalseWhenEndpointHasNoHandler()
+        {
+            // Arrange
+            var routeEndpoint = new RouteEndpoint
+            {
+                RequestDelegate = new Datadog.Trace.DiagnosticListeners.RequestDelegate()
+            };
+
+            // Act
+            var success = AspNetCoreEndpointCodeOrigin.TryGetTypeAndMethod(routeEndpoint, out var type, out var method);
+
+            // Assert
+            success.Should().BeFalse();
+            type.Should().BeNull();
+            method.Should().BeNull();
+        }
+
+        [Fact]
         public async Task CompleteSingleSpanDiagnosticObserverTest()
         {
             await using var tracer = GetTracer();
@@ -253,6 +318,30 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
                 builder.UseMvcWithDefaultRoute();
             }
         }
+
+#if NET6_0_OR_GREATER
+        private class EndpointHandlerTarget
+        {
+            public Task Handle(HttpContext context)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        private class RequestDelegateTarget
+        {
+#pragma warning disable SA1401 // Fields should be private
+#pragma warning disable SA1307 // Accessible fields should begin with upper-case letter
+            public readonly Delegate handler;
+#pragma warning restore SA1307 // Accessible fields should begin with upper-case letter
+#pragma warning restore SA1401 // Fields should be private
+
+            public RequestDelegateTarget(Delegate handler)
+            {
+                this.handler = handler;
+            }
+        }
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary of changes

- Improves ASP.NET Core code origin extraction for endpoint routing spans.
- Adds a shared `AspNetCoreEndpointCodeOrigin` helper used by both ASP.NET Core diagnostic observers.
- Allows endpoint detection to recognize MVC actions decorated with `[AcceptVerbs]` or method-level `[Route]`.
- Adds focused unit coverage for endpoint detector behavior and endpoint code-origin extraction paths.

## Reason for change

- Some ASP.NET Core endpoints did not get code origin metadata when the route endpoint method.
- MVC actions using `[AcceptVerbs]` or method-level `[Route]` were missing from endpoint method detection.

## Implementation details

- Centralizes route endpoint type/method extraction so both single-span and non-single-span ASP.NET Core observers use the same behavior.
- Preserves the existing `RequestDelegate.Method` path and adds the reviewed fallback through `RequestDelegate.Target.handler`.
- Updates `EndpointDetector` to match `AcceptVerbsAttribute` and `RouteAttribute`.

## Test coverage

- `AspNetCoreDiagnosticObserverTests`