### PR TITLE
[ASM Test] Add IIS CI coverage for WebApi null-action ASM test

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
@@ -132,6 +132,8 @@ namespace Datadog.Trace.Security.IntegrationTests
         }
 
         [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         public async Task TestNullAction()
         {
             // test integrations like ReflectedHttpActionDescriptor_ExecuteAsync_Integration and ControllerActionInvoker_InvokeAction_Integration dont crash

--- a/tracer/test/snapshots/Security.AspNetWebApi.Classic.enableSecurity=False.__scenario=null-action.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApi.Classic.enableSecurity=False.__scenario=null-action.verified.txt
@@ -9,6 +9,7 @@
     ParentId: Id_3,
     Tags: {
       aspnet.route: api/home/null-action/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -27,6 +28,7 @@
     Service: sample,
     Type: web,
     Tags: {
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -55,6 +57,7 @@
     ParentId: Id_6,
     Tags: {
       aspnet.route: api/home/null-action-async/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -73,6 +76,7 @@
     Service: sample,
     Type: web,
     Tags: {
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,

--- a/tracer/test/snapshots/Security.AspNetWebApi.Classic.enableSecurity=True.__scenario=null-action.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApi.Classic.enableSecurity=True.__scenario=null-action.verified.txt
@@ -9,6 +9,7 @@
     ParentId: Id_3,
     Tags: {
       aspnet.route: api/home/null-action/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -30,6 +31,7 @@
     Tags: {
       actor.ip: 86.242.244.246,
       appsec.event: true,
+      component: aspnet,
       env: integration_tests,
       http.client_ip: 127.0.0.1,
       http.method: GET,
@@ -71,6 +73,7 @@
     ParentId: Id_6,
     Tags: {
       aspnet.route: api/home/null-action-async/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -92,6 +95,7 @@
     Tags: {
       actor.ip: 86.242.244.246,
       appsec.event: true,
+      component: aspnet,
       env: integration_tests,
       http.client_ip: 127.0.0.1,
       http.method: GET,

--- a/tracer/test/snapshots/Security.AspNetWebApi.Integrated.enableSecurity=False.__scenario=null-action.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApi.Integrated.enableSecurity=False.__scenario=null-action.verified.txt
@@ -9,6 +9,7 @@
     ParentId: Id_3,
     Tags: {
       aspnet.route: api/home/null-action/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -27,6 +28,7 @@
     Service: sample,
     Type: web,
     Tags: {
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -55,6 +57,7 @@
     ParentId: Id_6,
     Tags: {
       aspnet.route: api/home/null-action-async/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -73,6 +76,7 @@
     Service: sample,
     Type: web,
     Tags: {
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,

--- a/tracer/test/snapshots/Security.AspNetWebApi.Integrated.enableSecurity=True.__scenario=null-action.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebApi.Integrated.enableSecurity=True.__scenario=null-action.verified.txt
@@ -9,6 +9,7 @@
     ParentId: Id_3,
     Tags: {
       aspnet.route: api/home/null-action/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -30,6 +31,7 @@
     Tags: {
       actor.ip: 86.242.244.246,
       appsec.event: true,
+      component: aspnet,
       env: integration_tests,
       http.client_ip: 127.0.0.1,
       http.method: GET,
@@ -72,6 +74,7 @@
     ParentId: Id_6,
     Tags: {
       aspnet.route: api/home/null-action-async/{pathparam}/{pathparam2},
+      component: aspnet,
       env: integration_tests,
       http.method: GET,
       http.request.headers.host: localhost:00000,
@@ -93,6 +96,7 @@
     Tags: {
       actor.ip: 86.242.244.246,
       appsec.event: true,
+      component: aspnet,
       env: integration_tests,
       http.client_ip: 127.0.0.1,
       http.method: GET,


### PR DESCRIPTION
## Summary of changes

- Adds the missing `RunOnWindows=True` and `LoadFromGAC=True` traits to `AspNetWebApi.TestNullAction`.
- Ensures the null-action WebApi ASM test is included by the Windows IIS AppSec CI filter.
- Updates the affected null-action snapshots for the current ASP.NET `component: aspnet` tag output.

## Reason for change

- `AspNetWebApi.TestNullAction` was not exercised by the IIS AppSec CI jobs, so snapshot changes could be missed by PR CI.
- Covering this test in IIS CI keeps local focused runs and CI validation aligned.

## Implementation details

- The trait additions match the neighboring IIS WebApi ASM tests in `AspNetWebApi.cs`.
- Snapshot updates cover classic/integrated IIS modes with security enabled and disabled.
- No shared IIS harness workaround changes are included.

## Test coverage

- `AspNetWebApi.TestNullAction`