### PR TITLE
Skip sending errors to instrumentation telemetry for performance counter initialization

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.RuntimeMetrics
             // That's because performance counters may rely on wmiApSrv being started,
             // and the windows service manager only allows one service at a time to be starting: https://docs.microsoft.com/en-us/windows/win32/services/service-startup
             _initializationTask = Task.Run(InitializePerformanceCounters);
-            _initializationTask.ContinueWith(t => Log.Error(t.Exception, "Error in performance counter initialization task"), TaskContinuationOptions.OnlyOnFaulted);
+            _initializationTask.ContinueWith(t => Log.ErrorSkipTelemetry(t.Exception, "Error in performance counter initialization task"), TaskContinuationOptions.OnlyOnFaulted);
         }
 
         public Task WaitForInitialization() => _initializationTask;


### PR DESCRIPTION
## Summary of changes

Skip sending errors to instrumentation telemetry for performance counter initialization

## Reason for change

We were already skipping logging these errors inside `InitializePerformanceCounters`, but after logging, these known failure paths call `throw`, which then gets caught and re-logged with a more generic error. There's little value in sending this to telemetry, because this is an app-level permissions issue that we can't resolve directly.

## Implementation details

`Error` -> `ErrorSkipTelemetry`

## Test coverage

meh

## Other details

[Error Tracking](https://app.datadoghq.com/error-tracking/issue/fcc3135c-3adf-11f0-a4d5-da7ad0900002)