### PR TITLE
Refactor `DiscoveryService` polling loop to allow less-flaky testing

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
         private readonly Task _discoveryTask;
         private readonly IDisposable? _settingSubscription;
         private readonly ServiceRemappingHash _serviceRemappingHash;
-        private IApiRequestFactory _apiRequestFactory;
+        private ApiFactoryHolder _apiRequestFactory;
         private AgentConfiguration? _configuration;
         private string? _configurationHash;
         private string _agentConfigStateHash = string.Empty;
@@ -70,29 +70,35 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 if (changes.UpdatedExporter is { } exporter)
                 {
                     var newFactory = CreateApiRequestFactory(exporter, containerMetadata.ContainerId, tcpTimeout);
-                    Interlocked.Exchange(ref _apiRequestFactory!, newFactory);
+                    Interlocked.Exchange(ref _apiRequestFactory!, new(newFactory));
                 }
             });
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DiscoveryService"/> class.
-        /// Public for testing purposes
-        /// </summary>
-        public DiscoveryService(
+        [TestingAndPrivateOnly]
+        internal DiscoveryService(
             IApiRequestFactory apiRequestFactory,
             ServiceRemappingHash serviceRemappingHash,
             int initialRetryDelayMs,
             int maxRetryDelayMs,
-            int recheckIntervalMs)
+            int recheckIntervalMs,
+            bool autoStartLoop = true)
         {
-            _apiRequestFactory = apiRequestFactory;
+            _apiRequestFactory = new(apiRequestFactory);
             _serviceRemappingHash = serviceRemappingHash;
             _initialRetryDelayMs = initialRetryDelayMs;
             _maxRetryDelayMs = maxRetryDelayMs;
             _recheckIntervalMs = recheckIntervalMs;
-            _discoveryTask = Task.Run(FetchConfigurationLoopAsync);
-            _discoveryTask.ContinueWith(t => Log.Error(t.Exception, "Error in discovery task"), TaskContinuationOptions.OnlyOnFaulted);
+
+            if (autoStartLoop)
+            {
+                _discoveryTask = Task.Run(FetchConfigurationLoopAsync);
+                _discoveryTask.ContinueWith(t => Log.Error(t.Exception, "Error in discovery task"), TaskContinuationOptions.OnlyOnFaulted);
+            }
+            else
+            {
+                _discoveryTask = Task.CompletedTask;
+            }
         }
 
         /// <summary>
@@ -230,54 +236,56 @@ namespace Datadog.Trace.Agent.DiscoveryService
             }
         }
 
+        /// <summary>
+        /// Runs a single iteration of the discovery loop. Returns the retry duration that should
+        /// be passed into the next call: <c>null</c> when the iteration succeeded (or didn't need
+        /// to refresh) — the loop should sleep for <see cref="_recheckIntervalMs"/> in that case —
+        /// or a non-null value when the iteration failed, expressing both how long the loop should
+        /// wait before retrying and the basis for the next exponential-backoff step.
+        /// </summary>
+        [TestingAndPrivateOnly]
+        internal async Task<int?> RunOneIterationAsync(int? previousRetryDuration)
+        {
+            // do we already have an update from the agent? If so, we can skip the loop
+            if (!RequireRefresh(_configurationHash, DateTimeOffset.UtcNow))
+            {
+                // no need to re-check, so reset the retry state
+                return null;
+            }
+
+            try
+            {
+                Log.Debug("Agent features discovery refresh required, contacting agent");
+                var requestFactory = Volatile.Read(ref _apiRequestFactory);
+                var api = requestFactory.ApiFactory.Create(requestFactory.Uri);
+
+                using var response = await api.GetAsync().ConfigureAwait(false);
+                if (response.StatusCode is >= 200 and < 300)
+                {
+                    await ProcessDiscoveryResponse(response).ConfigureAwait(false);
+                    return null;
+                }
+
+                Log.Warning("Error discovering available agent services");
+                return GetNextRetryDuration(previousRetryDuration);
+            }
+            catch (Exception exception)
+            {
+                Log.Warning(exception, "Error discovering available agent services");
+                return GetNextRetryDuration(previousRetryDuration);
+            }
+
+            int GetNextRetryDuration(int? previousDuration) =>
+                previousDuration is null ? _initialRetryDelayMs : Math.Min(previousDuration.Value * 2, _maxRetryDelayMs);
+        }
+
         private async Task FetchConfigurationLoopAsync()
         {
-            var requestFactory = _apiRequestFactory;
-            var uri = requestFactory.GetEndpoint("info");
-
-            var sleepDuration = _recheckIntervalMs;
-
+            int? retryDuration = null;
             while (!_processExit.Task.IsCompleted)
             {
-                // do we already have an update from the agent? If so, we can skip the loop
-                if (RequireRefresh(_configurationHash, DateTimeOffset.UtcNow))
-                {
-                    try
-                    {
-                        Log.Debug("Agent features discovery refresh required, contacting agent");
-                        // If the exporter settings have been updated, refresh the endpoint
-                        var updatedFactory = Volatile.Read(ref _apiRequestFactory);
-                        if (requestFactory != updatedFactory)
-                        {
-                            requestFactory = updatedFactory;
-                            uri = requestFactory.GetEndpoint("info");
-                        }
-
-                        var api = requestFactory.Create(uri);
-
-                        using var response = await api.GetAsync().ConfigureAwait(false);
-                        if (response.StatusCode is >= 200 and < 300)
-                        {
-                            await ProcessDiscoveryResponse(response).ConfigureAwait(false);
-                            sleepDuration = _recheckIntervalMs;
-                        }
-                        else
-                        {
-                            Log.Warning("Error discovering available agent services");
-                            sleepDuration = GetNextSleepDuration(sleepDuration);
-                        }
-                    }
-                    catch (Exception exception)
-                    {
-                        Log.Warning(exception, "Error discovering available agent services");
-                        sleepDuration = GetNextSleepDuration(sleepDuration);
-                    }
-                }
-                else
-                {
-                    // no need to re-check, so reset the check interval
-                    sleepDuration = _recheckIntervalMs;
-                }
+                retryDuration = await RunOneIterationAsync(retryDuration).ConfigureAwait(false);
+                var sleepDuration = retryDuration ?? _recheckIntervalMs;
 
                 try
                 {
@@ -289,9 +297,6 @@ namespace Datadog.Trace.Agent.DiscoveryService
             }
 
             Log.Debug("Discovery service exiting");
-
-            int GetNextSleepDuration(int? previousDuration) =>
-                previousDuration is null ? _initialRetryDelayMs : Math.Min(previousDuration.Value * 2, _maxRetryDelayMs);
         }
 
         [TestingAndPrivateOnly]
@@ -488,6 +493,13 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 productName: "discovery",
                 tcpTimeout: tcpTimeout,
                 httpHeaderHelper: containerId is null ? MinimalAgentHeaderHelper.Instance : new MinimalWithContainerIdAgentHeaderHelper(containerId));
+        }
+
+        private sealed class ApiFactoryHolder(IApiRequestFactory apiFactory)
+        {
+            public IApiRequestFactory ApiFactory { get; } = apiFactory;
+
+            public Uri Uri { get; } = apiFactory.GetEndpoint("info");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -32,15 +32,21 @@ public class DiscoveryServiceTests
     [Fact]
     public async Task HandlesFlakyConfiguration()
     {
-        using var mutex = new ManualResetEventSlim();
+        var notificationCount = 0;
         var factory = new TestRequestFactory(
             x => new FaultyApiRequest(x),
             x => new TestApiRequest(x));
 
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
-        ds.SubscribeToChanges(x => mutex.Set());
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
+        ds.SubscribeToChanges(_ => Interlocked.Increment(ref notificationCount));
 
-        mutex.Wait(30_000).Should().BeTrue("Should raise subscription changes");
+        // First iteration: FaultyApiRequest returns HTTP 500 → no callback, enters retry state.
+        var retry = await ds.RunOneIterationAsync(previousRetryDuration: null);
+        notificationCount.Should().Be(0);
+
+        // Second iteration: TestApiRequest succeeds → fires callback, exits retry state.
+        await ds.RunOneIterationAsync(retry);
+        notificationCount.Should().Be(1);
 
         await ds.DisposeAsync();
     }
@@ -52,19 +58,14 @@ public class DiscoveryServiceTests
         var clientDropP0s = true;
         var version = "1.26.3";
         var evpProxyEndpoint = "evp_proxy/v4";
-        using var mutex = new ManualResetEventSlim();
         var factory = new TestRequestFactory(
             x => new TestApiRequest(x, responseContent: GetConfig(clientDropP0s, version)));
 
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
-        ds.SubscribeToChanges(
-            x =>
-            {
-                config = x;
-                mutex.Set();
-            });
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
+        ds.SubscribeToChanges(x => config = x);
 
-        mutex.Wait(30_000).Should().BeTrue("Should raise subscription changes");
+        await ds.RunOneIterationAsync(previousRetryDuration: null);
+
         config.Should().NotBeNull();
         config.AgentVersion.Should().Be(version);
         config.ConfigurationEndpoint.Should().NotBeNullOrEmpty();
@@ -85,19 +86,14 @@ public class DiscoveryServiceTests
         var expectedHash = "9265333c1d9b94b2022dcc423a686786bacfeb7db425c61fae03b8248e08f819";
 
         AgentConfiguration config = null;
-        using var mutex = new ManualResetEventSlim();
         var factory = new TestRequestFactory(
             x => new TestApiRequest(x, responseContent: serializedConfig));
 
-        await using var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
-        ds.SubscribeToChanges(
-            x =>
-            {
-                config = x;
-                mutex.Set();
-            });
+        await using var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
+        ds.SubscribeToChanges(x => config = x);
 
-        mutex.Wait(30_000).Should().BeTrue("Should raise subscription changes");
+        await ds.RunOneIterationAsync(previousRetryDuration: null);
+
         config.Should().NotBeNull();
         config.AgentVersion.Should().Be("7.65.2");
         config.ConfigurationEndpoint.Should().Be("v0.7/config");
@@ -115,20 +111,15 @@ public class DiscoveryServiceTests
     public async Task DoesNotFireInitialCallbackIfInitialConfigNotFetched()
     {
         var notificationFired = false;
-        using var mutex = new ManualResetEventSlim();
-        var factory = new TestRequestFactory(
-            x =>
-            {
-                mutex.Wait(30_000).Should().BeTrue("Should make request to api");
-                return new TestApiRequest(x, responseContent: GetConfig());
-            });
+        var factory = new TestRequestFactory();
 
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
-        ds.SubscribeToChanges(x => notificationFired = true);
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
 
-        await Task.Delay(5_000); // should recheck 5 times in this duration
+        // Without any iteration having been run, _configuration is null, so the immediate-fire
+        // branch of SubscribeToChanges must not invoke the callback.
+        ds.SubscribeToChanges(_ => notificationFired = true);
+
         notificationFired.Should().BeFalse();
-        mutex.Set();
 
         await ds.DisposeAsync();
     }
@@ -136,22 +127,19 @@ public class DiscoveryServiceTests
     [Fact]
     public async Task FiresInitialCallbackIfInitialConfigAlreadyFetched()
     {
-        int notificationCount = 0;
-        using var mutex = new ManualResetEventSlim();
+        var notificationCount = 0;
         var factory = new TestRequestFactory(
-            x =>
-            {
-                return new TestApiRequest(x, responseContent: GetConfig());
-            },
+            x => new TestApiRequest(x, responseContent: GetConfig()),
             y => throw new Exception("Should not make a second request"));
 
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
-        // make sure we have config
-        ds.SubscribeToChanges(x => mutex.Set());
-        mutex.Wait(30_000).Should().BeTrue("Should make request to api");
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
 
-        ds.SubscribeToChanges(x => Interlocked.Increment(ref notificationCount));
-        Volatile.Read(ref notificationCount).Should().Be(1);
+        // Fetch config first.
+        await ds.RunOneIterationAsync(previousRetryDuration: null);
+
+        // Subscribing after config is set must immediate-fire exactly once.
+        ds.SubscribeToChanges(_ => Interlocked.Increment(ref notificationCount));
+        notificationCount.Should().Be(1);
 
         await ds.DisposeAsync();
     }
@@ -159,31 +147,21 @@ public class DiscoveryServiceTests
     [Fact]
     public async Task DoesNotFireCallbackOnRecheckIfNoChangesToConfig()
     {
-        int notificationCount = 0;
-        using var mutex1 = new ManualResetEventSlim();
-        using var mutex3 = new ManualResetEventSlim();
-        var recheckIntervalMs = 1_000; // ms
+        var notificationCount = 0;
         var factory = new TestRequestFactory(
-            x =>
-            {
-                mutex1.Wait(30_000).Should().BeTrue("Should make request to api");
-                return new TestApiRequest(x, responseContent: GetConfig());
-            },
             x => new TestApiRequest(x, responseContent: GetConfig()),
-            x =>
-            {
-                mutex3.Set();
-                return new TestApiRequest(x, responseContent: GetConfig());
-            });
+            x => new TestApiRequest(x, responseContent: GetConfig()),
+            x => new TestApiRequest(x, responseContent: GetConfig()));
 
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, recheckIntervalMs);
-        ds.SubscribeToChanges(x => Interlocked.Increment(ref notificationCount));
-        // fire first request
-        mutex1.Set();
-        // wait for third request
-        mutex3.Wait(30_000).Should().BeTrue("Should make third request to api");
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
+        ds.SubscribeToChanges(_ => Interlocked.Increment(ref notificationCount));
 
-        Volatile.Read(ref notificationCount).Should().Be(1); // initial
+        // Success-path tests don't enter retry; pass null (no prior retry state).
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // initial config → fires callback
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // same config → no callback
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // same config → no callback
+
+        notificationCount.Should().Be(1);
 
         await ds.DisposeAsync();
     }
@@ -192,30 +170,17 @@ public class DiscoveryServiceTests
     public async Task FiresCallbackOnRecheckIfHasChangesToConfig()
     {
         var notificationCount = 0;
-        using var mutex1 = new ManualResetEventSlim();
-        using var mutex3 = new ManualResetEventSlim();
-        var recheckIntervalMs = 1_000; // ms
         var factory = new TestRequestFactory(
-            x =>
-            {
-                mutex1.Wait(30_000).Should().BeTrue("Should make request to api");
-                return new TestApiRequest(x, responseContent: GetConfig(dropP0: true));
-            },
-            x => new TestApiRequest(x, responseContent: GetConfig(dropP0: false)),
-            x =>
-            {
-                mutex3.Set();
-                return new TestApiRequest(x, responseContent: GetConfig(dropP0: false));
-            });
+            x => new TestApiRequest(x, responseContent: GetConfig(dropP0: true)),
+            x => new TestApiRequest(x, responseContent: GetConfig(dropP0: false)));
 
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, recheckIntervalMs);
-        ds.SubscribeToChanges(x => Interlocked.Increment(ref notificationCount));
-        // fire first request
-        mutex1.Set();
-        // wait for third request
-        mutex3.Wait(30_000).Should().BeTrue("Should make third request to api");
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
+        ds.SubscribeToChanges(_ => Interlocked.Increment(ref notificationCount));
 
-        Volatile.Read(ref notificationCount).Should().Be(2); // initial and second
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // initial config → fires callback
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // dropP0 changed → fires callback again
+
+        notificationCount.Should().Be(2);
 
         await ds.DisposeAsync();
     }
@@ -224,33 +189,20 @@ public class DiscoveryServiceTests
     public async Task DoesNotFireAfterUnsubscribing()
     {
         var notificationCount = 0;
-        using var mutex1 = new ManualResetEventSlim();
-        using var mutex3 = new ManualResetEventSlim();
-
-        var recheckIntervalMs = 1_000; // ms
         var factory = new TestRequestFactory(
-            x =>
-            {
-                mutex1.Wait(30_000).Should().BeTrue("Should make request to api");
-                return new TestApiRequest(x, responseContent: GetConfig(dropP0: true));
-            },
+            x => new TestApiRequest(x, responseContent: GetConfig(dropP0: true)),
             x => new TestApiRequest(x, responseContent: GetConfig(dropP0: false)),
-            x =>
-            {
-                mutex3.Set();
-                return new TestApiRequest(x, responseContent: GetConfig(dropP0: false));
-            });
+            x => new TestApiRequest(x, responseContent: GetConfig(dropP0: false)));
 
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, recheckIntervalMs);
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
 
         ds.SubscribeToChanges(Callback);
 
-        // fire first request
-        mutex1.Set();
-        // wait for third request
-        mutex3.Wait(30_000).Should().BeTrue("Should make third request to api");
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // fires callback, which unsubscribes
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // different config, but no subscribers
+        await ds.RunOneIterationAsync(previousRetryDuration: null); // same as previous iter, no callback
 
-        Volatile.Read(ref notificationCount).Should().Be(1); // callback should only run once
+        notificationCount.Should().Be(1);
 
         await ds.DisposeAsync();
 
@@ -357,7 +309,7 @@ public class DiscoveryServiceTests
     {
         var recheckIntervalMs = 30_000;
         var factory = new TestRequestFactory();
-        await using var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, recheckIntervalMs);
+        await using var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, recheckIntervalMs, autoStartLoop: false);
 
         var now = DateTimeOffset.UtcNow;
         ds.SetCurrentConfigStateHash(agentHash);
@@ -366,12 +318,9 @@ public class DiscoveryServiceTests
     }
 
     [Fact]
-    [Flaky("This is an inherently flaky test as it relies on time periods")]
     public async Task HandlesFailuresInApiWithBackoff()
     {
-        using var mutex = new ManualResetEventSlim(initialState: false, spinCount: 0);
         var factory = new TestRequestFactory(
-            _ => new ThrowingRequest(),
             _ => new ThrowingRequest(),
             _ => new ThrowingRequest(),
             _ => new ThrowingRequest(),
@@ -382,16 +331,34 @@ public class DiscoveryServiceTests
         // These are the default values in the other constructor
         // but setting them explicitly here as it's the behaviour we're testing
         // not the exact values we choose later
-        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, initialRetryDelayMs: 500, maxRetryDelayMs: 5_000, recheckIntervalMs: 30_000);
-        ds.SubscribeToChanges(_ => mutex.Set());
+        const int initialRetryDelayMs = 500;
+        const int maxRetryDelayMs = 5_000;
+        var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, initialRetryDelayMs: initialRetryDelayMs, maxRetryDelayMs: maxRetryDelayMs, recheckIntervalMs: 30_000, autoStartLoop: false);
 
-        // wait for 0 + 500 + 1000 + 2000 + 4000 + 5000 ms (+ 2500 buffer).
-        // should not be set
-        mutex.Wait(15_000);
+        // Starting from no prior retry state (null), each failed iteration doubles the previous
+        // retry duration, capped at maxRetryDelayMs: 500 → 1000 → 2000 → 4000 → 5000 → 5000.
+        var retry = await ds.RunOneIterationAsync(previousRetryDuration: null);
+        retry.Should().Be(initialRetryDelayMs);
+
+        retry = await ds.RunOneIterationAsync(retry);
+        retry.Should().Be(1_000);
+
+        retry = await ds.RunOneIterationAsync(retry);
+        retry.Should().Be(2_000);
+
+        retry = await ds.RunOneIterationAsync(retry);
+        retry.Should().Be(4_000);
+
+        retry = await ds.RunOneIterationAsync(retry);
+        retry.Should().Be(maxRetryDelayMs);
+
+        // Once at the cap, subsequent failures stay at the cap.
+        retry = await ds.RunOneIterationAsync(retry);
+        retry.Should().Be(maxRetryDelayMs);
+
+        factory.RequestsSent.Count.Should().Be(6, "one request per iteration");
 
         await ds.DisposeAsync();
-        // add some leeway in case of slowness
-        factory.RequestsSent.Count.Should().BeInRange(3, 6, "Should make between 3 and 6 retries in 13s");
     }
 
 #if !NETFRAMEWORK
@@ -400,7 +367,6 @@ public class DiscoveryServiceTests
     public async Task ExtractsContainerTagsHashFromResponseHeader()
     {
         const string expectedTagsHash = "test-container-tags-hash-123";
-        using var mutex = new ManualResetEventSlim();
 
         var factory = new TestRequestFactory(x => new TestApiRequest(
             x,
@@ -408,11 +374,9 @@ public class DiscoveryServiceTests
             responseHeaders: new Dictionary<string, string> { { AgentHttpHeaderNames.ContainerTagsHash, expectedTagsHash } }));
 
         var serviceRemappingHash = new ServiceRemappingHash("process:tag,service:service-name");
+        var ds = new DiscoveryService(factory, serviceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
 
-        var ds = new DiscoveryService(factory, serviceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
-        ds.SubscribeToChanges(x => mutex.Set());
-
-        mutex.Wait(30_000).Should().BeTrue("Should raise subscription changes");
+        await ds.RunOneIterationAsync(previousRetryDuration: null);
 
         // Verify the container tags hash was extracted and stored
         serviceRemappingHash.ContainerTagsHash.Should().Be(expectedTagsHash);


### PR DESCRIPTION
## Summary of changes

- Refactor the `DiscoveryService` polling loop to split the "do poll" step from the "wait and loop" step
- Refactor the `DiscoveryServiceTests` to be less flaky by removing `Task.Delay()` and timeouts
- Fix bug with initial retry delay introduced in #7979

## Reason for change

The `DiscoveryServiceTests` are some of our flakiest. There's some particularly bad offenders, but for the most part they're _all_ flaky. The problem is that we have a background loop running, and we inherently have arbitrary timeouts and long tests to execute the loops. If the CI is overloaded (it always is) this is always going to be a source of flakiness.

As a side note, also discovered that #7979 introduced a bug where if there's a polling failure, we always wait 5s, instead of starting with 500ms and using exponential backup. Not a big deal, but fixed it in this PR at the same time.

## Implementation details

The important step is extracting the "do poll" step from the loop, and exposing it so it can be called from tests. That removes all the waiting and indeterminism, and the polling loop is simple enough that we can be confident that it's still correct.

We can then choose _not_ to start the background job, and instead let the tests manage the effective behaviour. This is quite similar to how our `AgentWriter` tests work in a lot of cases too.

## Test coverage

Essentially the same coverage as before, just now hopefully less flaky 🤞 
