### PR TITLE
[Serverless] Bump Datadog.Serverless.Compat to 1.5.0

### DIFF
--- a/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
+++ b/tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\Datadog.Trace.Annotations\Datadog.Trace.Annotations.csproj" />
 
     <!-- Use PrivateAssets="none" to stop excluding content files by default -->
-    <PackageReference Include="Datadog.Serverless.Compat" Version="1.4.0" PrivateAssets="none" />
+    <PackageReference Include="Datadog.Serverless.Compat" Version="1.5.0" PrivateAssets="none" />
 
     <!-- managed assemblies -->
     <None Include="$(SourcePath)/net6.0/Datadog.Trace.dll" Pack="true" Visible="false" PackagePath="contentFiles/any/any/datadog/net6.0/">


### PR DESCRIPTION
## Summary

- Bumps the `Datadog.Serverless.Compat` `PackageReference` in `tracer/src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj` from `1.4.0` → `1.5.0`.
- 1.5.0 ships multifunction named-pipe coordination for .NET on Azure Functions Premium plans. It bundles the [`datadog-serverless-compat/v0.24.0`](https://github.com/DataDog/serverless-components/releases/tag/datadog-serverless-compat%2Fv0.24.0) binary, which contains the dual TCP+pipe listener ([serverless-components#94](https://github.com/DataDog/serverless-components/pull/94)) and best-effort TCP-8126 bind ([serverless-components#129](https://github.com/DataDog/serverless-components/pull/129)) — both required to land the named-pipe path merged in [#8164](https://github.com/DataDog/dd-trace-dotnet/pull/8164).

## Test plan

- [ ] CI green (csproj-only change; should be a no-op outside of `Datadog.AzureFunctions` packaging)
- [ ] Confirm a built `Datadog.AzureFunctions` package resolves `Datadog.Serverless.Compat 1.5.0` from NuGet at restore time

🤖 Generated with [Claude Code](https://claude.com/claude-code)