### PR TITLE
[Debugger] Report retryable line probe resolution errors

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -30,6 +30,12 @@ using ProbeInfo = Datadog.Trace.Debugger.Expressions.ProbeInfo;
 
 namespace Datadog.Trace.Debugger
 {
+    internal delegate void NativeProbeInstrumentationRequester(
+        NativeMethodProbeDefinition[] methodProbes,
+        NativeLineProbeDefinition[] lineProbes,
+        NativeSpanProbeDefinition[] spanProbes,
+        NativeRemoveProbeRequest[] revertProbes);
+
     internal sealed class DynamicInstrumentation : IDisposable
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DynamicInstrumentation));
@@ -43,10 +49,12 @@ namespace Datadog.Trace.Debugger
         private readonly IDebuggerUploader _diagnosticsUploader;
         private readonly ILineProbeResolver _lineProbeResolver;
         private readonly List<ProbeDefinition> _unboundProbes;
+        private readonly Dictionary<string, string> _lastReportedUnboundProbeErrors;
         private readonly IProbeStatusPoller _probeStatusPoller;
         private readonly ConfigurationUpdater _configurationUpdater;
         private readonly IDogStatsd _dogStats;
         private readonly DebuggerSettings _settings;
+        private readonly NativeProbeInstrumentationRequester _instrumentProbes;
         private readonly object _instanceLock = new();
         private int _disposeState;
         private int _initializationState;
@@ -62,7 +70,8 @@ namespace Datadog.Trace.Debugger
             IDebuggerUploader diagnosticsUploader,
             IProbeStatusPoller probeStatusPoller,
             ConfigurationUpdater configurationUpdater,
-            IDogStatsd dogStats)
+            IDogStatsd dogStats,
+            NativeProbeInstrumentationRequester? instrumentProbes = null)
         {
             Log.Information("Initializing Dynamic Instrumentation");
             _settings = settings;
@@ -77,7 +86,9 @@ namespace Datadog.Trace.Debugger
             _configurationUpdater = configurationUpdater;
             _configurationUpdater.SetProbeInstrumentationHandlers(UpdateAddedProbeInstrumentations, UpdateRemovedProbeInstrumentations);
             _dogStats = dogStats;
+            _instrumentProbes = instrumentProbes ?? DebuggerNativeMethods.InstrumentProbes;
             _unboundProbes = new List<ProbeDefinition>();
+            _lastReportedUnboundProbeErrors = new Dictionary<string, string>();
             _subscription = new Subscription(
                 (updates, removals) =>
                 {
@@ -252,16 +263,25 @@ namespace Datadog.Trace.Debugger
                                             case LiveProbeResolveStatus.Bound:
                                                 lineProbes.Add(new NativeLineProbeDefinition(location!.ProbeDefinition.Id, location.Mvid, location.MethodToken, (int)location.BytecodeOffset, location.LineNumber, location.ProbeDefinition.Where.SourceFile));
                                                 fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0));
+                                                _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
                                                 ProbeExpressionsProcessor.Instance.AddProbeProcessor(addedProbe);
                                                 SetRateLimit(addedProbe);
                                                 break;
                                             case LiveProbeResolveStatus.Unbound:
-                                                Log.Information("ProbeID {ProbeID} is unbound.", addedProbe.Id);
+                                                // Unbound line probes remain retryable on future assembly loads. Some retryable
+                                                // outcomes are still reported as ERROR so the backend can show actionable user
+                                                // feedback while the tracer keeps looking for a later exact/unique match.
+                                                Log.Information("ProbeID {ProbeID} is unbound. It will be retried when new assemblies are loaded.", addedProbe.Id);
                                                 _unboundProbes.Add(addedProbe);
-                                                fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, new ProbeStatus(addedProbe.Id, Sink.Models.Status.RECEIVED, errorMessage: null)));
+                                                var unboundProbeStatus = lineProbeResult.ReportError
+                                                                             ? new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: lineProbeResult.Message)
+                                                                             : new ProbeStatus(addedProbe.Id, Sink.Models.Status.RECEIVED, errorMessage: null);
+                                                UpdateLastReportedUnboundProbeError(addedProbe.Id, lineProbeResult);
+                                                fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, unboundProbeStatus));
                                                 break;
                                             case LiveProbeResolveStatus.Error:
                                                 Log.Warning("ProbeID {ProbeID} error resolving live. Error: {Error}", addedProbe.Id, lineProbeResult.Message);
+                                                _lastReportedUnboundProbeErrors.Remove(addedProbe.Id);
                                                 fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: lineProbeResult.Message)));
                                                 break;
                                         }
@@ -308,7 +328,7 @@ namespace Datadog.Trace.Debugger
                     using var disposableSpanProbes = new DisposableEnumerable<NativeSpanProbeDefinition>(spanProbes);
                     if (methodProbes.Count != 0 || lineProbes.Count != 0 || spanProbes.Count != 0)
                     {
-                        DebuggerNativeMethods.InstrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
+                        _instrumentProbes(methodProbes.ToArray(), lineProbes.ToArray(), spanProbes.ToArray(), []);
                     }
 
                     var probeIds = fetchProbeStatus.Select(fp => fp.ProbeId).ToArray();
@@ -343,6 +363,31 @@ namespace Datadog.Trace.Debugger
             return values is { Length: > 0 } ? string.Join(" | ", values) : null;
         }
 
+        private void UpdateLastReportedUnboundProbeError(string probeId, LineProbeResolveResult result)
+        {
+            if (result.ReportError)
+            {
+                _lastReportedUnboundProbeErrors[probeId] = result.Message ?? string.Empty;
+            }
+            else
+            {
+                _lastReportedUnboundProbeErrors.Remove(probeId);
+            }
+        }
+
+        private bool ShouldReportUnboundProbeError(string probeId, string? message)
+        {
+            var errorMessage = message ?? string.Empty;
+            if (_lastReportedUnboundProbeErrors.TryGetValue(probeId, out var lastErrorMessage) &&
+                string.Equals(lastErrorMessage, errorMessage, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            _lastReportedUnboundProbeErrors[probeId] = errorMessage;
+            return true;
+        }
+
         internal void UpdateRemovedProbeInstrumentations(string[] removedProbesIds)
         {
             if (IsDisposed)
@@ -367,6 +412,7 @@ namespace Datadog.Trace.Debugger
                     try
                     {
                         _unboundProbes.RemoveAll(pd => pd.Id == id);
+                        _lastReportedUnboundProbeErrors.Remove(id);
 
                         _probeStatusPoller.RemoveProbes(removedProbesIds);
 
@@ -389,7 +435,7 @@ namespace Datadog.Trace.Debugger
                     var revertProbes = probesToRemoveFromNative
                        .Select(probeId => new NativeRemoveProbeRequest(probeId));
 
-                    DebuggerNativeMethods.InstrumentProbes([], [], [], revertProbes.ToArray());
+                    _instrumentProbes([], [], [], revertProbes.ToArray());
                 }
 
                 // This log entry is being checked in integration test
@@ -459,6 +505,41 @@ namespace Datadog.Trace.Debugger
                 ]);
         }
 
+        private void LogLineProbeRetryResolution(string probeId, AssemblyLoadEventArgs args, LineProbeResolveResult result)
+        {
+            if (!Log.IsEnabled(LogEventLevel.Debug))
+            {
+                return;
+            }
+
+            var diagnostics = result.Diagnostics;
+            Log.Debug(
+                "Rechecked unbound line probe for ProbeID {ProbeId} after assembly load {AssemblyName}. Result was '{Status}'. Reason was '{Reason}'. Message was: '{Message}'. ProbeFile={ProbeFile} ProbeLine={ProbeLine} RawLines={RawLines} ResolvedSourceFile={ResolvedSourceFile} PathMatchType={PathMatchType} MatchingTrailingSegments={MatchingTrailingSegments} FallbackFailureReason={FallbackFailureReason} QualifiedFallbackMatches={QualifiedFallbackMatches} AssemblyName={ResolvedAssemblyName} AssemblyLocation={ResolvedAssemblyLocation} ModuleVersionId={ModuleVersionId} ExceptionType={ExceptionType} LoadedAssemblies={LoadedAssemblies} SymbolicatedAssemblies={SymbolicatedAssemblies} SameFileNameMatches={SameFileNameMatches} SameFileNameExamples={SameFileNameExamples}",
+                [
+                    probeId,
+                    args.LoadedAssembly.GetName().Name,
+                    result.Status,
+                    result.Reason,
+                    result.Message,
+                    diagnostics?.ProbeFile,
+                    diagnostics?.ProbeLine,
+                    diagnostics?.RawLines,
+                    diagnostics?.ResolvedSourceFile,
+                    diagnostics?.PathMatchType,
+                    diagnostics?.MatchingTrailingSegments,
+                    diagnostics?.FallbackFailureReason,
+                    diagnostics?.QualifiedFallbackMatchCount,
+                    diagnostics?.AssemblyName,
+                    diagnostics?.AssemblyLocation,
+                    diagnostics?.ModuleVersionId,
+                    diagnostics?.ExceptionType,
+                    diagnostics?.LoadedAssemblyCount,
+                    diagnostics?.SymbolicatedAssemblyCount,
+                    diagnostics?.SameFileNameMatchCount,
+                    JoinLogValues(diagnostics?.SameFileNameExamples)
+                ]);
+        }
+
         private void CheckUnboundProbes(object? sender, AssemblyLoadEventArgs args)
         {
             // A new assembly was loaded, so re-examine whether the probe can now be resolved.
@@ -469,80 +550,92 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                // Initialize these lists only when there is at least one unbound probe that becomes bound, to reduce unnecessary allocations.
+                // Initialize these lists only when a retry reaches a terminal state, to reduce unnecessary allocations.
                 List<NativeLineProbeDefinition>? lineProbes = null;
-                List<ProbeDefinition>? noLongerUnboundProbes = null;
+                List<ProbeDefinition>? boundProbes = null;
+                List<ProbeDefinition>? probesToRemoveFromRetry = null;
                 var diagnosticLevel = Log.IsEnabled(LogEventLevel.Debug) ? LineProbeDiagnosticLevel.Full : LineProbeDiagnosticLevel.Minimal;
 
                 foreach (var unboundProbe in _unboundProbes)
                 {
                     var result = _lineProbeResolver.TryResolveLineProbe(unboundProbe, out var location, diagnosticLevel);
+                    LogLineProbeRetryResolution(unboundProbe.Id, args, result);
+
                     if (result.Status == LiveProbeResolveStatus.Bound)
                     {
                         lineProbes ??= new List<NativeLineProbeDefinition>();
-                        noLongerUnboundProbes ??= new List<ProbeDefinition>();
+                        boundProbes ??= new List<ProbeDefinition>();
+                        probesToRemoveFromRetry ??= new List<ProbeDefinition>();
 
-                        noLongerUnboundProbes.Add(unboundProbe);
+                        boundProbes.Add(unboundProbe);
+                        probesToRemoveFromRetry.Add(unboundProbe);
                         lineProbes.Add(new NativeLineProbeDefinition(location!.ProbeDefinition.Id, location.Mvid, location.MethodToken, (int)location.BytecodeOffset, location.LineNumber, location.ProbeDefinition.Where.SourceFile));
                     }
-                    else if (Log.IsEnabled(LogEventLevel.Debug))
+                    else if (result.Status == LiveProbeResolveStatus.Unbound)
                     {
-                        var diagnostics = result.Diagnostics;
-                        Log.Debug(
-                            "Rechecked unbound line probe for ProbeID {ProbeId} after assembly load {AssemblyName}. Result was '{Status}'. Reason was '{Reason}'. Message was: '{Message}'. ProbeFile={ProbeFile} ProbeLine={ProbeLine} RawLines={RawLines} ResolvedSourceFile={ResolvedSourceFile} PathMatchType={PathMatchType} MatchingTrailingSegments={MatchingTrailingSegments} FallbackFailureReason={FallbackFailureReason} QualifiedFallbackMatches={QualifiedFallbackMatches} AssemblyName={ResolvedAssemblyName} AssemblyLocation={ResolvedAssemblyLocation} ModuleVersionId={ModuleVersionId} ExceptionType={ExceptionType} LoadedAssemblies={LoadedAssemblies} SymbolicatedAssemblies={SymbolicatedAssemblies} SameFileNameMatches={SameFileNameMatches} SameFileNameExamples={SameFileNameExamples}",
-                            [
+                        if (result.ReportError && ShouldReportUnboundProbeError(unboundProbe.Id, result.Message))
+                        {
+                            _probeStatusPoller.UpdateProbe(
                                 unboundProbe.Id,
-                                args.LoadedAssembly.GetName().Name,
-                                result.Status,
-                                result.Reason,
-                                result.Message,
-                                diagnostics?.ProbeFile,
-                                diagnostics?.ProbeLine,
-                                diagnostics?.RawLines,
-                                diagnostics?.ResolvedSourceFile,
-                                diagnostics?.PathMatchType,
-                                diagnostics?.MatchingTrailingSegments,
-                                diagnostics?.FallbackFailureReason,
-                                diagnostics?.QualifiedFallbackMatchCount,
-                                diagnostics?.AssemblyName,
-                                diagnostics?.AssemblyLocation,
-                                diagnostics?.ModuleVersionId,
-                                diagnostics?.ExceptionType,
-                                diagnostics?.LoadedAssemblyCount,
-                                diagnostics?.SymbolicatedAssemblyCount,
-                                diagnostics?.SameFileNameMatchCount,
-                                JoinLogValues(diagnostics?.SameFileNameExamples)
-                            ]);
+                                new FetchProbeStatus(
+                                    unboundProbe.Id,
+                                    unboundProbe.Version ?? 0,
+                                    new ProbeStatus(unboundProbe.Id, Sink.Models.Status.ERROR, errorMessage: result.Message)));
+                        }
+                        else if (!result.ReportError)
+                        {
+                            _lastReportedUnboundProbeErrors.Remove(unboundProbe.Id);
+                        }
+                    }
+                    else if (result.Status == LiveProbeResolveStatus.Error)
+                    {
+                        probesToRemoveFromRetry ??= new List<ProbeDefinition>();
+                        probesToRemoveFromRetry.Add(unboundProbe);
+                        _lastReportedUnboundProbeErrors.Remove(unboundProbe.Id);
+                        _probeStatusPoller.UpdateProbe(
+                            unboundProbe.Id,
+                            new FetchProbeStatus(
+                                unboundProbe.Id,
+                                unboundProbe.Version ?? 0,
+                                new ProbeStatus(unboundProbe.Id, Sink.Models.Status.ERROR, errorMessage: result.Message)));
                     }
                 }
 
-                if (lineProbes?.Count > 0 && noLongerUnboundProbes != null)
+                if (lineProbes?.Count > 0 && boundProbes != null)
                 {
-                    Log.Information("Dynamic Instrumentation.CheckUnboundProbes: {Count} unbound probes became bound.", property: noLongerUnboundProbes.Count);
+                    Log.Information("Dynamic Instrumentation.CheckUnboundProbes: {Count} unbound probes became bound.", property: boundProbes.Count);
 
-                    // Register processors and samplers BEFORE the native call makes the IL live:
+                    _instrumentProbes([], lineProbes.ToArray(), [], []);
+
+					// Register processors and samplers BEFORE the native call makes the IL live:
                     // otherwise a probe hit between InstrumentProbes returning and SetRateLimit
                     // running would insert a default-rate sampler via GerOrAddSampler, and the
                     // configured rate would never take effect for that probe.
-                    foreach (var boundProbe in noLongerUnboundProbes)
+                    foreach (var boundProbe in boundProbes)
                     {
                         ProbeExpressionsProcessor.Instance.AddProbeProcessor(boundProbe);
                         SetRateLimit(boundProbe);
                     }
 
-                    DebuggerNativeMethods.InstrumentProbes([], lineProbes.ToArray(), [], []);
-
-                    foreach (var boundProbe in noLongerUnboundProbes)
+                    var probeIds = new string[lineProbes.Count];
+                    var newProbeStatuses = new FetchProbeStatus[boundProbes.Count];
+                    for (var i = 0; i < lineProbes.Count; i++)
                     {
-                        _unboundProbes.Remove(boundProbe);
+                        probeIds[i] = lineProbes[i].ProbeId;
+                        var boundProbe = boundProbes[i];
+                        newProbeStatuses[i] = new FetchProbeStatus(boundProbe.Id, boundProbe.Version ?? 0);
                     }
 
-                    // Update probe statuses
-
-                    var probeIds = noLongerUnboundProbes.Select(p => p.Id).ToArray();
-                    var newProbeStatuses = noLongerUnboundProbes.Select(p => new FetchProbeStatus(p.Id, p.Version ?? 0)).ToArray();
-
                     _probeStatusPoller.UpdateProbes(probeIds, newProbeStatuses);
+                }
+
+                if (probesToRemoveFromRetry != null)
+                {
+                    foreach (var probeToRemove in probesToRemoveFromRetry)
+                    {
+                        _unboundProbes.Remove(probeToRemove);
+                        _lastReportedUnboundProbeErrors.Remove(probeToRemove.Id);
+                    }
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Debugger
         private readonly IDebuggerUploader _diagnosticsUploader;
         private readonly ILineProbeResolver _lineProbeResolver;
         private readonly List<ProbeDefinition> _unboundProbes;
-        private readonly Dictionary<string, string> _lastReportedUnboundProbeErrors;
+        private readonly Dictionary<string, LineProbeResolveErrorKey> _lastReportedUnboundProbeErrors;
         private readonly IProbeStatusPoller _probeStatusPoller;
         private readonly ConfigurationUpdater _configurationUpdater;
         private readonly IDogStatsd _dogStats;
@@ -88,7 +88,7 @@ namespace Datadog.Trace.Debugger
             _dogStats = dogStats;
             _instrumentProbes = instrumentProbes ?? DebuggerNativeMethods.InstrumentProbes;
             _unboundProbes = new List<ProbeDefinition>();
-            _lastReportedUnboundProbeErrors = new Dictionary<string, string>();
+            _lastReportedUnboundProbeErrors = new Dictionary<string, LineProbeResolveErrorKey>();
             _subscription = new Subscription(
                 (updates, removals) =>
                 {
@@ -274,7 +274,7 @@ namespace Datadog.Trace.Debugger
                                                 Log.Information("ProbeID {ProbeID} is unbound. It will be retried when new assemblies are loaded.", addedProbe.Id);
                                                 _unboundProbes.Add(addedProbe);
                                                 var unboundProbeStatus = lineProbeResult.ReportError
-                                                                             ? new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: lineProbeResult.Message)
+                                                                             ? new ProbeStatus(addedProbe.Id, Sink.Models.Status.ERROR, errorMessage: GetLineProbeResolveMessage(lineProbeResult))
                                                                              : new ProbeStatus(addedProbe.Id, Sink.Models.Status.RECEIVED, errorMessage: null);
                                                 UpdateLastReportedUnboundProbeError(addedProbe.Id, lineProbeResult);
                                                 fetchProbeStatus.Add(new FetchProbeStatus(addedProbe.Id, addedProbe.Version ?? 0, unboundProbeStatus));
@@ -358,6 +358,28 @@ namespace Datadog.Trace.Debugger
             }
         }
 
+        private static LineProbeResolveErrorKey GetLineProbeResolveErrorKey(LineProbeResolveResult result)
+        {
+            return result.ErrorKey.IsEmpty ? new LineProbeResolveErrorKey(result.Reason) : result.ErrorKey;
+        }
+
+        private static string? GetLineProbeResolveMessage(LineProbeResolveResult result)
+        {
+            if (result.Message is not null)
+            {
+                return result.Message;
+            }
+
+            return result.Reason == LineProbeResolveReason.LoadedAssemblySourceFileMismatch
+                       ? LineProbeResolver.BuildLoadedAssemblySourceFileMismatchMessage(GetLineProbeResolveErrorDetails(result))
+                       : null;
+        }
+
+        private static LineProbeResolveErrorDetails GetLineProbeResolveErrorDetails(LineProbeResolveResult result)
+        {
+            return result.ErrorDetails.IsEmpty ? new LineProbeResolveErrorDetails(GetLineProbeResolveErrorKey(result)) : result.ErrorDetails;
+        }
+
         private static string? JoinLogValues(string[]? values)
         {
             return values is { Length: > 0 } ? string.Join(" | ", values) : null;
@@ -367,7 +389,7 @@ namespace Datadog.Trace.Debugger
         {
             if (result.ReportError)
             {
-                _lastReportedUnboundProbeErrors[probeId] = result.Message ?? string.Empty;
+                _lastReportedUnboundProbeErrors[probeId] = GetLineProbeResolveErrorKey(result);
             }
             else
             {
@@ -375,16 +397,16 @@ namespace Datadog.Trace.Debugger
             }
         }
 
-        private bool ShouldReportUnboundProbeError(string probeId, string? message)
+        private bool ShouldReportUnboundProbeError(string probeId, LineProbeResolveResult result)
         {
-            var errorMessage = message ?? string.Empty;
+            var errorKey = GetLineProbeResolveErrorKey(result);
             if (_lastReportedUnboundProbeErrors.TryGetValue(probeId, out var lastErrorMessage) &&
-                string.Equals(lastErrorMessage, errorMessage, StringComparison.Ordinal))
+                lastErrorMessage == errorKey)
             {
                 return false;
             }
 
-            _lastReportedUnboundProbeErrors[probeId] = errorMessage;
+            _lastReportedUnboundProbeErrors[probeId] = errorKey;
             return true;
         }
 
@@ -573,14 +595,15 @@ namespace Datadog.Trace.Debugger
                     }
                     else if (result.Status == LiveProbeResolveStatus.Unbound)
                     {
-                        if (result.ReportError && ShouldReportUnboundProbeError(unboundProbe.Id, result.Message))
+                        if (result.ReportError && ShouldReportUnboundProbeError(unboundProbe.Id, result))
                         {
+                            var errorMessage = GetLineProbeResolveMessage(result);
                             _probeStatusPoller.UpdateProbe(
                                 unboundProbe.Id,
                                 new FetchProbeStatus(
                                     unboundProbe.Id,
                                     unboundProbe.Version ?? 0,
-                                    new ProbeStatus(unboundProbe.Id, Sink.Models.Status.ERROR, errorMessage: result.Message)));
+                                    new ProbeStatus(unboundProbe.Id, Sink.Models.Status.ERROR, errorMessage: errorMessage)));
                         }
                         else if (!result.ReportError)
                         {

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -589,6 +589,7 @@ namespace Datadog.Trace.Debugger
                     }
                     else if (result.Status == LiveProbeResolveStatus.Error)
                     {
+                        Log.Debug("ProbeID {ProbeID} error resolving during retry. Error: {Error}", unboundProbe.Id, result.Message);
                         probesToRemoveFromRetry ??= new List<ProbeDefinition>();
                         probesToRemoveFromRetry.Add(unboundProbe);
                         _lastReportedUnboundProbeErrors.Remove(unboundProbe.Id);
@@ -605,9 +606,7 @@ namespace Datadog.Trace.Debugger
                 {
                     Log.Information("Dynamic Instrumentation.CheckUnboundProbes: {Count} unbound probes became bound.", property: boundProbes.Count);
 
-                    _instrumentProbes([], lineProbes.ToArray(), [], []);
-
-					// Register processors and samplers BEFORE the native call makes the IL live:
+                    // Register processors and samplers BEFORE the native call makes the IL live:
                     // otherwise a probe hit between InstrumentProbes returning and SetRateLimit
                     // running would insert a default-rate sampler via GerOrAddSampler, and the
                     // configured rate would never take effect for that probe.
@@ -616,6 +615,8 @@ namespace Datadog.Trace.Debugger
                         ProbeExpressionsProcessor.Instance.AddProbeProcessor(boundProbe);
                         SetRateLimit(boundProbe);
                     }
+
+                    _instrumentProbes([], lineProbes.ToArray(), [], []);
 
                     var probeIds = new string[lineProbes.Count];
                     var newProbeStatuses = new FetchProbeStatus[boundProbes.Count];

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -400,8 +400,8 @@ namespace Datadog.Trace.Debugger
         private bool ShouldReportUnboundProbeError(string probeId, LineProbeResolveResult result)
         {
             var errorKey = GetLineProbeResolveErrorKey(result);
-            if (_lastReportedUnboundProbeErrors.TryGetValue(probeId, out var lastErrorMessage) &&
-                lastErrorMessage == errorKey)
+            if (_lastReportedUnboundProbeErrors.TryGetValue(probeId, out var lastErrorKey) &&
+                lastErrorKey == errorKey)
             {
                 return false;
             }
@@ -428,6 +428,8 @@ namespace Datadog.Trace.Debugger
             {
                 var boundedProbes = _probeStatusPoller.GetBoundedProbes();
                 var probesToRemoveFromNative = new List<string>();
+                _probeStatusPoller.RemoveProbes(removedProbesIds);
+
                 for (var i = 0; i < removedProbesIds.Length; i++)
                 {
                     var id = removedProbesIds[i];
@@ -435,8 +437,6 @@ namespace Datadog.Trace.Debugger
                     {
                         _unboundProbes.RemoveAll(pd => pd.Id == id);
                         _lastReportedUnboundProbeErrors.Remove(id);
-
-                        _probeStatusPoller.RemoveProbes(removedProbesIds);
 
                         ProbeRateLimiter.Instance.ResetRate(id);
                         ProbeExpressionsProcessor.Instance.Remove(id);

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -17,6 +17,7 @@ using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Debugger
 {
@@ -62,9 +63,20 @@ namespace Datadog.Trace.Debugger
             return separatorIndex >= 0 ? span.Slice(separatorIndex + 1).ToString() : span.ToString();
         }
 
-        private static string BuildLoadedAssemblySourceFileMismatchMessage()
+        private static string BuildLoadedAssemblySourceFileMismatchMessage(AssemblySearchDiagnostics diagnostics)
         {
-            return "Source file location for probe did not match the PDB document path of a loaded, symbolicated assembly with the same file name.";
+            var builder = StringBuilderCache.Acquire();
+            builder.Append("Source file location for probe did not uniquely match the PDB document path of a loaded, symbolicated assembly with the same file name.");
+            builder.Append(" Fallback failure reason: ");
+            builder.Append(diagnostics.FallbackFailureReason);
+            builder.Append(". Best matching trailing segments: ");
+            builder.Append(diagnostics.BestMatchingTrailingSegments);
+            builder.Append(". Qualified fallback matches: ");
+            builder.Append(diagnostics.QualifiedFallbackMatchCount);
+            builder.Append(". Same file name matches: ");
+            builder.Append(diagnostics.SameFileNameMatchCount);
+            builder.Append('.');
+            return StringBuilderCache.GetStringAndRelease(builder);
         }
 
         private static string BuildAssemblyNotLoadedOrSymbolsUnavailableMessage()
@@ -292,11 +304,17 @@ namespace Datadog.Trace.Debugger
 
                 if (!TryFindAssemblyContainingFile(sourceFile, diagnosticLevel, out var assemblyPathMatch, out var searchDiagnostics))
                 {
-                    var reason = searchDiagnostics is { SameFileNameMatchCount: > 0 }
+                    var isSourceFileMismatch = searchDiagnostics is { SameFileNameMatchCount: > 0 };
+                    // Resolver outcome matrix:
+                    // - no same-file candidate: Unbound, ReportError=false. DynamicInstrumentation reports RECEIVED and retries on future assembly loads.
+                    // - same-file candidates but no exact/unique fallback: Unbound, ReportError=true. DynamicInstrumentation reports ERROR with this message, but keeps retrying in case a later assembly provides an exact/unique match.
+                    // - invalid probe metadata / missing PDB / missing sequence point / unexpected exception: Error. DynamicInstrumentation reports ERROR and does not keep the probe in the retry set.
+                    // - bound: Bound. DynamicInstrumentation requests instrumentation; future assembly loads do not invalidate the already bound location.
+                    var reason = isSourceFileMismatch
                                      ? LineProbeResolveReason.LoadedAssemblySourceFileMismatch
                                      : LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable;
-                    var message = searchDiagnostics is { SameFileNameMatchCount: > 0 }
-                                      ? BuildLoadedAssemblySourceFileMismatchMessage()
+                    var message = isSourceFileMismatch && searchDiagnostics is not null
+                                      ? BuildLoadedAssemblySourceFileMismatchMessage(searchDiagnostics)
                                       : BuildAssemblyNotLoadedOrSymbolsUnavailableMessage();
                     var unresolvedDiagnostics = diagnosticLevel == LineProbeDiagnosticLevel.Full
                                                     ? searchDiagnostics?.ToDiagnostics(lineNum, probe.Id) ?? BuildMinimalDiagnostics(sourceFile, lineNum, probe.Id)
@@ -306,7 +324,8 @@ namespace Datadog.Trace.Debugger
                         LiveProbeResolveStatus.Unbound,
                         reason,
                         message,
-                        unresolvedDiagnostics);
+                        unresolvedDiagnostics,
+                        ReportError: isSourceFileMismatch);
                 }
 
                 var filePathFromPdb = assemblyPathMatch.Path;

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -63,18 +63,18 @@ namespace Datadog.Trace.Debugger
             return separatorIndex >= 0 ? span.Slice(separatorIndex + 1).ToString() : span.ToString();
         }
 
-        private static string BuildLoadedAssemblySourceFileMismatchMessage(AssemblySearchDiagnostics diagnostics)
+        internal static string BuildLoadedAssemblySourceFileMismatchMessage(LineProbeResolveErrorDetails details)
         {
             var builder = StringBuilderCache.Acquire();
             builder.Append("Source file location for probe did not uniquely match the PDB document path of a loaded, symbolicated assembly with the same file name.");
             builder.Append(" Fallback failure reason: ");
-            builder.Append(diagnostics.FallbackFailureReason);
+            builder.Append(details.Key.FallbackFailureReason);
             builder.Append(". Best matching trailing segments: ");
-            builder.Append(diagnostics.BestMatchingTrailingSegments);
+            builder.Append(details.BestMatchingTrailingSegments);
             builder.Append(". Qualified fallback matches: ");
-            builder.Append(diagnostics.QualifiedFallbackMatchCount);
+            builder.Append(details.QualifiedFallbackMatchCount);
             builder.Append(". Same file name matches: ");
-            builder.Append(diagnostics.SameFileNameMatchCount);
+            builder.Append(details.SameFileNameMatchCount);
             builder.Append('.');
             return StringBuilderCache.GetStringAndRelease(builder);
         }
@@ -313,18 +313,22 @@ namespace Datadog.Trace.Debugger
                     var reason = isSourceFileMismatch
                                      ? LineProbeResolveReason.LoadedAssemblySourceFileMismatch
                                      : LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable;
-                    var message = isSourceFileMismatch && searchDiagnostics is not null
-                                      ? BuildLoadedAssemblySourceFileMismatchMessage(searchDiagnostics)
-                                      : BuildAssemblyNotLoadedOrSymbolsUnavailableMessage();
+                    var errorKey = searchDiagnostics?.ToErrorKey(reason) ?? new LineProbeResolveErrorKey(reason);
+                    var errorDetails = searchDiagnostics?.ToErrorDetails(errorKey) ?? new LineProbeResolveErrorDetails(errorKey);
                     var unresolvedDiagnostics = diagnosticLevel == LineProbeDiagnosticLevel.Full
                                                     ? searchDiagnostics?.ToDiagnostics(lineNum, probe.Id) ?? BuildMinimalDiagnostics(sourceFile, lineNum, probe.Id)
                                                     : BuildMinimalDiagnostics(sourceFile, lineNum, probe.Id);
+                    var message = isSourceFileMismatch
+                                      ? diagnosticLevel == LineProbeDiagnosticLevel.Full ? BuildLoadedAssemblySourceFileMismatchMessage(errorDetails) : null
+                                      : BuildAssemblyNotLoadedOrSymbolsUnavailableMessage();
 
                     return new LineProbeResolveResult(
                         LiveProbeResolveStatus.Unbound,
                         reason,
                         message,
                         unresolvedDiagnostics,
+                        errorKey,
+                        errorDetails,
                         ReportError: isSourceFileMismatch);
                 }
 
@@ -788,6 +792,22 @@ namespace Datadog.Trace.Debugger
                     SymbolicatedAssemblyCount: SymbolicatedAssemblyCount,
                     SameFileNameMatchCount: SameFileNameMatchCount,
                     SameFileNameExamples: SameFileNameExamples);
+            }
+
+            public LineProbeResolveErrorKey ToErrorKey(LineProbeResolveReason reason)
+            {
+                return new LineProbeResolveErrorKey(
+                    reason,
+                    FallbackFailureReason);
+            }
+
+            public LineProbeResolveErrorDetails ToErrorDetails(LineProbeResolveErrorKey key)
+            {
+                return new LineProbeResolveErrorDetails(
+                    key,
+                    BestMatchingTrailingSegments,
+                    QualifiedFallbackMatchCount,
+                    SameFileNameMatchCount);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Models/LineProbeResolveResult.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Models/LineProbeResolveResult.cs
@@ -9,5 +9,6 @@ namespace Datadog.Trace.Debugger.Models
         LiveProbeResolveStatus Status,
         LineProbeResolveReason Reason = LineProbeResolveReason.None,
         string Message = null,
-        LineProbeResolutionDiagnostics Diagnostics = null);
+        LineProbeResolutionDiagnostics Diagnostics = null,
+        bool ReportError = false);
 }

--- a/tracer/src/Datadog.Trace/Debugger/Models/LineProbeResolveResult.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Models/LineProbeResolveResult.cs
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#pragma warning disable SA1201 // Elements should appear in the correct order - keep result payload types together.
+#pragma warning disable SA1402 // File may only contain a single type - keep result payload types together.
+
 namespace Datadog.Trace.Debugger.Models
 {
     internal sealed record LineProbeResolveResult(
@@ -10,5 +13,26 @@ namespace Datadog.Trace.Debugger.Models
         LineProbeResolveReason Reason = LineProbeResolveReason.None,
         string Message = null,
         LineProbeResolutionDiagnostics Diagnostics = null,
+        LineProbeResolveErrorKey ErrorKey = default,
+        LineProbeResolveErrorDetails ErrorDetails = default,
         bool ReportError = false);
+
+    internal readonly record struct LineProbeResolveErrorKey(
+        LineProbeResolveReason Reason,
+        LineProbeFallbackFailureReason FallbackFailureReason = LineProbeFallbackFailureReason.None)
+    {
+        public bool IsEmpty => Reason == LineProbeResolveReason.None;
+    }
+
+    internal readonly record struct LineProbeResolveErrorDetails(
+        LineProbeResolveErrorKey Key,
+        int BestMatchingTrailingSegments = 0,
+        int QualifiedFallbackMatchCount = 0,
+        int SameFileNameMatchCount = 0)
+    {
+        public bool IsEmpty => Key.IsEmpty;
+    }
 }
+
+#pragma warning restore SA1402
+#pragma warning restore SA1201

--- a/tracer/src/Datadog.Trace/Debugger/ProbeStatuses/ProbeStatusPoller.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ProbeStatuses/ProbeStatusPoller.cs
@@ -135,16 +135,14 @@ namespace Datadog.Trace.Debugger.ProbeStatuses
                                .Select(p => p.ProbeId)
                                .ToArray();
 
-            var probeStatuses = _probes.Where(p => !p.ShouldFetch())
-                                       .Select(p => p.ProbeStatus)
-                                       .ToList();
+            PInvoke.ProbeStatus[] probeStatuses = null;
 
             if (probesToFetch.Length != 0)
             {
-                probeStatuses.AddRange(DebuggerNativeMethods.GetProbesStatuses(probesToFetch));
+                probeStatuses = DebuggerNativeMethods.GetProbesStatuses(probesToFetch);
             }
 
-            if (probeStatuses.Count == 0)
+            if (probeStatuses is null || probeStatuses.Length == 0)
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/Debugger/Sink/Models/ProbeException.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/Models/ProbeException.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Debugger.Sink.Models
         [JsonProperty("message")]
         public string Message { get; set; }
 
-        [JsonProperty("stacktrace")]
+        [JsonProperty("stacktrace", NullValueHandling = NullValueHandling.Ignore)]
         public string StackTrace { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Sink/Models/ProbeException.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/Models/ProbeException.cs
@@ -15,7 +15,9 @@ namespace Datadog.Trace.Debugger.Sink.Models
         [JsonProperty("message")]
         public string Message { get; set; }
 
-        [JsonProperty("stacktrace", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("stacktrace")]
         public string StackTrace { get; set; }
+
+        public bool ShouldSerializeStackTrace() => StackTrace is not null;
     }
 }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericClass.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericClass.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Failed to instrument the method. [Error Code: 1]",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Placing line probes in async generic methods in Release builds is currently not supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericStruct.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericStruct.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Failed to instrument the method. [Error Code: 1]",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncWithGenericArgumentAndLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncWithGenericArgumentAndLocal.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Failed to instrument the method. [Error Code: 1]",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncWithMultiplePhasingAndProbes_#6..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncWithMultiplePhasingAndProbes_#6..verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Probe location did not map out to a valid bytecode offset",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "35543785-ac9a-85ea-44af-13938dff3136",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.ByRefLikeTest.verified.txt
@@ -53,7 +53,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "1828a3f0-e94b-eb91-81e3-12bcf19ac41a",
@@ -73,7 +72,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods in a `ref-struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "3c5a4d30-f652-b355-51d6-9589d1d290b4",
@@ -93,7 +91,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "86a95ec1-5bda-bd57-3f8e-e610398f9334",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.EmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.EmptyCtorTest.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Instrumentation of static/non-static constructors is not supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -181,7 +181,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods in a `ref-struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "03da93fa-95b1-4bbc-89e2-6c29cb8f1744",
@@ -201,7 +200,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "22df6346-f993-1027-bd1a-f25f3a06ca56",
@@ -221,7 +219,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods in a `ref-struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "23827d5e-fc78-6898-4039-dec54409f8c4",
@@ -241,7 +238,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "35543785-ac9a-85ea-44af-13938dff3136",
@@ -261,7 +257,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "b16773f7-ded8-a522-43ce-b51d18f9205e",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericInnerValueTypeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericInnerValueTypeTest.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Probe location did not map out to a valid bytecode offset",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericRefReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericRefReturnTest.verified.txt
@@ -21,7 +21,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MethodWithMultiplePhasingAndProbes_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MethodWithMultiplePhasingAndProbes_#2..verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Probe location did not map out to a valid bytecode offset",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "31d232fd-e292-63a1-cfc5-f0e71d98afd1",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MethodWithMultiplePhasingAndProbes_#6..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MethodWithMultiplePhasingAndProbes_#6..verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Probe location did not map out to a valid bytecode offset",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "35543785-ac9a-85ea-44af-13938dff3136",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonEmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonEmptyCtorTest.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Instrumentation of static/non-static constructors is not supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonSupportedInstrumentationTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonSupportedInstrumentationTest.verified.txt
@@ -5,7 +5,6 @@
       "diagnostics": {
         "exception": {
           "message": "Failed to instrument the method. [Error Code: 1]",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NotSupportedFailureTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NotSupportedFailureTest.verified.txt
@@ -131,7 +131,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "31d232fd-e292-63a1-cfc5-f0e71d98afd1",
@@ -149,7 +148,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "35543785-ac9a-85ea-44af-13938dff3136",
@@ -167,7 +165,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods in a `ref-struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "3c5a4d30-f652-b355-51d6-9589d1d290b4",
@@ -185,7 +182,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods in a `ref-struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "b16773f7-ded8-a522-43ce-b51d18f9205e",
@@ -203,7 +199,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "b1fd073e-cd92-947d-4b6b-d9bd0380b1f2",
@@ -221,7 +216,6 @@
       "diagnostics": {
         "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
           "type": "NO_TYPE"
         },
         "probeId": "d1bf6b7f-7fae-6c5f-3c28-d47a96e0ad70",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
@@ -394,6 +394,14 @@ public class LineProbeResolverTest
         result.Diagnostics.FallbackFailureReason.Should().Be(LineProbeFallbackFailureReason.NoQualifiedSuffixMatch);
         result.Diagnostics.MatchingTrailingSegments.Should().Be(1);
         result.Diagnostics.QualifiedFallbackMatchCount.Should().Be(0);
+        result.ErrorKey.Should().Be(new LineProbeResolveErrorKey(
+            LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+            LineProbeFallbackFailureReason.NoQualifiedSuffixMatch));
+        result.ErrorDetails.Should().Be(new LineProbeResolveErrorDetails(
+            result.ErrorKey,
+            BestMatchingTrailingSegments: 1,
+            QualifiedFallbackMatchCount: 0,
+            result.Diagnostics.SameFileNameMatchCount));
         result.Message.Should().Contain("did not uniquely match the PDB document path");
         result.Message.Should().Contain("loaded, symbolicated assembly with the same file name");
         result.Message.Should().Contain("Fallback failure reason: NoQualifiedSuffixMatch");
@@ -479,7 +487,15 @@ public class LineProbeResolverTest
         result.Diagnostics.MatchingTrailingSegments.Should().BeNull();
         result.Diagnostics.FallbackFailureReason.Should().BeNull();
         result.Diagnostics.SameFileNameExamples.Should().BeNull();
-        result.Message.Should().Contain("Fallback failure reason: NoQualifiedSuffixMatch");
+        result.ErrorKey.Should().Be(new LineProbeResolveErrorKey(
+            LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+            LineProbeFallbackFailureReason.NoQualifiedSuffixMatch));
+        result.ErrorDetails.Should().Be(new LineProbeResolveErrorDetails(
+            result.ErrorKey,
+            BestMatchingTrailingSegments: 1,
+            QualifiedFallbackMatchCount: 0,
+            SameFileNameMatchCount: 1));
+        result.Message.Should().BeNull();
         loc.Should().BeNull();
     }
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LineProbeResolverTest.cs
@@ -378,13 +378,14 @@ public class LineProbeResolverTest
     }
 
     [Fact]
-    public void SameFileNamePathMismatchReturnsSpecificUnboundReason()
+    public void SameFileNamePathMismatchReturnsRetryableUnboundWithReportedError()
     {
         _probeDefinition.Where.SourceFile = @"some\other\folder\LambdaSingleLine.cs";
 
         var result = _lineProbeResolver.TryResolveLineProbe(_probeDefinition, out var loc);
 
         result.Status.Should().Be(LiveProbeResolveStatus.Unbound);
+        result.ReportError.Should().BeTrue();
         result.Reason.Should().Be(LineProbeResolveReason.LoadedAssemblySourceFileMismatch);
         result.Diagnostics.LoadedAssemblyCount.Should().BeGreaterThan(0);
         result.Diagnostics.SymbolicatedAssemblyCount.Should().BeGreaterThan(0);
@@ -393,8 +394,10 @@ public class LineProbeResolverTest
         result.Diagnostics.FallbackFailureReason.Should().Be(LineProbeFallbackFailureReason.NoQualifiedSuffixMatch);
         result.Diagnostics.MatchingTrailingSegments.Should().Be(1);
         result.Diagnostics.QualifiedFallbackMatchCount.Should().Be(0);
-        result.Message.Should().Contain("did not match the PDB document path");
+        result.Message.Should().Contain("did not uniquely match the PDB document path");
         result.Message.Should().Contain("loaded, symbolicated assembly with the same file name");
+        result.Message.Should().Contain("Fallback failure reason: NoQualifiedSuffixMatch");
+        result.Message.Should().Contain("Qualified fallback matches: 0");
         result.Message.Should().NotContain("assembly is not loaded yet");
         result.Message.Should().NotContain("symbols are unavailable");
         loc.Should().BeNull();
@@ -408,6 +411,7 @@ public class LineProbeResolverTest
         var result = _lineProbeResolver.TryResolveLineProbe(_probeDefinition, out var loc);
 
         result.Status.Should().Be(LiveProbeResolveStatus.Unbound);
+        result.ReportError.Should().BeFalse();
         result.Reason.Should().Be(LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable);
         result.Diagnostics.SameFileNameMatchCount.Should().Be(0);
         result.Message.Should().Contain("assembly is not loaded yet");
@@ -424,6 +428,7 @@ public class LineProbeResolverTest
         var result = _lineProbeResolver.TryResolveLineProbe(_probeDefinition, out var loc);
 
         result.Status.Should().Be(LiveProbeResolveStatus.Unbound);
+        result.ReportError.Should().BeFalse();
         result.Reason.Should().Be(LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable);
         result.Diagnostics.FallbackFailureReason.Should().Be(LineProbeFallbackFailureReason.NoSameFileNameCandidates);
         result.Diagnostics.SameFileNameMatchCount.Should().Be(0);
@@ -460,19 +465,21 @@ public class LineProbeResolverTest
     }
 
     [Fact]
-    public void MinimalDiagnosticsOnUnboundResolutionKeepReasonButSkipDetailedFields()
+    public void MinimalDiagnosticsOnSourceFileMismatchKeepRetryableReportedErrorButSkipDetailedFields()
     {
         _probeDefinition.Where.SourceFile = @"some\other\folder\LambdaSingleLine.cs";
 
         var result = _lineProbeResolver.TryResolveLineProbe(_probeDefinition, out var loc, LineProbeDiagnosticLevel.Minimal);
 
         result.Status.Should().Be(LiveProbeResolveStatus.Unbound);
+        result.ReportError.Should().BeTrue();
         result.Reason.Should().Be(LineProbeResolveReason.LoadedAssemblySourceFileMismatch);
         result.Diagnostics.ProbeFile.Should().Be(_probeDefinition.Where.SourceFile);
         result.Diagnostics.ProbeLine.Should().Be(int.Parse(_probeDefinition.Where.Lines[0]));
         result.Diagnostics.MatchingTrailingSegments.Should().BeNull();
         result.Diagnostics.FallbackFailureReason.Should().BeNull();
         result.Diagnostics.SameFileNameExamples.Should().BeNull();
+        result.Message.Should().Contain("Fallback failure reason: NoQualifiedSuffixMatch");
         loc.Should().BeNull();
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -328,6 +328,8 @@ public class DynamicInstrumentationTests
                     LiveProbeResolveStatus.Unbound,
                     LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
                     "Source file location for probe did not uniquely match the PDB document path.",
+                    ErrorKey: SourceMismatchKey(),
+                    ErrorDetails: SourceMismatchDetails(),
                     ReportError: true));
             var probeStatusPoller = new ProbeStatusPollerMock();
             var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
@@ -347,6 +349,37 @@ public class DynamicInstrumentationTests
         }
 
         [Fact]
+        public void UpdateAddedProbeInstrumentations_RetryableLineProbeResolutionFailureBuildsErrorStatusFromKey()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                    ErrorKey: SourceMismatchKey(),
+                    ErrorDetails: SourceMismatchDetails(),
+                    ReportError: true));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-source-mismatch",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "wrong/path/MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+
+            var status = probeStatusPoller.UpdatedProbeStatuses.Should().ContainSingle().Subject.ProbeStatus;
+            status.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+            status.ErrorMessage.Should().Contain("Source file location for probe did not uniquely match the PDB document path");
+            status.ErrorMessage.Should().Contain("Fallback failure reason: NoQualifiedSuffixMatch");
+        }
+
+        [Fact]
         public void UpdateAddedProbeInstrumentations_RetryableLineProbeResolutionFailureKeepsProbeRetryable()
         {
             var settings = DebuggerSettings.FromSource(
@@ -357,6 +390,8 @@ public class DynamicInstrumentationTests
                     LiveProbeResolveStatus.Unbound,
                     LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
                     "Source file location for probe did not uniquely match the PDB document path.",
+                    ErrorKey: SourceMismatchKey(),
+                    ErrorDetails: SourceMismatchDetails(),
                     ReportError: true));
             var probeStatusPoller = new ProbeStatusPollerMock();
             var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
@@ -408,7 +443,8 @@ public class DynamicInstrumentationTests
             lineProbeResolver.NextResult = new LineProbeResolveResult(
                 LiveProbeResolveStatus.Unbound,
                 LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
-                "Source file location for probe did not uniquely match the PDB document path.",
+                ErrorKey: SourceMismatchKey(),
+                ErrorDetails: SourceMismatchDetails(),
                 ReportError: true);
             debugger.GetType()
                     .GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -417,7 +453,8 @@ public class DynamicInstrumentationTests
             probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
             probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.RECEIVED);
             probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
-            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.ErrorMessage.Should().Be("Source file location for probe did not uniquely match the PDB document path.");
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.ErrorMessage.Should().Contain("Source file location for probe did not uniquely match the PDB document path");
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.ErrorMessage.Should().Contain("Fallback failure reason: NoQualifiedSuffixMatch");
         }
 
         [Fact]
@@ -446,7 +483,8 @@ public class DynamicInstrumentationTests
             lineProbeResolver.NextResult = new LineProbeResolveResult(
                 LiveProbeResolveStatus.Unbound,
                 LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
-                "Source file location for probe did not uniquely match the PDB document path.",
+                ErrorKey: SourceMismatchKey(),
+                ErrorDetails: SourceMismatchDetails(),
                 ReportError: true);
             var checkUnboundProbes = debugger.GetType().GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!;
             checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
@@ -455,6 +493,98 @@ public class DynamicInstrumentationTests
             probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
             probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.RECEIVED);
             probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+        }
+
+        [Fact]
+        public void CheckUnboundProbes_RetryableLineProbeResolutionFailureDoesNotRepeatWhenOnlyCountsChange()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable,
+                    "Source file location for probe was not found in any currently loaded assembly."));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-source-mismatch",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "wrong/path/MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+            var checkUnboundProbes = debugger.GetType().GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Unbound,
+                LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                ErrorKey: SourceMismatchKey(),
+                ErrorDetails: SourceMismatchDetails(bestMatchingTrailingSegments: 1, qualifiedFallbackMatchCount: 0, sameFileNameMatchCount: 1),
+                ReportError: true);
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Unbound,
+                LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                ErrorKey: SourceMismatchKey(),
+                ErrorDetails: SourceMismatchDetails(bestMatchingTrailingSegments: 3, qualifiedFallbackMatchCount: 2, sameFileNameMatchCount: 4),
+                ReportError: true);
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
+            probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.RECEIVED);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.ErrorMessage.Should().Contain("Same file name matches: 1");
+        }
+
+        [Fact]
+        public void CheckUnboundProbes_RetryableLineProbeResolutionFailureReportsChangedErrorKey()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable,
+                    "Source file location for probe was not found in any currently loaded assembly."));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-source-mismatch",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "wrong/path/MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+            var checkUnboundProbes = debugger.GetType().GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Unbound,
+                LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                ErrorKey: SourceMismatchKey(),
+                ErrorDetails: SourceMismatchDetails(),
+                ReportError: true);
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Unbound,
+                LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                ErrorKey: SourceMismatchKey(LineProbeFallbackFailureReason.AmbiguousQualifiedMatches),
+                ErrorDetails: SourceMismatchDetails(LineProbeFallbackFailureReason.AmbiguousQualifiedMatches, bestMatchingTrailingSegments: 3, qualifiedFallbackMatchCount: 2, sameFileNameMatchCount: 2),
+                ReportError: true);
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(3);
+            probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.RECEIVED);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.ErrorMessage.Should().Contain("Fallback failure reason: NoQualifiedSuffixMatch");
+            probeStatusPoller.UpdatedProbeStatuses[2].ProbeStatus.ErrorMessage.Should().Contain("Fallback failure reason: AmbiguousQualifiedMatches");
         }
 
         [Fact]
@@ -687,6 +817,26 @@ public class DynamicInstrumentationTests
 
             debugger.IsInitialized.Should().BeTrue("file probes should not wait for the RCM availability timeout");
             GetFileProbes(debugger).Should().NotBeNull();
+        }
+
+        private static LineProbeResolveErrorKey SourceMismatchKey(LineProbeFallbackFailureReason fallbackFailureReason = LineProbeFallbackFailureReason.NoQualifiedSuffixMatch)
+        {
+            return new LineProbeResolveErrorKey(
+                LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                fallbackFailureReason);
+        }
+
+        private static LineProbeResolveErrorDetails SourceMismatchDetails(
+            LineProbeFallbackFailureReason fallbackFailureReason = LineProbeFallbackFailureReason.NoQualifiedSuffixMatch,
+            int bestMatchingTrailingSegments = 1,
+            int qualifiedFallbackMatchCount = 0,
+            int sameFileNameMatchCount = 1)
+        {
+            return new LineProbeResolveErrorDetails(
+                SourceMismatchKey(fallbackFailureReason),
+                bestMatchingTrailingSegments,
+                qualifiedFallbackMatchCount,
+                sameFileNameMatchCount);
         }
 
         private static ProbeConfiguration? GetFileProbes(DynamicInstrumentation debugger)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -413,7 +413,7 @@ public class DynamicInstrumentationTests
 
             probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
             probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
-            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Should().Be(ProbeStatus.Default);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Should().Be(global::Datadog.Trace.Debugger.PInvoke.ProbeStatus.Default);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -17,7 +17,6 @@ using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Models;
-using Datadog.Trace.Debugger.PInvoke;
 using Datadog.Trace.Debugger.ProbeStatuses;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.DogStatsd;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -17,6 +17,7 @@ using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Models;
+using Datadog.Trace.Debugger.PInvoke;
 using Datadog.Trace.Debugger.ProbeStatuses;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.DogStatsd;
@@ -316,6 +317,184 @@ public class DynamicInstrumentationTests
             }
         }
 
+        [Fact]
+        public void UpdateAddedProbeInstrumentations_RetryableLineProbeResolutionFailureReportsErrorStatus()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                    "Source file location for probe did not uniquely match the PDB document path.",
+                    ReportError: true));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-source-mismatch",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "wrong/path/MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+
+            var status = probeStatusPoller.UpdatedProbeStatuses.Should().ContainSingle().Subject.ProbeStatus;
+            status.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+            status.ErrorMessage.Should().Be("Source file location for probe did not uniquely match the PDB document path.");
+        }
+
+        [Fact]
+        public void UpdateAddedProbeInstrumentations_RetryableLineProbeResolutionFailureKeepsProbeRetryable()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                    "Source file location for probe did not uniquely match the PDB document path.",
+                    ReportError: true));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-source-mismatch",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "wrong/path/MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Bound,
+                Diagnostics: new LineProbeResolutionDiagnostics(ProbeFile: "wrong/path/MyClass.cs", ProbeLine: 25));
+            debugger.GetType()
+                    .GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
+            probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Should().Be(ProbeStatus.Default);
+        }
+
+        [Fact]
+        public void CheckUnboundProbes_RetryableLineProbeResolutionFailureCanTransitionToErrorStatus()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable,
+                    "Source file location for probe was not found in any currently loaded assembly."));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-source-mismatch",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "wrong/path/MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Unbound,
+                LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                "Source file location for probe did not uniquely match the PDB document path.",
+                ReportError: true);
+            debugger.GetType()
+                    .GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
+            probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.RECEIVED);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.ErrorMessage.Should().Be("Source file location for probe did not uniquely match the PDB document path.");
+        }
+
+        [Fact]
+        public void CheckUnboundProbes_RetryableLineProbeResolutionFailureDoesNotRepeatSameErrorStatus()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable,
+                    "Source file location for probe was not found in any currently loaded assembly."));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-source-mismatch",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "wrong/path/MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Unbound,
+                LineProbeResolveReason.LoadedAssemblySourceFileMismatch,
+                "Source file location for probe did not uniquely match the PDB document path.",
+                ReportError: true);
+            var checkUnboundProbes = debugger.GetType().GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
+            probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.RECEIVED);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+        }
+
+        [Fact]
+        public void CheckUnboundProbes_TerminalLineProbeResolutionFailureStopsRetrying()
+        {
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" }, }),
+                NullConfigurationTelemetry.Instance);
+            var lineProbeResolver = new LineProbeResolverMock(
+                new LineProbeResolveResult(
+                    LiveProbeResolveStatus.Unbound,
+                    LineProbeResolveReason.AssemblyNotLoadedOrSymbolsUnavailable,
+                    "Source file location for probe was not found in any currently loaded assembly."));
+            var probeStatusPoller = new ProbeStatusPollerMock();
+            var debugger = CreateDebugger(settings, lineProbeResolver: lineProbeResolver, probeStatusPoller: probeStatusPoller);
+            var probe = new LogProbe
+            {
+                Id = "line-probe-missing-pdb",
+                Language = "dotnet",
+                Where = new Where { SourceFile = "MyClass.cs", Lines = ["25"] },
+                CaptureSnapshot = true
+            };
+
+            debugger.UpdateAddedProbeInstrumentations([probe]);
+
+            lineProbeResolver.NextResult = new LineProbeResolveResult(
+                LiveProbeResolveStatus.Error,
+                LineProbeResolveReason.MissingPdb,
+                "Failed to read from PDB");
+            var checkUnboundProbes = debugger.GetType().GetMethod("CheckUnboundProbes", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+            checkUnboundProbes.Invoke(debugger, [null, new AssemblyLoadEventArgs(typeof(DynamicInstrumentationTests).Assembly)]);
+
+            lineProbeResolver.CallCount.Should().Be(2);
+            probeStatusPoller.UpdatedProbeStatuses.Should().HaveCount(2);
+            probeStatusPoller.UpdatedProbeStatuses[0].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.RECEIVED);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.Status.Should().Be(global::Datadog.Trace.Debugger.Sink.Models.Status.ERROR);
+            probeStatusPoller.UpdatedProbeStatuses[1].ProbeStatus.ErrorMessage.Should().Be("Failed to read from PDB");
+        }
+
         [Theory]
         [InlineData(null, false, "non-existent file")]
         [InlineData("{ invalid json }", true, "invalid json")]
@@ -564,7 +743,8 @@ public class DynamicInstrumentationTests
                 diagnosticsUploader,
                 probeStatusPoller,
                 ConfigurationUpdater.Create("env", "version", 0),
-                global::Datadog.Trace.DogStatsd.NoOpStatsd.Instance);
+                global::Datadog.Trace.DogStatsd.NoOpStatsd.Instance,
+                (_, _, _, _) => { });
             _debuggers.Add(debugger);
             return debugger;
         }
@@ -852,13 +1032,37 @@ public class DynamicInstrumentationTests
 
     private class LineProbeResolverMock : ILineProbeResolver
     {
+        private readonly LineProbeResolveResult _result;
+
+        public LineProbeResolverMock()
+            : this(new LineProbeResolveResult(LiveProbeResolveStatus.Error, LineProbeResolveReason.MissingPdb, "PDB not available in unit test"))
+        {
+        }
+
+        public LineProbeResolverMock(LineProbeResolveResult result)
+        {
+            _result = result;
+        }
+
         internal bool Called { get; private set; }
+
+        internal int CallCount { get; private set; }
+
+        internal LineProbeResolveResult? NextResult { get; set; }
 
         public LineProbeResolveResult TryResolveLineProbe(ProbeDefinition probe, out LineProbeResolver.BoundLineProbeLocation? location, LineProbeDiagnosticLevel diagnosticLevel = LineProbeDiagnosticLevel.Full)
         {
             Called = true;
+            CallCount++;
+            var result = NextResult ?? _result;
+            if (result.Status == LiveProbeResolveStatus.Bound)
+            {
+                location = new LineProbeResolver.BoundLineProbeLocation(probe, Guid.NewGuid(), methodToken: 1, bytecodeOffset: 0, lineNumber: 25);
+                return result;
+            }
+
             location = null;
-            return new LineProbeResolveResult(LiveProbeResolveStatus.Error, LineProbeResolveReason.MissingPdb, "PDB not available in unit test");
+            return result;
         }
     }
 
@@ -893,7 +1097,11 @@ public class DynamicInstrumentationTests
 
     private class ProbeStatusPollerMock : IProbeStatusPoller
     {
+        private readonly List<FetchProbeStatus> _updatedProbeStatuses = new();
+
         internal bool Called { get; private set; }
+
+        internal IReadOnlyList<FetchProbeStatus> UpdatedProbeStatuses => _updatedProbeStatuses;
 
         public void StartPolling()
         {
@@ -913,11 +1121,13 @@ public class DynamicInstrumentationTests
         public void UpdateProbes(string[] probeIds, FetchProbeStatus[] newProbeStatuses)
         {
             Called = true;
+            _updatedProbeStatuses.AddRange(newProbeStatuses);
         }
 
         public void UpdateProbe(string probeId, FetchProbeStatus newProbeStatus)
         {
             Called = true;
+            _updatedProbeStatuses.Add(newProbeStatus);
         }
 
         public string[] GetBoundedProbes()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeStatusSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeStatusSinkTests.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Debugger.ProbeStatuses;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Sink.Models;
 using Datadog.Trace.Util;
+using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
@@ -123,6 +124,7 @@ namespace Datadog.Trace.Tests.Debugger
             probe.DebuggerDiagnostics.Diagnostics.Exception.Message.Should().Be(errorMessage);
             probe.DebuggerDiagnostics.Diagnostics.Exception.StackTrace.Should().BeNull();
             JsonConvert.SerializeObject(probe).Should().NotContain("stacktrace");
+            JsonHelper.SerializeObject(probe).Should().NotContain("stacktrace");
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeStatusSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeStatusSinkTests.cs
@@ -542,6 +542,27 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void PollerDoesNotReplayExplicitErrorStatusOnPoll()
+        {
+            _timeLord.StopTime();
+            var probeId = Guid.NewGuid().ToString();
+            using var poller = ProbeStatusPoller.Create(_sink, _settings);
+            var fetchProbeStatus = new FetchProbeStatus(probeId, 1, new NativeProbeStatus(probeId, Status.ERROR, "error"));
+
+            poller.UpdateProbe(probeId, fetchProbeStatus);
+            _sink.GetDiagnostics().Should().Equal(new[]
+            {
+                new ProbeStatus(nameof(ProbeStatusSinkTests), probeId, Status.ERROR, probeVersion: 1, errorMessage: "error")
+            });
+
+            poller.GetType()
+                  .GetMethod("OnProbeStatusesPoll", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                  .Invoke(poller, []);
+
+            _sink.GetDiagnostics().Should().BeEmpty();
+        }
+
+        [Fact]
         public void PollerDropsQueuedExplicitStatusWhenUpdatingToNewExplicitVersion()
         {
             var probeId = Guid.NewGuid().ToString();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeStatusSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeStatusSinkTests.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Debugger.ProbeStatuses;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Sink.Models;
 using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
 using NativeProbeStatus = Datadog.Trace.Debugger.PInvoke.ProbeStatus;
@@ -105,6 +106,23 @@ namespace Datadog.Trace.Tests.Debugger
             probe.DebuggerDiagnostics.Diagnostics.Exception.Type.Should().Be(exception.GetType().Name);
             probe.DebuggerDiagnostics.Diagnostics.Exception.Message.Should().Be(exception.Message);
             probe.DebuggerDiagnostics.Diagnostics.Exception.StackTrace.Should().Be(exception.StackTrace);
+        }
+
+        [Fact]
+        public void AddError_WithOnlyMessage_OmitsStackTrace()
+        {
+            var probeId = Guid.NewGuid().ToString();
+            var errorMessage = $"Test error at ${nameof(AddError_WithOnlyMessage_OmitsStackTrace)}";
+
+            _sink.AddProbeStatus(probeId, Status.ERROR, errorMessage: errorMessage);
+
+            var probe = _sink.GetDiagnostics().Should().ContainSingle().Subject;
+            probe.DebuggerDiagnostics.Diagnostics.Status.Should().Be(Status.ERROR);
+            probe.DebuggerDiagnostics.Diagnostics.Exception.Should().NotBeNull();
+            probe.DebuggerDiagnostics.Diagnostics.Exception.Type.Should().Be("NO_TYPE");
+            probe.DebuggerDiagnostics.Diagnostics.Exception.Message.Should().Be(errorMessage);
+            probe.DebuggerDiagnostics.Diagnostics.Exception.StackTrace.Should().BeNull();
+            JsonConvert.SerializeObject(probe).Should().NotContain("stacktrace");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes
- Report retryable line-probe source path mismatches as backend `ERROR` statuses with actionable fallback diagnostics.
- Keep retryable line probes in the unbound retry set so later assembly loads can still bind them.
- Stop retrying terminal resolver errors while continuing to retry non-terminal unbound results.
- Deduplicate repeated retryable line-probe error reports by stable error key instead of full rendered message/details.
- Avoid replaying explicitly pushed probe error statuses during status polling.
- Add focused resolver, DynamicInstrumentation, and probe status poller coverage for the new status transitions.

## Reason for change
- Some line-probe resolution failures were only visible locally in logs, leaving users without backend feedback about why a probe did not bind.
- Repeated retry attempts could resend equivalent error statuses when only diagnostic counts changed, creating noisy backend updates.

## Implementation details
- Adds `LineProbeResolveResult.ReportError` to separate retryability from backend status reporting.
- Adds line-probe resolve error key/details payloads so `DynamicInstrumentation` can deduplicate by failure category while still rendering detailed messages.
- `DynamicInstrumentation` reports `Unbound + ReportError` as `ERROR`, keeps those probes retryable, and only reports again when the stable error key changes.
- Terminal `Error` results are reported as `ERROR` and removed from retry tracking.
- Source-file mismatch messages include fallback diagnostics when available; detailed diagnostic collection remains gated by diagnostic level.
- `ProbeStatusPoller` drops explicit status updates after they are sent so poll cycles do not replay them.

## Test coverage
- Added `LineProbeResolverTest` coverage for source-file mismatch error keys/details.
- Added `DynamicInstrumentationTests` coverage for retryable line-probe errors, deduplication when only diagnostic counts change, and reporting again when the stable error key changes.
- Added `ProbeStatusSinkTests` coverage to ensure explicit error statuses are not replayed on poll.