### PR TITLE
[ASM Test] Mark WebApi null-action test as end-to-end

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
@@ -131,6 +131,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, body, 5, expectedSpans, settings, "application/json");
         }
 
+        [Trait("Category", "EndToEnd")]
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]


### PR DESCRIPTION
## Summary of changes
- Mark the WebApi null-action ASM IIS test with the EndToEnd category trait.

## Reason for change
- Keeps the test metadata consistent with the neighboring WebApi IIS tests added by #8597.

## Implementation details
- Adds only the missing `[Trait("Category", "EndToEnd")]` attribute to `TestNullAction`.

## Test coverage
- metadata-only test attribute change.
