### PR TITLE
Exclude OpenTelemetry.Api from benchmark PR comments

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/post-pr-comment.sh
@@ -26,9 +26,14 @@ red='\033[1;91m'
 normal='\033[0m'
 
 # Check for baseline files
+# Exclude OpenTelemetry.Api benchmarks from PR comments since they only run on master (not on PRs).
 shopt -s nullglob
 baseline_files=("$ARTIFACTS_DIR"/baseline*.converted.json)
-candidate_files=("$ARTIFACTS_DIR"/candidate*.converted.json)
+candidate_files=()
+for f in "$ARTIFACTS_DIR"/candidate*.converted.json; do
+    [[ "$f" == *OpenTelemetry.Api.* ]] && continue
+    candidate_files+=("$f")
+done
 shopt -u nullglob
 
 if [ ${#candidate_files[@]} -eq 0 ]; then


### PR DESCRIPTION
## Summary of changes

Exclude `OpenTelemetry.Api` benchmark results from PR comment comparison.

## Reason for change

As a follow up to enabling OTel microbenchmarks, the PR comment has become very noisy, as it's expecting all the benchmarks, even though we don't run them on PRs.

https://github.com/DataDog/dd-trace-dotnet/pull/8593#issuecomment-4414182916

## Implementation details

Filter out `candidate.OpenTelemetry.Api.*` files when globbing for candidate results in `post-pr-comment.sh`. These benchmarks only run on master (Nuke doesn't build `Benchmarks.OpenTelemetry.Api` on PRs), so including them causes "scenarios present only in baseline" warnings.

## Test coverage

CI pipeline on this branch.

## Other details

<!-- Fixes #{issue} -->