### PR TITLE
ci: replace secrets.GITHUB_TOKEN with dd-octo-sts

### DIFF
--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       pull-requests: write # need to modify existing PR
       issues: write # need to potentially create a new milestone
+      id-token: write # required for dd-octo-sts OIDC token
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,8 +25,15 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto-add-vnext-milestone-to-pr
+
       - name: "Assign to vNext Milestone"
         run: ./tracer/build.sh AssignPullRequestToMilestone
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           PullRequestNumber: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -12,8 +12,6 @@ jobs:
     permissions:
       actions: read # read secrets
       id-token: write # Required for dd-octo-sts authentication
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       - name: Support longpaths
@@ -26,6 +24,13 @@ jobs:
           scope: DataDog/dd-trace-dotnet
           policy: self.auto_bump_test_package_versions.create-pr
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto-bump-test-package-versions
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -35,6 +40,8 @@ jobs:
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions --PackageVersionCooldownDays 2
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: Read bump report
         id: bump

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -1,21 +1,28 @@
 name: Check snapshots
 
 on:
-- pull_request
+  - pull_request
 
 jobs:
   check-snapshots:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write # need to add a comment to a PR
+      id-token: write # required for dd-octo-sts OIDC token
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto-check-snapshots
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
@@ -24,6 +31,6 @@ jobs:
       - name: "Check Snapshots"
         run: ./tracer/build.sh SummaryOfSnapshotChanges
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           PullRequestNumber: "${{ github.event.pull_request.number }}"
           TargetBranch: "${{ github.base_ref }}"

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -3,11 +3,10 @@ name: Auto Block PR on Code Freeze
 on:
   pull_request:
     branches:
-      - 'main'
-      - 'master'
-      - 'release/**'
-      - 'hotfix/**'
-
+      - "main"
+      - "master"
+      - "release/**"
+      - "hotfix/**"
 
 jobs:
   check_for_code_freeze:
@@ -16,41 +15,49 @@ jobs:
       contents: read
       issues: read # need to read milestones
       statuses: write # add a commit status check
+      id-token: write # required for dd-octo-sts OIDC token
 
     steps:
-    - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
-      name: 'Get Milestones'
-      id: milestones
-      with:
-        route: GET /repos/{owner}/{repo}/milestones
-        owner: DataDog
-        repo: dd-trace-dotnet
-        state: open
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto-code-freeze-block-pr
 
-    - run: |
-        set -o pipefail
-        sha="${{ github.event.pull_request.head.sha }}"
-        targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/auto_code_freeze_block_pr.yml"
-        state="success"
-        description="No code freeze is in place"
-        json=$(cat << 'ENDOFMESSAGE'
-          ${{ steps.milestones.outputs.data }}
-        ENDOFMESSAGE
-        )
-        
-        if addr=$(echo $json | jq -er '.[] | select(.title == "Code Freeze")'); then
-          state="failure"
-          description="A code freeze is in place"
-        fi
-        
-        echo "$description, setting check status $state"
-        
-        curl -fX POST \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
-            -d '{"state":"'"$state"'","context":"code_freeze","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
+      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+        name: "Get Milestones"
+        id: milestones
+        with:
+          route: GET /repos/{owner}/{repo}/milestones
+          owner: DataDog
+          repo: dd-trace-dotnet
+          state: open
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
-      name: 'Check Code Freeze status'
+      - run: |
+          set -o pipefail
+          sha="${{ github.event.pull_request.head.sha }}"
+          targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/auto_code_freeze_block_pr.yml"
+          state="success"
+          description="No code freeze is in place"
+          json=$(cat << 'ENDOFMESSAGE'
+            ${{ steps.milestones.outputs.data }}
+          ENDOFMESSAGE
+          )
+
+          if addr=$(echo $json | jq -er '.[] | select(.title == "Code Freeze")'); then
+            state="failure"
+            description="A code freeze is in place"
+          fi
+
+          echo "$description, setting check status $state"
+
+          curl -fX POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ steps.generate-token.outputs.token }}" \
+              "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
+              -d '{"state":"'"$state"'","context":"code_freeze","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
+
+        name: "Check Code Freeze status"

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -17,8 +17,6 @@ jobs:
       contents: write # Creates a branch
       issues: write # Closes milestones
       id-token: write # Required for dd-octo-sts authentication
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       - name: Support longpaths
@@ -30,6 +28,13 @@ jobs:
         with:
           scope: DataDog/dd-trace-dotnet
           policy: self.auto_create_version_bump_pr.create-pr
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto-create-version-bump-pr
 
       - name: "Select branch"
         id: select_branch
@@ -59,21 +64,27 @@ jobs:
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog
         env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           RELEASE_NOTES: ${{ github.event.release.body }}
 
       - name: "CalculateNextVersion"
         run: .\tracer\build.ps1 CalculateNextVersion
         id: versions
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion
         env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           NewVersion: ${{ steps.versions.outputs.version }}
           NewIsPrerelease: ${{ steps.versions.outputs.isprerelease }}
 
       - name: "Verify Changes"
         id: changes
         run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: Create Pull Request
         id: pr
@@ -90,6 +101,7 @@ jobs:
       - name: "Close previous milestone"
         run: .\tracer\build.ps1 CloseMilestone
         env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           Version: ${{steps.versions.outputs.previous_version}}
 
       - name: Display output

--- a/.github/workflows/auto_deploy_aas_test_apps.yml
+++ b/.github/workflows/auto_deploy_aas_test_apps.yml
@@ -3,8 +3,8 @@ name: Auto deploy AAS test apps
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * TUE'
-    - cron: '0 0 * * FRI'
+    - cron: "0 0 * * TUE"
+    - cron: "0 0 * * FRI"
 
 jobs:
   deploy_aas_test_apps:
@@ -12,17 +12,22 @@ jobs:
     permissions:
       contents: read
       actions: read # read secrets
-      issues: read # Read milestones milestones
+      issues: read # Read milestones
       id-token: write # required for dd-octo-sts OIDC token
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto-deploy-aas-test-apps
+
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
-        name: 'Open Code Freeze Milestone'
+        name: "Open Code Freeze Milestone"
         id: milestones
         if: github.event_name != 'workflow_dispatch'
         with:
@@ -31,16 +36,16 @@ jobs:
           repo: dd-trace-dotnet
           state: open
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
-      - name: 'Check if code freeze is in place'
+      - name: "Check if code freeze is in place"
         if: github.event_name != 'workflow_dispatch' # don't check if triggered manually
         run: |
           json=$(cat << 'ENDOFMESSAGE'
             ${{ steps.milestones.outputs.data }}
           ENDOFMESSAGE
           )
-          
+
           if addr=$(echo $json | jq -er '.[] | select(.title == "Code Freeze")'); then
             echo "A code freeze is in place, we should not trigger a deployment."
             echo "stop=true" >> "$GITHUB_ENV"
@@ -57,7 +62,7 @@ jobs:
           policy: dd-trace-dotnet.github.deploy-aas-dev-apps
 
       - uses: ./.github/actions/deploy-aas-dev-apps
-        name: 'Trigger AAS deploy'
+        name: "Trigger AAS deploy"
         if: env.stop != 'true'
         with:
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -6,16 +6,23 @@ on:
 
 jobs:
   add-labels:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write # Update labels on PRs (might not be necessary, but we call the UpdateIssue API so...)
       pull-requests: write # Update labels on PRs
+      id-token: write # required for dd-octo-sts OIDC token
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.auto-label-prs
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
@@ -25,11 +32,11 @@ jobs:
         if: github.event.action != 'labeled'
         run: ./tracer/build.sh AssignLabelsToPullRequest
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           PullRequestNumber: "${{ github.event.pull_request.number }}"
 
       - name: "Validate PR has labels"
         run: ./tracer/build.sh ValidatePrLabels
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          PullRequestNumber: "${{ github.event.pull_request.number }}" 
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
+          PullRequestNumber: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   end_code_freeze:
-    if: | 
-      github.event_name == 'workflow_dispatch' || 
+    if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'closed')
     runs-on: ubuntu-latest
     permissions:
@@ -16,29 +16,35 @@ jobs:
       pull-requests: read # Fetches PRs
       issues: write # Opens milestones
       statuses: write # add a commit status check
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      id-token: write # required for dd-octo-sts OIDC token
 
     steps:
-    - name: Clone dd-trace-dotnet repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Clone dd-trace-dotnet repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
-      name: 'Close Code Freeze Milestone'
-      id: milestones
-      if: github.event_name == 'workflow_dispatch'
-      with:
-        route: PATCH /repos/{owner}/{repo}/milestones/115
-        owner: DataDog
-        repo: dd-trace-dotnet
-        state: closed
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.code-freeze-end
 
-    # Unfreeze PRs
-    - uses: ./.github/actions/pr-status-updater
-      name: 'Unfreeze PRs'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        state: success
-        workflow_name: code_freeze_end.yml # this allows for a click through to go to the action
+      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+        name: "Close Code Freeze Milestone"
+        id: milestones
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          route: PATCH /repos/{owner}/{repo}/milestones/115
+          owner: DataDog
+          repo: dd-trace-dotnet
+          state: closed
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
+
+      # Unfreeze PRs
+      - uses: ./.github/actions/pr-status-updater
+        name: "Unfreeze PRs"
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          state: success
+          workflow_name: code_freeze_end.yml # this allows for a click through to go to the action

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   start_code_freeze:
-    if: | 
-      github.event_name == 'workflow_dispatch' || 
+    if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'open')
     runs-on: ubuntu-latest
     permissions:
@@ -18,15 +18,20 @@ jobs:
       issues: write # Opens milestones
       statuses: write # add a commit status check
       id-token: write # required for dd-octo-sts OIDC token
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.code-freeze-start
+
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
-        name: 'Open Code Freeze Milestone'
+        name: "Open Code Freeze Milestone"
         id: milestones
         if: github.event_name == 'workflow_dispatch'
         with:
@@ -35,12 +40,12 @@ jobs:
           repo: dd-trace-dotnet
           state: open
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - uses: ./.github/actions/pr-status-updater
-        name: 'Freeze PRs'
+        name: "Freeze PRs"
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           state: failure
           workflow_name: code_freeze_start.yml # this allows for a click through to go to the action
 
@@ -52,6 +57,6 @@ jobs:
           policy: dd-trace-dotnet.github.deploy-aas-dev-apps
 
       - uses: ./.github/actions/deploy-aas-dev-apps
-        name: 'Trigger AAS deploy'
+        name: "Trigger AAS deploy"
         with:
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -8,16 +8,16 @@ on:
   workflow_dispatch:
     inputs:
       azdo_build_id:
-        description: 'The specific AzDo build from which the release artifacts will be downloaded.'
+        description: "The specific AzDo build from which the release artifacts will be downloaded."
         required: true
 
       is_release_version:
         description: 'Is this run generating release artifacts? Set to "True" to publish `:latest` tags, otherwise generates `:latest-snapshot` tags'
         required: true
-        default: 'False'
+        default: "False"
 
       branch_name:
-        description: 'Branch name for tagging (optional). If provided, tags as branch name instead of latest_snapshot'
+        description: "Branch name for tagging (optional). If provided, tags as branch name instead of latest_snapshot"
         required: false
 
 jobs:
@@ -27,47 +27,55 @@ jobs:
       contents: read
       actions: read # read secrets
       packages: write # pushing to ghcr.io
+      id-token: write # required for dd-octo-sts OIDC token
     env:
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
-    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
-      with:
-        global-json-file: global.json
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.create-system-test-docker-base-images
 
-    - name: "Get current version"
-      id: versions
-      run: ./tracer/build.sh OutputCurrentVersionToGitHub
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          global-json-file: global.json
 
-    - name: "Download build assets from Azure Pipelines"
-      id: assets
-      run: ./tracer/build.sh DownloadAzurePipelineFromBuild
-      env:
-        AzureDevopsBuildId: "${{ github.event.inputs.azdo_build_id }}"
+      - name: "Get current version"
+        id: versions
+        run: ./tracer/build.sh OutputCurrentVersionToGitHub
 
-    - name: "Sanitize branch name"
-      id: image_tag
-      run: |
-        BRANCH="$BRANCH_NAME_INPUT"
-        if [[ -z "$BRANCH" ]]; then
-          echo "ERROR: Missing required 'branch_name' input. Aborting docker image build."
-          exit 1
-        fi
-        SAFE_TAG="${BRANCH//\//_}"
-        echo "tag=$SAFE_TAG" >> $GITHUB_OUTPUT
-      env:
-        BRANCH_NAME_INPUT: "${{ github.event.inputs.branch_name }}"
+      - name: "Download build assets from Azure Pipelines"
+        id: assets
+        run: ./tracer/build.sh DownloadAzurePipelineFromBuild
+        env:
+          AzureDevopsBuildId: "${{ github.event.inputs.azdo_build_id }}"
 
-    - uses: ./.github/actions/create-system-test-docker-base-images
-      name: 'Create system test docker images'
-      with:
-        artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
-        package_version: "${{steps.versions.outputs.version}}"
-        lib_waf_version: "${{steps.versions.outputs.lib_waf_version}}"
-        waf_rules_version: "${{steps.versions.outputs.waf_rules_version}}"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        image_tag: ${{steps.image_tag.outputs.tag}}
+      - name: "Sanitize branch name"
+        id: image_tag
+        run: |
+          BRANCH="$BRANCH_NAME_INPUT"
+          if [[ -z "$BRANCH" ]]; then
+            echo "ERROR: Missing required 'branch_name' input. Aborting docker image build."
+            exit 1
+          fi
+          SAFE_TAG="${BRANCH//\//_}"
+          echo "tag=$SAFE_TAG" >> $GITHUB_OUTPUT
+        env:
+          BRANCH_NAME_INPUT: "${{ github.event.inputs.branch_name }}"
+
+      - uses: ./.github/actions/create-system-test-docker-base-images
+        name: "Create system test docker images"
+        with:
+          artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
+          package_version: "${{steps.versions.outputs.version}}"
+          lib_waf_version: "${{steps.versions.outputs.lib_waf_version}}"
+          waf_rules_version: "${{steps.versions.outputs.waf_rules_version}}"
+          github_token: ${{ steps.generate-token.outputs.token }}
+          image_tag: ${{steps.image_tag.outputs.tag}}

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -4,33 +4,33 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Hotfix Version Number (x.x.x)'
+        description: "Hotfix Version Number (x.x.x)"
         required: true
       is_prerelease:
-        description: 'Is Prerelease version? (true/false)'
-        default: 'false'
+        description: "Is Prerelease version? (true/false)"
+        default: "false"
         required: true
 
 jobs:
   check_tag:
     runs-on: ubuntu-latest
     steps:
-        - name: Verify running from a tag
-          run: |
-            if [[ "${{  github.ref }}" != refs/tags/* ]]; then
-              echo "Error: This workflow can only be run from a tag"
-              echo "Current ref: ${{ github.ref }}"
-              exit 1
-            fi
+      - name: Verify running from a tag
+        run: |
+          if [[ "${{  github.ref }}" != refs/tags/* ]]; then
+            echo "Error: This workflow can only be run from a tag"
+            echo "Current ref: ${{ github.ref }}"
+            exit 1
+          fi
 
   bump_version:
     needs: check_tag
     runs-on: windows-latest
     permissions:
       contents: write # Push branches
-      issues: write # change milestones 
+      issues: write # change milestones
+      id-token: write # Required for dd-octo-sts authentication
     env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       NewVersion: "${{ github.event.inputs.version }}"
       NewIsPrerelease: "${{ github.event.inputs.is_prerelease }}"
 
@@ -40,6 +40,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.create-hotfix-branch
 
       - name: "Configure Git Credentials"
         run: |
@@ -52,14 +59,20 @@ jobs:
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: "Verify Changes"
         id: changes
         run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump -ExpectChangelogUpdate false
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: "Output Version"
         id: versions
         run: .\tracer\build.ps1 OutputCurrentVersionToGitHub
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: "Push hotfix branch"
         run: |
@@ -67,3 +80,5 @@ jobs:
           git add .
           git commit -m "[Version Bump] ${{steps.versions.outputs.full_version}}"
           git push origin -u hotfix/${{ steps.versions.outputs.full_version }}
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"

--- a/.github/workflows/create_skip_code_freeze.yml
+++ b/.github/workflows/create_skip_code_freeze.yml
@@ -9,14 +9,22 @@ jobs:
     permissions:
       contents: read
       issues: write
-    
+      id-token: write
+
     steps:
-      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
-        name: 'Open Skip Milestone'
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.create-skip-code-freeze
+
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+        name: "Open Skip Milestone"
         with:
           route: PATCH /repos/{owner}/{repo}/milestones/183
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           state: open
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -18,7 +18,6 @@ jobs:
       issues: write # Closes milestones
       id-token: write # Required for dd-octo-sts authentication
     env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       NewVersion: "${{ github.event.inputs.version }}"
       NewIsPrerelease: "${{ github.event.inputs.is_prerelease }}"
 
@@ -33,6 +32,13 @@ jobs:
           scope: DataDog/dd-trace-dotnet
           policy: self.force_manual_version_bump.create-pr
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.force-manual-version-bump
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -42,14 +48,20 @@ jobs:
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: "Verify Changes"
         id: changes
         run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump -ExpectChangelogUpdate false
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: "Output Version"
         id: versions
         run: .\tracer\build.ps1 OutputCurrentVersionToGitHub
+        env:
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
 
       - name: Create Pull Request
         id: pr

--- a/.github/workflows/generate_package_versions.yml
+++ b/.github/workflows/generate_package_versions.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: write # Pushes to a branch
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      id-token: write # Required for dd-octo-sts authentication
 
     steps:
       - name: Fail if branch is on master
@@ -24,12 +23,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.generate-package-versions
+
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Create commits
         run: |
@@ -38,4 +46,4 @@ jobs:
           git commit -am "Updated package versions"
           git push
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       statuses: write # Update status checks
+      id-token: write # required for dd-octo-sts OIDC token
 
     steps:
       - name: Fail if branch is not version-bump PR or bot PR
@@ -16,6 +17,13 @@ jobs:
         run: |
           echo "This workflow should only be triggered on the version-bump-x.x.x or bot/* branches but found  ${{ github.ref }}"
           exit 1
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.override-version-bump-pr-checks
 
       - run: |
           set -o pipefail
@@ -27,14 +35,14 @@ jobs:
           targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/override_version_bump_pr_checks.yml"
           state="success"
           description="Forced override (via GitHub Action)"
-          
+
           for context in ${contexts[@]}; do
             echo "Forcing check check status to $state for $context"
-          
+
             curl -X POST \
             --fail-with-body \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.generate-token.outputs.token }}" \
               "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
               -d '{"state":"'"$state"'","context":"'"$context"'","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
           done

--- a/.github/workflows/scheduled_aas_deploy.yml
+++ b/.github/workflows/scheduled_aas_deploy.yml
@@ -2,15 +2,15 @@ name: Scheduled AAS Deployment
 
 on:
   schedule:
-    - cron: '30 22 * * FRI'  # Every Friday at 10:30 PM UTC
+    - cron: "30 22 * * FRI" # Every Friday at 10:30 PM UTC
   workflow_dispatch:
     inputs:
       force_deploy:
-        description: '[TESTING] Force deployment regardless of code freeze status'
+        description: "[TESTING] Force deployment regardless of code freeze status"
         type: boolean
         default: false
       override_week:
-        description: '[TESTING] Override week number (empty = use current week, even number = deploy)'
+        description: "[TESTING] Override week number (empty = use current week, even number = deploy)"
         required: false
         type: string
 
@@ -22,7 +22,7 @@ jobs:
       actions: read
       issues: write
       id-token: write # required for dd-octo-sts OIDC token
-    
+
     steps:
       - name: Calculate week number
         id: week
@@ -52,17 +52,25 @@ jobs:
             echo "should_proceed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get GitHub Token via dd-octo-sts
+        if: steps.should_run.outputs.should_proceed == 'true'
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.scheduled-aas-deploy
+
       # Check skip milestone
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
         if: steps.should_run.outputs.should_proceed == 'true'
-        name: 'Check Skip Milestone'
+        name: "Check Skip Milestone"
         id: skip_milestone
         with:
           route: GET /repos/{owner}/{repo}/milestones/183 # Skip Scheduled Code Freeze milestone ID
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Process skip state
         if: steps.should_run.outputs.should_proceed == 'true'
@@ -81,14 +89,14 @@ jobs:
       # Close skip milestone if we're skipping
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
         if: steps.should_run.outputs.should_proceed == 'true' && steps.check_skip.outputs.should_proceed == 'false'
-        name: 'Close Skip Milestone'
+        name: "Close Skip Milestone"
         with:
           route: PATCH /repos/{owner}/{repo}/milestones/183 # Skip Scheduled Code Freeze milestone ID
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           state: closed
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       # Checkout and deploy if we should proceed
       - name: Clone repository
@@ -105,6 +113,6 @@ jobs:
 
       - uses: ./.github/actions/deploy-aas-dev-apps
         if: steps.check_skip.outputs.should_proceed == 'true'
-        name: 'Trigger AAS deploy'
+        name: "Trigger AAS deploy"
         with:
           github_token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/scheduled_code_freeze.yml
+++ b/.github/workflows/scheduled_code_freeze.yml
@@ -2,15 +2,15 @@ name: Scheduled Code Freeze
 
 on:
   schedule:
-    - cron: '3 21 * * FRI'  # Every Friday at 9:03 PM UTC
+    - cron: "3 21 * * FRI" # Every Friday at 9:03 PM UTC
   workflow_dispatch:
     inputs:
       force_run:
-        description: '[TESTING] Force run even if not alternating Friday'
+        description: "[TESTING] Force run even if not alternating Friday"
         type: boolean
         default: false
       override_week:
-        description: '[TESTING] Override week number (empty = use current week, even number = freeze)'
+        description: "[TESTING] Override week number (empty = use current week, even number = freeze)"
         required: false
         type: string
 
@@ -23,7 +23,8 @@ jobs:
       pull-requests: read
       issues: write
       statuses: write
-    
+      id-token: write # required for dd-octo-sts OIDC token
+
     steps:
       - name: Calculate week number
         id: week
@@ -53,17 +54,25 @@ jobs:
             echo "should_proceed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get GitHub Token via dd-octo-sts
+        if: steps.should_run.outputs.should_proceed == 'true'
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-dotnet
+          policy: self.scheduled-code-freeze
+
       # Check skip milestone
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
         if: steps.should_run.outputs.should_proceed == 'true'
-        name: 'Check Skip Milestone'
+        name: "Check Skip Milestone"
         id: skip_milestone
         with:
           route: GET /repos/{owner}/{repo}/milestones/183 # Skip Scheduled Code Freeze milestone ID
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Process skip state
         if: steps.should_run.outputs.should_proceed == 'true'
@@ -82,7 +91,7 @@ jobs:
       # Open code freeze milestone
       - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
         if: steps.check_skip.outputs.should_proceed == 'true'
-        name: 'Open Code Freeze Milestone'
+        name: "Open Code Freeze Milestone"
         id: open_freeze
         with:
           route: PATCH /repos/{owner}/{repo}/milestones/115 # Code Freeze milestone ID
@@ -90,7 +99,7 @@ jobs:
           repo: ${{ github.event.repository.name }}
           state: open
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Checkout for PR updates
         if: steps.check_skip.outputs.should_proceed == 'true' && success()
@@ -100,6 +109,6 @@ jobs:
       - uses: ./.github/actions/pr-status-updater
         if: steps.check_skip.outputs.should_proceed == 'true' && success()
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           state: failure
           workflow_name: scheduled_code_freeze.yml


### PR DESCRIPTION
> **Stacked on #8612** (chainguard policies — merge first).

## Summary of changes

Replace all `secrets.GITHUB_TOKEN` usage across 17 GitHub Actions workflows with OIDC tokens obtained from `DataDog/dd-octo-sts-action`. Add 17 corresponding Chainguard policy files.

## Reason for change

The dd-octo-sts token exchange is auditable and governed by Chainguard policy files that explicitly declare which workflow, event, and ref pattern may request which permissions.

## Implementation details

- Each workflow now calls `DataDog/dd-octo-sts-action` to mint a scoped token.
- Workflows that already used `dd-octo-sts` for cross-repo operations (AAS deploy, PR creation) now obtain a second token scoped to this repo.
- Added 17 Chainguard policy files defining the permission boundary for each token grant.
- No functional changes to what the workflows do.

## Test coverage

Watch CI. All workflows should behave identically to before.

## Jira

- [APMLP-1601](https://datadoghq.atlassian.net/browse/APMLP-1601)


[APMLP-1601]: https://datadoghq.atlassian.net/browse/APMLP-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ