### PR TITLE
Add handling of `OutOfMemoryException` to runtime metrics polyfill

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsPolyfill.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsPolyfill.cs
@@ -299,6 +299,10 @@ internal sealed class RuntimeMetricsPolyfill : IDisposable
             var tag = _exceptionTagCache.GetOrAdd(typeName, static name => new KeyValuePair<string, object?>("error.type", name));
             _exceptions?.Add(1, tag);
         }
+        catch
+        {
+            // Don't want to escape here
+        }
         finally
         {
             _handlingFirstChanceException = false;

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsPolyfill.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsPolyfill.cs
@@ -280,16 +280,29 @@ internal sealed class RuntimeMetricsPolyfill : IDisposable
 
     private void OnFirstChanceException(object? sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e)
     {
+        if (e.Exception is OutOfMemoryException)
+        {
+            // We have a special path for OOM because we can't allocate
+            // Doing anything here is liable to throw exceptions
+            return;
+        }
+
         if (_handlingFirstChanceException)
         {
             return;
         }
 
-        _handlingFirstChanceException = true;
-        var typeName = e.Exception.GetType().Name;
-        var tag = _exceptionTagCache.GetOrAdd(typeName, static name => new KeyValuePair<string, object?>("error.type", name));
-        _exceptions?.Add(1, tag);
-        _handlingFirstChanceException = false;
+        try
+        {
+            _handlingFirstChanceException = true;
+            var typeName = e.Exception.GetType().Name;
+            var tag = _exceptionTagCache.GetOrAdd(typeName, static name => new KeyValuePair<string, object?>("error.type", name));
+            _exceptions?.Add(1, tag);
+        }
+        finally
+        {
+            _handlingFirstChanceException = false;
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary of changes

Adds explicit handling of `OutOfMemoryException` to runtime metrics polyfill added in #8457 

## Reason for change

Doing anything when you have an `OutOfMemoryException` is liable to cause allocation, and trigger a full-on crash. We have guards for this today in `RuntimeMetricsWriter`, so we should probably do something similar with our pollyfill too.

## Implementation details

- Add an explicit guard to the handler for `OutOfMemoryException`
- Use try-finally to ensure we definitely reset `_handlingFirstChanceException`

## Test coverage

Not easy to test in practice, and relatively self explanatory so meh
