### PR TITLE
Fix ASM accessing `HttpRequest.Headers` on .NET Framework without guarding

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -71,7 +71,7 @@ internal readonly partial struct SecurityCoordinator
 
     internal static SecurityCoordinator Get(Security security, Span span, HttpTransport transport) => new(security, span, transport);
 
-    internal static Dictionary<string, object>? ExtractHeadersFromRequest(IHeaderDictionary headers) => ExtractHeaders(headers.Keys, key => GetHeaderValueForWaf(headers, key));
+    internal static Dictionary<string, object>? ExtractHeadersFromRequest(IHeaderDictionary headers) => ExtractHeaders(headers.Keys, headers, static (collection, key) => GetHeaderValueForWaf((IHeaderDictionary)collection, key));
 
     private static object GetHeaderAsArray(StringValues value) => value.Count == 1 ? value[0] : value;
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -410,8 +410,10 @@ internal readonly partial struct SecurityCoordinator
     public Dictionary<string, object> GetBasicRequestArgsForWaf()
     {
         var request = _httpTransport.Context.Request;
-        var headers = request.Headers;
-        var headersDic = ExtractHeaders(headers.AllKeys, headers, static (collection, key) => GetHeaderValueForWaf((NameValueCollection)collection, key));
+        var headers = RequestDataHelper.GetHeaders(request);
+        var headersDic = headers is not null
+                             ? ExtractHeaders(headers.AllKeys, headers, static (collection, key) => GetHeaderValueForWaf((NameValueCollection)collection, key))
+                             : null;
         var cookiesDic = ExtractCookiesFromRequest(request);
 
         var queryString = RequestDataHelper.GetQueryString(request);

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -411,7 +411,7 @@ internal readonly partial struct SecurityCoordinator
     {
         var request = _httpTransport.Context.Request;
         var headers = request.Headers;
-        var headersDic = ExtractHeaders(headers.AllKeys, key => GetHeaderValueForWaf(headers, key));
+        var headersDic = ExtractHeaders(headers.AllKeys, headers, static (collection, key) => GetHeaderValueForWaf((NameValueCollection)collection, key));
         var cookiesDic = ExtractCookiesFromRequest(request);
 
         var queryString = RequestDataHelper.GetQueryString(request);

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -216,7 +216,7 @@ internal readonly partial struct SecurityCoordinator
     }
 
 #pragma warning disable CA1859 // Use concrete types where possible for improved performance - It's not actually possible here
-    private static Dictionary<string, object>? ExtractHeaders(ICollection<string> keys, Func<string, object> getHeaderValue)
+    private static Dictionary<string, object>? ExtractHeaders(ICollection<string> keys, object collection, Func<object, string, object> getHeaderValue)
 #pragma warning restore CA1859
     {
         if (keys.Count > 0)
@@ -228,7 +228,7 @@ internal readonly partial struct SecurityCoordinator
                 if (!currentKey.Equals("cookie", StringComparison.OrdinalIgnoreCase))
                 {
                     currentKey = currentKey.ToLowerInvariant();
-                    var value = getHeaderValue(currentKey);
+                    var value = getHeaderValue(collection, currentKey);
 #if NETCOREAPP
                     if (!headersDic.TryAdd(currentKey, value))
                     {


### PR DESCRIPTION
## Summary of changes

- Remove need for allocating a closure
- Fix potential `HttpRequestValidationException` leaking in ASM paths

## Reason for change

Calling `HttpRequest.Headers` can throw an `HttpRequestValidationException` if the headers contain "dangerous values". We guarded against that in #5943 by adding a helper, but in #6164 we refactored, and stopped using it.

## Implementation details

- Reinstates using `RequestDataHelper.GetHeaders()` instead of calling `request.Headers` directly. 
- Removes the need for a closure allocation every time you call `SecurityCoordinator.ExtractHeaders()` by allowing you to pass the collection in to the method, and passing that through to the `Func`. Not required, just a minor perf optimization

## Test coverage

Meh - correctness should be covered by existing tests. Adding a regression test seems overkill tbh

