### PR TITLE
ci: add dd-octo-sts chainguard policy files

### DIFF
--- a/.github/chainguard/self.auto-add-vnext-milestone-to-pr.sts.yaml
+++ b/.github/chainguard/self.auto-add-vnext-milestone-to-pr.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_add_vnext_milestone_to_pr\.yml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.auto-bump-test-package-versions.sts.yaml
+++ b/.github/chainguard/self.auto-bump-test-package-versions.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (schedule|pull_request_target|workflow_dispatch)
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_bump_test_package_versions\.yml@refs/heads/.+
+
+permissions:
+  contents: read

--- a/.github/chainguard/self.auto-check-snapshots.sts.yaml
+++ b/.github/chainguard/self.auto-check-snapshots.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_check_snapshots\.yml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  pull_requests: write

--- a/.github/chainguard/self.auto-code-freeze-block-pr.sts.yaml
+++ b/.github/chainguard/self.auto-code-freeze-block-pr.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_code_freeze_block_pr\.yml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  issues: read
+  statuses: write

--- a/.github/chainguard/self.auto-create-version-bump-pr.sts.yaml
+++ b/.github/chainguard/self.auto-create-version-bump-pr.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/tags/.+"
+
+claim_pattern:
+  event_name: release
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_create_version_bump_pr\.yml@refs/tags/.+
+
+permissions:
+  contents: read
+  issues: write

--- a/.github/chainguard/self.auto-deploy-aas-test-apps.sts.yaml
+++ b/.github/chainguard/self.auto-deploy-aas-test-apps.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (workflow_dispatch|schedule)
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_deploy_aas_test_apps\.yml@refs/heads/.+
+
+permissions:
+  issues: read
+  actions: read

--- a/.github/chainguard/self.auto-label-prs.sts.yaml
+++ b/.github/chainguard/self.auto-label-prs.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/auto_label_prs\.yml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  contents: read
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.code-freeze-end.sts.yaml
+++ b/.github/chainguard/self.code-freeze-end.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (workflow_dispatch|milestone)
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/code_freeze_end\.yml@refs/heads/.+
+
+permissions:
+  issues: write
+  statuses: write
+  pull_requests: read

--- a/.github/chainguard/self.code-freeze-start.sts.yaml
+++ b/.github/chainguard/self.code-freeze-start.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (workflow_dispatch|milestone)
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/code_freeze_start\.yml@refs/heads/.+
+
+permissions:
+  issues: write
+  statuses: write
+  pull_requests: read

--- a/.github/chainguard/self.create-hotfix-branch.sts.yaml
+++ b/.github/chainguard/self.create-hotfix-branch.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/tags/.+"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/create_hotfix_branch\.yml@refs/tags/.+
+
+permissions:
+  contents: write
+  issues: write

--- a/.github/chainguard/self.create-skip-code-freeze.sts.yaml
+++ b/.github/chainguard/self.create-skip-code-freeze.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/create_skip_code_freeze\.yml@refs/heads/.+
+
+permissions:
+  issues: write

--- a/.github/chainguard/self.create-system-test-docker-base-images.sts.yaml
+++ b/.github/chainguard/self.create-system-test-docker-base-images.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/create-system-test-docker-base-images\.yml@refs/heads/.+
+
+permissions:
+  packages: write

--- a/.github/chainguard/self.force-manual-version-bump.sts.yaml
+++ b/.github/chainguard/self.force-manual-version-bump.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/force_manual_version_bump\.yml@refs/heads/.+
+
+permissions:
+  contents: read
+  issues: write

--- a/.github/chainguard/self.generate-package-versions.sts.yaml
+++ b/.github/chainguard/self.generate-package-versions.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/generate_package_versions\.yml@refs/heads/.+
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.override-version-bump-pr-checks.sts.yaml
+++ b/.github/chainguard/self.override-version-bump-pr-checks.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/override_version_bump_pr_checks\.yml@refs/heads/.+
+
+permissions:
+  statuses: write

--- a/.github/chainguard/self.scheduled-aas-deploy.sts.yaml
+++ b/.github/chainguard/self.scheduled-aas-deploy.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/scheduled_aas_deploy\.yml@refs/heads/.+
+
+permissions:
+  issues: write

--- a/.github/chainguard/self.scheduled-code-freeze.sts.yaml
+++ b/.github/chainguard/self.scheduled-code-freeze.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-dotnet:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  repository: DataDog/dd-trace-dotnet
+  job_workflow_ref: DataDog/dd-trace-dotnet/\.github/workflows/scheduled_code_freeze\.yml@refs/heads/.+
+
+permissions:
+  issues: write
+  statuses: write
+  pull_requests: read


### PR DESCRIPTION
## Summary of changes

Add 17 Chainguard policy files under `.github/chainguard/` for the upcoming migration of `secrets.GITHUB_TOKEN` to `DataDog/dd-octo-sts-action`.

## Reason for change

These policies must be on the default branch before the corresponding workflow changes can use them. They declare which workflow, event, and ref pattern may request which permissions via the dd-octo-sts OIDC token exchange.

## Implementation details

Policy files only — no workflow changes.

## Test coverage

No functional impact. Stacked with #8607.

## Jira

- [APMLP-1601](https://datadoghq.atlassian.net/browse/APMLP-1601)


[APMLP-1601]: https://datadoghq.atlassian.net/browse/APMLP-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ