### PR TITLE
Ensure we wrap the process path in quotes before running it

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/crashhandler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/crashhandler.cpp
@@ -378,6 +378,8 @@ namespace datadog::shared::nativeloader
             }
 
             std::wstringstream ss;
+            // Note that this automatically quotes the fs::path string, so spaces don't cause issues here
+            // https://en.cppreference.com/w/cpp/filesystem/path/operator_ltltgtgt
             ss << ddDotnetPath << " createdump " << pid << " --crashthread " << tid << " --dd-native-exception-code " << std::dec << pExceptionInformation->exceptionRecord.ExceptionCode;
             auto commandLine = ss.str();
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
@@ -32,10 +32,13 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
 {
 #if _WIN32
     // For windows we combine the processPath and args into a single, space separated, string
-    // and pass null for the application name
-    // We assume that all the required escaping has been done etc
-
-    std::string combined = processPath;
+    // and pass null for the application name. The processPath is wrapped in quotes so that
+    // Windows' first-token parsing in lpCommandLine treats paths containing spaces as a single
+    // token (otherwise e.g. "C:\Program Files\foo.exe" could resolve to "C:\Program.exe").
+    // If the caller has already quoted the path, we leave it alone (assumption: starts with a
+    // quote => ends with a quote). Callers are responsible for any escaping required for args.
+    const bool alreadyQuoted = !processPath.empty() && processPath.front() == '"';
+    std::string combined = alreadyQuoted ? processPath : "\"" + processPath + "\"";
     for(const auto &arg: args)
     {
         combined += " " + arg;


### PR DESCRIPTION
## Summary of changes

Wrap the telemetry handler path in quotes before executing

## Reason for change

If the telemetry path contains a space, we'd try to run the wrong path. Wrapping the value in quotes first ensures it's treated as a single argument.

## Implementation details

Manually wrap with `"`. This is only called in a single place, in which we read from an env var. The simple fix is to check if it starts with a quote, and if not, wrap it. There's edge cases here, but this should be a "good enough" fix. 

## Test coverage

Covered by existing tests, they should be unchanged.

## Other details

Added a comment to a similar path that's _not_ affected, because it use `fs::path` instead, which automatically does the quoting.