### PR TITLE
Refactor `TracesTransportType` and fix OTLP traces endpoint bug when APM UDS socket is set

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -31,6 +31,7 @@ src/Datadog.Trace/Tracer.cs
 src/Datadog.Trace/TracerConstants.cs
 src/Datadog.Trace/TracerManager.cs
 src/Datadog.Trace/TracerManagerFactory.cs
+src/Datadog.Trace/Agent/AgentTransportType.cs
 src/Datadog.Trace/Agent/Api.cs
 src/Datadog.Trace/Agent/ApiOtlp.cs
 src/Datadog.Trace/Agent/IApi.cs
@@ -47,7 +48,6 @@ src/Datadog.Trace/Agent/StatsAggregator.cs
 src/Datadog.Trace/Agent/StatsBucket.cs
 src/Datadog.Trace/Agent/StatsBuffer.cs
 src/Datadog.Trace/Agent/TracesTransportStrategy.cs
-src/Datadog.Trace/Agent/TracesTransportType.cs
 src/Datadog.Trace/AppSec/AddressesConstants.cs
 src/Datadog.Trace/AppSec/AppSecRateLimiter.cs
 src/Datadog.Trace/AppSec/BlockingAction.cs

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/AgentConnectivityCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/AgentConnectivityCheck.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
             var baseEndpoint = settings.AgentUri;
 
-            if (settings.TracesTransport is TracesTransportType.WindowsNamedPipe or TracesTransportType.UnixDomainSocket)
+            if (settings.AgentTransport is AgentTransportType.WindowsNamedPipe or AgentTransportType.UnixDomainSocket)
             {
                 baseEndpoint = new Uri("http://localhost");
             }
@@ -98,12 +98,12 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
         private static HttpClient CreateHttpClient(ExporterSettings settings)
         {
-            switch (settings.TracesTransport)
+            switch (settings.AgentTransport)
             {
-                case TracesTransportType.Default:
+                case AgentTransportType.Default:
                     return new HttpClient();
 
-                case TracesTransportType.UnixDomainSocket:
+                case AgentTransportType.UnixDomainSocket:
                     {
                         var handler = new SocketsHttpHandler
                         {
@@ -119,7 +119,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                         return new HttpClient(handler);
                     }
 
-                case TracesTransportType.WindowsNamedPipe:
+                case AgentTransportType.WindowsNamedPipe:
                     {
                         var handler = new SocketsHttpHandler
                         {
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                     }
 
                 default:
-                    throw new InvalidOperationException("Unexpected transport type: " + settings.TracesTransport);
+                    throw new InvalidOperationException("Unexpected transport type: " + settings.AgentTransport);
             }
         }
 
@@ -144,7 +144,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             string transport;
             string endpoint;
 
-            if (settings.TracesTransport == TracesTransportType.UnixDomainSocket)
+            if (settings.AgentTransport == AgentTransportType.UnixDomainSocket)
             {
                 transport = "domain sockets";
                 endpoint = settings.TracesUnixDomainSocketPath ?? "<not set>";

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -55,7 +55,7 @@
 
   <ItemGroup>
     <Compile Include="..\Datadog.Trace\TracerConstants.cs" Link="TracerConstants.cs" />
-    <Compile Include="..\Datadog.Trace\Agent\TracesTransportType.cs" Link="TracesTransportType.cs" />
+    <Compile Include="..\Datadog.Trace\Agent\AgentTransportType.cs" Link="AgentTransportType.cs" />
     <Compile Include="..\Datadog.Trace\Configuration\DeprecationMessages.cs" Link="DeprecationMessages.cs" />
     <Compile Include="..\Datadog.Trace\Configuration\ExporterSettings.Shared.cs" Link="ExporterSettings.Shared.cs" />
     <Compile Include="..\Datadog.Trace\Configuration\OtlpProtocol.cs" Link="OtlpProtocol.cs" />

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/ExporterSettings.cs
@@ -54,6 +54,7 @@ public partial class ExporterSettings
         TracesPipeName = traceSettings.PipeName;
         TracesUnixDomainSocketPath = traceSettings.UdsPath;
         AgentUri = traceSettings.AgentUri;
+        AgentTransport = traceSettings.Transport;
     }
 
     /// <summary>
@@ -68,6 +69,7 @@ public partial class ExporterSettings
         TracesPipeName = traceSettings.PipeName;
         TracesUnixDomainSocketPath = traceSettings.UdsPath;
         AgentUri = traceSettings.AgentUri;
+        AgentTransport = traceSettings.Transport;
     }
 
     internal enum TelemetryErrorCode
@@ -77,9 +79,11 @@ public partial class ExporterSettings
 
     internal Uri AgentUri { get; }
 
+    internal AgentTransportType AgentTransport { get;  }
+
     internal List<string> ValidationWarnings { get; } = new();
 
-    internal TracesTransportType TracesTransport { get;  }
+    internal AgentTransportType TracesTransport { get;  }
 
     internal string? TracesPipeName { get; }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
@@ -38,18 +38,18 @@ internal static class AgentTransportStrategy
         HttpHeaderHelperBase httpHeaderHelper,
         Func<Uri, Uri>? getBaseEndpoint = null)
     {
-        var strategy = settings.TracesTransport;
+        var strategy = settings.AgentTransport;
 
         switch (strategy)
         {
-            case TracesTransportType.WindowsNamedPipe:
+            case AgentTransportType.WindowsNamedPipe:
                 Log.Information<string, string?, int>("Using " + nameof(NamedPipeClientStreamFactory) + " for {ProductName} transport, with pipe name {TracesPipeName} and timeout {TracesPipeTimeoutMs}ms.", productName, settings.TracesPipeName, settings.TracesPipeTimeoutMs);
                 return new HttpStreamRequestFactory(
                     new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs),
                     new DatadogHttpClient(httpHeaderHelper),
                     getBaseEndpoint?.Invoke(Localhost) ?? Localhost);
 
-            case TracesTransportType.UnixDomainSocket:
+            case AgentTransportType.UnixDomainSocket:
 #if NET5_0_OR_GREATER
                 Log.Information("Using " + nameof(SocketHandlerRequestFactory) + " for {ProductName} transport, with UDS path {Path}.", productName, settings.TracesUnixDomainSocketPath);
                 // use http://localhost as base endpoint
@@ -65,9 +65,9 @@ internal static class AgentTransportStrategy
                     getBaseEndpoint?.Invoke(Localhost) ?? Localhost);
 #else
                 Log.Error("Using Unix Domain Sockets for {ProductName} transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.", productName);
-                goto case TracesTransportType.Default;
+                goto case AgentTransportType.Default;
 #endif
-            case TracesTransportType.Default:
+            case AgentTransportType.Default:
             default:
 #if NETCOREAPP
                 Log.Information("Using " + nameof(HttpClientRequestFactory) + " for {ProductName} transport.", productName);

--- a/tracer/src/Datadog.Trace/Agent/AgentTransportType.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentTransportType.cs
@@ -1,4 +1,4 @@
-// <copyright file="TracesTransportType.cs" company="Datadog">
+// <copyright file="AgentTransportType.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -8,7 +8,7 @@ namespace Datadog.Trace.Agent
     /// <summary>
     /// Available types of transports.
     /// </summary>
-    internal enum TracesTransportType
+    internal enum AgentTransportType
     {
         /// <summary>
         /// Default transport.

--- a/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
+++ b/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
@@ -33,7 +33,6 @@ namespace Datadog.Trace.Agent
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly TracesEncoding _tracesEncoding;
         private readonly Uri _tracesEndpoint;
-        private readonly KeyValuePair<string, string>[] _tracesHeaders;
         private readonly Uri _statsEndpoint; // This endpoint is passed for the _sendStats callback, but otherwise unused
         private readonly SendCallback<SendStatsState> _sendStats;
         private readonly SendCallback<SendTracesState> _sendTraces;
@@ -50,7 +49,6 @@ namespace Datadog.Trace.Agent
             _apiRequestFactory = apiRequestFactory;
             _tracesEncoding = exporterSettings.TracesEncoding;
             _tracesEndpoint = exporterSettings.OtlpTracesEndpoint;
-            _tracesHeaders = exporterSettings.OtlpTracesHeaders ?? [];
             _statsEndpoint = exporterSettings.OtlpMetricsEndpoint;
             _log.Debug("Using traces endpoint {TracesEndpoint}", _tracesEndpoint.ToString());
 
@@ -177,11 +175,6 @@ namespace Datadog.Trace.Agent
 
             var traces = state.Traces;
             var numberOfTraces = state.NumberOfTraces;
-
-            foreach (var header in _tracesHeaders)
-            {
-                request.AddHeader(header.Key, header.Value);
-            }
 
             // TODO: Determine if we need to send the following information somehow:
             // - DroppedP0Traces

--- a/tracer/src/Datadog.Trace/Agent/ManagedApiOtlp.cs
+++ b/tracer/src/Datadog.Trace/Agent/ManagedApiOtlp.cs
@@ -34,7 +34,7 @@ internal sealed class ManagedApiOtlp : IApi
         [MemberNotNull(nameof(_api))]
         void UpdateApi(TracerSettings settings, ExporterSettings exporterSettings)
         {
-            var apiRequestFactory = TracesTransportStrategy.Get(exporterSettings);
+            var apiRequestFactory = OtlpTransportStrategy.GetTraces(exporterSettings);
             var api = new ApiOtlp(apiRequestFactory, settings, exporterSettings);
             Interlocked.Exchange(ref _api!, api);
         }

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/EventPlatformPayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/EventPlatformPayload.cs
@@ -153,13 +153,13 @@ internal abstract class EventPlatformPayload
             // Use Agent EVP Proxy
             // CI Visibility doesn't allow re-configuration, so only need to use the "initial" settings
             var exporterSettings = _settings.TracerSettings.Manager.InitialExporterSettings;
-            switch (exporterSettings.TracesTransport)
+            switch (exporterSettings.AgentTransport)
             {
-                case TracesTransportType.WindowsNamedPipe:
-                case TracesTransportType.UnixDomainSocket:
+                case AgentTransportType.WindowsNamedPipe:
+                case AgentTransportType.UnixDomainSocket:
                     builder = new UriBuilder("http://localhost");
                     break;
-                case TracesTransportType.Default:
+                case AgentTransportType.Default:
                 default:
                     builder = new UriBuilder(exporterSettings.AgentUri);
                     break;

--- a/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManagement.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManagement.cs
@@ -160,7 +160,7 @@ internal sealed class TestOptimizationTracerManagement : ITestOptimizationTracer
     {
         IApiRequestFactory? factory;
         var exporterSettings = tracerSettings.Manager.InitialExporterSettings;
-        if (exporterSettings.TracesTransport != TracesTransportType.Default)
+        if (exporterSettings.AgentTransport != AgentTransportType.Default)
         {
             factory = AgentTransportStrategy.Get(
                 exporterSettings,

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.Shared.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.Shared.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Configuration
 
             if (!string.IsNullOrEmpty(tracesPipeName))
             {
-                RecordTraceTransport(nameof(TracesTransportType.WindowsNamedPipe), origin);
+                RecordTraceTransport(nameof(AgentTransportType.WindowsNamedPipe), origin);
 
                 // The Uri isn't needed anymore in that case, just populating it for retro compatibility.
                 if (!Uri.TryCreate($"http://{agentHost ?? DefaultAgentHost}:{agentPort ?? DefaultAgentPort}", UriKind.Absolute, out var uri))
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Configuration
                 }
 
                 return new TraceTransportSettings(
-                    TracesTransportType.WindowsNamedPipe,
+                    AgentTransportType.WindowsNamedPipe,
                     GetAgentUriReplacingLocalhost(uri, origin),
                     PipeName: tracesPipeName);
             }
@@ -207,12 +207,12 @@ namespace Datadog.Trace.Configuration
 
         private TraceTransportSettings GetAgentUriAndTransport(Uri uri, ConfigurationOrigins origin)
         {
-            TracesTransportType transport;
+            AgentTransportType transport;
             string? udsPath;
             if (uri.OriginalString.StartsWith(UnixDomainSocketPrefix, StringComparison.OrdinalIgnoreCase))
             {
 #if NETCOREAPP3_1_OR_GREATER
-                transport = TracesTransportType.UnixDomainSocket;
+                transport = AgentTransportType.UnixDomainSocket;
                 udsPath = uri.PathAndQuery;
 
                 var absoluteUri = uri.AbsoluteUri.Replace(UnixDomainSocketPrefix, string.Empty);
@@ -231,7 +231,7 @@ namespace Datadog.Trace.Configuration
                     ValidationWarnings.Add($"The socket provided {uri.PathAndQuery} cannot be found. The tracer will still rely on this socket to send traces.");
                 }
 
-                RecordTraceTransport(nameof(TracesTransportType.UnixDomainSocket), origin);
+                RecordTraceTransport(nameof(AgentTransportType.UnixDomainSocket), origin);
                 _telemetry.Record(
                     ConfigurationKeys.TracesUnixDomainSocketPath,
                     TracesUnixDomainSocketPath,
@@ -253,9 +253,9 @@ namespace Datadog.Trace.Configuration
             }
             else
             {
-                transport = TracesTransportType.Default;
+                transport = AgentTransportType.Default;
                 udsPath = null;
-                RecordTraceTransport(nameof(TracesTransportType.Default), origin);
+                RecordTraceTransport(nameof(AgentTransportType.Default), origin);
             }
 
             var agentUri = GetAgentUriReplacingLocalhost(uri, origin);
@@ -288,8 +288,12 @@ namespace Datadog.Trace.Configuration
             }
 
 #endif
+            var transport = uri.OriginalString.StartsWith(UnixDomainSocketPrefix, StringComparison.OrdinalIgnoreCase)
+                                ? AgentTransportType.UnixDomainSocket
+                                : AgentTransportType.Default;
+
             // TODO: Record OTLP transport telemetry
-            return new(uri, OtlpProtocol: otlpProtocol);
+            return new(transport, uri, OtlpProtocol: otlpProtocol);
         }
 
         private Uri GetAgentUriReplacingLocalhost(Uri uri, ConfigurationOrigins origin)
@@ -328,8 +332,8 @@ namespace Datadog.Trace.Configuration
             };
         }
 
-        private readonly record struct TraceTransportSettings(TracesTransportType Transport, Uri AgentUri, string? UdsPath = null, string? PipeName = null);
+        private readonly record struct TraceTransportSettings(AgentTransportType Transport, Uri AgentUri, string? UdsPath = null, string? PipeName = null);
 
-        private readonly record struct OtlpTransportSettings(Uri OtlpSignalEndpoint, OtlpProtocol OtlpProtocol = OtlpProtocol.HttpProtobuf);
+        private readonly record struct OtlpTransportSettings(AgentTransportType Transport, Uri OtlpSignalEndpoint, OtlpProtocol OtlpProtocol = OtlpProtocol.HttpProtobuf);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -94,6 +94,8 @@ namespace Datadog.Trace.Configuration
                 agentPort: rawSettings.TraceAgentPort,
                 tracesUnixDomainSocketPath: rawSettings.TracesUnixDomainSocketPath);
 
+            AgentTransport = traceSettings.Transport;
+
             TracesEncoding = TracesEncoding.DatadogV0_4;
             TracesTransport = traceSettings.Transport;
             TracesPipeName = traceSettings.PipeName;
@@ -110,6 +112,7 @@ namespace Datadog.Trace.Configuration
 
             if (rawSettings.OtelTracesExporter == "otlp")
             {
+                TracesTransport = otlpTraceSettings.Transport;
                 TracesEncoding = otlpTraceSettings.OtlpProtocol switch
                 {
                     OtlpProtocol.Grpc => TracesEncoding.DatadogV0_4,
@@ -172,7 +175,7 @@ namespace Datadog.Trace.Configuration
             // 1. That's not a valid Uri - we would need to use a custom Uri scheme (e.g. npipe://) and also
             //    use / instead of \, i.e. @$"npipe:////./pipe/{TracesPipeName}"
             // 2. AgentUri is exposed publicly, so we can't change it without potentially breaking behaviour
-            TracesTransportType.WindowsNamedPipe => $@"\\.\pipe\{TracesPipeName}",
+            AgentTransportType.WindowsNamedPipe => $@"\\.\pipe\{TracesPipeName}",
             _ => AgentUri.ToString()
         };
 
@@ -258,9 +261,14 @@ namespace Datadog.Trace.Configuration
         internal TracesEncoding TracesEncoding { get; }
 
         /// <summary>
+        /// Gets the transport used to send requests to the Agent.
+        /// </summary>
+        internal AgentTransportType AgentTransport { get; }
+
+        /// <summary>
         /// Gets the transport used to send traces to the Agent.
         /// </summary>
-        internal TracesTransportType TracesTransport { get; }
+        internal AgentTransportType TracesTransport { get; }
 
         /// <summary>
         /// Gets the transport used to connect to the DogStatsD.

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -123,6 +123,8 @@ namespace Datadog.Trace.Configuration
 
                 if (TracesEncoding == TracesEncoding.DatadogV0_4)
                 {
+                    // Reset to the original transport used to connect to the agent since we're sending Datadog v0.4 traces
+                    TracesTransport = traceSettings.Transport;
                     ValidationWarnings.Add($"Found OTEL_TRACES_EXPORTER=otlp, but calculated OTLP protocol {otlpTraceSettings.OtlpProtocol.ToString()} is not yet supported. Falling back to Datadog v0.4 encoding.");
                 }
             }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -791,7 +791,7 @@ namespace Datadog.Trace.Configuration
                 // and so we allow and enable the datapipeline. Later, they could configure the app in code to send over UDS.
                 // This is a problem, as we currently don't support toggling the data pipeline at runtime, so we explicitly block
                 // this scenario in the public API.
-                if (Manager.InitialExporterSettings.TracesTransport == TracesTransportType.UnixDomainSocket && FrameworkDescription.Instance.IsWindows())
+                if (Manager.InitialExporterSettings.TracesTransport == AgentTransportType.UnixDomainSocket && FrameworkDescription.Instance.IsWindows())
                 {
                     DataPipelineEnabled = false;
                     Log.Warning(

--- a/tracer/src/Datadog.Trace/HttpOverStreams/OtlpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/OtlpHeaderHelper.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using Datadog.Trace;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.HttpOverStreams;
@@ -17,10 +18,14 @@ internal sealed class OtlpHeaderHelper : HttpHeaderHelperBase
 
     public OtlpHeaderHelper(KeyValuePair<string, string>[] signalHeaders)
     {
-        DefaultHeaders = signalHeaders;
+        DefaultHeaders =
+        [
+            ..signalHeaders,
+            new(HttpHeaderNames.TracingEnabled, "false"),
+        ];
 
         var sb = StringBuilderCache.Acquire();
-        foreach (var kvp in signalHeaders)
+        foreach (var kvp in DefaultHeaders)
         {
             sb.Append(kvp.Key);
             sb.Append(": ");

--- a/tracer/src/Datadog.Trace/HttpOverStreams/OtlpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/OtlpHeaderHelper.cs
@@ -1,0 +1,37 @@
+// <copyright file="OtlpHeaderHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.HttpOverStreams;
+
+internal sealed class OtlpHeaderHelper : HttpHeaderHelperBase
+{
+    private readonly string _serializedHeaders;
+
+    public OtlpHeaderHelper(KeyValuePair<string, string>[] signalHeaders)
+    {
+        DefaultHeaders = signalHeaders;
+
+        var sb = StringBuilderCache.Acquire();
+        foreach (var kvp in signalHeaders)
+        {
+            sb.Append(kvp.Key);
+            sb.Append(": ");
+            sb.Append(kvp.Value);
+            sb.Append(DatadogHttpValues.CrLf);
+        }
+
+        _serializedHeaders = StringBuilderCache.GetStringAndRelease(sb);
+    }
+
+    public override KeyValuePair<string, string>[] DefaultHeaders { get; }
+
+    protected override string HttpSerializedDefaultHeaders => _serializedHeaders;
+}

--- a/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/ManagedTraceExporter.cs
+++ b/tracer/src/Datadog.Trace/LibDatadog/DataPipeline/ManagedTraceExporter.cs
@@ -179,8 +179,8 @@ internal sealed class ManagedTraceExporter : IApi, IDisposable
         static string GetUrl(ExporterSettings exporterSettings) =>
             exporterSettings.TracesTransport switch
             {
-                TracesTransportType.WindowsNamedPipe => $"windows://./pipe/{exporterSettings.TracesPipeName}",
-                TracesTransportType.UnixDomainSocket => $"unix://{exporterSettings.TracesUnixDomainSocketPath}",
+                AgentTransportType.WindowsNamedPipe => $"windows://./pipe/{exporterSettings.TracesPipeName}",
+                AgentTransportType.UnixDomainSocket => $"unix://{exporterSettings.TracesUnixDomainSocketPath}",
                 _ => exporterSettings.AgentUri.ToString()
             };
     }

--- a/tracer/src/Datadog.Trace/OtlpTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/OtlpTransportStrategy.cs
@@ -1,0 +1,63 @@
+// <copyright file="OtlpTransportStrategy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Agent.StreamFactories;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Agent;
+
+internal static class OtlpTransportStrategy
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(OtlpTransportStrategy));
+    private static readonly Uri Localhost = new Uri("http://localhost");
+
+    public static IApiRequestFactory GetTraces(
+        ExporterSettings settings)
+    {
+        return Get(settings.TracesTransport, settings.OtlpTracesEndpoint, settings.OtlpTracesHeaders ?? [], settings.OtlpTracesTimeoutMs, "traces");
+    }
+
+    private static IApiRequestFactory Get(
+        AgentTransportType strategy,
+        Uri signalEndpoint,
+        KeyValuePair<string, string>[] signalHeaders,
+        int timeoutMs,
+        string productName)
+    {
+        switch (strategy)
+        {
+            case AgentTransportType.WindowsNamedPipe:
+                Log.Information<string, string?, int>("Using " + nameof(NamedPipeClientStreamFactory) + " for {ProductName} transport, with pipe name {TracesPipeName} and timeout {TracesPipeTimeoutMs}ms.", productName, signalEndpoint.ToString(), timeoutMs);
+                return new HttpStreamRequestFactory(
+                    new NamedPipeClientStreamFactory(signalEndpoint.ToString(), timeoutMs),
+                    new DatadogHttpClient(new OtlpHeaderHelper(signalHeaders)),
+                    Localhost);
+
+            case AgentTransportType.UnixDomainSocket:
+                Log.Information("Using " + nameof(SocketHandlerRequestFactory) + " for {ProductName} transport, with UDS path {Path}.", productName, signalEndpoint.ToString());
+                // use http://localhost as base endpoint
+                return new SocketHandlerRequestFactory(
+                    new UnixDomainSocketStreamFactory(signalEndpoint.ToString()),
+                    signalHeaders,
+                    Localhost);
+            case AgentTransportType.Default:
+            default:
+                Log.Information("Using " + nameof(HttpClientRequestFactory) + " for {ProductName} transport.", productName);
+                return new HttpClientRequestFactory(
+                    signalEndpoint,
+                    signalHeaders,
+                    timeout: TimeSpan.FromMilliseconds(timeoutMs));
+        }
+    }
+}
+#endif

--- a/tracer/src/Datadog.Trace/OtlpTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/OtlpTransportStrategy.cs
@@ -34,13 +34,15 @@ internal static class OtlpTransportStrategy
         int timeoutMs,
         string productName)
     {
+        var httpHeaderHelper = new OtlpHeaderHelper(signalHeaders);
+
         switch (strategy)
         {
             case AgentTransportType.WindowsNamedPipe:
                 Log.Information<string, string?, int>("Using " + nameof(NamedPipeClientStreamFactory) + " for {ProductName} transport, with pipe name {TracesPipeName} and timeout {TracesPipeTimeoutMs}ms.", productName, signalEndpoint.ToString(), timeoutMs);
                 return new HttpStreamRequestFactory(
                     new NamedPipeClientStreamFactory(signalEndpoint.ToString(), timeoutMs),
-                    new DatadogHttpClient(new OtlpHeaderHelper(signalHeaders)),
+                    new DatadogHttpClient(httpHeaderHelper),
                     Localhost);
 
             case AgentTransportType.UnixDomainSocket:
@@ -48,14 +50,14 @@ internal static class OtlpTransportStrategy
                 // use http://localhost as base endpoint
                 return new SocketHandlerRequestFactory(
                     new UnixDomainSocketStreamFactory(signalEndpoint.ToString()),
-                    signalHeaders,
+                    httpHeaderHelper.DefaultHeaders,
                     Localhost);
             case AgentTransportType.Default:
             default:
                 Log.Information("Using " + nameof(HttpClientRequestFactory) + " for {ProductName} transport.", productName);
                 return new HttpClientRequestFactory(
                     signalEndpoint,
-                    signalHeaders,
+                    httpHeaderHelper.DefaultHeaders,
                     timeout: TimeSpan.FromMilliseconds(timeoutMs));
         }
     }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -428,7 +428,7 @@ namespace Datadog.Trace
                     writer.WriteValue(exporterSettings.TraceAgentUriBase);
 
                     writer.WritePropertyName("agent_transport");
-                    writer.WriteValue(exporterSettings.TracesTransport.ToString());
+                    writer.WriteValue(exporterSettings.AgentTransport.ToString());
 
                     writer.WritePropertyName("debug");
                     writer.WriteValue(GlobalSettings.Instance.DebugEnabled);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -274,6 +274,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
             else
             {
+                // Regression test: When not using DD_AGENT_HOST, set DD_APM_RECEIVER_SOCKET to ensure that OTLP traces
+                // are successfully sent over TCP/IP when the opt-in OTLP export is enabled with an http endpoint
+                SetEnvironmentVariable("DD_APM_RECEIVER_SOCKET", "/var/run/datadog/apm.socket");
                 SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", $"http://{testAgentHost}:{otlpPort}");
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -274,9 +274,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
             else
             {
-                // Regression test: When not using DD_AGENT_HOST, set DD_APM_RECEIVER_SOCKET to ensure that OTLP traces
-                // are successfully sent over TCP/IP when the opt-in OTLP export is enabled with an http endpoint
-                SetEnvironmentVariable("DD_APM_RECEIVER_SOCKET", "/var/run/datadog/apm.socket");
                 SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", $"http://{testAgentHost}:{otlpPort}");
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -52,26 +52,26 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Flaky("Named pipes is flaky", maxRetries: 3)]
         public async Task TransportsWorkCorrectly(TestTransports transport, bool dataPipelineEnabled)
         {
-            var transportType = TracesTransportTypeFromTestTransport(transport);
+            var transportType = AgentTransportTypeFromTestTransport(transport);
             await RunTest(transportType, dataPipelineEnabled);
         }
 
-        private TracesTransportType TracesTransportTypeFromTestTransport(TestTransports transport)
+        private AgentTransportType AgentTransportTypeFromTestTransport(TestTransports transport)
         {
             return transport switch
             {
-                TestTransports.Tcp => TracesTransportType.Default,
-                TestTransports.WindowsNamedPipe => TracesTransportType.WindowsNamedPipe,
-                TestTransports.Uds => TracesTransportType.UnixDomainSocket,
+                TestTransports.Tcp => AgentTransportType.Default,
+                TestTransports.WindowsNamedPipe => AgentTransportType.WindowsNamedPipe,
+                TestTransports.Uds => AgentTransportType.UnixDomainSocket,
                 _ => throw new InvalidOperationException($"Unknown transport {transport}"),
             };
         }
 
-        private async Task RunTest(TracesTransportType transportType, bool dataPipelineEnabled)
+        private async Task RunTest(AgentTransportType transportType, bool dataPipelineEnabled)
         {
             const int expectedSpanCount = 1;
 
-            if (transportType == TracesTransportType.WindowsNamedPipe && !EnvironmentTools.IsWindows())
+            if (transportType == AgentTransportType.WindowsNamedPipe && !EnvironmentTools.IsWindows())
             {
                 throw new SkipException("WindowsNamedPipe transport is only supported on Windows");
             }
@@ -99,24 +99,24 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             await telemetry.AssertConfigurationAsync(ConfigTelemetryData.AgentTraceTransport, transportType.ToString());
-            MockTracerAgent GetAgent(TracesTransportType type, bool canUseDogStatsd)
+            MockTracerAgent GetAgent(AgentTransportType type, bool canUseDogStatsd)
                 => type switch
                 {
-                    TracesTransportType.Default => MockTracerAgent.Create(Output, useStatsd: canUseDogStatsd),
-                    TracesTransportType.WindowsNamedPipe => MockTracerAgent.Create(Output, new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}") { UseDogstatsD = canUseDogStatsd }),
+                    AgentTransportType.Default => MockTracerAgent.Create(Output, useStatsd: canUseDogStatsd),
+                    AgentTransportType.WindowsNamedPipe => MockTracerAgent.Create(Output, new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}") { UseDogstatsD = canUseDogStatsd }),
 #if NETCOREAPP3_1_OR_GREATER
-                    TracesTransportType.UnixDomainSocket
+                    AgentTransportType.UnixDomainSocket
                         => MockTracerAgent.Create(Output, new UnixDomainSocketConfig(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), canUseDogStatsd ? Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()) : null) { UseDogstatsD = canUseDogStatsd }),
 #endif
                     _ => throw new InvalidOperationException("Unsupported transport type " + type),
                 };
 
-            TestTransports GetTransport(TracesTransportType type)
+            TestTransports GetTransport(AgentTransportType type)
                 => type switch
                 {
-                    TracesTransportType.Default => TestTransports.Tcp,
-                    TracesTransportType.UnixDomainSocket => TestTransports.Uds,
-                    TracesTransportType.WindowsNamedPipe => TestTransports.WindowsNamedPipe,
+                    AgentTransportType.Default => TestTransports.Tcp,
+                    AgentTransportType.UnixDomainSocket => TestTransports.Uds,
+                    AgentTransportType.WindowsNamedPipe => TestTransports.WindowsNamedPipe,
                     _ => throw new InvalidOperationException("Unsupported transport type " + type),
                 };
         }

--- a/tracer/test/Datadog.Trace.Tests/Agent/ManagedApiOtlpTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ManagedApiOtlpTests.cs
@@ -1,0 +1,93 @@
+// <copyright file="ManagedApiOtlpTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Collections.Specialized;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Agent;
+
+public class ManagedApiOtlpTests
+{
+    [Fact]
+    public void CreateOtlpRequestFactory_WhenApmUsesUnixDomainSocket_UsesDefaultOtlpEndpoint()
+    {
+        // Simulate the Linux scenario: APM UDS exists at the default path,
+        // but the OTLP endpoint is explicitly set to http://localhost:4318
+        var source = BuildSource("OTEL_TRACES_EXPORTER:otlp");
+        Func<string, bool> fileExists = path => path == ExporterSettings.DefaultTracesUnixDomainSocket;
+        var exporterSettings = new ExporterSettings(source, fileExists, NullConfigurationTelemetry.Instance);
+
+        // Verify the APM transport is UDS (this is the precondition that caused the bug)
+        exporterSettings.TracesTransport.Should().Be(AgentTransportType.Default);
+
+        var factory = OtlpTransportStrategy.GetTraces(exporterSettings);
+
+        // The factory must be a plain HttpClientRequestFactory, not a
+        // SocketHandlerRequestFactory (which would route through the APM UDS)
+        factory.Should().BeOfType<HttpClientRequestFactory>();
+    }
+
+    [Theory]
+    [InlineData("http://localhost:4318", "http://localhost:4318/v1/traces")]
+    [InlineData("http://otel-collector:4318", "http://otel-collector:4318/v1/traces")]
+    [InlineData("http://localhost:9999", "http://localhost:9999/v1/traces")]
+    public void CreateOtlpRequestFactory_WhenApmUsesUnixDomainSocket_UsesOtlpGeneralEndpoint(string otlpEndpoint, string expectedTracesEndpoint)
+    {
+        var source = BuildSource(
+            $"OTEL_EXPORTER_OTLP_ENDPOINT:{otlpEndpoint}",
+            "OTEL_TRACES_EXPORTER:otlp");
+        Func<string, bool> fileExists = path => path == ExporterSettings.DefaultTracesUnixDomainSocket;
+        var exporterSettings = new ExporterSettings(source, fileExists, NullConfigurationTelemetry.Instance);
+
+        // Verify the OTLP endpoint is correct
+        exporterSettings.OtlpTracesEndpoint.Should().Be(new Uri(expectedTracesEndpoint));
+
+        var factory = OtlpTransportStrategy.GetTraces(exporterSettings);
+
+        // The factory should target the OTLP endpoint's authority
+        var expectedBase = new Uri($"{new Uri(expectedTracesEndpoint).Scheme}://{new Uri(expectedTracesEndpoint).Authority}");
+        factory.Info(exporterSettings.OtlpTracesEndpoint).Should().Be(new Uri(expectedBase, "/v1/traces").ToString());
+    }
+
+    [Fact]
+    public void CreateOtlpRequestFactory_WithExplicitTracesEndpoint_UsesOtlpSignalEndpoint()
+    {
+        var source = BuildSource(
+            "OTEL_EXPORTER_OTLP_ENDPOINT:http://general-endpoint:4318",
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:http://traces-endpoint:4318/v1/traces",
+            "OTEL_TRACES_EXPORTER:otlp");
+        var exporterSettings = new ExporterSettings(source, _ => false, NullConfigurationTelemetry.Instance);
+
+        exporterSettings.OtlpTracesEndpoint.Should().Be(new Uri("http://traces-endpoint:4318/v1/traces"));
+
+        var factory = OtlpTransportStrategy.GetTraces(exporterSettings);
+
+        factory.Should().BeOfType<HttpClientRequestFactory>();
+        factory.Info(exporterSettings.OtlpTracesEndpoint).Should().Be("http://traces-endpoint:4318/v1/traces");
+    }
+
+    private static NameValueConfigurationSource BuildSource(params string[] config)
+    {
+        var configNameValues = new NameValueCollection();
+
+        foreach (var item in config)
+        {
+            var separatorIndex = item.IndexOf(':');
+            configNameValues.Add(item.Substring(0, separatorIndex), item.Substring(separatorIndex + 1));
+        }
+
+        return new NameValueConfigurationSource(configNameValues);
+    }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsAzureFunctionsPipeTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsAzureFunctionsPipeTests.cs
@@ -37,7 +37,8 @@ namespace Datadog.Trace.Tests.Configuration
             if (expectedPipeName is not null)
             {
                 settings.TracesPipeName.Should().Be(expectedPipeName);
-                settings.TracesTransport.Should().Be(TracesTransportType.WindowsNamedPipe);
+                settings.TracesTransport.Should().Be(AgentTransportType.WindowsNamedPipe);
+                settings.AgentTransport.Should().Be(AgentTransportType.WindowsNamedPipe);
             }
             else
             {
@@ -102,7 +103,8 @@ namespace Datadog.Trace.Tests.Configuration
             var settings = new ExporterSettings(raw, _ => false, telemetry, pipeNames);
 
             settings.TracesPipeName.Should().Be(expected);
-            settings.TracesTransport.Should().Be(TracesTransportType.WindowsNamedPipe);
+            settings.TracesTransport.Should().Be(AgentTransportType.WindowsNamedPipe);
+            settings.AgentTransport.Should().Be(AgentTransportType.WindowsNamedPipe);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.Shared.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.Shared.cs
@@ -85,10 +85,10 @@ public partial class ExporterSettingsTests
     public void RelativeAgentUrlShouldWarn(string param, string expectedSocket)
     {
         var settingsFromSource = Setup("DD_TRACE_AGENT_URL", param);
-        settingsFromSource.TracesTransport.Should().Be(TracesTransportType.UnixDomainSocket);
+        settingsFromSource.AgentTransport.Should().Be(AgentTransportType.UnixDomainSocket);
         settingsFromSource.TracesUnixDomainSocketPath.Should().Be(expectedSocket);
         Assert.Equal(new Uri(param), settingsFromSource.AgentUri);
-        CheckDefaultValues(settingsFromSource, "TracesUnixDomainSocketPath", "AgentUri", "TracesTransport");
+        CheckDefaultValues(settingsFromSource, "TracesUnixDomainSocketPath", "AgentUri", "AgentTransport");
         settingsFromSource.ValidationWarnings.Should().Contain($"The provided Uri {param} contains a relative path which may not work. This is the path to the socket that will be used: /socket.soc");
     }
 
@@ -100,10 +100,10 @@ public partial class ExporterSettingsTests
         var settingsFromSource = Setup("DD_APM_RECEIVER_SOCKET", param);
         var uri = new Uri(ExporterSettings.UnixDomainSocketPrefix + param);
 
-        settingsFromSource.TracesTransport.Should().Be(TracesTransportType.UnixDomainSocket);
+        settingsFromSource.AgentTransport.Should().Be(AgentTransportType.UnixDomainSocket);
         settingsFromSource.TracesUnixDomainSocketPath.Should().Be(expectedSocket);
         settingsFromSource.AgentUri.Should().Be(uri);
-        CheckDefaultValues(settingsFromSource, "TracesUnixDomainSocketPath", "AgentUri", "TracesTransport");
+        CheckDefaultValues(settingsFromSource, "TracesUnixDomainSocketPath", "AgentUri", "AgentTransport");
         settingsFromSource.ValidationWarnings.Should().Contain($"The provided Uri {uri.AbsoluteUri} contains a relative path which may not work. This is the path to the socket that will be used: {expectedSocket}");
         settingsFromSource.ValidationWarnings.Should().Contain($"The socket provided {expectedSocket} cannot be found. The tracer will still rely on this socket to send traces.");
     }
@@ -284,27 +284,27 @@ public partial class ExporterSettingsTests
 
     private void AssertHttpIsConfigured(ExporterSettings settings, Uri expectedUri)
     {
-        settings.TracesTransport.Should().Be(TracesTransportType.Default);
+        settings.AgentTransport.Should().Be(AgentTransportType.Default);
         settings.AgentUri.Should().Be(expectedUri);
         settings.AgentUri.Host.Should().NotBeEquivalentTo("localhost");
-        CheckDefaultValues(settings, "AgentUri", "TracesTransport", "MetricsHostname");
+        CheckDefaultValues(settings, "AgentUri", "AgentTransport", "MetricsHostname");
     }
 
     private void AssertUdsIsConfigured(ExporterSettings settings, string socketPath)
     {
-        settings.TracesTransport.Should().Be(TracesTransportType.UnixDomainSocket);
+        settings.AgentTransport.Should().Be(AgentTransportType.UnixDomainSocket);
         settings.TracesUnixDomainSocketPath.Should().Be(socketPath);
         settings.AgentUri.Host.Should().NotBeEquivalentTo("localhost");
-        CheckDefaultValues(settings, "TracesUnixDomainSocketPath", "AgentUri", "TracesTransport");
+        CheckDefaultValues(settings, "TracesUnixDomainSocketPath", "AgentUri", "AgentTransport");
     }
 
     private void AssertPipeIsConfigured(ExporterSettings settings, string pipeName)
     {
-        settings.TracesTransport.Should().Be(TracesTransportType.WindowsNamedPipe);
+        settings.AgentTransport.Should().Be(AgentTransportType.WindowsNamedPipe);
         settings.TracesPipeName.Should().Be(pipeName);
         settings.AgentUri.Should().NotBeNull();
         settings.AgentUri.Host.Should().NotBeEquivalentTo("localhost");
-        CheckDefaultValues(settings, "TracesPipeName", "AgentUri", "TracesTransport", "TracesPipeTimeoutMs");
+        CheckDefaultValues(settings, "TracesPipeName", "AgentUri", "AgentTransport", "TracesPipeTimeoutMs");
     }
 
     private Func<string, bool> NoFile()
@@ -338,9 +338,9 @@ public partial class ExporterSettingsTests
             settings.AgentUri.AbsoluteUri.Should().Be("http://127.0.0.1:8126/");
         }
 
-        if (!paramToIgnore.Contains("TracesTransport"))
+        if (!paramToIgnore.Contains("AgentTransport"))
         {
-            settings.TracesTransport.Should().Be(TracesTransportType.Default);
+            settings.AgentTransport.Should().Be(AgentTransportType.Default);
         }
 
         if (!paramToIgnore.Contains("TracesPipeName"))

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -310,7 +310,7 @@ namespace Datadog.Trace.Tests.Configuration
                     $"DD_TRACE_AGENT_PORT:{port}"),
                 NoFile());
 
-            settings.TracesTransport.Should().Be(TracesTransportType.Default);
+            settings.TracesTransport.Should().Be(AgentTransportType.Default);
             settings.TraceAgentUriBase.Should().Be(settings.AgentUri.ToString());
         }
 
@@ -327,7 +327,7 @@ namespace Datadog.Trace.Tests.Configuration
                     $"DD_APM_RECEIVER_SOCKET:{apmReceiverSocket}"),
                 NoFile());
 
-            settings.TracesTransport.Should().Be(TracesTransportType.UnixDomainSocket);
+            settings.TracesTransport.Should().Be(AgentTransportType.UnixDomainSocket);
             settings.TraceAgentUriBase.Should().Be(settings.AgentUri.ToString());
         }
 #endif
@@ -338,7 +338,7 @@ namespace Datadog.Trace.Tests.Configuration
             var pipeName = "something";
             var settings = Setup("DD_TRACE_PIPE_NAME", pipeName);
 
-            settings.TracesTransport.Should().Be(TracesTransportType.WindowsNamedPipe);
+            settings.TracesTransport.Should().Be(AgentTransportType.WindowsNamedPipe);
             settings.TraceAgentUriBase.Should().Be(@"\\.\pipe\" + pipeName);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -36,13 +36,13 @@ public class DataStreamsMonitoringTransportTests
     }
 
     public static IEnumerable<object[]> Data =>
-        Enum.GetValues(typeof(TracesTransportType))
-            .Cast<TracesTransportType>()
+        Enum.GetValues(typeof(AgentTransportType))
+            .Cast<AgentTransportType>()
 #if !NETCOREAPP3_1_OR_GREATER
-            .Where(x => x != TracesTransportType.UnixDomainSocket)
+            .Where(x => x != AgentTransportType.UnixDomainSocket)
 #endif
              // Run named pipes tests only on Windows
-            .Where(x => EnvironmentTools.IsWindows() || x != TracesTransportType.WindowsNamedPipe)
+            .Where(x => EnvironmentTools.IsWindows() || x != AgentTransportType.WindowsNamedPipe)
             .Select(x => new object[] { x });
 
     [SkippableTheory]
@@ -51,7 +51,7 @@ public class DataStreamsMonitoringTransportTests
     [Trait("RunOnWindows", "True")]
     public async Task TransportsWorkCorrectly(Enum transport)
     {
-        using var agent = Create((TracesTransportType)transport);
+        using var agent = Create((AgentTransportType)transport);
 
         // We don't want to trigger a flush based on the timer, only based on the disposal of the writer
         // That ensures we only get a single payload
@@ -111,13 +111,13 @@ public class DataStreamsMonitoringTransportTests
     private BacklogPoint CreateBacklogPoint(long timestamp = 0)
         => new BacklogPoint("type:produce", 100, timestamp != 0 ? timestamp : DateTimeOffset.UtcNow.ToUnixTimeNanoseconds());
 
-    private MockTracerAgent Create(TracesTransportType transportType)
+    private MockTracerAgent Create(AgentTransportType transportType)
         => transportType switch
         {
-            TracesTransportType.Default => MockTracerAgent.Create(_output),
-            TracesTransportType.WindowsNamedPipe => MockTracerAgent.Create(_output, new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}")),
+            AgentTransportType.Default => MockTracerAgent.Create(_output),
+            AgentTransportType.WindowsNamedPipe => MockTracerAgent.Create(_output, new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}")),
 #if NETCOREAPP3_1_OR_GREATER
-            TracesTransportType.UnixDomainSocket => MockTracerAgent.Create(
+            AgentTransportType.UnixDomainSocket => MockTracerAgent.Create(
                 _output,
                 new UnixDomainSocketConfig(
                     Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()),


### PR DESCRIPTION
## Summary of changes
Refactors the `TracesTransportType` to `AgentTransportType` and updates its usage across the repository to better separate "agent communication" from "traces communication".

Also fixes a bug related to this issue where setting the APM UDS socket affected the HttpClient used by OTLP traces export.

## Reason for change
The primary motivation was to resolve the following OTLP traces export issue: When OTLP traces export is enabled through the configuration `OTEL_TRACES_EXPORTER=otlp`, the endpoint defaults to TCP/IP communication with endpoint `http://localhost:4317` or `http://localhost:4318`. However, when `DD_APM_RECEIVER_SOCKET` is configured and its socket file is present, the underlying HTTP client is erroneously being configured for UDS communication rather than TCP/IP.

## Implementation details
- Rename enum TracesTransportType to AgentTransportType (still used by `ExporterSettings.TracesTransport`)
- Add new AgentTransport property (type=AgentTransportType) to the ExporterSettings to separate logical traces endpoint vs agent endpoint
- Change some usage of `ExporterSettings.TracesTransport` to `ExporterSettings.AgentTransport`. When OTLP traces export is enabled, override the previously calculated `ExporterSettings.TracesTransport` with the calculated transport from the OTLP configurations
- Instruct `ManagedApiOtlp` to create an api factory by calling a new `OtlpTransportStrategy.GetTraces` method rather than `TracesTransportStrategy.Get`. This will properly set the headers, endpoint, and timeout values for the underlying HTTP client following the OTLP configuration rather than the original DD Agent configuration.

## Test coverage
Existing tests are exercised and a few new unit tests are added to validate the transport and endpoint. Some tests still use the `ExporterSettings.TracesTransport` property to make assertions about traces specifically, while other tests have been updated to assert against `ExporterSettings.AgentTransport`

## Other details
`OtlpTransportStrategy` reuses the logic from `AgentTransportStrategy` to create HTTP clients for HTTP, Named Pipes, and UDS even though the latter two are untested. If desired, we can remove those code paths as they are currently untested.

Supercedes #8460 