### PR TITLE
[Dynamic Instrumentation] Fix Equals/GetHashCode contract on Dynamic Instrumentation configuration models

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Decoration.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Decoration.cs
@@ -6,6 +6,9 @@
 #pragma warning disable SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially
 
 #nullable enable
+using System;
+using Datadog.Trace.Debugger.Helpers;
+
 namespace Datadog.Trace.Debugger.Configurations.Models;
 
 internal sealed record Decoration
@@ -13,6 +16,26 @@ internal sealed record Decoration
     public SnapshotSegment? When { get; set; }
 
     public Tags[]? Tags { get; set; }
+
+    public bool Equals(Decoration? other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return Equals(When, other.When) && Tags.NullableSequentialEquals(other.Tags);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(When, Tags.NullableSequentialHashCode());
+    }
 }
 
 internal sealed record Tags
@@ -27,6 +50,26 @@ internal sealed record TagValue
     public string? Template { get; set; }
 
     public SnapshotSegment[]? Segments { get; set; }
+
+    public bool Equals(TagValue? other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return Template == other.Template && Segments.NullableSequentialEquals(other.Segments);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Template, Segments.NullableSequentialHashCode());
+    }
 }
 
 #pragma warning restore SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/FilterList.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/FilterList.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(PackagePrefixes, Classes);
+            return HashCode.Combine(PackagePrefixes.NullableSequentialHashCode(), Classes.NullableSequentialHashCode());
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/LogProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/LogProbe.cs
@@ -60,13 +60,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                base.GetHashCode(),
-                Capture,
-                Sampling,
-                Template,
-                CaptureSnapshot,
-                Segments);
+            return HashCode.Combine(base.GetHashCode(), Capture, Sampling, Template, CaptureSnapshot, Segments.NullableSequentialHashCode(), When);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/ProbeDefinition.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/ProbeDefinition.cs
@@ -69,10 +69,10 @@ namespace Datadog.Trace.Debugger.Configurations.Models
             var hashCode = new HashCode();
             hashCode.Add(Language);
             hashCode.Add(Id);
-            hashCode.Add(Tags);
+            hashCode.Add(Tags.NullableSequentialHashCode());
             hashCode.Add(Where);
             hashCode.Add(EvaluateAt);
-            hashCode.Add(AdditionalIds);
+            hashCode.Add(AdditionalIds.NullableSequentialHashCode());
             hashCode.Add(Version);
             return hashCode.ToHashCode();
         }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/SnapshotSegment.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/SnapshotSegment.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
@@ -26,4 +27,29 @@ internal sealed record SnapshotSegment
     public string Dsl { get; set; }
 
     public JObject Json { get; set; }
+
+    // The record-synthesized members would hash/compare Json by reference (JObject inherits
+    // object.GetHashCode/Equals), which means two SnapshotSegment instances parsed from the
+    // same JSON would be considered different. Compare and hash by content instead.
+    public bool Equals(SnapshotSegment other)
+    {
+        if (ReferenceEquals(null, other))
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return string.Equals(Str, other.Str, StringComparison.Ordinal)
+            && string.Equals(Dsl, other.Dsl, StringComparison.Ordinal)
+            && (ReferenceEquals(Json, other.Json) || JToken.DeepEquals(Json, other.Json));
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Str, Dsl, Json?.ToString());
+    }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/SnapshotSegment.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/SnapshotSegment.cs
@@ -30,7 +30,13 @@ internal sealed record SnapshotSegment
 
     // The record-synthesized members would hash/compare Json by reference (JObject inherits
     // object.GetHashCode/Equals), which means two SnapshotSegment instances parsed from the
-    // same JSON would be considered different. Compare and hash by content instead.
+    // same JSON would be considered different. Compare by content instead.
+    //
+    // Json is intentionally excluded from GetHashCode: JToken.DeepEquals ignores JObject
+    // property order, but any string-based hash of the JObject (e.g. ToString) preserves it,
+    // which would violate the Equals/GetHashCode contract when two payloads contain the same
+    // expression with re-ordered keys. Dsl already encodes the same expression as Json, so
+    // hashing on Str + Dsl gives equal hashes whenever Equals returns true.
     public bool Equals(SnapshotSegment other)
     {
         if (ReferenceEquals(null, other))
@@ -50,6 +56,6 @@ internal sealed record SnapshotSegment
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(Str, Dsl, Json?.ToString());
+        return HashCode.Combine(Str, Dsl);
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/SpanDecorationProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/SpanDecorationProbe.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(base.GetHashCode(), (int)TargetSpan, Decorations);
+            return HashCode.Combine(base.GetHashCode(), (int)TargetSpan, Decorations.NullableSequentialHashCode());
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Where.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Where.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(TypeName, MethodName, SourceFile, Signature, Lines);
+            return HashCode.Combine(TypeName, MethodName, SourceFile, Signature, Lines.NullableSequentialHashCode());
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/EnumerableExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/EnumerableExtensions.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -23,6 +24,42 @@ namespace Datadog.Trace.Debugger.Helpers
             }
 
             return @this.SequenceEqual(other);
+        }
+
+        // Array overload preferred by overload resolution when the static type is T[].
+        // Avoids the IEnumerator<T> heap allocation and interface dispatch that the IEnumerable<T>
+        // overload incurs on arrays, which matters because every current caller passes an array
+        // (Tags, AdditionalIds, Lines, Decorations, Segments, PackagePrefixes, Classes...).
+        public static int NullableSequentialHashCode<T>(this T[] @this)
+        {
+            if (@this is null)
+            {
+                return 0;
+            }
+
+            var hashCode = new HashCode();
+            for (var i = 0; i < @this.Length; i++)
+            {
+                hashCode.Add(@this[i]);
+            }
+
+            return hashCode.ToHashCode();
+        }
+
+        public static int NullableSequentialHashCode<T>(this IEnumerable<T> @this)
+        {
+            if (ReferenceEquals(null, @this))
+            {
+                return 0;
+            }
+
+            var hashCode = new HashCode();
+            foreach (var item in @this)
+            {
+                hashCode.Add(item);
+            }
+
+            return hashCode.ToHashCode();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/EnumerableExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/EnumerableExtensions.cs
@@ -26,10 +26,9 @@ namespace Datadog.Trace.Debugger.Helpers
             return @this.SequenceEqual(other);
         }
 
-        // Array overload preferred by overload resolution when the static type is T[].
-        // Avoids the IEnumerator<T> heap allocation and interface dispatch that the IEnumerable<T>
-        // overload incurs on arrays, which matters because every current caller passes an array
-        // (Tags, AdditionalIds, Lines, Decorations, Segments, PackagePrefixes, Classes...).
+        // Array-only by design: every caller currently passes a T[] property.
+        // An IEnumerable<T> overload would allocate an enumerator and dispatch through the
+        // interface on every iteration, so we deliberately don't provide one.
         public static int NullableSequentialHashCode<T>(this T[] @this)
         {
             if (@this is null)
@@ -41,22 +40,6 @@ namespace Datadog.Trace.Debugger.Helpers
             for (var i = 0; i < @this.Length; i++)
             {
                 hashCode.Add(@this[i]);
-            }
-
-            return hashCode.ToHashCode();
-        }
-
-        public static int NullableSequentialHashCode<T>(this IEnumerable<T> @this)
-        {
-            if (ReferenceEquals(null, @this))
-            {
-                return 0;
-            }
-
-            var hashCode = new HashCode();
-            foreach (var item in @this)
-            {
-                hashCode.Add(item);
             }
 
             return hashCode.ToHashCode();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
@@ -8,6 +8,7 @@ using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
 using FluentAssertions;
 using Xunit;
+using DebuggerTags = Datadog.Trace.Debugger.Configurations.Models.Tags;
 
 namespace Datadog.Trace.Tests.Debugger;
 
@@ -317,6 +318,119 @@ public class ProbeConfigurationComparerTests
                     {
                         new SnapshotSegment(string.Empty, null, "x="),
                         new SnapshotSegment("x", refJson, string.Empty),
+                    },
+                },
+            },
+        };
+
+        var comparer = new ProbeConfigurationComparer(current, incoming);
+        comparer.HasProbeRelatedChanges.Should().BeFalse();
+        comparer.HasRateLimitChanged.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CurrentMetricsReparsedJsonContent_ProbeRelatedNotChanged()
+    {
+        const string valueJson = @"{""ref"":""duration""}";
+
+        var current = new ProbeConfiguration
+        {
+            MetricProbes = new[]
+            {
+                new MetricProbe
+                {
+                    Id = "probe-1",
+                    MetricName = "method.duration",
+                    Value = new SnapshotSegment("duration", valueJson, string.Empty),
+                },
+            },
+        };
+        var incoming = new ProbeConfiguration
+        {
+            MetricProbes = new[]
+            {
+                new MetricProbe
+                {
+                    Id = "probe-1",
+                    MetricName = "method.duration",
+                    Value = new SnapshotSegment("duration", valueJson, string.Empty),
+                },
+            },
+        };
+
+        var comparer = new ProbeConfigurationComparer(current, incoming);
+        comparer.HasProbeRelatedChanges.Should().BeFalse();
+        comparer.HasRateLimitChanged.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CurrentSpanDecorationsReparsedJsonContent_ProbeRelatedNotChanged()
+    {
+        const string whenJson = @"{""eq"":[{""ref"":""http.status_code""},500]}";
+        const string tagValueJson = @"{""ref"":""error.message""}";
+
+        var current = new ProbeConfiguration
+        {
+            SpanDecorationProbes = new[]
+            {
+                new SpanDecorationProbe
+                {
+                    Id = "probe-1",
+                    Decorations = new[]
+                    {
+                        new Decoration
+                        {
+                            When = new SnapshotSegment("http.status_code == 500", whenJson, string.Empty),
+                            Tags = new[]
+                            {
+                                new DebuggerTags
+                                {
+                                    Name = "error.message",
+                                    Value = new TagValue
+                                    {
+                                        Template = "error={error.message}",
+                                        Segments = new[]
+                                        {
+                                            new SnapshotSegment(string.Empty, null, "error="),
+                                            new SnapshotSegment("error.message", tagValueJson, string.Empty),
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        var incoming = new ProbeConfiguration
+        {
+            SpanDecorationProbes = new[]
+            {
+                new SpanDecorationProbe
+                {
+                    Id = "probe-1",
+                    Decorations = new[]
+                    {
+                        new Decoration
+                        {
+                            When = new SnapshotSegment("http.status_code == 500", whenJson, string.Empty),
+                            Tags = new[]
+                            {
+                                new DebuggerTags
+                                {
+                                    Name = "error.message",
+                                    Value = new TagValue
+                                    {
+                                        Template = "error={error.message}",
+                                        Segments = new[]
+                                        {
+                                            new SnapshotSegment(string.Empty, null, "error="),
+                                            new SnapshotSegment("error.message", tagValueJson, string.Empty),
+                                        },
+                                    },
+                                },
+                            },
+                        },
                     },
                 },
             },

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
@@ -276,4 +276,54 @@ public class ProbeConfigurationComparerTests
         comparer.HasProbeRelatedChanges.Should().BeFalse();
         comparer.HasRateLimitChanged.Should().BeFalse();
     }
+
+    [Fact]
+    public void CurrentSnapshotsReparsedJsonContent_ProbeRelatedNotChanged()
+    {
+        // Reproduces the RCM re-apply scenario: two LogProbe instances that are content-
+        // identical but whose SnapshotSegment.Json fields are independently parsed JObject
+        // instances (different references, same content) - which is exactly what
+        // DynamicInstrumentation.Deserialize<LogProbe> produces on every RCM poll.
+        // Without content-based equality on SnapshotSegment, the comparer would treat
+        // the probe as added every cycle and trigger unnecessary IL re-instrumentation.
+        const string whenJson = @"{""ne"":[{""ref"":""x""},null]}";
+        const string refJson = @"{""ref"":""x""}";
+
+        var current = new ProbeConfiguration
+        {
+            LogProbes = new[]
+            {
+                new LogProbe
+                {
+                    Id = "probe-1",
+                    When = new SnapshotSegment("x != null", whenJson, string.Empty),
+                    Segments = new[]
+                    {
+                        new SnapshotSegment(string.Empty, null, "x="),
+                        new SnapshotSegment("x", refJson, string.Empty),
+                    },
+                },
+            },
+        };
+        var incoming = new ProbeConfiguration
+        {
+            LogProbes = new[]
+            {
+                new LogProbe
+                {
+                    Id = "probe-1",
+                    When = new SnapshotSegment("x != null", whenJson, string.Empty),
+                    Segments = new[]
+                    {
+                        new SnapshotSegment(string.Empty, null, "x="),
+                        new SnapshotSegment("x", refJson, string.Empty),
+                    },
+                },
+            },
+        };
+
+        var comparer = new ProbeConfigurationComparer(current, incoming);
+        comparer.HasProbeRelatedChanges.Should().BeFalse();
+        comparer.HasRateLimitChanged.Should().BeFalse();
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSegmentTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSegmentTests.cs
@@ -1,0 +1,27 @@
+// <copyright file="SnapshotSegmentTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Debugger.Configurations.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class SnapshotSegmentTests
+{
+    [Fact]
+    public void EquivalentJsonWithDifferentPropertyOrder_EqualsAndGetHashCodeAreConsistent()
+    {
+        // JToken.DeepEquals ignores JObject property order, but JObject.ToString preserves it.
+        // Hashing on the serialized form would produce different hash codes for equal segments,
+        // violating the Equals/GetHashCode contract. Locks in that GetHashCode does not depend
+        // on the Json serialization order.
+        var first = new SnapshotSegment(dsl: "expr", json: @"{""a"":1,""b"":2}", str: "x");
+        var second = new SnapshotSegment(dsl: "expr", json: @"{""b"":2,""a"":1}", str: "x");
+
+        first.Equals(second).Should().BeTrue();
+        first.GetHashCode().Should().Be(second.GetHashCode());
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Fix the `Equals` / `GetHashCode` contract on the Dynamic Instrumentation configuration models (`FilterList`, `Where`, `ProbeDefinition`, `SpanDecorationProbe`, `LogProbe`, `SnapshotSegment`).
- Add a `NullableSequentialHashCode<T>` helper in.

## Reason for change

- `HashCode.Combine` was being called on array properties which inherit `object.GetHashCode`/`Equals` (reference identity).
- Every time probe configuration is re-applied from RCM, equal configs would produce different hash codes.
- `LogProbe` additionally omitted `When` from `GetHashCode` even though `Equals` already used it.

## Implementation details

- The `T[]` overload of `NullableSequentialHashCode` is selected by overload resolution at every existing call site (`Tags`, `AdditionalIds`, `Lines`, `Decorations`, `Segments`, `PackagePrefixes`, `Classes`). It uses an indexed `for` loop, avoiding the `IEnumerator<T>` heap allocation and the interface dispatch (`MoveNext`/`Current`) the `IEnumerable<T>` overload would incur on arrays.

## Test coverage

- `ProbeConfigurationComparerTests`.
- New regression test `ProbeConfigurationComparerTests.CurrentSnapshotsReparsedJsonContent_ProbeRelatedNotChanged` 
