### PR TITLE
[Debugger] Reduce noisy Info logs to debug in native code

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -290,7 +290,7 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, Rejit
 
     if (probes.empty())
     {
-        Logger::Info("There are no probes for methodDef: ", methodHandler->GetMethodDef());
+        Logger::Debug("There are no probes for methodDef: ", methodHandler->GetMethodDef());
         return S_OK;
     }
 
@@ -2506,8 +2506,8 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
         return E_FAIL;
     }
 
-    Logger::Info("*** DebuggerMethodRewriter::Rewrite() Finished: ", caller->type.name, ".", caller->name,
-                 "() [IsVoid=", isVoid, ", IsStatic=", isStatic, ", Arguments=", numArgs, "]");
+    Logger::Debug("*** DebuggerMethodRewriter::Rewrite() Finished: ", caller->type.name, ".", caller->name,
+                  "() [IsVoid=", isVoid, ", IsStatic=", isStatic, ", Arguments=", numArgs, "]");
 
     hr = this->m_corProfiler->info_->ApplyMetaData(module_id);
     if (FAILED(hr))

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
@@ -429,7 +429,7 @@ void DebuggerProbesInstrumentationRequester::RemoveProbes(debugger::DebuggerRemo
                     }
                     else
                     {
-                        Logger::Info("Removed from the method handler Probe Id: ", probeIdToRemove);
+                        Logger::Debug("Removed from the method handler Probe Id: ", probeIdToRemove);
                     }
 
                     revertRequests.emplace(method);
@@ -771,7 +771,7 @@ void DebuggerProbesInstrumentationRequester::InstrumentProbes(
     // to be called from managed land.
     if (!revertRequests.empty())
     {
-        Logger::Info("About to RequestRevert for ", revertRequests.size(), " methods.");
+        Logger::Debug("About to RequestRevert for ", revertRequests.size(), " methods.");
 
         // RequestRevert
         std::vector<MethodIdentifier> requests(revertRequests.size());
@@ -785,7 +785,7 @@ void DebuggerProbesInstrumentationRequester::InstrumentProbes(
 
     if (!rejitRequests.empty())
     {
-        Logger::Info("About to RequestRejit for ", rejitRequests.size(), " methods.");
+        Logger::Debug("About to RequestRejit for ", rejitRequests.size(), " methods.");
 
         // RequestRejit
         auto promise = std::make_shared<std::promise<void>>();
@@ -806,7 +806,7 @@ int DebuggerProbesInstrumentationRequester::GetProbesStatuses(WCHAR** probeIds, 
         return 0;
     }
 
-    Logger::Info("Received ", probeIdsLength, " probes (ids) from managed side for status.");
+    Logger::Debug("Received ", probeIdsLength, " probes (ids) from managed side for status.");
 
     if (probeIdsLength <= 0)
     {
@@ -969,7 +969,7 @@ void DebuggerProbesInstrumentationRequester::ModuleLoadFinished_AddMetadataToMod
 
         if (typeInfo.isGeneric)
         {
-            Logger::Info(
+            Logger::Debug(
                 "Skipping IsFirstEntry field addition as we don't support generic async methods yet. [ModuleId=",
                 moduleInfo.id, ", Assembly=", moduleInfo.assembly.name, ", Type=", typeInfo.name,
                 ", IsValueType=", typeInfo.valueType, "]");
@@ -978,9 +978,9 @@ void DebuggerProbesInstrumentationRequester::ModuleLoadFinished_AddMetadataToMod
 
         if (typeInfo.IsStaticClass())
         {
-            Logger::Info("skipping IsFirstEntry field addition as we encountered a static class. [ModuleId=",
-                         moduleInfo.id, ", Assembly=", moduleInfo.assembly.name, ", Type=", typeInfo.name,
-                         ", IsValueType=", typeInfo.valueType, "]");
+            Logger::Debug("skipping IsFirstEntry field addition as we encountered a static class. [ModuleId=",
+                          moduleInfo.id, ", Assembly=", moduleInfo.assembly.name, ", Type=", typeInfo.name,
+                          ", IsValueType=", typeInfo.valueType, "]");
             continue;
         }
 
@@ -1061,7 +1061,7 @@ HRESULT DebuggerProbesInstrumentationRequester::NotifyReJITError(ModuleID module
         Logger::Info("Marking ", probeIds.size(), " probes as failed due to ReJITError notification.");
         for (const auto& probeId : probeIds)
         {
-            Logger::Info("Marking ", probeId, " as Error.");
+            Logger::Debug("Marking ", probeId, " as Error.");
             ProbesMetadataTracker::Instance()->SetErrorProbeStatus(probeId,
                                                                    GetGenericErrorMessageWithHr(hrStatus));
         }

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
@@ -270,8 +270,8 @@ bool DebuggerRejitPreprocessor::CheckExactSignatureMatch(ComPtr<IMetaDataImport2
     // instrumentation target
     if (numOfArgs != numOfArgsTargetMethod - thisArg)
     {
-        Logger::Info("    * Skipping ", functionInfo.type.name, ".", functionInfo.name,
-                     ": the methoddef doesn't have the right number of arguments (", numOfArgs, " arguments).");
+        Logger::Debug("    * Skipping ", functionInfo.type.name, ".", functionInfo.name,
+                      ": the methoddef doesn't have the right number of arguments (", numOfArgs, " arguments).");
         return false;
     }
 
@@ -293,8 +293,8 @@ bool DebuggerRejitPreprocessor::CheckExactSignatureMatch(ComPtr<IMetaDataImport2
     }
     if (argumentsMismatch)
     {
-        Logger::Info("    * Skipping ", targetMethod.method_name,
-                     ": the methoddef doesn't have the right type of arguments.");
+        Logger::Debug("    * Skipping ", targetMethod.method_name,
+                      ": the methoddef doesn't have the right type of arguments.");
         return false;
     }
 


### PR DESCRIPTION
## Summary of changes

Lower native log calls from `Info` to `Debug` in the debugger / dynamic instrumentation native code (`debugger_probes_instrumentation_requester.cpp`, `debugger_rejit_preprocessor.cpp`, `debugger_method_rewriter.cpp`).

## Reason for change

These messages fire per-method, per-loop-iteration, or per-polled-call and were noisy at default verbosity without adding information beyond the batch-summary `Info` logs that already stay at `Info`.

## Implementation details

Level-only change. No strings modified, no behavior change. No `IsDebugEnabled()` guards needed.

## Test coverage

All existing tests.