### PR TITLE
[Debugger] Fix Timer leaks and missing rate updates in probe rate limiter

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -520,12 +520,20 @@ namespace Datadog.Trace.Debugger
                 {
                     Log.Information("Dynamic Instrumentation.CheckUnboundProbes: {Count} unbound probes became bound.", property: noLongerUnboundProbes.Count);
 
-                    DebuggerNativeMethods.InstrumentProbes([], lineProbes.ToArray(), [], []);
-
+                    // Register processors and samplers BEFORE the native call makes the IL live:
+                    // otherwise a probe hit between InstrumentProbes returning and SetRateLimit
+                    // running would insert a default-rate sampler via GerOrAddSampler, and the
+                    // configured rate would never take effect for that probe.
                     foreach (var boundProbe in noLongerUnboundProbes)
                     {
                         ProbeExpressionsProcessor.Instance.AddProbeProcessor(boundProbe);
                         SetRateLimit(boundProbe);
+                    }
+
+                    DebuggerNativeMethods.InstrumentProbes([], lineProbes.ToArray(), [], []);
+
+                    foreach (var boundProbe in noLongerUnboundProbes)
+                    {
                         _unboundProbes.Remove(boundProbe);
                     }
 

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
@@ -47,6 +47,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
         /// weight assigned by a plain arithmetic average (= 1/N).
         /// </summary>
         private readonly double _emaAlpha;
+        private readonly object _maintenanceLock = new();
         private int _samplesPerWindow;
 
         private Counts _countsRef;
@@ -109,7 +110,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
             if (NextDouble() < _probability)
             {
-                return _countsRef.AddSample(_samplesBudget);
+                return _countsRef.AddSample(Volatile.Read(ref _samplesBudget));
             }
 
             return false;
@@ -150,10 +151,11 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         private void UpdateSamplesPerWindow(int samplesPerWindow)
         {
-            // Plain writes match the rest of the class's relaxed memory model; rate change is
-            // visible "eventually" and self-corrects on the next window roll.
-            _samplesPerWindow = samplesPerWindow;
-            _samplesBudget = samplesPerWindow + ((long)_budgetLookback * samplesPerWindow);
+            lock (_maintenanceLock)
+            {
+                _samplesPerWindow = samplesPerWindow;
+                Volatile.Write(ref _samplesBudget, samplesPerWindow + ((long)_budgetLookback * samplesPerWindow));
+            }
         }
 
         private long CalculateBudgetEma(long sampledCount)
@@ -170,47 +172,54 @@ namespace Datadog.Trace.Debugger.RateLimiting
         {
             try
             {
-                var counts = _countsSlots[_countsSlotIndex];
+                Action rollWindowCallback;
 
-                // Semi-atomically replace the Counts instance such that sample requests during window maintenance will be
-                // using the newly created counts instead of the ones currently processed by the maintenance routine.
-                // We are ok with slightly racy outcome where totaCount and sampledCount may not be totally in sync
-                // because it allows to avoid contention in the hot-path and the effect on the overall sample rate is minimal
-                // and will get compensated in the long run.
-                // Theoretically, a compensating system might be devised but it will always require introducing a single point
-                // of contention and add a fair amount of complexity. Considering that we are ok with keeping the target sampling
-                // rate within certain error margins and this data race is not breaking the margin it is better to keep the
-                // code simple and reasonably fast.
-                _countsSlotIndex = (_countsSlotIndex + 1) % 2;
-                _countsRef = _countsSlots[_countsSlotIndex];
-                var totalCount = counts.TestCount();
-                var sampledCount = counts.SampleCount();
-
-                _samplesBudget = CalculateBudgetEma(sampledCount);
-
-                if (_totalCountRunningAverage == 0 || _emaAlpha <= 0.0)
+                lock (_maintenanceLock)
                 {
-                    _totalCountRunningAverage = totalCount;
+                    var counts = _countsSlots[_countsSlotIndex];
+
+                    // Semi-atomically replace the Counts instance such that sample requests during window maintenance will be
+                    // using the newly created counts instead of the ones currently processed by the maintenance routine.
+                    // We are ok with slightly racy outcome where totaCount and sampledCount may not be totally in sync
+                    // because it allows to avoid contention in the hot-path and the effect on the overall sample rate is minimal
+                    // and will get compensated in the long run.
+                    // Theoretically, a compensating system might be devised but it will always require introducing a single point
+                    // of contention and add a fair amount of complexity. Considering that we are ok with keeping the target sampling
+                    // rate within certain error margins and this data race is not breaking the margin it is better to keep the
+                    // code simple and reasonably fast.
+                    _countsSlotIndex = (_countsSlotIndex + 1) % 2;
+                    _countsRef = _countsSlots[_countsSlotIndex];
+                    var totalCount = counts.TestCount();
+                    var sampledCount = counts.SampleCount();
+
+                    var samplesBudget = CalculateBudgetEma(sampledCount);
+                    Volatile.Write(ref _samplesBudget, samplesBudget);
+
+                    if (_totalCountRunningAverage == 0 || _emaAlpha <= 0.0)
+                    {
+                        _totalCountRunningAverage = totalCount;
+                    }
+                    else
+                    {
+                        _totalCountRunningAverage = _totalCountRunningAverage + (_emaAlpha * (totalCount - _totalCountRunningAverage));
+                    }
+
+                    if (_totalCountRunningAverage <= 0)
+                    {
+                        _probability = 1;
+                    }
+                    else
+                    {
+                        _probability = Math.Min(samplesBudget / _totalCountRunningAverage, 1.0);
+                    }
+
+                    counts.Reset();
+                    rollWindowCallback = _rollWindowCallback;
                 }
-                else
-                {
-                    _totalCountRunningAverage = _totalCountRunningAverage + (_emaAlpha * (totalCount - _totalCountRunningAverage));
-                }
 
-                if (_totalCountRunningAverage <= 0)
+                if (rollWindowCallback != null)
                 {
-                    _probability = 1;
-                }
-                else
-                {
-                    _probability = Math.Min(_samplesBudget / _totalCountRunningAverage, 1.0);
-                }
-
-                counts.Reset();
-
-                if (_rollWindowCallback != null)
-                {
-                    _rollWindowCallback();
+                    rollWindowCallback();
                 }
             }
             catch (Exception e)
@@ -227,7 +236,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
             {
                 TestCount = counts.TestCount(),
                 SampleCount = counts.SampleCount(),
-                Budget = _samplesBudget,
+                Budget = Volatile.Read(ref _samplesBudget),
                 Probability = _probability,
                 TotalAverage = _totalCountRunningAverage
             };

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
@@ -150,10 +150,8 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         private void UpdateSamplesPerWindow(int samplesPerWindow)
         {
-            // The sampler operates with relaxed memory semantics throughout (Sample/RollWindow read
-            // and write _samplesBudget without barriers), so we deliberately don't introduce
-            // synchronization here either. A rate update becomes visible to other threads "eventually",
-            // which is fine: sampling is approximate and self-correcting on the next window roll.
+            // Plain writes match the rest of the class's relaxed memory model; rate change is
+            // visible "eventually" and self-corrects on the next window roll.
             _samplesPerWindow = samplesPerWindow;
             _samplesBudget = samplesPerWindow + ((long)_budgetLookback * samplesPerWindow);
         }

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
     /// to compensate for too rapid changes in the incoming events rate and maintain the target average
     /// number of samples per window.
     /// </summary>
-    internal sealed class AdaptiveSampler : IAdaptiveSampler
+    internal sealed class AdaptiveSampler : IAdaptiveSampler, IDisposable
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AdaptiveSampler>();
 
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
         /// weight assigned by a plain arithmetic average (= 1/N).
         /// </summary>
         private readonly double _emaAlpha;
-        private readonly int _samplesPerWindow;
+        private int _samplesPerWindow;
 
         private Counts _countsRef;
 
@@ -89,10 +89,9 @@ namespace Datadog.Trace.Debugger.RateLimiting
                 budgetLookback = 1;
             }
 
-            _samplesPerWindow = samplesPerWindow;
             _budgetLookback = budgetLookback;
+            UpdateSamplesPerWindow(samplesPerWindow);
 
-            _samplesBudget = samplesPerWindow + (budgetLookback * samplesPerWindow);
             _emaAlpha = ComputeIntervalAlpha(averageLookback);
             _budgetAlpha = ComputeIntervalAlpha(budgetLookback);
 
@@ -134,9 +133,29 @@ namespace Datadog.Trace.Debugger.RateLimiting
             return ThreadSafeRandom.Shared.NextDouble();
         }
 
+        public void SetRate(int samplesPerWindow)
+        {
+            UpdateSamplesPerWindow(samplesPerWindow);
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+        }
+
         private double ComputeIntervalAlpha(int lookback)
         {
             return 1 - Math.Pow(lookback, -1.0 / lookback);
+        }
+
+        private void UpdateSamplesPerWindow(int samplesPerWindow)
+        {
+            // The sampler operates with relaxed memory semantics throughout (Sample/RollWindow read
+            // and write _samplesBudget without barriers), so we deliberately don't introduce
+            // synchronization here either. A rate update becomes visible to other threads "eventually",
+            // which is fine: sampling is approximate and self-correcting on the next window roll.
+            _samplesPerWindow = samplesPerWindow;
+            _samplesBudget = samplesPerWindow + ((long)_budgetLookback * samplesPerWindow);
         }
 
         private long CalculateBudgetEma(long sampledCount)

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/IAdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/IAdaptiveSampler.cs
@@ -4,9 +4,11 @@
 // </copyright>
 
 #nullable enable
+using System;
+
 namespace Datadog.Trace.Debugger.RateLimiting
 {
-    internal interface IAdaptiveSampler
+    internal interface IAdaptiveSampler : IDisposable
     {
         bool Sample();
 

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/NopAdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/NopAdaptiveSampler.cs
@@ -29,5 +29,9 @@ namespace Datadog.Trace.Debugger.RateLimiting
         {
             return 1.0;
         }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
@@ -48,13 +48,13 @@ namespace Datadog.Trace.Debugger.RateLimiting
             }
 
             var candidate = CreateSampler();
-            if (_samplers.TryAdd(probeId, candidate))
+            sampler = _samplers.GetOrAdd(probeId, candidate);
+            if (!ReferenceEquals(sampler, candidate))
             {
-                return candidate;
+                candidate.Dispose();
             }
 
-            candidate.Dispose();
-            return _samplers.TryGetValue(probeId, out sampler) ? sampler : candidate;
+            return sampler;
         }
 
         public bool TryAddSampler(string probeId, IAdaptiveSampler sampler)

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
@@ -40,14 +40,8 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         public IAdaptiveSampler GerOrAddSampler(string probeId)
         {
-            // Hot path: a sampler is almost always already present (added on probe instrumentation
-            // via SetRate/TryAddSampler). The TryGetValue fast path keeps that case allocation-free.
-            //
-            // We deliberately avoid ConcurrentDictionary.GetOrAdd(key, factory) because
-            // CreateSampler() allocates a System.Threading.Timer, and the runtime roots that Timer
-            // in its global timer queue. If GetOrAdd's factory is invoked but its TryAdd loses the
-            // race (a documented possibility), the losing AdaptiveSampler and its Timer would be
-            // leaked permanently.
+            // Avoid ConcurrentDictionary.GetOrAdd(factory): its factory can run more than once
+            // under contention, leaking the losing sampler's Timer (rooted by the runtime).
             if (_samplers.TryGetValue(probeId, out var sampler))
             {
                 return sampler;
@@ -82,8 +76,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
                 return;
             }
 
-            // Lost the insert race - apply the new rate to whoever won and dispose our candidate
-            // so its Timer doesn't get leaked into the runtime's timer queue.
+            // Lost the insert race - apply the new rate to the winner and dispose our candidate.
             if (_samplers.TryGetValue(probeId, out existing))
             {
                 UpdateExistingRate(probeId, existing, samplesPerSecond);
@@ -94,10 +87,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         public void ResetRate(string probeId)
         {
-            // Disposing the removed sampler is critical: AdaptiveSampler owns a Timer that the
-            // runtime keeps alive in its timer queue until disposed, which would otherwise pin the
-            // sampler (and its captured callback graph) for the lifetime of the process every time
-            // a probe is removed.
+            // Must dispose: AdaptiveSampler's Timer is rooted by the runtime until disposed.
             if (_samplers.TryRemove(probeId, out var removed))
             {
                 removed.Dispose();
@@ -112,8 +102,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
             }
             else
             {
-                // Non-AdaptiveSampler entries (e.g. NopAdaptiveSampler for span decoration / metric
-                // probes) intentionally don't honor a rate; nothing to update.
+                // NopAdaptiveSampler entries (span decoration / metric probes) don't honor a rate.
                 Log.Information("Adaptive sampler for {ProbeID} cannot be updated", probeId);
             }
         }

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
@@ -40,7 +40,27 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         public IAdaptiveSampler GerOrAddSampler(string probeId)
         {
-            return _samplers.GetOrAdd(probeId, _ => CreateSampler(1));
+            // Hot path: a sampler is almost always already present (added on probe instrumentation
+            // via SetRate/TryAddSampler). The TryGetValue fast path keeps that case allocation-free.
+            //
+            // We deliberately avoid ConcurrentDictionary.GetOrAdd(key, factory) because
+            // CreateSampler() allocates a System.Threading.Timer, and the runtime roots that Timer
+            // in its global timer queue. If GetOrAdd's factory is invoked but its TryAdd loses the
+            // race (a documented possibility), the losing AdaptiveSampler and its Timer would be
+            // leaked permanently.
+            if (_samplers.TryGetValue(probeId, out var sampler))
+            {
+                return sampler;
+            }
+
+            var candidate = CreateSampler();
+            if (_samplers.TryAdd(probeId, candidate))
+            {
+                return candidate;
+            }
+
+            candidate.Dispose();
+            return _samplers.TryGetValue(probeId, out sampler) ? sampler : candidate;
         }
 
         public bool TryAddSampler(string probeId, IAdaptiveSampler sampler)
@@ -50,24 +70,52 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         public void SetRate(string probeId, int samplesPerSecond)
         {
-            // We currently don't support updating the probe rate limit, and that is fine
-            // since the functionality in the UI is not exposed yet.
-            if (_samplers.TryGetValue(probeId, out _))
+            if (_samplers.TryGetValue(probeId, out var existing))
             {
-                Log.Information("Adaptive sampler already exist for {ProbeID}", probeId);
+                UpdateExistingRate(probeId, existing, samplesPerSecond);
                 return;
             }
 
-            var adaptiveSampler = CreateSampler(samplesPerSecond);
-            if (!_samplers.TryAdd(probeId, adaptiveSampler))
+            var candidate = CreateSampler(samplesPerSecond);
+            if (_samplers.TryAdd(probeId, candidate))
             {
-                Log.Information("Adaptive sampler already exist for {ProbeID}", probeId);
+                return;
             }
+
+            // Lost the insert race - apply the new rate to whoever won and dispose our candidate
+            // so its Timer doesn't get leaked into the runtime's timer queue.
+            if (_samplers.TryGetValue(probeId, out existing))
+            {
+                UpdateExistingRate(probeId, existing, samplesPerSecond);
+            }
+
+            candidate.Dispose();
         }
 
         public void ResetRate(string probeId)
         {
-            _samplers.TryRemove(probeId, out _);
+            // Disposing the removed sampler is critical: AdaptiveSampler owns a Timer that the
+            // runtime keeps alive in its timer queue until disposed, which would otherwise pin the
+            // sampler (and its captured callback graph) for the lifetime of the process every time
+            // a probe is removed.
+            if (_samplers.TryRemove(probeId, out var removed))
+            {
+                removed.Dispose();
+            }
+        }
+
+        private static void UpdateExistingRate(string probeId, IAdaptiveSampler existing, int samplesPerSecond)
+        {
+            if (existing is AdaptiveSampler adaptive)
+            {
+                adaptive.SetRate(samplesPerSecond);
+            }
+            else
+            {
+                // Non-AdaptiveSampler entries (e.g. NopAdaptiveSampler for span decoration / metric
+                // probes) intentionally don't honor a rate; nothing to update.
+                Log.Information("Adaptive sampler for {ProbeID} cannot be updated", probeId);
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/AdaptiveSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/AdaptiveSamplerTests.cs
@@ -121,7 +121,7 @@ public class AdaptiveSamplerTests
         const int budgetLookback = 4;
         var sampler = new AdaptiveSampler(WindowDuration, samplesPerWindow: initialRate, averageLookback: 1, budgetLookback: budgetLookback, rollWindowCallback: null);
 
-        // Drive a window roll so the sampler accumulates running stats we'll later confirm survive a rate change.
+        // Accumulate running stats; SetRate must preserve them (not behave like a re-create).
         sampler.Keep();
         sampler.Drop();
         sampler.RollWindow();
@@ -134,10 +134,6 @@ public class AdaptiveSamplerTests
 
         var afterUpdate = sampler.GetInternalState();
         Assert.Equal(newRate + (budgetLookback * newRate), afterUpdate.Budget);
-
-        // Running EMAs and probability must be preserved - mutating the rate must not behave like
-        // re-creating the sampler, otherwise every RCM-driven rate change would cause a transient
-        // sampling spike before the EMAs re-converge.
         Assert.Equal(beforeUpdate.TotalAverage, afterUpdate.TotalAverage);
         Assert.Equal(beforeUpdate.Probability, afterUpdate.Probability);
     }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/AdaptiveSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/AdaptiveSamplerTests.cs
@@ -113,4 +113,41 @@ public class AdaptiveSamplerTests
         Assert.Equal(expected: 3.0, state.TotalAverage);
         Assert.Equal(2.0 / 3.0, state.Probability);
     }
+
+    [Fact]
+    public void SetRate_UpdatesBudgetWithoutResettingHistory()
+    {
+        const int initialRate = 2;
+        const int budgetLookback = 4;
+        var sampler = new AdaptiveSampler(WindowDuration, samplesPerWindow: initialRate, averageLookback: 1, budgetLookback: budgetLookback, rollWindowCallback: null);
+
+        // Drive a window roll so the sampler accumulates running stats we'll later confirm survive a rate change.
+        sampler.Keep();
+        sampler.Drop();
+        sampler.RollWindow();
+
+        var beforeUpdate = sampler.GetInternalState();
+        Assert.NotEqual(expected: 0.0, beforeUpdate.TotalAverage);
+
+        const int newRate = 50;
+        sampler.SetRate(newRate);
+
+        var afterUpdate = sampler.GetInternalState();
+        Assert.Equal(newRate + (budgetLookback * newRate), afterUpdate.Budget);
+
+        // Running EMAs and probability must be preserved - mutating the rate must not behave like
+        // re-creating the sampler, otherwise every RCM-driven rate change would cause a transient
+        // sampling spike before the EMAs re-converge.
+        Assert.Equal(beforeUpdate.TotalAverage, afterUpdate.TotalAverage);
+        Assert.Equal(beforeUpdate.Probability, afterUpdate.Probability);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotentAndStopsTimer()
+    {
+        var sampler = new AdaptiveSampler(WindowDuration, samplesPerWindow: 1, averageLookback: 1, budgetLookback: 1, rollWindowCallback: null);
+
+        sampler.Dispose();
+        sampler.Dispose();
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -177,5 +177,9 @@ public class ProbeProcessorTests
         public bool Drop() => !Sample();
 
         public double NextDouble() => 0;
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
@@ -1,0 +1,100 @@
+// <copyright file="ProbeRateLimiterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Debugger.RateLimiting;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class ProbeRateLimiterTests
+{
+    [Fact]
+    public void SetRate_UpdatesExistingSamplerInPlace()
+    {
+        var limiter = ProbeRateLimiter.Instance;
+        var probeId = $"setrate-update-{Guid.NewGuid():N}";
+
+        try
+        {
+            limiter.SetRate(probeId, samplesPerSecond: 1);
+            var initial = limiter.GerOrAddSampler(probeId);
+
+            // Updating the rate must preserve the existing sampler instance: replacing it would
+            // wipe the running EMAs and cause a transient sampling spike on every RCM-driven
+            // rate change.
+            limiter.SetRate(probeId, samplesPerSecond: 100);
+            var afterUpdate = limiter.GerOrAddSampler(probeId);
+
+            Assert.Same(initial, afterUpdate);
+
+            var state = ((AdaptiveSampler)afterUpdate).GetInternalState();
+            // Budget = samplesPerWindow + (budgetLookback * samplesPerWindow), and the ProbeRateLimiter
+            // hard-codes budgetLookback=16, so 100 + 16*100 = 1700.
+            Assert.Equal(expected: 100 + (16 * 100), state.Budget);
+        }
+        finally
+        {
+            limiter.ResetRate(probeId);
+        }
+    }
+
+    [Fact]
+    public void ResetRate_DisposesRemovedSampler()
+    {
+        var limiter = ProbeRateLimiter.Instance;
+        var probeId = $"resetrate-dispose-{Guid.NewGuid():N}";
+        var tracker = new TrackingSampler();
+
+        Assert.True(limiter.TryAddSampler(probeId, tracker));
+
+        limiter.ResetRate(probeId);
+
+        // Without disposal the sampler graph (and, for real AdaptiveSampler instances, its Timer)
+        // would be rooted by the runtime forever - a leak that accumulates across every RCM
+        // probe removal over the process lifetime.
+        Assert.True(tracker.Disposed);
+    }
+
+    [Fact]
+    public void GerOrAddSampler_ReturnsExistingEntryWithoutLeakingCandidate()
+    {
+        var limiter = ProbeRateLimiter.Instance;
+        var probeId = $"getoradd-existing-{Guid.NewGuid():N}";
+        var preExisting = new TrackingSampler();
+
+        Assert.True(limiter.TryAddSampler(probeId, preExisting));
+
+        try
+        {
+            var resolved = limiter.GerOrAddSampler(probeId);
+
+            Assert.Same(preExisting, resolved);
+            Assert.False(preExisting.Disposed);
+        }
+        finally
+        {
+            limiter.ResetRate(probeId);
+        }
+    }
+
+    private sealed class TrackingSampler : IAdaptiveSampler
+    {
+        public bool Disposed { get; private set; }
+
+        public bool Sample() => true;
+
+        public bool Keep() => true;
+
+        public bool Drop() => true;
+
+        public double NextDouble() => 1.0;
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
@@ -22,17 +22,14 @@ public class ProbeRateLimiterTests
             limiter.SetRate(probeId, samplesPerSecond: 1);
             var initial = limiter.GerOrAddSampler(probeId);
 
-            // Updating the rate must preserve the existing sampler instance: replacing it would
-            // wipe the running EMAs and cause a transient sampling spike on every RCM-driven
-            // rate change.
+            // SetRate must mutate in place; replacing would wipe running EMAs.
             limiter.SetRate(probeId, samplesPerSecond: 100);
             var afterUpdate = limiter.GerOrAddSampler(probeId);
 
             Assert.Same(initial, afterUpdate);
 
+            // Budget = samplesPerWindow + (budgetLookback * samplesPerWindow); budgetLookback = 16.
             var state = ((AdaptiveSampler)afterUpdate).GetInternalState();
-            // Budget = samplesPerWindow + (budgetLookback * samplesPerWindow), and the ProbeRateLimiter
-            // hard-codes budgetLookback=16, so 100 + 16*100 = 1700.
             Assert.Equal(expected: 100 + (16 * 100), state.Budget);
         }
         finally
@@ -52,9 +49,7 @@ public class ProbeRateLimiterTests
 
         limiter.ResetRate(probeId);
 
-        // Without disposal the sampler graph (and, for real AdaptiveSampler instances, its Timer)
-        // would be rooted by the runtime forever - a leak that accumulates across every RCM
-        // probe removal over the process lifetime.
+        // Without disposal, an AdaptiveSampler's Timer would leak on every probe removal.
         Assert.True(tracker.Disposed);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeRateLimiterTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Threading;
 using Datadog.Trace.Debugger.RateLimiting;
 using Xunit;
 
@@ -19,8 +20,8 @@ public class ProbeRateLimiterTests
 
         try
         {
-            limiter.SetRate(probeId, samplesPerSecond: 1);
-            var initial = limiter.GerOrAddSampler(probeId);
+            var initial = new AdaptiveSampler(Timeout.InfiniteTimeSpan, samplesPerWindow: 1, averageLookback: 180, budgetLookback: 16, rollWindowCallback: null);
+            Assert.True(limiter.TryAddSampler(probeId, initial));
 
             // SetRate must mutate in place; replacing would wipe running EMAs.
             limiter.SetRate(probeId, samplesPerSecond: 100);


### PR DESCRIPTION
## Summary of changes

Fixes Timer/sampler leaks and a latent rate-update bug in `ProbeRateLimiter` and `AdaptiveSampler`. `AdaptiveSampler` allocates a `System.Threading.Timer` that the runtime roots until disposed; three code paths previously dropped samplers without disposing them, leaking one Timer (plus captured state) on every probe removal and on every dictionary insert race. Separately, RCM-driven rate updates were silently ignored when a sampler already existed.

## Reason for change

- Long-running services using Dynamic Instrumentation accumulate `Timer` instances on every RCM probe rotation — unbounded growth over the process lifetime.
- Line probes that go through the unbound → bound transition could end up stuck at the default rate of 1 because `CheckUnboundProbes` registered the sampler **after** making the IL live, opening a race window where the first probe hit inserts a default-rate sampler and the configured rate is then dropped by `SetRate`.

## Implementation details

- `IAdaptiveSampler` extends `IDisposable`; `AdaptiveSampler.Dispose` releases the internal `Timer`; `NopAdaptiveSampler.Dispose` is a no-op (singleton).
- `AdaptiveSampler.SetRate` mutates `_samplesPerWindow` / `_samplesBudget` in place. Uses the same relaxed memory semantics as the rest of the class.
- `ProbeRateLimiter.GerOrAddSampler` uses `TryGetValue` → `TryAdd` → `Dispose-on-lose` instead of `ConcurrentDictionary.GetOrAdd`, which can invoke its factory multiple times.
- `ProbeRateLimiter.SetRate` applies the new rate to the existing sampler instead of logging and returning; disposes the candidate if it loses the insert race.
- `ProbeRateLimiter.ResetRate` disposes the removed sampler.
- `DynamicInstrumentation.CheckUnboundProbes` now registers samplers and processors **before** calling `DebuggerNativeMethods.InstrumentProbes`, matching the ordering in `InstrumentAddedProbes` and closing the race at its source.

## Test coverage

- `AdaptiveSamplerTests` — `SetRate` updates budget and preserves running stats; `Dispose` is idempotent.
- `ProbeRateLimiterTests` (new) — `SetRate` updates the existing sampler in place; `ResetRate` disposes the removed sampler; `GerOrAddSampler` does not dispose existing entries.