### PR TITLE
Attempt to reduce flake in BuggyBits sample app

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -3,16 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Net.Sockets;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Demos.Util;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -44,8 +42,6 @@ namespace BuggyBits
 
     public class Program
     {
-        private const int HostBindRetries = 5;
-
         private static bool _disableLogs = false;
 
         public static async Task Main(string[] args)
@@ -58,8 +54,10 @@ namespace BuggyBits
 
             ParseCommandLine(args, out _disableLogs, out var timeout, out var iterations, out var scenario, out var nbIdleThreads);
 
-            using (var host = await StartHostWithPortResilience(args))
+            using (var host = CreateHostBuilder(args).Build())
             {
+                await host.StartAsync();
+
                 var rootUrl = GetBoundRootUrl(host);
                 WriteLine($"Listening to {rootUrl}");
 
@@ -127,116 +125,8 @@ namespace BuggyBits
             WriteLine($"The application exited after: {sw.Elapsed} at {DateTime.UtcNow}");
         }
 
-        private static async Task<IHost> StartHostWithPortResilience(string[] args)
-        {
-            var host = CreateHostBuilder(args).Build();
-            try
-            {
-                var rootUrl = GetConfiguredRootUrl(host);
-
-                for (var remainingRetries = HostBindRetries; ; remainingRetries--)
-                {
-                    try
-                    {
-                        WriteLine($"Starting web host at {rootUrl}");
-                        await host.StartAsync();
-                        return host;
-                    }
-                    catch (Exception ex) when (remainingRetries > 0 && IsAddressInUseException(ex))
-                    {
-                        var retryRootUrl = GetUrlWithNewPort(rootUrl);
-                        WriteLine($"Address already in use for {rootUrl}. Retrying on {retryRootUrl}.");
-
-                        host.Dispose();
-                        rootUrl = retryRootUrl;
-                        host = CreateHostBuilder(args, rootUrl).Build();
-                    }
-                }
-            }
-            catch
-            {
-                host.Dispose();
-                throw;
-            }
-        }
-
-        private static string GetConfiguredRootUrl(IHost host)
-        {
-            // ASP.NET Core accepts listening urls from launchSettings.json, ASPNETCORE_URLS,
-            // or --urls. If none are supplied, Kestrel uses this default.
-            var configuration = host.Services.GetService(typeof(IConfiguration)) as IConfiguration;
-            var rootUrl = configuration?["urls"];
-
-            if (string.IsNullOrEmpty(rootUrl))
-            {
-                rootUrl = "http://localhost:5000";
-            }
-
-            return GetFirstUrl(rootUrl);
-        }
-
-        private static string GetBoundRootUrl(IHost host)
-        {
-            var server = host.Services.GetService(typeof(IServer)) as IServer;
-            var addresses = server?.Features.Get<IServerAddressesFeature>()?.Addresses;
-
-            if (addresses != null)
-            {
-                foreach (var address in addresses)
-                {
-                    if (!string.IsNullOrEmpty(address))
-                    {
-                        return address.TrimEnd('/');
-                    }
-                }
-            }
-
-            return GetConfiguredRootUrl(host);
-        }
-
-        private static string GetFirstUrl(string urls)
-        {
-            var separatorIndex = urls.IndexOf(';');
-            if (separatorIndex >= 0)
-            {
-                urls = urls.Substring(0, separatorIndex);
-            }
-
-            return urls.TrimEnd('/');
-        }
-
-        private static string GetUrlWithNewPort(string rootUrl)
-        {
-            // Avoid UriBuilder here: ASP.NET Core wildcard hosts (http://*:5000, http://+:5000)
-            // are not valid Uri hosts and would throw UriFormatException. Since the retry always
-            // rebinds to 127.0.0.1 with an OS-assigned port, only the scheme needs to be preserved.
-            var schemeSeparator = rootUrl.IndexOf("://", StringComparison.Ordinal);
-            var scheme = schemeSeparator > 0 ? rootUrl.Substring(0, schemeSeparator) : "http";
-            return $"{scheme}://127.0.0.1:0";
-        }
-
-        private static bool IsAddressInUseException(Exception exception)
-        {
-            while (exception != null)
-            {
-                if (exception is SocketException socketException && socketException.SocketErrorCode == SocketError.AddressAlreadyInUse)
-                {
-                    return true;
-                }
-
-                if (exception.Message.IndexOf("address already in use", StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    return true;
-                }
-
-                exception = exception.InnerException;
-            }
-
-            return false;
-        }
-
-        public static IHostBuilder CreateHostBuilder(string[] args, string rootUrl = null) =>
-            Host.CreateDefaultBuilder(GetArgsWithUrlsOverride(args, rootUrl))
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
@@ -249,34 +139,13 @@ namespace BuggyBits
                     }
                 });
 
-        private static string[] GetArgsWithUrlsOverride(string[] args, string rootUrl)
+        private static string GetBoundRootUrl(IHost host)
         {
-            if (string.IsNullOrEmpty(rootUrl))
-            {
-                return args;
-            }
-
-            var effectiveArgs = new List<string>(args.Length + 2);
-            for (var i = 0; i < args.Length; i++)
-            {
-                var arg = args[i];
-                if (string.Equals(arg, "--urls", StringComparison.OrdinalIgnoreCase))
-                {
-                    i++;
-                    continue;
-                }
-
-                if (arg.StartsWith("--urls=", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                effectiveArgs.Add(arg);
-            }
-
-            effectiveArgs.Add("--urls");
-            effectiveArgs.Add(rootUrl);
-            return effectiveArgs.ToArray();
+            // Read the address Kestrel actually bound. Avoids race conditions where the caller
+            // passes a pre-picked port that another process grabs before we bind.
+            var server = (IServer)host.Services.GetService(typeof(IServer));
+            var address = server?.Features.Get<IServerAddressesFeature>()?.Addresses.FirstOrDefault();
+            return string.IsNullOrEmpty(address) ? "http://localhost:5000" : address.TrimEnd('/');
         }
 
         private static void ParseCommandLine(string[] args, out bool disableLogs, out TimeSpan timeout, out int iterations, out Scenario scenario, out int nbIdleThreads)

--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -3,13 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Demos.Util;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -42,6 +44,8 @@ namespace BuggyBits
 
     public class Program
     {
+        private const int HostBindRetries = 5;
+
         private static bool _disableLogs = false;
 
         public static async Task Main(string[] args)
@@ -54,38 +58,14 @@ namespace BuggyBits
 
             ParseCommandLine(args, out _disableLogs, out var timeout, out var iterations, out var scenario, out var nbIdleThreads);
 
-            using (var host = CreateHostBuilder(args).Build())
+            using (var host = await StartHostWithPortResilience(args))
             {
-                // ASP.NET Core accepts listening url via what is set by Visual Studio
-                // (from the launchsettings.json). It could be overriden by --Urls
-                // on the command line
-                var configuration = host.Services.GetService(typeof(IConfiguration)) as IConfiguration;
-                var rootUrl = configuration["urls"];
-
-                // otherwise, use the default ASP.NET Core value
-                if (string.IsNullOrEmpty(rootUrl))
-                {
-                    rootUrl = "http://localhost:5000";
-                }
-
-                // avoid race condition in CI to find an available port
-                int port = -1;
-                if (int.TryParse(rootUrl.Substring(rootUrl.LastIndexOf(':') + 1), out port))
-                {
-                    port = GetValidPort(port, 3);
-                    if (port != -1)
-                    {
-                        rootUrl = rootUrl.Substring(0, rootUrl.LastIndexOf(':') + 1) + port;
-                    }
-                }
-
+                var rootUrl = GetBoundRootUrl(host);
                 WriteLine($"Listening to {rootUrl}");
 
                 var cts = new CancellationTokenSource();
                 using (var selfInvoker = new SelfInvoker(cts.Token, scenario, nbIdleThreads, _disableLogs))
                 {
-                    await host.StartAsync();
-
                     WriteLine();
                     WriteLine($"Started at {DateTime.UtcNow}.");
 
@@ -147,8 +127,116 @@ namespace BuggyBits
             WriteLine($"The application exited after: {sw.Elapsed} at {DateTime.UtcNow}");
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
+        private static async Task<IHost> StartHostWithPortResilience(string[] args)
+        {
+            var host = CreateHostBuilder(args).Build();
+            try
+            {
+                var rootUrl = GetConfiguredRootUrl(host);
+
+                for (var remainingRetries = HostBindRetries; ; remainingRetries--)
+                {
+                    try
+                    {
+                        WriteLine($"Starting web host at {rootUrl}");
+                        await host.StartAsync();
+                        return host;
+                    }
+                    catch (Exception ex) when (remainingRetries > 0 && IsAddressInUseException(ex))
+                    {
+                        var retryRootUrl = GetUrlWithNewPort(rootUrl);
+                        WriteLine($"Address already in use for {rootUrl}. Retrying on {retryRootUrl}.");
+
+                        host.Dispose();
+                        rootUrl = retryRootUrl;
+                        host = CreateHostBuilder(args, rootUrl).Build();
+                    }
+                }
+            }
+            catch
+            {
+                host.Dispose();
+                throw;
+            }
+        }
+
+        private static string GetConfiguredRootUrl(IHost host)
+        {
+            // ASP.NET Core accepts listening urls from launchSettings.json, ASPNETCORE_URLS,
+            // or --urls. If none are supplied, Kestrel uses this default.
+            var configuration = host.Services.GetService(typeof(IConfiguration)) as IConfiguration;
+            var rootUrl = configuration?["urls"];
+
+            if (string.IsNullOrEmpty(rootUrl))
+            {
+                rootUrl = "http://localhost:5000";
+            }
+
+            return GetFirstUrl(rootUrl);
+        }
+
+        private static string GetBoundRootUrl(IHost host)
+        {
+            var server = host.Services.GetService(typeof(IServer)) as IServer;
+            var addresses = server?.Features.Get<IServerAddressesFeature>()?.Addresses;
+
+            if (addresses != null)
+            {
+                foreach (var address in addresses)
+                {
+                    if (!string.IsNullOrEmpty(address))
+                    {
+                        return address.TrimEnd('/');
+                    }
+                }
+            }
+
+            return GetConfiguredRootUrl(host);
+        }
+
+        private static string GetFirstUrl(string urls)
+        {
+            var separatorIndex = urls.IndexOf(';');
+            if (separatorIndex >= 0)
+            {
+                urls = urls.Substring(0, separatorIndex);
+            }
+
+            return urls.TrimEnd('/');
+        }
+
+        private static string GetUrlWithNewPort(string rootUrl)
+        {
+            // Avoid UriBuilder here: ASP.NET Core wildcard hosts (http://*:5000, http://+:5000)
+            // are not valid Uri hosts and would throw UriFormatException. Since the retry always
+            // rebinds to 127.0.0.1 with an OS-assigned port, only the scheme needs to be preserved.
+            var schemeSeparator = rootUrl.IndexOf("://", StringComparison.Ordinal);
+            var scheme = schemeSeparator > 0 ? rootUrl.Substring(0, schemeSeparator) : "http";
+            return $"{scheme}://127.0.0.1:0";
+        }
+
+        private static bool IsAddressInUseException(Exception exception)
+        {
+            while (exception != null)
+            {
+                if (exception is SocketException socketException && socketException.SocketErrorCode == SocketError.AddressAlreadyInUse)
+                {
+                    return true;
+                }
+
+                if (exception.Message.IndexOf("address already in use", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+
+                exception = exception.InnerException;
+            }
+
+            return false;
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args, string rootUrl = null) =>
+            Host.CreateDefaultBuilder(GetArgsWithUrlsOverride(args, rootUrl))
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
@@ -161,62 +249,34 @@ namespace BuggyBits
                     }
                 });
 
-        public static int GetOpenPort()
+        private static string[] GetArgsWithUrlsOverride(string[] args, string rootUrl)
         {
-            TcpListener tcpListener = null;
-            try
+            if (string.IsNullOrEmpty(rootUrl))
             {
-                tcpListener = new TcpListener(IPAddress.Loopback, 0);
-                tcpListener.Start();
-                var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
-                return port;
+                return args;
             }
-            finally
-            {
-                tcpListener?.Stop();
-            }
-        }
 
-        private static int GetValidPort(int initialPort, int retries)
-        {
-            var port = initialPort;
-            bool isPortValid = false;
-            while (true)
+            var effectiveArgs = new List<string>(args.Length + 2);
+            for (var i = 0; i < args.Length; i++)
             {
-                // seems like we can't reuse a listener if it fails to start,
-                // so create a new listener each time we retry
-                var listener = new HttpListener();
-                listener.Prefixes.Add($"http://127.0.0.1:{port}/");
-                listener.Prefixes.Add($"http://localhost:{port}/");
-
-                try
+                var arg = args[i];
+                if (string.Equals(arg, "--urls", StringComparison.OrdinalIgnoreCase))
                 {
-                    listener.Start();
+                    i++;
+                    continue;
+                }
 
-                    // success
-                    isPortValid = true;
-                    break;
-                }
-                catch (HttpListenerException) when (retries > 0)
+                if (arg.StartsWith("--urls=", StringComparison.OrdinalIgnoreCase))
                 {
-                    // only catch the exception if there are retries left
-                    port = GetOpenPort();
-                    retries--;
+                    continue;
                 }
-                finally
-                {
-                    listener.Close();
-                }
+
+                effectiveArgs.Add(arg);
             }
 
-            if (isPortValid)
-            {
-                return port;
-            }
-            else
-            {
-                return -1; // no valid port found
-            }
+            effectiveArgs.Add("--urls");
+            effectiveArgs.Add(rootUrl);
+            return effectiveArgs.ToArray();
         }
 
         private static void ParseCommandLine(string[] args, out bool disableLogs, out TimeSpan timeout, out int iterations, out Scenario scenario, out int nbIdleThreads)

--- a/profiler/src/Demos/Samples.Website-AspNetCore01/Program.cs
+++ b/profiler/src/Demos/Samples.Website-AspNetCore01/Program.cs
@@ -5,11 +5,13 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Demos.Util;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.Hosting;
 
 namespace Samples.Website_AspNetCore01
@@ -46,20 +48,6 @@ namespace Samples.Website_AspNetCore01
                 WriteLine($"host built in {sw.ElapsedMilliseconds} ms");
                 sw.Restart();
 
-                // ASP.NET Core accepts listening url via what is set by Visual Studio
-                // (from the launchsettings.json). It could be overriden by --Urls
-                // on the command line
-                var configuration = host.Services.GetService(typeof(IConfiguration)) as IConfiguration;
-                var rootUrl = configuration["Urls"];
-
-                // otherwise, use the default ASP.NET Core value
-                if (string.IsNullOrEmpty(rootUrl))
-                {
-                    rootUrl = "http://localhost:5000";
-                }
-
-                WriteLine($"Listening to {rootUrl}");
-
                 var cts = new CancellationTokenSource();
                 using (var selfInvoker = new SelfInvoker(cts.Token))
                 {
@@ -71,6 +59,12 @@ namespace Samples.Website_AspNetCore01
 
                     sw.Stop();
                     WriteLine($"host started in {sw.ElapsedMilliseconds} ms");
+
+                    // Read the address Kestrel actually bound (after StartAsync). Configuration["Urls"]
+                    // may be "http://127.0.0.1:0" when the test runner asks for a dynamic port, so the
+                    // bound address is the only reliable source of the real listening URL.
+                    var rootUrl = GetBoundRootUrl(host);
+                    WriteLine($"Listening to {rootUrl}");
 
                     WriteLine();
                     WriteLine($"Started at {DateTime.UtcNow}.");
@@ -106,6 +100,13 @@ namespace Samples.Website_AspNetCore01
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        private static string GetBoundRootUrl(IHost host)
+        {
+            var server = (IServer)host.Services.GetService(typeof(IServer));
+            var address = server?.Features.Get<IServerAddressesFeature>()?.Addresses.FirstOrDefault();
+            return string.IsNullOrEmpty(address) ? "http://localhost:5000" : address.TrimEnd('/');
+        }
 
         // Helper method to output both to the console (when the app runs in the console)
         // and via Trace to see them while running under IISExpress both in Visual Studio

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -153,8 +153,10 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             }
 
             // Use port 0 so Kestrel binds an OS-assigned free port and avoids the TOCTOU race
-            // of pre-picking a port. The actual bound URL is parsed from stdout after the run.
-            var arguments = $"--timeout {TestDurationInSeconds} --urls http://localhost:0";
+            // of pre-picking a port. Bind to 127.0.0.1 explicitly: Kestrel rejects "localhost:0"
+            // with InvalidOperationException ("Dynamic port binding is not supported when binding
+            // to localhost"). The actual bound URL is parsed from stdout after the run.
+            var arguments = $"--timeout {TestDurationInSeconds} --urls http://127.0.0.1:0";
             if (!string.IsNullOrEmpty(_commandLine))
             {
                 arguments += $" {_commandLine}";

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -151,10 +152,9 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 throw new Exception($"Unable to find executing assembly at {applicationPath}");
             }
 
-            // Look for a free open port to pass to the ASP.NET Core applications
-            // that accept --urls on their command line
-            _appListenerPort = $"http://localhost:{TcpPortProvider.GetOpenPort()}";
-            var arguments = $"--timeout {TestDurationInSeconds} --urls {_appListenerPort}";
+            // Use port 0 so Kestrel binds an OS-assigned free port and avoids the TOCTOU race
+            // of pre-picking a port. The actual bound URL is parsed from stdout after the run.
+            var arguments = $"--timeout {TestDurationInSeconds} --urls http://localhost:0";
             if (!string.IsNullOrEmpty(_commandLine))
             {
                 arguments += $" {_commandLine}";
@@ -195,6 +195,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             var standardOutput = processHelper.StandardOutput;
             var errorOutput = processHelper.ErrorOutput;
             ProcessOutput = standardOutput;
+            _appListenerPort = ExtractListeningUrl(standardOutput);
 
             if (!ranToCompletion)
             {
@@ -250,6 +251,19 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         private void SetEnvironmentVariables(StringDictionary environmentVariables, MockDatadogAgent agent)
         {
             Environment.PopulateEnvironmentVariables(environmentVariables, agent, ProfilingExportsIntervalInSeconds, ServiceName);
+        }
+
+        // Matches BuggyBits ("Listening to http://...") and ASP.NET Core's default Kestrel
+        // startup log ("Now listening on: http://..."). Returns null if neither is found.
+        private static string ExtractListeningUrl(string output)
+        {
+            if (string.IsNullOrEmpty(output))
+            {
+                return null;
+            }
+
+            var match = Regex.Match(output, @"(?:Listening to|Now listening on:)\s+(http://\S+)");
+            return match.Success ? match.Groups[1].Value.TrimEnd('/') : null;
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Attempts to fix some flake within the Buggy Bits sample app/integration tests by letting kestrel go and decide what port to use.

## Reason for change

This was the cause of 3 flakes last release so trying to improve that. 

Assumption:  `TestApplicationRunner` was calling `TcpPortProvider.GetOpenPort()` to find a free port, then passing that port to the sample app via `--urls`. Between those two steps another process could grab the port, causing the sample app to fail to bind.

## Implementation details

The fix is to let Kestrel pick the port itself. The sample apps now start up, ask Kestrel which port it actually bound, and log that URL. The test runner reads the URL back out of the sample app's stdout instead of deciding the port up front. The old hand-rolled port-probing and retry logic in BuggyBits is gone.

## Test coverage

This is it 😃 

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
