### PR TITLE
[Debugger] DEBUG-4260 Add capture expression to log probe

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -234,7 +234,6 @@ src/Datadog.Trace/Debugger/Configurations/Trie.cs
 src/Datadog.Trace/Debugger/Expressions/CaptureInfo.cs
 src/Datadog.Trace/Debugger/Expressions/CompiledExpression.cs
 src/Datadog.Trace/Debugger/Expressions/Enums.cs
-src/Datadog.Trace/Debugger/Expressions/ExpressionEvaluationResult.cs
 src/Datadog.Trace/Debugger/Expressions/MethodScopeMembers.cs
 src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
 src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/CaptureExpression.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/CaptureExpression.cs
@@ -1,0 +1,55 @@
+// <copyright file="CaptureExpression.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.Debugger.Configurations.Models
+{
+    internal sealed class CaptureExpression : IEquatable<CaptureExpression>
+    {
+        public string? Name { get; set; }
+
+        public SnapshotSegment? Expr { get; set; }
+
+        public Capture? Capture { get; set; }
+
+        public bool Equals(CaptureExpression? other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Name == other.Name && Equals(Expr, other.Expr) && Equals(Capture, other.Capture);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((CaptureExpression)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Name, Expr, Capture);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/LogProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/LogProbe.cs
@@ -23,6 +23,8 @@ namespace Datadog.Trace.Debugger.Configurations.Models
 
         public SnapshotSegment? When { get; set; }
 
+        public CaptureExpression[]? CaptureExpressions { get; set; }
+
         public bool Equals(LogProbe? other)
         {
             if (ReferenceEquals(null, other))
@@ -35,7 +37,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
                 return true;
             }
 
-            return base.Equals(other) && Equals(Capture, other.Capture) && Equals(Sampling, other.Sampling) && Template == other.Template && CaptureSnapshot == other.CaptureSnapshot && Segments.NullableSequentialEquals(other.Segments) && Equals(When, other.When);
+            return base.Equals(other) && Equals(Capture, other.Capture) && Equals(Sampling, other.Sampling) && Template == other.Template && CaptureSnapshot == other.CaptureSnapshot && Segments.NullableSequentialEquals(other.Segments) && Equals(When, other.When) && CaptureExpressions.NullableSequentialEquals(other.CaptureExpressions);
         }
 
         public override bool Equals(object? obj)
@@ -60,7 +62,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(base.GetHashCode(), Capture, Sampling, Template, CaptureSnapshot, Segments.NullableSequentialHashCode(), When);
+            return HashCode.Combine(base.GetHashCode(), Capture, Sampling, Template, CaptureSnapshot, Segments.NullableSequentialHashCode(), When, CaptureExpressions.NullableSequentialHashCode());
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -330,7 +330,7 @@ namespace Datadog.Trace.Debugger
                     ProbeRateLimiter.Instance.SetRate(probe.Id, (int)sampling.SnapshotsPerSecond);
                     break;
                 case LogProbe logProbe:
-                    ProbeRateLimiter.Instance.SetRate(probe.Id, logProbe.CaptureSnapshot ? 1 : 5000);
+                    ProbeRateLimiter.Instance.SetRate(probe.Id, logProbe.CaptureSnapshot || logProbe.CaptureExpressions is { Length: > 0 } ? 1 : 5000);
                     break;
                 case SpanDecorationProbe or MetricProbe:
                     ProbeRateLimiter.Instance.TryAddSampler(probe.Id, NopAdaptiveSampler.Instance);

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProcessor.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
         public MethodUniqueIdentifier Method { get; }
 
-        public bool ShouldProcess(in ProbeData probeData)
+        private bool ShouldProcess()
         {
             if (!ShadowStackHolder.IsShadowStackTrackingEnabled)
             {
@@ -51,6 +51,18 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 return false;
             }
 
+            return true;
+        }
+
+        public bool TryBeginProcess(in ProbeData probeData, out IDebuggerSnapshotCreator snapshotCreator)
+        {
+            if (!ShouldProcess())
+            {
+                snapshotCreator = null!;
+                return false;
+            }
+
+            snapshotCreator = CreateSnapshotCreator();
             return true;
         }
 
@@ -245,7 +257,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             return this;
         }
 
-        public IDebuggerSnapshotCreator CreateSnapshotCreator()
+        private ExceptionSnapshotCreator CreateSnapshotCreator()
         {
             // ReSharper disable once InconsistentlySynchronizedField
             return new ExceptionSnapshotCreator(_processors, ProbeId);

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayProcessor.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
@@ -54,11 +55,11 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             return true;
         }
 
-        public bool TryBeginProcess(in ProbeData probeData, out IDebuggerSnapshotCreator snapshotCreator)
+        public bool TryBeginProcess(in ProbeData probeData, [NotNullWhen(true)] out IDebuggerSnapshotCreator? snapshotCreator)
         {
             if (!ShouldProcess())
             {
-                snapshotCreator = null!;
+                snapshotCreator = null;
                 return false;
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/CaptureExpressionDefinition.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/CaptureExpressionDefinition.cs
@@ -1,0 +1,26 @@
+// <copyright file="CaptureExpressionDefinition.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.Debugger.Configurations.Models;
+
+namespace Datadog.Trace.Debugger.Expressions;
+
+internal readonly struct CaptureExpressionDefinition
+{
+    internal CaptureExpressionDefinition(string name, DebuggerExpression? expression, CaptureLimitInfo captureLimitInfo)
+    {
+        Name = name;
+        Expression = expression;
+        CaptureLimitInfo = captureLimitInfo;
+    }
+
+    internal string Name { get; }
+
+    internal DebuggerExpression? Expression { get; }
+
+    internal CaptureLimitInfo CaptureLimitInfo { get; }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ExpressionEvaluationResult.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ExpressionEvaluationResult.cs
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
+using System;
 using System.Collections.Generic;
 using Datadog.Trace.Debugger.Models;
 
@@ -10,29 +13,59 @@ namespace Datadog.Trace.Debugger.Expressions;
 
 internal ref struct ExpressionEvaluationResult
 {
-    internal string Template { get; set; }
+    internal string? Template { get; set; }
 
     internal bool? Condition { get; set; }
 
     internal double? Metric { get; set; }
 
-    internal DecorationResult[] Decorations { get; set; }
+    internal DecorationResult[]? Decorations { get; set; }
 
-    internal List<EvaluationError> Errors { get; set; }
+    internal CaptureExpressionResult[]? CaptureExpressions { get; set; }
+
+    internal int CaptureExpressionCount { get; set; }
+
+    internal List<EvaluationError>? Errors { get; set; }
 
     internal readonly bool HasError => Errors is { Count: > 0 };
 
+    internal readonly bool HasCaptureExpressions => CaptureExpressionCount > 0;
+
     internal readonly bool IsNull()
     {
-        return Template == null && Condition == null && Metric == null && Decorations?.Length == 0 && Errors == null;
+        return Template == null
+            && Condition == null
+            && Metric == null
+            && (Decorations == null || Decorations.Length == 0)
+            && CaptureExpressionCount == 0
+            && Errors == null;
     }
 
     internal struct DecorationResult
     {
-        internal string TagName { get; set; }
+        internal string? TagName { get; set; }
 
-        internal string Value { get; set; }
+        internal string? Value { get; set; }
 
-        internal EvaluationError[] Errors { get; set; }
+        internal EvaluationError[]? Errors { get; set; }
+    }
+
+    internal readonly struct CaptureExpressionResult
+    {
+        internal CaptureExpressionResult(string name, object? value, Type type, CaptureLimitInfo captureLimitInfo)
+        {
+            Name = name;
+            Value = value;
+            Type = type;
+            CaptureLimitInfo = captureLimitInfo;
+        }
+
+        internal string Name { get; }
+
+        internal object? Value { get; }
+
+        internal Type Type { get; }
+
+        internal CaptureLimitInfo CaptureLimitInfo { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/IProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/IProbeProcessor.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
 using Datadog.Trace.Debugger.Snapshots;
@@ -13,7 +14,7 @@ namespace Datadog.Trace.Debugger.Expressions
 {
     internal interface IProbeProcessor
     {
-        bool TryBeginProcess(in ProbeData probeData, out IDebuggerSnapshotCreator snapshotCreator);
+        bool TryBeginProcess(in ProbeData probeData, [NotNullWhen(true)] out IDebuggerSnapshotCreator? snapshotCreator);
 
         bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator snapshotCreator, in ProbeData probeData);
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/IProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/IProbeProcessor.cs
@@ -13,14 +13,12 @@ namespace Datadog.Trace.Debugger.Expressions
 {
     internal interface IProbeProcessor
     {
-        bool ShouldProcess(in ProbeData probeData);
+        bool TryBeginProcess(in ProbeData probeData, out IDebuggerSnapshotCreator snapshotCreator);
 
         bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator snapshotCreator, in ProbeData probeData);
 
         void LogException(Exception ex, IDebuggerSnapshotCreator snapshotCreator);
 
         IProbeProcessor UpdateProbeProcessor(ProbeDefinition probe);
-
-        IDebuggerSnapshotCreator CreateSnapshotCreator();
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
@@ -30,12 +30,14 @@ internal sealed class ProbeExpressionEvaluator
         DebuggerExpression?[]? templates,
         DebuggerExpression? condition,
         DebuggerExpression? metric,
-        KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? spanDecorations)
+        KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? spanDecorations,
+        CaptureExpressionDefinition[]? captureExpressions)
     {
         Templates = templates;
         Condition = condition;
         Metric = metric;
         SpanDecorations = spanDecorations;
+        CaptureExpressions = captureExpressions;
     }
 
     /// <summary>
@@ -128,13 +130,51 @@ internal sealed class ProbeExpressionEvaluator
 
     internal KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? SpanDecorations { get; }
 
+    internal CaptureExpressionDefinition[]? CaptureExpressions { get; }
+
     internal ExpressionEvaluationResult Evaluate(MethodScopeMembers scopeMembers)
     {
-        if (Templates == null && Condition == null && Metric == null && SpanDecorations == null)
+        return Evaluate(scopeMembers, out _);
+    }
+
+    internal ExpressionEvaluationResult Evaluate(MethodScopeMembers scopeMembers, out ProbeExpressionsCacheEntry? entry)
+    {
+        if (Templates == null && Condition == null && Metric == null && SpanDecorations == null && CaptureExpressions == null)
         {
+            entry = null;
             return default;
         }
 
+        entry = GetCacheEntry(scopeMembers);
+        var compiled = entry.GetOrCompile(this, scopeMembers);
+
+        ExpressionEvaluationResult result = default;
+        EvaluateTemplates(ref result, scopeMembers, compiled.Templates);
+        EvaluateCondition(ref result, scopeMembers, compiled.Condition);
+        EvaluateMetric(ref result, scopeMembers, compiled.Metric);
+        EvaluateSpanDecorations(ref result, scopeMembers, compiled.Decorations);
+        return result;
+    }
+
+    internal void EvaluateCaptureExpressions(ref ExpressionEvaluationResult result, MethodScopeMembers scopeMembers)
+    {
+        EvaluateCaptureExpressions(ref result, scopeMembers, entry: null);
+    }
+
+    internal void EvaluateCaptureExpressions(ref ExpressionEvaluationResult result, MethodScopeMembers scopeMembers, ProbeExpressionsCacheEntry? entry)
+    {
+        if (CaptureExpressions == null)
+        {
+            return;
+        }
+
+        entry ??= GetCacheEntry(scopeMembers);
+        var compiledExpressions = entry.GetOrCompileCaptureExpressions(this, scopeMembers);
+        EvaluateCaptureExpressionsCore(ref result, scopeMembers, compiledExpressions, CaptureExpressions);
+    }
+
+    private ProbeExpressionsCacheEntry GetCacheEntry(MethodScopeMembers scopeMembers)
+    {
         // Use runtime types for caching/compilation safety (polymorphic calls can break casts if we compile for declared types).
         var invocationTarget = scopeMembers.InvocationTarget;
         var thisType = invocationTarget.Value?.GetType() ?? invocationTarget.Type ?? typeof(object);
@@ -147,15 +187,7 @@ internal sealed class ProbeExpressionEvaluator
         var memberCount = scopeMembers.MemberCount;
         var bucketKey = new ProbeExpressionsBucketKey(thisType, returnRuntimeType, memberCount);
         var bucket = _cache.GetOrAdd(bucketKey, static _ => new ProbeExpressionsBucket(Log));
-        var entry = bucket.GetOrAdd(scopeMembers, memberCount);
-        var compiled = entry.GetOrCompile(this, scopeMembers);
-
-        ExpressionEvaluationResult result = default;
-        EvaluateTemplates(ref result, scopeMembers, compiled.Templates);
-        EvaluateCondition(ref result, scopeMembers, compiled.Condition);
-        EvaluateMetric(ref result, scopeMembers, compiled.Metric);
-        EvaluateSpanDecorations(ref result, scopeMembers, compiled.Decorations);
-        return result;
+        return bucket.GetOrAdd(scopeMembers, memberCount);
     }
 
     private void EvaluateTemplates(ref ExpressionEvaluationResult result, MethodScopeMembers scopeMembers, CompiledExpression<string>[]? compiledExpressions)
@@ -406,6 +438,63 @@ internal sealed class ProbeExpressionEvaluator
         }
     }
 
+    private void EvaluateCaptureExpressionsCore(ref ExpressionEvaluationResult result, MethodScopeMembers scopeMembers, CompiledExpression<object>[]? compiledExpressions, CaptureExpressionDefinition[] captureExpressions)
+    {
+        if (compiledExpressions == null)
+        {
+            return;
+        }
+
+        ExpressionEvaluationResult.CaptureExpressionResult[]? capturedValues = null;
+        var capturedValuesCount = 0;
+        for (int i = 0; i < compiledExpressions.Length; i++)
+        {
+            var compiledExpression = compiledExpressions[i];
+            try
+            {
+                var captureExpression = captureExpressions[i];
+                // CreateCaptureExpressions guarantees Name is a non-empty, non-null string.
+                var name = captureExpression.Name;
+
+                if (!IsExpression(compiledExpression))
+                {
+                    continue;
+                }
+
+                var value = compiledExpression.Delegate(scopeMembers.InvocationTarget, scopeMembers.Return, scopeMembers.Duration, scopeMembers.Exception, scopeMembers.Members);
+                if (value is UndefinedValue)
+                {
+                    if (compiledExpression.Errors != null)
+                    {
+                        (result.Errors ??= new List<EvaluationError>()).AddRange(compiledExpression.Errors);
+                    }
+
+                    continue;
+                }
+
+                // Runtime failures can leave slack in the array; CaptureExpressionCount is the authoritative length.
+                (capturedValues ??= new ExpressionEvaluationResult.CaptureExpressionResult[compiledExpressions.Length])[capturedValuesCount++] =
+                    new ExpressionEvaluationResult.CaptureExpressionResult(
+                    name,
+                    value,
+                    value?.GetType() ?? typeof(object),
+                    captureExpression.CaptureLimitInfo);
+
+                if (compiledExpression.Errors != null)
+                {
+                    (result.Errors ??= new List<EvaluationError>()).AddRange(compiledExpression.Errors);
+                }
+            }
+            catch (Exception e)
+            {
+                HandleException(ref result, compiledExpression, e);
+            }
+        }
+
+        result.CaptureExpressions = capturedValues;
+        result.CaptureExpressionCount = capturedValuesCount;
+    }
+
     private CompiledExpression<string>[]? CompileTemplates(MethodScopeMembers scopeMembers)
     {
         if (Templates == null)
@@ -519,6 +608,28 @@ internal sealed class ProbeExpressionEvaluator
         if (Log.IsEnabled(LogEventLevel.Debug))
         {
             Log.Debug("{Class}.{Method}: Finished to compile span decorations", nameof(ProbeExpressionEvaluator), nameof(CompileDecorations));
+        }
+
+        return compiledExpressions;
+    }
+
+    internal CompiledExpression<object>[]? CompileCaptureExpressions(MethodScopeMembers scopeMembers)
+    {
+        if (CaptureExpressions == null)
+        {
+            return null;
+        }
+
+        // Keep this array index-aligned with CaptureExpressions; evaluation uses the same index to read
+        // the capture name and limits for each compiled delegate.
+        var compiledExpressions = new CompiledExpression<object>[CaptureExpressions.Length];
+        for (int i = 0; i < CaptureExpressions.Length; i++)
+        {
+            var expression = CaptureExpressions[i].Expression;
+            if (expression?.Json != null && IsExpression(expression) == true)
+            {
+                compiledExpressions[i] = ProbeExpressionParser<object>.ParseExpression(expression.Value.Json, scopeMembers);
+            }
         }
 
         return compiledExpressions;

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -412,6 +412,11 @@ internal partial class ProbeExpressionParser<T>
             // metric
             return Expression.Return(ReturnTarget, Expression.Constant(0), typeof(T));
         }
+        else if (typeof(T) == typeof(object))
+        {
+            // capture expression
+            return Expression.Return(ReturnTarget, Expression.Constant(Expressions.UndefinedValue.Instance, typeof(object)), typeof(T));
+        }
         else
         {
             throw new ArgumentException($"Unsupported type: {typeof(T).FullName}");

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -48,6 +48,11 @@ internal partial class ProbeExpressionParser<T>
                 return (T)(object)true;
             }
 
+            if (typeof(T) == typeof(object))
+            {
+                return (T)(object)Expressions.UndefinedValue.Instance;
+            }
+
             return default;
         };
     }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsCacheEntry.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsCacheEntry.cs
@@ -14,14 +14,18 @@ internal sealed class ProbeExpressionsCacheEntry
 {
     private readonly object _compileLock;
     private int _compiledInitialized; // 0 = not compiled, 1 = compiled
+    private int _captureExpressionsCompiledInitialized; // 0 = not compiled, 1 = compiled
     private CompiledProbeExpressions _compiled;
+    private CompiledExpression<object>[]? _captureExpressions;
 
     public ProbeExpressionsCacheEntry(Type?[] memberRuntimeTypes)
     {
         MemberRuntimeTypes = memberRuntimeTypes;
         _compileLock = new object();
         _compiledInitialized = 0;
+        _captureExpressionsCompiledInitialized = 0;
         _compiled = default;
+        _captureExpressions = null;
     }
 
     public Type?[] MemberRuntimeTypes { get; }
@@ -55,6 +59,25 @@ internal sealed class ProbeExpressionsCacheEntry
         }
 
         return _compiled;
+    }
+
+    public CompiledExpression<object>[]? GetOrCompileCaptureExpressions(ProbeExpressionEvaluator evaluator, MethodScopeMembers scopeMembers)
+    {
+        if (Volatile.Read(ref _captureExpressionsCompiledInitialized) == 1)
+        {
+            return _captureExpressions;
+        }
+
+        lock (_compileLock)
+        {
+            if (_captureExpressionsCompiledInitialized == 0)
+            {
+                _captureExpressions = evaluator.CompileCaptureExpressions(scopeMembers);
+                Volatile.Write(ref _captureExpressionsCompiledInitialized, 1);
+            }
+        }
+
+        return _captureExpressions;
     }
 
     public bool Matches(ScopeMember[] members, int memberCount)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.Debugger.Expressions
         /// <remarks>Exceptions should be caught and logged by the caller</remarks>
         internal ProbeProcessor(ProbeDefinition probe)
         {
+            // The instance is not published until after construction, so a plain assignment is sufficient here.
             _state = ProbeProcessorState.Create(probe);
         }
 
@@ -96,12 +97,12 @@ namespace Datadog.Trace.Debugger.Expressions
             return result.Count == 0 ? null : result.ToArray();
         }
 
-        public bool TryBeginProcess(in ProbeData probeData, out IDebuggerSnapshotCreator snapshotCreator)
+        public bool TryBeginProcess(in ProbeData probeData, [NotNullWhen(true)] out IDebuggerSnapshotCreator? snapshotCreator)
         {
             var state = Volatile.Read(ref _state);
             if (!state.HasCondition && !probeData.Sampler.Sample())
             {
-                snapshotCreator = null!;
+                snapshotCreator = null;
                 return false;
             }
 
@@ -111,8 +112,12 @@ namespace Datadog.Trace.Debugger.Expressions
 
         public bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator inSnapshotCreator, in ProbeData probeData)
         {
-            var snapshotCreator = (DebuggerSnapshotCreator)inSnapshotCreator;
-            var state = snapshotCreator.ProbeProcessorState!;
+            if (inSnapshotCreator is not DebuggerSnapshotCreator { ProbeProcessorState: { } state } snapshotCreator)
+            {
+                throw new InvalidOperationException($"{nameof(ProbeProcessor)}.{nameof(Process)} requires a snapshot creator produced by {nameof(TryBeginProcess)}.");
+            }
+
+            var probeInfo = state.ProbeInfo;
 
             if (DebuggerManager.Instance.DynamicInstrumentation?.IsInitialized == false)
             {
@@ -135,12 +140,12 @@ namespace Datadog.Trace.Debugger.Expressions
                     case MethodState.BeginLineAsync:
                     case MethodState.EntryStart:
                     case MethodState.EntryAsync:
-                        var captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, state.ProbeInfo.EvaluateAt, state.HasCondition);
+                        var captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, probeInfo.EvaluateAt, state.HasCondition);
                         if (captureBehaviour == CaptureBehaviour.Evaluate && info.IsAsyncCapture())
                         {
                             AddAsyncMethodArguments(snapshotCreator, ref info);
                             snapshotCreator.AddScopeMember(info.Name, info.Type, info.Value, info.MemberKind);
-                            evaluationResult = Evaluate(state, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
+                            evaluationResult = Evaluate(state, probeInfo, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
                             if (shouldStopCapture)
                             {
                                 snapshotCreator.Stop();
@@ -158,7 +163,7 @@ namespace Datadog.Trace.Debugger.Expressions
                         break;
                     case MethodState.ExitStart:
                     case MethodState.ExitStartAsync:
-                        captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, state.ProbeInfo.EvaluateAt, state.HasCondition);
+                        captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, probeInfo.EvaluateAt, state.HasCondition);
                         switch (captureBehaviour)
                         {
                             case CaptureBehaviour.Stop:
@@ -189,7 +194,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     case MethodState.ExitEnd:
                     case MethodState.ExitEndAsync:
                         {
-                            captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, state.ProbeInfo.EvaluateAt, state.HasCondition);
+                            captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, probeInfo.EvaluateAt, state.HasCondition);
                             switch (captureBehaviour)
                             {
                                 case CaptureBehaviour.NoCapture or CaptureBehaviour.Stop:
@@ -206,7 +211,7 @@ namespace Datadog.Trace.Debugger.Expressions
                                         }
 
                                         snapshotCreator.AddScopeMember(info.Name, info.Type, info.Value, info.MemberKind);
-                                        evaluationResult = Evaluate(state, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
+                                        evaluationResult = Evaluate(state, probeInfo, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
                                         if (shouldStopCapture)
                                         {
                                             snapshotCreator.Stop();
@@ -246,11 +251,11 @@ namespace Datadog.Trace.Debugger.Expressions
                             $"{info.MethodState} is not valid value here");
                 }
 
-                return ProcessCapture(state, ref info, snapshotCreator, ref evaluationResult);
+                return ProcessCapture(state, probeInfo, ref info, snapshotCreator, ref evaluationResult);
             }
             catch (Exception e)
             {
-                Log.Error(e, "Failed to process probe. Probe Id: {ProbeId}", state.ProbeInfo.ProbeId);
+                Log.Error(e, "Failed to process probe. Probe Id: {ProbeId}", probeInfo.ProbeId);
                 return false;
             }
             finally
@@ -259,7 +264,7 @@ namespace Datadog.Trace.Debugger.Expressions
             }
         }
 
-        private ExpressionEvaluationResult Evaluate(ProbeProcessorState state, DebuggerSnapshotCreator snapshotCreator, out bool shouldStopCapture, IAdaptiveSampler sampler)
+        private ExpressionEvaluationResult Evaluate(ProbeProcessorState state, ProbeInfo probeInfo, DebuggerSnapshotCreator snapshotCreator, out bool shouldStopCapture, IAdaptiveSampler sampler)
         {
             ExpressionEvaluationResult evaluationResult = default;
             shouldStopCapture = false;
@@ -282,14 +287,14 @@ namespace Datadog.Trace.Debugger.Expressions
             }
             catch (Exception e)
             {
-                Log.Error(e, "Failed to evaluate expression for probe: {ProbeId}", state.ProbeInfo.ProbeId);
+                Log.Error(e, "Failed to evaluate expression for probe: {ProbeId}", probeInfo.ProbeId);
                 if (evaluationResult.IsNull())
                 {
                     evaluationResult = new ExpressionEvaluationResult();
                 }
 
                 evaluationResult.Errors ??= new List<EvaluationError>();
-                evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {state.ProbeInfo.ProbeId}. Error: {e.Message}" });
+                evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {probeInfo.ProbeId}. Error: {e.Message}" });
             }
 
             if (state.ShouldCaptureExpressions && evaluationResult.IsNull())
@@ -309,8 +314,8 @@ namespace Datadog.Trace.Debugger.Expressions
             {
                 state.LogEvaluationState(snapshotCreator.MethodScopeMembers!);
 
-                Log.Error("Evaluation result should not be null. Probe: {ProbeId}", state.ProbeInfo.ProbeId);
-                evaluationResult.Errors = new List<EvaluationError> { new() { Message = $"Evaluation result is null. Probe ID: {state.ProbeInfo.ProbeId}" } };
+                Log.Error("Evaluation result should not be null. Probe: {ProbeId}", probeInfo.ProbeId);
+                evaluationResult.Errors = new List<EvaluationError> { new() { Message = $"Evaluation result is null. Probe ID: {probeInfo.ProbeId}" } };
             }
 
             if (Log.IsEnabled(LogEventLevel.Debug) && evaluationResult.Errors is { Count: > 0 } errors)
@@ -318,9 +323,9 @@ namespace Datadog.Trace.Debugger.Expressions
                 Log.Debug("Evaluation errors: {Errors}", errors.Select(er => $"Expression: {er.Expression}{Environment.NewLine}Error: {er.Message}"));
             }
 
-            if (evaluationResult.Metric.HasValue && state.ProbeInfo.MetricKind.HasValue)
+            if (evaluationResult.Metric.HasValue && probeInfo.MetricKind.HasValue)
             {
-                DebuggerManager.Instance.DynamicInstrumentation?.SendMetrics(state.ProbeInfo, state.ProbeInfo.MetricKind.Value, state.ProbeInfo.MetricName, evaluationResult.Metric.Value, state.ProbeInfo.ProbeId);
+                DebuggerManager.Instance.DynamicInstrumentation?.SendMetrics(probeInfo, probeInfo.MetricKind.Value, probeInfo.MetricName, evaluationResult.Metric.Value, probeInfo.ProbeId);
                 // snapshot creator is created for all probes in the method invokers,
                 // if it is a metric probe, once we sent the value, we can stop the invokers and dispose the snapshot creator
                 snapshotCreator.Dispose();
@@ -329,14 +334,14 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (evaluationResult.Decorations != null)
             {
-                SetSpanDecoration(state, snapshotCreator, ref shouldStopCapture, evaluationResult);
+                SetSpanDecoration(state, in probeInfo, snapshotCreator, ref shouldStopCapture, evaluationResult);
             }
 
             if (evaluationResult.HasError)
             {
                 // Probes with conditions defer sampling until after the condition is evaluated,
                 // so evaluation errors must honor that same sampler before emitting a snapshot.
-                if (state.ProbeInfo.HasCondition && !sampler.Sample())
+                if (probeInfo.HasCondition && !sampler.Sample())
                 {
                     shouldStopCapture = true;
                 }
@@ -370,7 +375,7 @@ namespace Datadog.Trace.Debugger.Expressions
             return evaluationResult;
         }
 
-        private void SetSpanDecoration(ProbeProcessorState state, DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)
+        private void SetSpanDecoration(ProbeProcessorState state, in ProbeInfo probeInfo, DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)
         {
             var decorations = evaluationResult.Decorations;
             if (decorations == null)
@@ -378,9 +383,9 @@ namespace Datadog.Trace.Debugger.Expressions
                 return;
             }
 
-            if (!TryGetScope(state.ProbeInfo, out var scope))
+            if (!TryGetScope(in probeInfo, out var scope))
             {
-                Log.Debug("No active scope available, skipping span decoration. Probe: {ProbeId}", state.ProbeInfo.ProbeId);
+                Log.Debug("No active scope available, skipping span decoration. Probe: {ProbeId}", probeInfo.ProbeId);
                 return;
             }
 
@@ -398,12 +403,12 @@ namespace Datadog.Trace.Debugger.Expressions
                 var probeIdTag = $"{DynamicPrefix}{tagName}.probe_id";
                 ISpan? targetSpan = null;
 
-                if (state.ProbeInfo.TargetSpan == null)
+                if (probeInfo.TargetSpan == null)
                 {
-                    Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span is null", tagName, state.ProbeInfo.ProbeId);
+                    Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span is null", tagName, probeInfo.ProbeId);
                 }
 
-                switch (state.ProbeInfo.TargetSpan)
+                switch (probeInfo.TargetSpan)
                 {
                     case TargetSpan.Root:
                         targetSpan = scope.Root?.Span;
@@ -412,18 +417,18 @@ namespace Datadog.Trace.Debugger.Expressions
                         targetSpan = scope.Span;
                         break;
                     default:
-                        Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span {Span} is invalid", tagName, state.ProbeInfo.ProbeId, state.ProbeInfo.TargetSpan);
+                        Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span {Span} is invalid", tagName, probeInfo.ProbeId, probeInfo.TargetSpan);
                         break;
                 }
 
                 if (targetSpan == null)
                 {
-                    Log.Warning("We can't set the {Tag} tag. Probe ID: {ProbeId}, because the chosen span {Span} is not available", tagName, state.ProbeInfo.ProbeId, state.ProbeInfo.TargetSpan);
+                    Log.Warning("We can't set the {Tag} tag. Probe ID: {ProbeId}, because the chosen span {Span} is not available", tagName, probeInfo.ProbeId, probeInfo.TargetSpan);
                     continue;
                 }
 
                 targetSpan.SetTag(tagName, decoration.Value);
-                targetSpan.SetTag(probeIdTag, state.ProbeInfo.ProbeId);
+                targetSpan.SetTag(probeIdTag, probeInfo.ProbeId);
                 if (decoration.Errors?.Length > 0)
                 {
                     targetSpan.SetTag(evaluationErrorTag, string.Join(";", decoration.Errors));
@@ -436,7 +441,7 @@ namespace Datadog.Trace.Debugger.Expressions
                 attachedTags = true;
                 if (Log.IsEnabled(LogEventLevel.Debug))
                 {
-                    Log.Debug("Successfully attached tag {Tag} to span {Span}. ProbID: {ProbeId}", tagName, targetSpan.SpanId, state.ProbeInfo.ProbeId);
+                    Log.Debug("Successfully attached tag {Tag} to span {Span}. ProbID: {ProbeId}", tagName, targetSpan.SpanId, probeInfo.ProbeId);
                 }
             }
 
@@ -449,11 +454,11 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (attachedTags)
             {
-                DebuggerManager.Instance.DynamicInstrumentation?.SetProbeStatusToEmitting(state.ProbeInfo);
+                DebuggerManager.Instance.DynamicInstrumentation?.SetProbeStatusToEmitting(probeInfo);
             }
         }
 
-        private bool TryGetScope(ProbeInfo probeInfo, [NotNullWhen(true)] out Scope? scope)
+        private bool TryGetScope(in ProbeInfo probeInfo, [NotNullWhen(true)] out Scope? scope)
         {
             try
             {
@@ -520,15 +525,15 @@ namespace Datadog.Trace.Debugger.Expressions
             }
         }
 
-        private bool ProcessCapture<TCapture>(ProbeProcessorState state, ref CaptureInfo<TCapture> info, DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
+        private bool ProcessCapture<TCapture>(ProbeProcessorState state, ProbeInfo probeInfo, ref CaptureInfo<TCapture> info, DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
         {
-            switch (state.ProbeInfo.ProbeLocation)
+            switch (probeInfo.ProbeLocation)
             {
                 case ProbeLocation.Method:
-                    ProcessMethod(state, ref info, ref snapshotCreator, ref evaluationResult);
+                    ProcessMethod(state, in probeInfo, ref info, ref snapshotCreator, ref evaluationResult);
                     break;
                 case ProbeLocation.Line:
-                    ProcessLine(state, ref info, ref snapshotCreator, ref evaluationResult);
+                    ProcessLine(state, in probeInfo, ref info, ref snapshotCreator, ref evaluationResult);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException($"{nameof(ProbeInfo.ProbeLocation)}", $"{info.MethodState} is not valid value here");
@@ -537,7 +542,7 @@ namespace Datadog.Trace.Debugger.Expressions
             return true;
         }
 
-        private void ProcessMethod<TCapture>(ProbeProcessorState state, ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
+        private void ProcessMethod<TCapture>(ProbeProcessorState state, in ProbeInfo probeInfo, ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
         {
             switch (info.MethodState)
             {
@@ -556,10 +561,10 @@ namespace Datadog.Trace.Debugger.Expressions
                         }
                     }
 
-                    if (!state.ProbeInfo.IsFullSnapshot)
+                    if (!probeInfo.IsFullSnapshot)
                     {
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
-                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(probeInfo.ProbeId, probeInfo.ProbeVersion, ref info);
+                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(probeInfo, snapshot);
                         break;
                     }
 
@@ -581,10 +586,10 @@ namespace Datadog.Trace.Debugger.Expressions
                         }
                     }
 
-                    if (!state.ProbeInfo.IsFullSnapshot)
+                    if (!probeInfo.IsFullSnapshot)
                     {
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
-                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(probeInfo.ProbeId, probeInfo.ProbeVersion, ref info);
+                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(probeInfo, snapshot);
                         break;
                     }
 
@@ -610,14 +615,14 @@ namespace Datadog.Trace.Debugger.Expressions
                             }
                         }
 
-                        if (state.ProbeInfo.IsFullSnapshot)
+                        if (probeInfo.IsFullSnapshot)
                         {
                             snapshotCreator.ProcessDelayedSnapshot(ref info, state.HasCondition);
                             snapshotCreator.CaptureExitMethodEndMarker(ref info);
                         }
 
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
-                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(probeInfo.ProbeId, probeInfo.ProbeVersion, ref info);
+                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(probeInfo, snapshot);
                         snapshotCreator.Stop();
                         break;
                     }
@@ -633,7 +638,7 @@ namespace Datadog.Trace.Debugger.Expressions
             }
         }
 
-        private void ProcessLine<TCapture>(ProbeProcessorState state, ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
+        private void ProcessLine<TCapture>(ProbeProcessorState state, in ProbeInfo probeInfo, ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
         {
             switch (info.MethodState)
             {
@@ -655,14 +660,14 @@ namespace Datadog.Trace.Debugger.Expressions
                         }
                     }
 
-                    if (state.ProbeInfo.IsFullSnapshot)
+                    if (probeInfo.IsFullSnapshot)
                     {
                         snapshotCreator.ProcessDelayedSnapshot(ref info, state.HasCondition);
                         snapshotCreator.CaptureEndLine(ref info);
                     }
 
-                    var snapshot = snapshotCreator.FinalizeLineSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
-                    DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
+                    var snapshot = snapshotCreator.FinalizeLineSnapshot(probeInfo.ProbeId, probeInfo.ProbeVersion, ref info);
+                    DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(probeInfo, snapshot);
                     snapshotCreator.Stop();
                     break;
 
@@ -808,8 +813,9 @@ namespace Datadog.Trace.Debugger.Expressions
                     return evaluator;
                 }
 
-                Interlocked.CompareExchange(ref _evaluator, new ProbeExpressionEvaluator(Templates, Condition, Metric, SpanDecorations, CaptureExpressions), null);
-                return _evaluator!;
+                var newEvaluator = new ProbeExpressionEvaluator(Templates, Condition, Metric, SpanDecorations, CaptureExpressions);
+                var previousEvaluator = Interlocked.CompareExchange(ref _evaluator, newEvaluator, null);
+                return previousEvaluator ?? newEvaluator;
             }
 
             internal void LogEvaluationState(MethodScopeMembers methodScopeMembers)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -265,6 +265,24 @@ namespace Datadog.Trace.Debugger.Expressions
             }
         }
 
+        private static void EvaluateCaptureExpressionsIfNeeded(
+            ProbeProcessorState state,
+            DebuggerSnapshotCreator snapshotCreator,
+            ProbeExpressionsCacheEntry? cacheEntry,
+            ref ProbeExpressionEvaluator? evaluator,
+            ref ExpressionEvaluationResult evaluationResult,
+            ref bool captureExpressionsEvaluated)
+        {
+            if (!state.ShouldCaptureExpressions || captureExpressionsEvaluated)
+            {
+                return;
+            }
+
+            evaluator ??= state.GetOrCreateEvaluator();
+            evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
+            captureExpressionsEvaluated = true;
+        }
+
         private ExpressionEvaluationResult Evaluate(ProbeProcessorState state, ProbeInfo probeInfo, DebuggerSnapshotCreator snapshotCreator, out bool shouldStopCapture, IAdaptiveSampler sampler)
         {
             ExpressionEvaluationResult evaluationResult = default;
@@ -365,24 +383,6 @@ namespace Datadog.Trace.Debugger.Expressions
             EvaluateCaptureExpressionsIfNeeded(state, snapshotCreator, cacheEntry, ref evaluator, ref evaluationResult, ref captureExpressionsEvaluated);
 
             return evaluationResult;
-        }
-
-        private static void EvaluateCaptureExpressionsIfNeeded(
-            ProbeProcessorState state,
-            DebuggerSnapshotCreator snapshotCreator,
-            ProbeExpressionsCacheEntry? cacheEntry,
-            ref ProbeExpressionEvaluator? evaluator,
-            ref ExpressionEvaluationResult evaluationResult,
-            ref bool captureExpressionsEvaluated)
-        {
-            if (!state.ShouldCaptureExpressions || captureExpressionsEvaluated)
-            {
-                return;
-            }
-
-            evaluator ??= state.GetOrCreateEvaluator();
-            evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
-            captureExpressionsEvaluated = true;
         }
 
         private void SetSpanDecoration(ProbeProcessorState state, in ProbeInfo probeInfo, DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -38,7 +38,8 @@ namespace Datadog.Trace.Debugger.Expressions
         /// <remarks>Exceptions should be caught and logged by the caller</remarks>
         internal ProbeProcessor(ProbeDefinition probe)
         {
-            // The instance is not published until after construction, so a plain assignment is sufficient here.
+            // New processors are published through ConcurrentDictionary only after construction;
+            // later state replacements use Volatile.Write and readers use Volatile.Read.
             _state = ProbeProcessorState.Create(probe);
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -300,9 +300,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (state.ShouldCaptureExpressions && evaluationResult.IsNull())
             {
-                evaluator ??= state.GetOrCreateEvaluator();
-                evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
-                captureExpressionsEvaluated = true;
+                EvaluateCaptureExpressionsIfNeeded(state, snapshotCreator, cacheEntry, ref evaluator, ref evaluationResult, ref captureExpressionsEvaluated);
             }
 
             if (captureExpressionsEvaluated && evaluationResult.IsNull())
@@ -347,11 +345,9 @@ namespace Datadog.Trace.Debugger.Expressions
                     shouldStopCapture = true;
                 }
 
-                if (!shouldStopCapture && state.ShouldCaptureExpressions && !captureExpressionsEvaluated)
+                if (!shouldStopCapture)
                 {
-                    evaluator ??= state.GetOrCreateEvaluator();
-                    evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
-                    captureExpressionsEvaluated = true;
+                    EvaluateCaptureExpressionsIfNeeded(state, snapshotCreator, cacheEntry, ref evaluator, ref evaluationResult, ref captureExpressionsEvaluated);
                 }
 
                 return evaluationResult;
@@ -366,14 +362,27 @@ namespace Datadog.Trace.Debugger.Expressions
                 return evaluationResult;
             }
 
-            if (state.ShouldCaptureExpressions && !captureExpressionsEvaluated)
-            {
-                evaluator ??= state.GetOrCreateEvaluator();
-                evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
-                captureExpressionsEvaluated = true;
-            }
+            EvaluateCaptureExpressionsIfNeeded(state, snapshotCreator, cacheEntry, ref evaluator, ref evaluationResult, ref captureExpressionsEvaluated);
 
             return evaluationResult;
+        }
+
+        private static void EvaluateCaptureExpressionsIfNeeded(
+            ProbeProcessorState state,
+            DebuggerSnapshotCreator snapshotCreator,
+            ProbeExpressionsCacheEntry? cacheEntry,
+            ref ProbeExpressionEvaluator? evaluator,
+            ref ExpressionEvaluationResult evaluationResult,
+            ref bool captureExpressionsEvaluated)
+        {
+            if (!state.ShouldCaptureExpressions || captureExpressionsEvaluated)
+            {
+                return;
+            }
+
+            evaluator ??= state.GetOrCreateEvaluator();
+            evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
+            captureExpressionsEvaluated = true;
         }
 
         private void SetSpanDecoration(ProbeProcessorState state, in ProbeInfo probeInfo, DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -28,12 +28,7 @@ namespace Datadog.Trace.Debugger.Expressions
         private const string DynamicPrefix = "_dd.di.";
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProbeProcessor));
 
-        private ProbeExpressionEvaluator? _evaluator;
-        private DebuggerExpression?[]? _templates;
-        private DebuggerExpression? _condition;
-        private DebuggerExpression? _metric;
-        private KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? _spanDecorations;
-        private CaptureExpressionDefinition[]? _captureExpressions;
+        private ProbeProcessorState _state;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProbeProcessor"/> class, that correlated to probe id
@@ -43,60 +38,10 @@ namespace Datadog.Trace.Debugger.Expressions
         /// <remarks>Exceptions should be caught and logged by the caller</remarks>
         internal ProbeProcessor(ProbeDefinition probe)
         {
-            InitializeProbeProcessor(probe);
+            _state = ProbeProcessorState.Create(probe);
         }
 
-        internal ProbeInfo ProbeInfo { get; private set; }
-
-        private bool IsMetricCountWithoutExpression => ProbeInfo.ProbeType == ProbeType.Metric && (_metric?.Json == null) && ProbeInfo.MetricKind == MetricKind.COUNT;
-
-        private bool ShouldCaptureExpressions => !ProbeInfo.IsFullSnapshot && _captureExpressions is { Length: > 0 };
-
-        private void InitializeProbeProcessor(ProbeDefinition probe)
-        {
-            _evaluator = null;
-            var location = probe.Where.MethodName != null
-                               ? ProbeLocation.Method
-                               : ProbeLocation.Line;
-
-            var probeType = probe switch
-            {
-                LogProbe { CaptureSnapshot: true } => ProbeType.Snapshot,
-                LogProbe { CaptureSnapshot: false } => ProbeType.Log,
-                MetricProbe => ProbeType.Metric,
-                SpanDecorationProbe => ProbeType.SpanDecoration,
-                _ => throw new ArgumentOutOfRangeException(nameof(probe), probe, "Unsupported probe type")
-            };
-
-            var evaluateAt = location switch
-            {
-                ProbeLocation.Method => probe.EvaluateAt,
-                ProbeLocation.Line => EvaluateAt.Entry,
-                _ => throw new ArgumentOutOfRangeException(nameof(location), location, "Unsupported probe location")
-            };
-
-            SetExpressions(probe);
-
-            var maxInfo = ToCaptureLimitInfo((probe as LogProbe)?.Capture);
-
-            ProbeInfo = new ProbeInfo(
-                probe.Id,
-                probe.Version ?? 0,
-                probeType,
-                location,
-                evaluateAt,
-                (probe as MetricProbe)?.Kind,
-                (probe as MetricProbe)?.MetricName,
-                HasCondition(),
-                probe.Tags,
-                (probe as SpanDecorationProbe)?.TargetSpan,
-                maxInfo);
-        }
-
-        [DebuggerStepThrough]
-        private bool HasCondition() => _condition.HasValue;
-
-        private DebuggerExpression? ToDebuggerExpression(SnapshotSegment? segment)
+        private static DebuggerExpression? ToDebuggerExpression(SnapshotSegment? segment)
         {
             return segment == null ? null : new DebuggerExpression(segment.Dsl, segment.Json?.ToString(), segment.Str);
         }
@@ -107,16 +52,11 @@ namespace Datadog.Trace.Debugger.Expressions
 
         public IProbeProcessor UpdateProbeProcessor(ProbeDefinition probe)
         {
-            InitializeProbeProcessor(probe);
+            Volatile.Write(ref _state, ProbeProcessorState.Create(probe));
             return this;
         }
 
-        public IDebuggerSnapshotCreator CreateSnapshotCreator()
-        {
-            return new DebuggerSnapshotCreator(ProbeInfo.IsFullSnapshot, ProbeInfo.ProbeLocation, ProbeInfo.HasCondition, ProbeInfo.Tags, ProbeInfo.CaptureLimitInfo, DebuggerManager.ProcessTagsProvider, DebuggerManager.ServiceNameProvider);
-        }
-
-        private CaptureLimitInfo ToCaptureLimitInfo(Capture? capture)
+        private static CaptureLimitInfo ToCaptureLimitInfo(Capture? capture)
         {
             return capture != null
                 ? new CaptureLimitInfo(
@@ -131,7 +71,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     MaxLength: DebuggerSettings.DefaultMaxStringLength);
         }
 
-        private CaptureExpressionDefinition[]? CreateCaptureExpressions(CaptureExpression[]? captureExpressions)
+        private static CaptureExpressionDefinition[]? CreateCaptureExpressions(CaptureExpression[]? captureExpressions)
         {
             if (captureExpressions == null || captureExpressions.Length == 0)
             {
@@ -156,71 +96,23 @@ namespace Datadog.Trace.Debugger.Expressions
             return result.Count == 0 ? null : result.ToArray();
         }
 
-        private void SetExpressions(ProbeDefinition probe)
+        public bool TryBeginProcess(in ProbeData probeData, out IDebuggerSnapshotCreator snapshotCreator)
         {
-            // ReSharper disable once PossibleInvalidOperationException
-            switch (probe)
+            var state = Volatile.Read(ref _state);
+            if (!state.HasCondition && !probeData.Sampler.Sample())
             {
-                case LogProbe logProbe:
-                    _metric = null;
-                    _spanDecorations = null;
-                    _templates = logProbe.Segments?.Select(ToDebuggerExpression).ToArray();
-                    _condition = ToDebuggerExpression(logProbe.When);
-                    _captureExpressions = logProbe.CaptureSnapshot ? null : CreateCaptureExpressions(logProbe.CaptureExpressions);
-                    break;
-                case MetricProbe metricProbe:
-                    _templates = null;
-                    _condition = null;
-                    _spanDecorations = null;
-                    _captureExpressions = null;
-                    _metric = ToDebuggerExpression(metricProbe.Value);
-                    break;
-                case SpanDecorationProbe spanDecorationProbe:
-                    _templates = null;
-                    _condition = null;
-                    _metric = null;
-                    _captureExpressions = null;
-                    _spanDecorations = spanDecorationProbe.
-                        Decorations
-                      ?.Where(dec => dec != null)
-                       .Select(
-                            dec =>
-                            {
-                                var whenExpression = ToDebuggerExpression(dec.When);
-                                var keyValuePairs = dec.Tags?.Select(
-                                                            tag => new KeyValuePair<string?, DebuggerExpression?[]>(
-                                                                tag.Name,
-                                                                tag.Value?.Segments?.Select(ToDebuggerExpression).ToArray() ?? []))
-                                                       .ToArray();
-
-                                return new KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>(whenExpression, keyValuePairs ?? []);
-                            })
-                       .ToArray();
-
-                    break;
-            }
-        }
-
-        private ProbeExpressionEvaluator GetOrCreateEvaluator()
-        {
-            var evaluator = Volatile.Read(ref _evaluator);
-            if (evaluator != null)
-            {
-                return evaluator;
+                snapshotCreator = null!;
+                return false;
             }
 
-            Interlocked.CompareExchange(ref _evaluator, new ProbeExpressionEvaluator(_templates, _condition, _metric, _spanDecorations, _captureExpressions), null);
-            return _evaluator!;
-        }
-
-        public bool ShouldProcess(in ProbeData probeData)
-        {
-            return HasCondition() || probeData.Sampler.Sample();
+            snapshotCreator = new DebuggerSnapshotCreator(state);
+            return true;
         }
 
         public bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator inSnapshotCreator, in ProbeData probeData)
         {
             var snapshotCreator = (DebuggerSnapshotCreator)inSnapshotCreator;
+            var state = snapshotCreator.ProbeProcessorState!;
 
             if (DebuggerManager.Instance.DynamicInstrumentation?.IsInitialized == false)
             {
@@ -243,12 +135,12 @@ namespace Datadog.Trace.Debugger.Expressions
                     case MethodState.BeginLineAsync:
                     case MethodState.EntryStart:
                     case MethodState.EntryAsync:
-                        var captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, ProbeInfo.EvaluateAt, HasCondition());
+                        var captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, state.ProbeInfo.EvaluateAt, state.HasCondition);
                         if (captureBehaviour == CaptureBehaviour.Evaluate && info.IsAsyncCapture())
                         {
                             AddAsyncMethodArguments(snapshotCreator, ref info);
                             snapshotCreator.AddScopeMember(info.Name, info.Type, info.Value, info.MemberKind);
-                            evaluationResult = Evaluate(snapshotCreator, out var shouldStopCapture, probeData.Sampler);
+                            evaluationResult = Evaluate(state, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
                             if (shouldStopCapture)
                             {
                                 snapshotCreator.Stop();
@@ -266,7 +158,7 @@ namespace Datadog.Trace.Debugger.Expressions
                         break;
                     case MethodState.ExitStart:
                     case MethodState.ExitStartAsync:
-                        captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, ProbeInfo.EvaluateAt, HasCondition());
+                        captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, state.ProbeInfo.EvaluateAt, state.HasCondition);
                         switch (captureBehaviour)
                         {
                             case CaptureBehaviour.Stop:
@@ -297,7 +189,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     case MethodState.ExitEnd:
                     case MethodState.ExitEndAsync:
                         {
-                            captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, ProbeInfo.EvaluateAt, HasCondition());
+                            captureBehaviour = snapshotCreator.DefineSnapshotBehavior(ref info, state.ProbeInfo.EvaluateAt, state.HasCondition);
                             switch (captureBehaviour)
                             {
                                 case CaptureBehaviour.NoCapture or CaptureBehaviour.Stop:
@@ -314,7 +206,7 @@ namespace Datadog.Trace.Debugger.Expressions
                                         }
 
                                         snapshotCreator.AddScopeMember(info.Name, info.Type, info.Value, info.MemberKind);
-                                        evaluationResult = Evaluate(snapshotCreator, out var shouldStopCapture, probeData.Sampler);
+                                        evaluationResult = Evaluate(state, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
                                         if (shouldStopCapture)
                                         {
                                             snapshotCreator.Stop();
@@ -354,11 +246,11 @@ namespace Datadog.Trace.Debugger.Expressions
                             $"{info.MethodState} is not valid value here");
                 }
 
-                return ProcessCapture(ref info, snapshotCreator, ref evaluationResult);
+                return ProcessCapture(state, ref info, snapshotCreator, ref evaluationResult);
             }
             catch (Exception e)
             {
-                Log.Error(e, "Failed to process probe. Probe Id: {ProbeId}", ProbeInfo.ProbeId);
+                Log.Error(e, "Failed to process probe. Probe Id: {ProbeId}", state.ProbeInfo.ProbeId);
                 return false;
             }
             finally
@@ -367,7 +259,7 @@ namespace Datadog.Trace.Debugger.Expressions
             }
         }
 
-        private ExpressionEvaluationResult Evaluate(DebuggerSnapshotCreator snapshotCreator, out bool shouldStopCapture, IAdaptiveSampler sampler)
+        private ExpressionEvaluationResult Evaluate(ProbeProcessorState state, DebuggerSnapshotCreator snapshotCreator, out bool shouldStopCapture, IAdaptiveSampler sampler)
         {
             ExpressionEvaluationResult evaluationResult = default;
             shouldStopCapture = false;
@@ -376,7 +268,7 @@ namespace Datadog.Trace.Debugger.Expressions
             ProbeExpressionEvaluator? evaluator = null;
             try
             {
-                if (IsMetricCountWithoutExpression)
+                if (state.IsMetricCountWithoutExpression)
                 {
                     evaluationResult = new ExpressionEvaluationResult { Metric = 1 };
                 }
@@ -384,25 +276,25 @@ namespace Datadog.Trace.Debugger.Expressions
                 {
                     // we are taking the duration at the evaluation time - this might be different from what we have in the snapshot
                     snapshotCreator.SetDuration();
-                    evaluator = GetOrCreateEvaluator();
+                    evaluator = state.GetOrCreateEvaluator();
                     evaluationResult = evaluator.Evaluate(snapshotCreator.MethodScopeMembers!, out cacheEntry);
                 }
             }
             catch (Exception e)
             {
-                Log.Error(e, "Failed to evaluate expression for probe: {ProbeId}", ProbeInfo.ProbeId);
+                Log.Error(e, "Failed to evaluate expression for probe: {ProbeId}", state.ProbeInfo.ProbeId);
                 if (evaluationResult.IsNull())
                 {
                     evaluationResult = new ExpressionEvaluationResult();
                 }
 
                 evaluationResult.Errors ??= new List<EvaluationError>();
-                evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {ProbeInfo.ProbeId}. Error: {e.Message}" });
+                evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {state.ProbeInfo.ProbeId}. Error: {e.Message}" });
             }
 
-            if (ShouldCaptureExpressions && evaluationResult.IsNull())
+            if (state.ShouldCaptureExpressions && evaluationResult.IsNull())
             {
-                evaluator ??= GetOrCreateEvaluator();
+                evaluator ??= state.GetOrCreateEvaluator();
                 evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
                 captureExpressionsEvaluated = true;
             }
@@ -415,10 +307,10 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (evaluationResult.IsNull())
             {
-                LogEvaluationState(snapshotCreator.MethodScopeMembers!);
+                state.LogEvaluationState(snapshotCreator.MethodScopeMembers!);
 
-                Log.Error("Evaluation result should not be null. Probe: {ProbeId}", ProbeInfo.ProbeId);
-                evaluationResult.Errors = new List<EvaluationError> { new() { Message = $"Evaluation result is null. Probe ID: {ProbeInfo.ProbeId}" } };
+                Log.Error("Evaluation result should not be null. Probe: {ProbeId}", state.ProbeInfo.ProbeId);
+                evaluationResult.Errors = new List<EvaluationError> { new() { Message = $"Evaluation result is null. Probe ID: {state.ProbeInfo.ProbeId}" } };
             }
 
             if (Log.IsEnabled(LogEventLevel.Debug) && evaluationResult.Errors is { Count: > 0 } errors)
@@ -426,9 +318,9 @@ namespace Datadog.Trace.Debugger.Expressions
                 Log.Debug("Evaluation errors: {Errors}", errors.Select(er => $"Expression: {er.Expression}{Environment.NewLine}Error: {er.Message}"));
             }
 
-            if (evaluationResult.Metric.HasValue && ProbeInfo.MetricKind.HasValue)
+            if (evaluationResult.Metric.HasValue && state.ProbeInfo.MetricKind.HasValue)
             {
-                DebuggerManager.Instance.DynamicInstrumentation?.SendMetrics(ProbeInfo, ProbeInfo.MetricKind.Value, ProbeInfo.MetricName, evaluationResult.Metric.Value, ProbeInfo.ProbeId);
+                DebuggerManager.Instance.DynamicInstrumentation?.SendMetrics(state.ProbeInfo, state.ProbeInfo.MetricKind.Value, state.ProbeInfo.MetricName, evaluationResult.Metric.Value, state.ProbeInfo.ProbeId);
                 // snapshot creator is created for all probes in the method invokers,
                 // if it is a metric probe, once we sent the value, we can stop the invokers and dispose the snapshot creator
                 snapshotCreator.Dispose();
@@ -437,21 +329,21 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (evaluationResult.Decorations != null)
             {
-                SetSpanDecoration(snapshotCreator, ref shouldStopCapture, evaluationResult);
+                SetSpanDecoration(state, snapshotCreator, ref shouldStopCapture, evaluationResult);
             }
 
             if (evaluationResult.HasError)
             {
                 // Probes with conditions defer sampling until after the condition is evaluated,
                 // so evaluation errors must honor that same sampler before emitting a snapshot.
-                if (ProbeInfo.HasCondition && !sampler.Sample())
+                if (state.ProbeInfo.HasCondition && !sampler.Sample())
                 {
                     shouldStopCapture = true;
                 }
 
-                if (!shouldStopCapture && ShouldCaptureExpressions && !captureExpressionsEvaluated)
+                if (!shouldStopCapture && state.ShouldCaptureExpressions && !captureExpressionsEvaluated)
                 {
-                    evaluator ??= GetOrCreateEvaluator();
+                    evaluator ??= state.GetOrCreateEvaluator();
                     evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
                     captureExpressionsEvaluated = true;
                 }
@@ -468,9 +360,9 @@ namespace Datadog.Trace.Debugger.Expressions
                 return evaluationResult;
             }
 
-            if (ShouldCaptureExpressions && !captureExpressionsEvaluated)
+            if (state.ShouldCaptureExpressions && !captureExpressionsEvaluated)
             {
-                evaluator ??= GetOrCreateEvaluator();
+                evaluator ??= state.GetOrCreateEvaluator();
                 evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
                 captureExpressionsEvaluated = true;
             }
@@ -478,42 +370,7 @@ namespace Datadog.Trace.Debugger.Expressions
             return evaluationResult;
         }
 
-        private void LogEvaluationState(MethodScopeMembers methodScopeMembers)
-        {
-            if (_templates == null
-             && _condition == null
-             && _metric == null
-             && _spanDecorations == null
-             && _captureExpressions == null)
-            {
-                return;
-            }
-
-            // this should never happen, but if it does, we want to log it for further investigation
-            Log.Error("Evaluation state error: we thought that evaluation result is null but that not true. probably we are using an incorrect version of ProbeExpressionEvaluator");
-
-            try
-            {
-                if (Log.IsEnabled(LogEventLevel.Debug))
-                {
-                    var instance = methodScopeMembers.InvocationTarget;
-                    var members = methodScopeMembers.Members?.Select(m => new { Name = m.Name, Type = m.Type?.FullName ?? m.Type?.Name }).ToList();
-                    string? membersAsString = null;
-                    if (members?.Count > 0)
-                    {
-                        membersAsString = string.Join(";", members);
-                    }
-
-                    Log.Error("Evaluation state error: Target Method: Type = {Type}, Name = {Name}. Method Members: {Members}", instance.Type?.FullName ?? instance.Type?.Name, instance.Name, membersAsString);
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-        }
-
-        private void SetSpanDecoration(DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)
+        private void SetSpanDecoration(ProbeProcessorState state, DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)
         {
             var decorations = evaluationResult.Decorations;
             if (decorations == null)
@@ -521,9 +378,9 @@ namespace Datadog.Trace.Debugger.Expressions
                 return;
             }
 
-            if (!TryGetScope(out var scope))
+            if (!TryGetScope(state.ProbeInfo, out var scope))
             {
-                Log.Debug("No active scope available, skipping span decoration. Probe: {ProbeId}", ProbeInfo.ProbeId);
+                Log.Debug("No active scope available, skipping span decoration. Probe: {ProbeId}", state.ProbeInfo.ProbeId);
                 return;
             }
 
@@ -541,12 +398,12 @@ namespace Datadog.Trace.Debugger.Expressions
                 var probeIdTag = $"{DynamicPrefix}{tagName}.probe_id";
                 ISpan? targetSpan = null;
 
-                if (ProbeInfo.TargetSpan == null)
+                if (state.ProbeInfo.TargetSpan == null)
                 {
-                    Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span is null", tagName, ProbeInfo.ProbeId);
+                    Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span is null", tagName, state.ProbeInfo.ProbeId);
                 }
 
-                switch (ProbeInfo.TargetSpan)
+                switch (state.ProbeInfo.TargetSpan)
                 {
                     case TargetSpan.Root:
                         targetSpan = scope.Root?.Span;
@@ -555,18 +412,18 @@ namespace Datadog.Trace.Debugger.Expressions
                         targetSpan = scope.Span;
                         break;
                     default:
-                        Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span {Span} is invalid", tagName, ProbeInfo.ProbeId, ProbeInfo.TargetSpan);
+                        Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span {Span} is invalid", tagName, state.ProbeInfo.ProbeId, state.ProbeInfo.TargetSpan);
                         break;
                 }
 
                 if (targetSpan == null)
                 {
-                    Log.Warning("We can't set the {Tag} tag. Probe ID: {ProbeId}, because the chosen span {Span} is not available", tagName, ProbeInfo.ProbeId, ProbeInfo.TargetSpan);
+                    Log.Warning("We can't set the {Tag} tag. Probe ID: {ProbeId}, because the chosen span {Span} is not available", tagName, state.ProbeInfo.ProbeId, state.ProbeInfo.TargetSpan);
                     continue;
                 }
 
                 targetSpan.SetTag(tagName, decoration.Value);
-                targetSpan.SetTag(probeIdTag, ProbeInfo.ProbeId);
+                targetSpan.SetTag(probeIdTag, state.ProbeInfo.ProbeId);
                 if (decoration.Errors?.Length > 0)
                 {
                     targetSpan.SetTag(evaluationErrorTag, string.Join(";", decoration.Errors));
@@ -579,7 +436,7 @@ namespace Datadog.Trace.Debugger.Expressions
                 attachedTags = true;
                 if (Log.IsEnabled(LogEventLevel.Debug))
                 {
-                    Log.Debug("Successfully attached tag {Tag} to span {Span}. ProbID: {ProbeId}", tagName, targetSpan.SpanId, ProbeInfo.ProbeId);
+                    Log.Debug("Successfully attached tag {Tag} to span {Span}. ProbID: {ProbeId}", tagName, targetSpan.SpanId, state.ProbeInfo.ProbeId);
                 }
             }
 
@@ -592,11 +449,11 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (attachedTags)
             {
-                DebuggerManager.Instance.DynamicInstrumentation?.SetProbeStatusToEmitting(ProbeInfo);
+                DebuggerManager.Instance.DynamicInstrumentation?.SetProbeStatusToEmitting(state.ProbeInfo);
             }
         }
 
-        private bool TryGetScope([NotNullWhen(true)] out Scope? scope)
+        private bool TryGetScope(ProbeInfo probeInfo, [NotNullWhen(true)] out Scope? scope)
         {
             try
             {
@@ -614,18 +471,18 @@ namespace Datadog.Trace.Debugger.Expressions
                     return scope != null;
                 }
 
-                Log.Warning("Unable to find active scope in WCF context for span decoration. Probe ID: {ProbeId}", ProbeInfo.ProbeId);
+                Log.Warning("Unable to find active scope in WCF context for span decoration. Probe ID: {ProbeId}", probeInfo.ProbeId);
                 scope = null;
                 return false;
 #else
-                Log.Warning("No active scope available for span decoration. Probe ID: {ProbeId}", ProbeInfo.ProbeId);
+                Log.Warning("No active scope available for span decoration. Probe ID: {ProbeId}", probeInfo.ProbeId);
                 scope = null;
                 return false;
 #endif
             }
             catch (Exception e)
             {
-                Log.Error(e, "Error while trying to get active scope for span decoration. Probe ID: {ProbeId}", ProbeInfo.ProbeId);
+                Log.Error(e, "Error while trying to get active scope for span decoration. Probe ID: {ProbeId}", probeInfo.ProbeId);
                 scope = null;
                 return false;
             }
@@ -663,15 +520,15 @@ namespace Datadog.Trace.Debugger.Expressions
             }
         }
 
-        private bool ProcessCapture<TCapture>(ref CaptureInfo<TCapture> info, DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
+        private bool ProcessCapture<TCapture>(ProbeProcessorState state, ref CaptureInfo<TCapture> info, DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
         {
-            switch (ProbeInfo.ProbeLocation)
+            switch (state.ProbeInfo.ProbeLocation)
             {
                 case ProbeLocation.Method:
-                    ProcessMethod(ref info, ref snapshotCreator, ref evaluationResult);
+                    ProcessMethod(state, ref info, ref snapshotCreator, ref evaluationResult);
                     break;
                 case ProbeLocation.Line:
-                    ProcessLine(ref info, ref snapshotCreator, ref evaluationResult);
+                    ProcessLine(state, ref info, ref snapshotCreator, ref evaluationResult);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException($"{nameof(ProbeInfo.ProbeLocation)}", $"{info.MethodState} is not valid value here");
@@ -680,7 +537,7 @@ namespace Datadog.Trace.Debugger.Expressions
             return true;
         }
 
-        private void ProcessMethod<TCapture>(ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
+        private void ProcessMethod<TCapture>(ProbeProcessorState state, ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
         {
             switch (info.MethodState)
             {
@@ -691,7 +548,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                     {
                         snapshotCreator.SetEvaluationResult(ref evaluationResult);
-                        if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                        if (state.ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
                         {
                             snapshotCreator.StartEntry();
                             snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
@@ -699,14 +556,14 @@ namespace Datadog.Trace.Debugger.Expressions
                         }
                     }
 
-                    if (!ProbeInfo.IsFullSnapshot)
+                    if (!state.ProbeInfo.IsFullSnapshot)
                     {
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
-                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(ProbeInfo, snapshot);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
+                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
                         break;
                     }
 
-                    if (!snapshotCreator.ProcessDelayedSnapshot(ref info, HasCondition()))
+                    if (!snapshotCreator.ProcessDelayedSnapshot(ref info, state.HasCondition))
                     {
                         snapshotCreator.CaptureEntryAsyncMethod(ref info);
                     }
@@ -716,7 +573,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                     {
                         snapshotCreator.SetEvaluationResult(ref evaluationResult);
-                        if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                        if (state.ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
                         {
                             snapshotCreator.StartEntry();
                             snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
@@ -724,14 +581,14 @@ namespace Datadog.Trace.Debugger.Expressions
                         }
                     }
 
-                    if (!ProbeInfo.IsFullSnapshot)
+                    if (!state.ProbeInfo.IsFullSnapshot)
                     {
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
-                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(ProbeInfo, snapshot);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
+                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
                         break;
                     }
 
-                    snapshotCreator.ProcessDelayedSnapshot(ref info, HasCondition());
+                    snapshotCreator.ProcessDelayedSnapshot(ref info, state.HasCondition);
                     snapshotCreator.CaptureEntryMethodEndMarker(info.Value, info.Type);
 
                     break;
@@ -745,7 +602,7 @@ namespace Datadog.Trace.Debugger.Expressions
                         if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                         {
                             snapshotCreator.SetEvaluationResult(ref evaluationResult);
-                            if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                            if (state.ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
                             {
                                 snapshotCreator.StartReturn();
                                 snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
@@ -753,14 +610,14 @@ namespace Datadog.Trace.Debugger.Expressions
                             }
                         }
 
-                        if (ProbeInfo.IsFullSnapshot)
+                        if (state.ProbeInfo.IsFullSnapshot)
                         {
-                            snapshotCreator.ProcessDelayedSnapshot(ref info, HasCondition());
+                            snapshotCreator.ProcessDelayedSnapshot(ref info, state.HasCondition);
                             snapshotCreator.CaptureExitMethodEndMarker(ref info);
                         }
 
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
-                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(ProbeInfo, snapshot);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
+                        DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
                         snapshotCreator.Stop();
                         break;
                     }
@@ -776,7 +633,7 @@ namespace Datadog.Trace.Debugger.Expressions
             }
         }
 
-        private void ProcessLine<TCapture>(ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
+        private void ProcessLine<TCapture>(ProbeProcessorState state, ref CaptureInfo<TCapture> info, ref DebuggerSnapshotCreator snapshotCreator, ref ExpressionEvaluationResult evaluationResult)
         {
             switch (info.MethodState)
             {
@@ -790,7 +647,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                     {
                         snapshotCreator.SetEvaluationResult(ref evaluationResult);
-                        if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                        if (state.ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
                         {
                             snapshotCreator.StartLines(info.LineCaptureInfo.LineNumber);
                             snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
@@ -798,14 +655,14 @@ namespace Datadog.Trace.Debugger.Expressions
                         }
                     }
 
-                    if (ProbeInfo.IsFullSnapshot)
+                    if (state.ProbeInfo.IsFullSnapshot)
                     {
-                        snapshotCreator.ProcessDelayedSnapshot(ref info, HasCondition());
+                        snapshotCreator.ProcessDelayedSnapshot(ref info, state.HasCondition);
                         snapshotCreator.CaptureEndLine(ref info);
                     }
 
-                    var snapshot = snapshotCreator.FinalizeLineSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
-                    DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(ProbeInfo, snapshot);
+                    var snapshot = snapshotCreator.FinalizeLineSnapshot(state.ProbeInfo.ProbeId, state.ProbeInfo.ProbeVersion, ref info);
+                    DebuggerManager.Instance.DynamicInstrumentation?.AddSnapshot(state.ProbeInfo, snapshot);
                     snapshotCreator.Stop();
                     break;
 
@@ -817,6 +674,177 @@ namespace Datadog.Trace.Debugger.Expressions
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(info.MethodState));
+            }
+        }
+
+        internal sealed class ProbeProcessorState
+        {
+            private ProbeExpressionEvaluator? _evaluator;
+
+            private ProbeProcessorState(
+                ProbeInfo probeInfo,
+                DebuggerExpression?[]? templates,
+                DebuggerExpression? condition,
+                DebuggerExpression? metric,
+                KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? spanDecorations,
+                CaptureExpressionDefinition[]? captureExpressions)
+            {
+                ProbeInfo = probeInfo;
+                Templates = templates;
+                Condition = condition;
+                Metric = metric;
+                SpanDecorations = spanDecorations;
+                CaptureExpressions = captureExpressions;
+                HasCondition = condition.HasValue;
+                IsMetricCountWithoutExpression = probeInfo.ProbeType == ProbeType.Metric && (metric?.Json == null) && probeInfo.MetricKind == MetricKind.COUNT;
+                ShouldCaptureExpressions = !probeInfo.IsFullSnapshot && captureExpressions is { Length: > 0 };
+            }
+
+            internal ProbeInfo ProbeInfo { get; }
+
+            private DebuggerExpression?[]? Templates { get; }
+
+            private DebuggerExpression? Condition { get; }
+
+            private DebuggerExpression? Metric { get; }
+
+            private KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? SpanDecorations { get; }
+
+            private CaptureExpressionDefinition[]? CaptureExpressions { get; }
+
+            internal bool HasCondition { get; }
+
+            internal bool IsMetricCountWithoutExpression { get; }
+
+            internal bool ShouldCaptureExpressions { get; }
+
+            internal static ProbeProcessorState Create(ProbeDefinition probe)
+            {
+                var location = probe.Where.MethodName != null
+                                   ? ProbeLocation.Method
+                                   : ProbeLocation.Line;
+
+                var probeType = probe switch
+                {
+                    LogProbe { CaptureSnapshot: true } => ProbeType.Snapshot,
+                    LogProbe { CaptureSnapshot: false } => ProbeType.Log,
+                    MetricProbe => ProbeType.Metric,
+                    SpanDecorationProbe => ProbeType.SpanDecoration,
+                    _ => throw new ArgumentOutOfRangeException(nameof(probe), probe, "Unsupported probe type")
+                };
+
+                var evaluateAt = location switch
+                {
+                    ProbeLocation.Method => probe.EvaluateAt,
+                    ProbeLocation.Line => EvaluateAt.Entry,
+                    _ => throw new ArgumentOutOfRangeException(nameof(location), location, "Unsupported probe location")
+                };
+
+                var templates = default(DebuggerExpression?[]?);
+                DebuggerExpression? condition = null;
+                DebuggerExpression? metric = null;
+                KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? spanDecorations = null;
+                CaptureExpressionDefinition[]? captureExpressions = null;
+
+                // ReSharper disable once PossibleInvalidOperationException
+                switch (probe)
+                {
+                    case LogProbe logProbe:
+                        templates = logProbe.Segments?.Select(ToDebuggerExpression).ToArray();
+                        condition = ToDebuggerExpression(logProbe.When);
+                        captureExpressions = logProbe.CaptureSnapshot ? null : CreateCaptureExpressions(logProbe.CaptureExpressions);
+                        break;
+                    case MetricProbe metricProbe:
+                        metric = ToDebuggerExpression(metricProbe.Value);
+                        break;
+                    case SpanDecorationProbe spanDecorationProbe:
+                        spanDecorations = spanDecorationProbe.
+                            Decorations
+                          ?.Where(dec => dec != null)
+                           .Select(
+                                dec =>
+                                {
+                                    var whenExpression = ToDebuggerExpression(dec.When);
+                                    var keyValuePairs = dec.Tags?.Select(
+                                                                tag => new KeyValuePair<string?, DebuggerExpression?[]>(
+                                                                    tag.Name,
+                                                                    tag.Value?.Segments?.Select(ToDebuggerExpression).ToArray() ?? []))
+                                                           .ToArray();
+
+                                    return new KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>(whenExpression, keyValuePairs ?? []);
+                                })
+                           .ToArray();
+
+                        break;
+                }
+
+                var probeInfo = new ProbeInfo(
+                    probe.Id,
+                    probe.Version ?? 0,
+                    probeType,
+                    location,
+                    evaluateAt,
+                    (probe as MetricProbe)?.Kind,
+                    (probe as MetricProbe)?.MetricName,
+                    condition.HasValue,
+                    probe.Tags,
+                    (probe as SpanDecorationProbe)?.TargetSpan,
+                    ToCaptureLimitInfo((probe as LogProbe)?.Capture));
+
+                return new ProbeProcessorState(
+                    probeInfo,
+                    templates,
+                    condition,
+                    metric,
+                    spanDecorations,
+                    captureExpressions);
+            }
+
+            internal ProbeExpressionEvaluator GetOrCreateEvaluator()
+            {
+                var evaluator = Volatile.Read(ref _evaluator);
+                if (evaluator != null)
+                {
+                    return evaluator;
+                }
+
+                Interlocked.CompareExchange(ref _evaluator, new ProbeExpressionEvaluator(Templates, Condition, Metric, SpanDecorations, CaptureExpressions), null);
+                return _evaluator!;
+            }
+
+            internal void LogEvaluationState(MethodScopeMembers methodScopeMembers)
+            {
+                if (Templates == null
+                 && Condition == null
+                 && Metric == null
+                 && SpanDecorations == null
+                 && CaptureExpressions == null)
+                {
+                    return;
+                }
+
+                // this should never happen, but if it does, we want to log it for further investigation
+                Log.Error("Evaluation state error: we thought that evaluation result is null but that not true. probably we are using an incorrect version of ProbeExpressionEvaluator");
+
+                try
+                {
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        var instance = methodScopeMembers.InvocationTarget;
+                        var members = methodScopeMembers.Members?.Select(m => new { Name = m.Name, Type = m.Type?.FullName ?? m.Type?.Name }).ToList();
+                        string? membersAsString = null;
+                        if (members?.Count > 0)
+                        {
+                            membersAsString = string.Join(";", members);
+                        }
+
+                        Log.Error("Evaluation state error: Target Method: Type = {Type}, Name = {Name}. Method Members: {Members}", instance.Type?.FullName ?? instance.Type?.Name, instance.Name, membersAsString);
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -33,6 +33,7 @@ namespace Datadog.Trace.Debugger.Expressions
         private DebuggerExpression? _condition;
         private DebuggerExpression? _metric;
         private KeyValuePair<DebuggerExpression?, KeyValuePair<string?, DebuggerExpression?[]>[]>[]? _spanDecorations;
+        private CaptureExpressionDefinition[]? _captureExpressions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProbeProcessor"/> class, that correlated to probe id
@@ -48,6 +49,8 @@ namespace Datadog.Trace.Debugger.Expressions
         internal ProbeInfo ProbeInfo { get; private set; }
 
         private bool IsMetricCountWithoutExpression => ProbeInfo.ProbeType == ProbeType.Metric && (_metric?.Json == null) && ProbeInfo.MetricKind == MetricKind.COUNT;
+
+        private bool ShouldCaptureExpressions => !ProbeInfo.IsFullSnapshot && _captureExpressions is { Length: > 0 };
 
         private void InitializeProbeProcessor(ProbeDefinition probe)
         {
@@ -74,18 +77,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
             SetExpressions(probe);
 
-            var capture = (probe as LogProbe)?.Capture;
-            var maxInfo = capture != null
-                ? new CaptureLimitInfo(
-                    MaxReferenceDepth: capture.Value.MaxReferenceDepth <= 0 ? DebuggerSettings.DefaultMaxDepthToSerialize : capture.Value.MaxReferenceDepth,
-                    MaxCollectionSize: capture.Value.MaxCollectionSize <= 0 ? DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy : capture.Value.MaxCollectionSize,
-                    MaxFieldCount: capture.Value.MaxFieldCount <= 0 ? DebuggerSettings.DefaultMaxNumberOfFieldsToCopy : capture.Value.MaxFieldCount,
-                    MaxLength: capture.Value.MaxLength <= 0 ? DebuggerSettings.DefaultMaxStringLength : capture.Value.MaxLength)
-                : new CaptureLimitInfo(
-                    MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
-                    MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
-                    MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy,
-                    MaxLength: DebuggerSettings.DefaultMaxStringLength);
+            var maxInfo = ToCaptureLimitInfo((probe as LogProbe)?.Capture);
 
             ProbeInfo = new ProbeInfo(
                 probe.Id,
@@ -124,19 +116,70 @@ namespace Datadog.Trace.Debugger.Expressions
             return new DebuggerSnapshotCreator(ProbeInfo.IsFullSnapshot, ProbeInfo.ProbeLocation, ProbeInfo.HasCondition, ProbeInfo.Tags, ProbeInfo.CaptureLimitInfo, DebuggerManager.ProcessTagsProvider, DebuggerManager.ServiceNameProvider);
         }
 
+        private CaptureLimitInfo ToCaptureLimitInfo(Capture? capture)
+        {
+            return capture != null
+                ? new CaptureLimitInfo(
+                    MaxReferenceDepth: capture.Value.MaxReferenceDepth <= 0 ? DebuggerSettings.DefaultMaxDepthToSerialize : capture.Value.MaxReferenceDepth,
+                    MaxCollectionSize: capture.Value.MaxCollectionSize <= 0 ? DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy : capture.Value.MaxCollectionSize,
+                    MaxFieldCount: capture.Value.MaxFieldCount <= 0 ? DebuggerSettings.DefaultMaxNumberOfFieldsToCopy : capture.Value.MaxFieldCount,
+                    MaxLength: capture.Value.MaxLength <= 0 ? DebuggerSettings.DefaultMaxStringLength : capture.Value.MaxLength)
+                : new CaptureLimitInfo(
+                    MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                    MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+                    MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy,
+                    MaxLength: DebuggerSettings.DefaultMaxStringLength);
+        }
+
+        private CaptureExpressionDefinition[]? CreateCaptureExpressions(CaptureExpression[]? captureExpressions)
+        {
+            if (captureExpressions == null || captureExpressions.Length == 0)
+            {
+                return null;
+            }
+
+            var result = new List<CaptureExpressionDefinition>(captureExpressions.Length);
+            for (int i = 0; i < captureExpressions.Length; i++)
+            {
+                var captureExpression = captureExpressions[i];
+                if (captureExpression?.Name is not { Length: > 0 } name)
+                {
+                    continue;
+                }
+
+                result.Add(new CaptureExpressionDefinition(
+                    name,
+                    ToDebuggerExpression(captureExpression.Expr),
+                    ToCaptureLimitInfo(captureExpression.Capture)));
+            }
+
+            return result.Count == 0 ? null : result.ToArray();
+        }
+
         private void SetExpressions(ProbeDefinition probe)
         {
             // ReSharper disable once PossibleInvalidOperationException
             switch (probe)
             {
                 case LogProbe logProbe:
+                    _metric = null;
+                    _spanDecorations = null;
                     _templates = logProbe.Segments?.Select(ToDebuggerExpression).ToArray();
                     _condition = ToDebuggerExpression(logProbe.When);
+                    _captureExpressions = logProbe.CaptureSnapshot ? null : CreateCaptureExpressions(logProbe.CaptureExpressions);
                     break;
                 case MetricProbe metricProbe:
+                    _templates = null;
+                    _condition = null;
+                    _spanDecorations = null;
+                    _captureExpressions = null;
                     _metric = ToDebuggerExpression(metricProbe.Value);
                     break;
                 case SpanDecorationProbe spanDecorationProbe:
+                    _templates = null;
+                    _condition = null;
+                    _metric = null;
+                    _captureExpressions = null;
                     _spanDecorations = spanDecorationProbe.
                         Decorations
                       ?.Where(dec => dec != null)
@@ -160,8 +203,14 @@ namespace Datadog.Trace.Debugger.Expressions
 
         private ProbeExpressionEvaluator GetOrCreateEvaluator()
         {
-            Interlocked.CompareExchange(ref _evaluator, new ProbeExpressionEvaluator(_templates, _condition, _metric, _spanDecorations), null);
-            return _evaluator;
+            var evaluator = Volatile.Read(ref _evaluator);
+            if (evaluator != null)
+            {
+                return evaluator;
+            }
+
+            Interlocked.CompareExchange(ref _evaluator, new ProbeExpressionEvaluator(_templates, _condition, _metric, _spanDecorations, _captureExpressions), null);
+            return _evaluator!;
         }
 
         public bool ShouldProcess(in ProbeData probeData)
@@ -322,6 +371,9 @@ namespace Datadog.Trace.Debugger.Expressions
         {
             ExpressionEvaluationResult evaluationResult = default;
             shouldStopCapture = false;
+            var captureExpressionsEvaluated = false;
+            ProbeExpressionsCacheEntry? cacheEntry = null;
+            ProbeExpressionEvaluator? evaluator = null;
             try
             {
                 if (IsMetricCountWithoutExpression)
@@ -332,7 +384,8 @@ namespace Datadog.Trace.Debugger.Expressions
                 {
                     // we are taking the duration at the evaluation time - this might be different from what we have in the snapshot
                     snapshotCreator.SetDuration();
-                    evaluationResult = GetOrCreateEvaluator().Evaluate(snapshotCreator.MethodScopeMembers!);
+                    evaluator = GetOrCreateEvaluator();
+                    evaluationResult = evaluator.Evaluate(snapshotCreator.MethodScopeMembers!, out cacheEntry);
                 }
             }
             catch (Exception e)
@@ -347,6 +400,19 @@ namespace Datadog.Trace.Debugger.Expressions
                 evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {ProbeInfo.ProbeId}. Error: {e.Message}" });
             }
 
+            if (ShouldCaptureExpressions && evaluationResult.IsNull())
+            {
+                evaluator ??= GetOrCreateEvaluator();
+                evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
+                captureExpressionsEvaluated = true;
+            }
+
+            if (captureExpressionsEvaluated && evaluationResult.IsNull())
+            {
+                shouldStopCapture = true;
+                return evaluationResult;
+            }
+
             if (evaluationResult.IsNull())
             {
                 LogEvaluationState(snapshotCreator.MethodScopeMembers!);
@@ -355,9 +421,9 @@ namespace Datadog.Trace.Debugger.Expressions
                 evaluationResult.Errors = new List<EvaluationError> { new() { Message = $"Evaluation result is null. Probe ID: {ProbeInfo.ProbeId}" } };
             }
 
-            if (Log.IsEnabled(LogEventLevel.Debug) && evaluationResult.HasError)
+            if (Log.IsEnabled(LogEventLevel.Debug) && evaluationResult.Errors is { Count: > 0 } errors)
             {
-                Log.Debug("Evaluation errors: {Errors}", evaluationResult.Errors.Select(er => $"Expression: {er.Expression}{Environment.NewLine}Error: {er.Message}"));
+                Log.Debug("Evaluation errors: {Errors}", errors.Select(er => $"Expression: {er.Expression}{Environment.NewLine}Error: {er.Message}"));
             }
 
             if (evaluationResult.Metric.HasValue && ProbeInfo.MetricKind.HasValue)
@@ -383,6 +449,13 @@ namespace Datadog.Trace.Debugger.Expressions
                     shouldStopCapture = true;
                 }
 
+                if (!shouldStopCapture && ShouldCaptureExpressions && !captureExpressionsEvaluated)
+                {
+                    evaluator ??= GetOrCreateEvaluator();
+                    evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
+                    captureExpressionsEvaluated = true;
+                }
+
                 return evaluationResult;
             }
 
@@ -395,6 +468,13 @@ namespace Datadog.Trace.Debugger.Expressions
                 return evaluationResult;
             }
 
+            if (ShouldCaptureExpressions && !captureExpressionsEvaluated)
+            {
+                evaluator ??= GetOrCreateEvaluator();
+                evaluator.EvaluateCaptureExpressions(ref evaluationResult, snapshotCreator.MethodScopeMembers!, cacheEntry);
+                captureExpressionsEvaluated = true;
+            }
+
             return evaluationResult;
         }
 
@@ -403,7 +483,8 @@ namespace Datadog.Trace.Debugger.Expressions
             if (_templates == null
              && _condition == null
              && _metric == null
-             && _spanDecorations == null)
+             && _spanDecorations == null
+             && _captureExpressions == null)
             {
                 return;
             }
@@ -434,6 +515,12 @@ namespace Datadog.Trace.Debugger.Expressions
 
         private void SetSpanDecoration(DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)
         {
+            var decorations = evaluationResult.Decorations;
+            if (decorations == null)
+            {
+                return;
+            }
+
             if (!TryGetScope(out var scope))
             {
                 Log.Debug("No active scope available, skipping span decoration. Probe: {ProbeId}", ProbeInfo.ProbeId);
@@ -442,16 +529,21 @@ namespace Datadog.Trace.Debugger.Expressions
 
             var attachedTags = false;
 
-            for (int i = 0; i < evaluationResult.Decorations.Length; i++)
+            for (int i = 0; i < decorations.Length; i++)
             {
-                var decoration = evaluationResult.Decorations[i];
-                var evaluationErrorTag = $"{DynamicPrefix}{decoration.TagName}.evaluation_error";
-                var probeIdTag = $"{DynamicPrefix}{decoration.TagName}.probe_id";
+                var decoration = decorations[i];
+                if (decoration.TagName is not { Length: > 0 } tagName)
+                {
+                    continue;
+                }
+
+                var evaluationErrorTag = $"{DynamicPrefix}{tagName}.evaluation_error";
+                var probeIdTag = $"{DynamicPrefix}{tagName}.probe_id";
                 ISpan? targetSpan = null;
 
                 if (ProbeInfo.TargetSpan == null)
                 {
-                    Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span is null", decoration.TagName, ProbeInfo.ProbeId);
+                    Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span is null", tagName, ProbeInfo.ProbeId);
                 }
 
                 switch (ProbeInfo.TargetSpan)
@@ -463,17 +555,17 @@ namespace Datadog.Trace.Debugger.Expressions
                         targetSpan = scope.Span;
                         break;
                     default:
-                        Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span {Span} is invalid", decoration.TagName, ProbeInfo.ProbeId, ProbeInfo.TargetSpan);
+                        Log.Error("We can't set the {Tag} tag. Probe ID: {ProbeId}, because target span {Span} is invalid", tagName, ProbeInfo.ProbeId, ProbeInfo.TargetSpan);
                         break;
                 }
 
                 if (targetSpan == null)
                 {
-                    Log.Warning("We can't set the {Tag} tag. Probe ID: {ProbeId}, because the chosen span {Span} is not available", decoration.TagName, ProbeInfo.ProbeId, ProbeInfo.TargetSpan);
+                    Log.Warning("We can't set the {Tag} tag. Probe ID: {ProbeId}, because the chosen span {Span} is not available", tagName, ProbeInfo.ProbeId, ProbeInfo.TargetSpan);
                     continue;
                 }
 
-                targetSpan.SetTag(decoration.TagName, decoration.Value);
+                targetSpan.SetTag(tagName, decoration.Value);
                 targetSpan.SetTag(probeIdTag, ProbeInfo.ProbeId);
                 if (decoration.Errors?.Length > 0)
                 {
@@ -487,7 +579,7 @@ namespace Datadog.Trace.Debugger.Expressions
                 attachedTags = true;
                 if (Log.IsEnabled(LogEventLevel.Debug))
                 {
-                    Log.Debug("Successfully attached tag {Tag} to span {Span}. ProbID: {ProbeId}", decoration.TagName, targetSpan.SpanId, ProbeInfo.ProbeId);
+                    Log.Debug("Successfully attached tag {Tag} to span {Span}. ProbID: {ProbeId}", tagName, targetSpan.SpanId, ProbeInfo.ProbeId);
                 }
             }
 
@@ -599,6 +691,12 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                     {
                         snapshotCreator.SetEvaluationResult(ref evaluationResult);
+                        if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                        {
+                            snapshotCreator.StartEntry();
+                            snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
+                            snapshotCreator.EndEntry();
+                        }
                     }
 
                     if (!ProbeInfo.IsFullSnapshot)
@@ -618,6 +716,12 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                     {
                         snapshotCreator.SetEvaluationResult(ref evaluationResult);
+                        if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                        {
+                            snapshotCreator.StartEntry();
+                            snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
+                            snapshotCreator.EndEntry();
+                        }
                     }
 
                     if (!ProbeInfo.IsFullSnapshot)
@@ -641,6 +745,12 @@ namespace Datadog.Trace.Debugger.Expressions
                         if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                         {
                             snapshotCreator.SetEvaluationResult(ref evaluationResult);
+                            if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                            {
+                                snapshotCreator.StartReturn();
+                                snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
+                                snapshotCreator.EndReturn();
+                            }
                         }
 
                         if (ProbeInfo.IsFullSnapshot)
@@ -680,6 +790,12 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (snapshotCreator.CaptureBehaviour == CaptureBehaviour.Evaluate)
                     {
                         snapshotCreator.SetEvaluationResult(ref evaluationResult);
+                        if (ShouldCaptureExpressions && evaluationResult.HasCaptureExpressions)
+                        {
+                            snapshotCreator.StartLines(info.LineCaptureInfo.LineNumber);
+                            snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
+                            snapshotCreator.EndReturn();
+                        }
                     }
 
                     if (ProbeInfo.IsFullSnapshot)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Debugger.Expressions
         private const string DynamicPrefix = "_dd.di.";
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProbeProcessor));
 
-        private ProbeProcessorState _state;
+        private volatile ProbeProcessorState _state;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProbeProcessor"/> class, that correlated to probe id
@@ -38,8 +38,6 @@ namespace Datadog.Trace.Debugger.Expressions
         /// <remarks>Exceptions should be caught and logged by the caller</remarks>
         internal ProbeProcessor(ProbeDefinition probe)
         {
-            // New processors are published through ConcurrentDictionary only after construction;
-            // later state replacements use Volatile.Write and readers use Volatile.Read.
             _state = ProbeProcessorState.Create(probe);
         }
 
@@ -54,7 +52,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
         public IProbeProcessor UpdateProbeProcessor(ProbeDefinition probe)
         {
-            Volatile.Write(ref _state, ProbeProcessorState.Create(probe));
+            _state = ProbeProcessorState.Create(probe);
             return this;
         }
 
@@ -100,7 +98,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
         public bool TryBeginProcess(in ProbeData probeData, [NotNullWhen(true)] out IDebuggerSnapshotCreator? snapshotCreator)
         {
-            var state = Volatile.Read(ref _state);
+            var state = _state;
             if (!state.HasCondition && !probeData.Sampler.Sample())
             {
                 snapshotCreator = null;

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
@@ -173,13 +173,13 @@ namespace Datadog.Trace.Debugger.Instrumentation
                     return CreateInvalidatedAsyncLineDebuggerState();
                 }
 
-                if (!probeData.Processor.ShouldProcess(in probeData))
+                if (!probeData.Processor.TryBeginProcess(in probeData, out var snapshotCreator))
                 {
                     return CreateInvalidatedAsyncLineDebuggerState();
                 }
 
                 var kickoffParentObject = AsyncHelper.GetAsyncKickoffThisObject(instance);
-                var state = new AsyncLineDebuggerState(probeId, scope: default, methodMetadataIndex, ref probeData, lineNumber, probeFilePath, instance, kickoffParentObject);
+                var state = new AsyncLineDebuggerState(probeId, scope: default, methodMetadataIndex, ref probeData, lineNumber, probeFilePath, instance, kickoffParentObject, snapshotCreator);
                 var asyncInfo = new AsyncCaptureInfo(state.MoveNextInvocationTarget, state.KickoffInvocationTarget, state.MethodMetadataInfo.KickoffInvocationTargetType, hoistedLocals: state.MethodMetadataInfo.AsyncMethodHoistedLocals, hoistedArgs: state.MethodMetadataInfo.AsyncMethodHoistedArguments);
                 var captureInfo = new CaptureInfo<Type>(state.MethodMetadataIndex, value: null, type: state.MethodMetadataInfo.DeclaringType, methodState: MethodState.BeginLineAsync, localsCount: state.MethodMetadataInfo.LocalVariableNames.Length, argumentsCount: state.MethodMetadataInfo.ParameterNames.Length, lineCaptureInfo: new LineCaptureInfo(lineNumber, probeFilePath), asyncCaptureInfo: asyncInfo);
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerState.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerState.cs
@@ -49,7 +49,8 @@ namespace Datadog.Trace.Debugger.Instrumentation
         /// <param name="probeFilePath">The path to the file of the probe</param>
         /// <param name="invocationTarget">The instance object (or null for static methods)</param>
         /// <param name="kickoffInvocationTarget">The instance object (or null for static methods) of the kickoff method</param>
-        internal AsyncLineDebuggerState(string probeId, Scope scope, int methodMetadataIndex, ref ProbeData probeData, int lineNumber, string probeFilePath, object invocationTarget, object kickoffInvocationTarget)
+        /// <param name="snapshotCreator">The snapshot creator associated with the executing probe configuration</param>
+        internal AsyncLineDebuggerState(string probeId, Scope scope, int methodMetadataIndex, ref ProbeData probeData, int lineNumber, string probeFilePath, object invocationTarget, object kickoffInvocationTarget, IDebuggerSnapshotCreator snapshotCreator)
         {
             _probeId = probeId;
             _scope = scope;
@@ -57,8 +58,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
             _lineNumber = lineNumber;
             _probeFilePath = probeFilePath;
             HasLocalsOrReturnValue = false;
-            var processor = probeData.Processor;
-            SnapshotCreator = processor.CreateSnapshotCreator();
+            SnapshotCreator = snapshotCreator;
             ProbeData = probeData;
             _moveNextInvocationTarget = invocationTarget;
             _kickoffInvocationTarget = kickoffInvocationTarget;

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.SingleProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.SingleProbe.cs
@@ -172,13 +172,13 @@ namespace Datadog.Trace.Debugger.Instrumentation
                 return;
             }
 
-            if (!probeData.Processor.ShouldProcess(in probeData))
+            if (!probeData.Processor.TryBeginProcess(in probeData, out var snapshotCreator))
             {
                 state = AsyncMethodDebuggerState.CreateInvalidatedDebuggerState();
                 return;
             }
 
-            var asyncState = new AsyncMethodDebuggerState(probeId, ref probeData)
+            var asyncState = new AsyncMethodDebuggerState(probeId, ref probeData, snapshotCreator)
             {
                 KickoffInvocationTarget = kickoffInfo.KickoffParentObject,
                 StartTime = DateTimeOffset.UtcNow,

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerState.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerState.cs
@@ -27,13 +27,12 @@ namespace Datadog.Trace.Debugger.Instrumentation
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncMethodDebuggerState"/> class.
         /// </summary>
-        internal AsyncMethodDebuggerState(string probeId, ref ProbeData probeData)
+        internal AsyncMethodDebuggerState(string probeId, ref ProbeData probeData, IDebuggerSnapshotCreator snapshotCreator)
         {
             ProbeId = probeId;
             HasLocalsOrReturnValue = false;
             HasArguments = false;
-            var processor = probeData.Processor;
-            SnapshotCreator = processor.CreateSnapshotCreator();
+            SnapshotCreator = snapshotCreator;
             ProbeData = probeData;
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerInvoker.cs
@@ -198,12 +198,12 @@ namespace Datadog.Trace.Debugger.Instrumentation
                     return CreateInvalidatedLineDebuggerState();
                 }
 
-                if (!probeData.Processor.ShouldProcess(in probeData))
+                if (!probeData.Processor.TryBeginProcess(in probeData, out var snapshotCreator))
                 {
                     return CreateInvalidatedLineDebuggerState();
                 }
 
-                var state = new LineDebuggerState(probeId, scope: default, methodMetadataIndex, ref probeData, lineNumber, probeFilePath, instance);
+                var state = new LineDebuggerState(probeId, scope: default, methodMetadataIndex, ref probeData, lineNumber, probeFilePath, instance, snapshotCreator);
                 var captureInfo = new CaptureInfo<Type>(state.MethodMetadataIndex, invocationTargetType: state.MethodMetadataInfo.DeclaringType, methodState: MethodState.BeginLine, localsCount: state.MethodMetadataInfo.LocalVariableNames.Length, argumentsCount: state.MethodMetadataInfo.ParameterNames.Length, lineCaptureInfo: new LineCaptureInfo(lineNumber, probeFilePath));
 
                 if (!state.ProbeData.Processor.Process(ref captureInfo, state.SnapshotCreator, in probeData))

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerState.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerState.cs
@@ -44,7 +44,8 @@ namespace Datadog.Trace.Debugger.Instrumentation
         /// <param name="lineNumber">The line number where the probe is located on</param>
         /// <param name="probeFilePath">The path to the file of the probe</param>
         /// <param name="invocationTarget">The instance object (or null for static methods)</param>
-        internal LineDebuggerState(string probeId, Scope scope, int methodMetadataIndex, ref ProbeData probeData, int lineNumber, string probeFilePath, object invocationTarget)
+        /// <param name="snapshotCreator">The snapshot creator associated with the executing probe configuration</param>
+        internal LineDebuggerState(string probeId, Scope scope, int methodMetadataIndex, ref ProbeData probeData, int lineNumber, string probeFilePath, object invocationTarget, IDebuggerSnapshotCreator snapshotCreator)
         {
             _probeId = probeId;
             _scope = scope;
@@ -52,8 +53,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
             _lineNumber = lineNumber;
             _probeFilePath = probeFilePath;
             HasLocalsOrReturnValue = false;
-            var processor = probeData.Processor;
-            SnapshotCreator = processor.CreateSnapshotCreator();
+            SnapshotCreator = snapshotCreator;
             ProbeData = probeData;
             InvocationTarget = invocationTarget;
         }

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.SingleProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.SingleProbe.cs
@@ -96,12 +96,12 @@ namespace Datadog.Trace.Debugger.Instrumentation
                 return CreateInvalidatedDebuggerState();
             }
 
-            if (!probeData.Processor.ShouldProcess(in probeData))
+            if (!probeData.Processor.TryBeginProcess(in probeData, out var snapshotCreator))
             {
                 return CreateInvalidatedDebuggerState();
             }
 
-            var state = new MethodDebuggerState(probeId, scope: default, methodMetadataIndex, ref probeData, instance);
+            var state = new MethodDebuggerState(probeId, scope: default, methodMetadataIndex, ref probeData, instance, snapshotCreator);
 
             var captureInfo = new CaptureInfo<Type>(state.MethodMetadataIndex, value: null, method: state.MethodMetadataInfo.Method, type: state.MethodMetadataInfo.DeclaringType, invocationTargetType: state.MethodMetadataInfo.DeclaringType, methodState: MethodState.EntryStart, localsCount: state.MethodMetadataInfo.LocalVariableNames.Length, argumentsCount: state.MethodMetadataInfo.ParameterNames.Length);
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerState.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerState.cs
@@ -48,15 +48,15 @@ namespace Datadog.Trace.Debugger.Instrumentation
         /// <param name="methodMetadataIndex">The unique index of the method's <see cref="Collections.MethodMetadataInfo"/></param>
         /// <param name="probeData">The <see cref="ProbeData"/> associated with the executing instrumentation</param>
         /// <param name="invocationTarget">The current invocation target ('this' object)</param>
-        internal MethodDebuggerState(string probeId, Scope scope, int methodMetadataIndex, ref ProbeData probeData, object invocationTarget)
+        /// <param name="snapshotCreator">The snapshot creator associated with the executing probe configuration</param>
+        internal MethodDebuggerState(string probeId, Scope scope, int methodMetadataIndex, ref ProbeData probeData, object invocationTarget, IDebuggerSnapshotCreator snapshotCreator)
         {
             _probeId = probeId;
             _scope = scope;
             _methodMetadataIndex = methodMetadataIndex;
             HasLocalsOrReturnValue = false;
             InvocationTarget = invocationTarget;
-            var processor = probeData.Processor;
-            SnapshotCreator = processor.CreateSnapshotCreator();
+            SnapshotCreator = snapshotCreator;
             ProbeData = probeData;
             MethodPhase = EvaluateAt.Entry;
         }

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -289,6 +289,16 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void StartEntry()
         {
+            if (!_isFullSnapshot && !_capturesOpen)
+            {
+                StartCaptures();
+            }
+
+            if (_entryOpen)
+            {
+                return;
+            }
+
             JsonWriter.WritePropertyName("entry");
             JsonWriter.WriteStartObject();
             _entryOpen = true;
@@ -300,6 +310,11 @@ namespace Datadog.Trace.Debugger.Snapshots
             if (!_isFullSnapshot && !_capturesOpen)
             {
                 StartCaptures();
+            }
+
+            if (_linesOpen)
+            {
+                return;
             }
 
             JsonWriter.WritePropertyName("lines");
@@ -504,6 +519,27 @@ namespace Datadog.Trace.Debugger.Snapshots
             StartLocalsOrArgsIfNeeded("locals");
             // in case TLocal is object and we have the concrete type, use it
             DebuggerSnapshotSerializer.Serialize(value, type ?? typeof(TLocal), name, JsonWriter, _limitInfo);
+        }
+
+        internal void CaptureCaptureExpressions(ref ExpressionEvaluationResult evaluationResult)
+        {
+            var captureExpressions = evaluationResult.CaptureExpressions;
+            var captureExpressionCount = evaluationResult.CaptureExpressionCount;
+            if (captureExpressions == null || captureExpressionCount == 0)
+            {
+                return;
+            }
+
+            CloseLocalsOrArgsIfOpen();
+            JsonWriter.WritePropertyName("captureExpressions");
+            JsonWriter.WriteStartObject();
+            for (int i = 0; i < captureExpressionCount; i++)
+            {
+                var captureExpression = captureExpressions[i];
+                DebuggerSnapshotSerializer.Serialize(captureExpression.Value, captureExpression.Type, captureExpression.Name, JsonWriter, captureExpression.CaptureLimitInfo);
+            }
+
+            JsonWriter.WriteEndObject();
         }
 
         internal void CaptureException(Exception ex)

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -77,6 +77,12 @@ namespace Datadog.Trace.Debugger.Snapshots
             Initialize();
         }
 
+        internal DebuggerSnapshotCreator(ProbeProcessor.ProbeProcessorState probeProcessorState)
+            : this(probeProcessorState.ProbeInfo.IsFullSnapshot, probeProcessorState.ProbeInfo.ProbeLocation, probeProcessorState.ProbeInfo.HasCondition, probeProcessorState.ProbeInfo.Tags, probeProcessorState.ProbeInfo.CaptureLimitInfo, DebuggerManager.ProcessTagsProvider, DebuggerManager.ServiceNameProvider)
+        {
+            ProbeProcessorState = probeProcessorState;
+        }
+
         public DebuggerSnapshotCreator(bool isFullSnapshot, ProbeLocation location, bool hasCondition, string[] tags, MethodScopeMembers methodScopeMembers, CaptureLimitInfo limitInfo, Func<string?> processTagsProvider, Func<string> serviceNameProvider)
             : this(isFullSnapshot, location, hasCondition, tags, limitInfo, processTagsProvider, serviceNameProvider)
         {
@@ -102,6 +108,8 @@ namespace Datadog.Trace.Debugger.Snapshots
         }
 
         internal MethodScopeMembers? MethodScopeMembers { get; private set; }
+
+        internal ProbeProcessor.ProbeProcessorState? ProbeProcessorState { get; }
 
         internal bool ProbeHasCondition { get; }
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsComplex.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsComplex.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "return": {
+            "captureExpressions": {
+              "collection_first_element": {
+                "type": "String",
+                "value": "one"
+              },
+              "dictionary_value": {
+                "type": "String",
+                "value": "second"
+              },
+              "nested_field": {
+                "type": "String",
+                "value": "testValue"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsComplex"
+          },
+          "version": 0
+        },
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsComplex",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsLine.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsLine.verified.txt
@@ -1,0 +1,105 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "19": {
+              "captureExpressions": {
+                "inputValue": {
+                  "type": "String",
+                  "value": "testValue"
+                },
+                "localValue": {
+                  "type": "Int32",
+                  "value": "9"
+                },
+                "testStruct": {
+                  "fields": {
+                    "Collection": {
+                      "elements": [
+                        {
+                          "type": "String",
+                          "value": "one"
+                        },
+                        {
+                          "type": "String",
+                          "value": "two"
+                        },
+                        {
+                          "type": "String",
+                          "value": "three"
+                        }
+                      ],
+                      "size": 3,
+                      "type": "List`1"
+                    },
+                    "Dictionary": {
+                      "entries": [
+                        [
+                          {
+                            "type": "String",
+                            "value": "one"
+                          },
+                          {
+                            "type": "String",
+                            "value": "first"
+                          }
+                        ],
+                        [
+                          {
+                            "type": "String",
+                            "value": "two"
+                          },
+                          {
+                            "type": "String",
+                            "value": "second"
+                          }
+                        ]
+                      ],
+                      "size": 2,
+                      "type": "Dictionary`2"
+                    },
+                    "StringValue": {
+                      "type": "String",
+                      "value": "testValue"
+                    }
+                  },
+                  "type": "CaptureExpressionTestStruct"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "CaptureExpressionsLine.cs",
+            "lines": [
+              "19"
+            ]
+          },
+          "version": 0
+        },
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsLine",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsMethod.verified.txt
@@ -1,0 +1,101 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "return": {
+            "captureExpressions": {
+              "inputValue": {
+                "type": "String",
+                "value": "testValue"
+              },
+              "localValue": {
+                "type": "Int32",
+                "value": "9"
+              },
+              "testStruct": {
+                "fields": {
+                  "Collection": {
+                    "elements": [
+                      {
+                        "type": "String",
+                        "value": "one"
+                      },
+                      {
+                        "type": "String",
+                        "value": "two"
+                      },
+                      {
+                        "type": "String",
+                        "value": "three"
+                      }
+                    ],
+                    "size": 3,
+                    "type": "List`1"
+                  },
+                  "Dictionary": {
+                    "entries": [
+                      [
+                        {
+                          "type": "String",
+                          "value": "one"
+                        },
+                        {
+                          "type": "String",
+                          "value": "first"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "String",
+                          "value": "two"
+                        },
+                        {
+                          "type": "String",
+                          "value": "second"
+                        }
+                      ]
+                    ],
+                    "size": 2,
+                    "type": "Dictionary`2"
+                  },
+                  "StringValue": {
+                    "type": "String",
+                    "value": "testValue"
+                  }
+                },
+                "type": "CaptureExpressionTestStruct"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsMethod"
+          },
+          "version": 0
+        },
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsMethod",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsMultipleProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CaptureExpressionsMultipleProbes.verified.txt
@@ -1,0 +1,151 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "return": {
+            "captureExpressions": {
+              "collection_first_element": {
+                "type": "String",
+                "value": "one"
+              },
+              "dictionary_value": {
+                "type": "String",
+                "value": "second"
+              },
+              "nested_field": {
+                "type": "String",
+                "value": "testValue"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsMultipleProbes"
+          },
+          "version": 0
+        },
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsMultipleProbes",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "return": {
+            "captureExpressions": {
+              "inputValue": {
+                "type": "String",
+                "value": "testValue"
+              },
+              "localValue": {
+                "type": "Int32",
+                "value": "9"
+              },
+              "testStruct": {
+                "fields": {
+                  "Collection": {
+                    "elements": [
+                      {
+                        "type": "String",
+                        "value": "one"
+                      },
+                      {
+                        "type": "String",
+                        "value": "two"
+                      },
+                      {
+                        "type": "String",
+                        "value": "three"
+                      }
+                    ],
+                    "size": 3,
+                    "type": "List`1"
+                  },
+                  "Dictionary": {
+                    "entries": [
+                      [
+                        {
+                          "type": "String",
+                          "value": "one"
+                        },
+                        {
+                          "type": "String",
+                          "value": "first"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "String",
+                          "value": "two"
+                        },
+                        {
+                          "type": "String",
+                          "value": "second"
+                        }
+                      ]
+                    ],
+                    "size": 2,
+                    "type": "Dictionary`2"
+                  },
+                  "StringValue": {
+                    "type": "String",
+                    "value": "testValue"
+                  }
+                },
+                "type": "CaptureExpressionTestStruct"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsMultipleProbes"
+          },
+          "version": 0
+        },
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.CaptureExpressionsMultipleProbes",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsComplex.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsComplex.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsLine.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsLine.verified.txt
@@ -1,0 +1,18 @@
+[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsMethod.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsMultipleProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CaptureExpressionsMultipleProbes.verified.txt
@@ -1,0 +1,34 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Emitted probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
@@ -166,12 +166,12 @@ internal static class DebuggerTestHelper
 
     internal static ProbeDefinition CreateDefaultLogProbe(string typeName, string methodName, DeterministicGuidGenerator guidGenerator, MethodProbeTestDataAttribute probeTestData = null)
     {
-        return CreateBasicProbe<LogProbe>(probeTestData?.ProbeId ?? guidGenerator.New().ToString()).WithSampling().WithDefaultTemplate().WithCapture(probeTestData?.CaptureSnapshot).WithMethodWhere(typeName, methodName, probeTestData: probeTestData);
+        return CreateBasicProbe<LogProbe>(probeTestData?.ProbeId ?? guidGenerator.New().ToString()).WithSampling().WithDefaultTemplate().WithCapture(probeTestData?.CaptureSnapshot).WithCaptureExpressions(probeTestData).WithMethodWhere(typeName, methodName, probeTestData: probeTestData);
     }
 
     internal static ProbeDefinition CreateLogLineProbe(Type type, LineProbeTestDataAttribute line, DeterministicGuidGenerator guidGenerator)
     {
-        return CreateBasicProbe<LogProbe>(line?.ProbeId ?? guidGenerator.New().ToString()).WithCapture(line?.CaptureSnapshot).WithSampling().WithTemplate(line).WithWhen(line).WithLineProbeWhere(type, line);
+        return CreateBasicProbe<LogProbe>(line?.ProbeId ?? guidGenerator.New().ToString()).WithCapture(line?.CaptureSnapshot).WithSampling().WithTemplate(line).WithWhen(line).WithCaptureExpressions(line).WithLineProbeWhere(type, line);
     }
 
     private static ProbeDefinition WithMethodWhere(this ProbeDefinition snapshot, string typeName, string methodName, MethodBase method = null, MethodProbeTestDataAttribute probeTestData = null)
@@ -266,6 +266,22 @@ internal static class DebuggerTestHelper
 
         snapshot.When = new SnapshotSegment(string.Empty, att.ConditionJson, null);
         snapshot.EvaluateAt = ParseEnum<EvaluateAt>(att.EvaluateAt);
+        return snapshot;
+    }
+
+    private static LogProbe WithCaptureExpressions(this LogProbe snapshot, ProbeAttributeBase att)
+    {
+        if (att == null || string.IsNullOrEmpty(att.CaptureExpressionsJson))
+        {
+            return snapshot;
+        }
+
+        snapshot.CaptureExpressions = JsonConvert.DeserializeObject<CaptureExpression[]>(att.CaptureExpressionsJson);
+        if (!string.IsNullOrEmpty(att.EvaluateAt))
+        {
+            snapshot.EvaluateAt = ParseEnum<EvaluateAt>(att.EvaluateAt);
+        }
+
         return snapshot;
     }
 
@@ -379,7 +395,7 @@ internal static class DebuggerTestHelper
             throw new InvalidOperationException("Probe attribute is null");
         }
 
-        return CreateBasicProbe<LogProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithCapture(probeTestData.CaptureSnapshot).WithSampling().WithTemplate(probeTestData).WithWhen(probeTestData).WithMethodWhere(typeName, method.Name, method, probeTestData);
+        return CreateBasicProbe<LogProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithCapture(probeTestData.CaptureSnapshot).WithSampling().WithTemplate(probeTestData).WithWhen(probeTestData).WithCaptureExpressions(probeTestData).WithMethodWhere(typeName, method.Name, method, probeTestData);
     }
 
     private static MethodProbeTestDataAttribute GetProbeTestData<T>(MethodBase method, int testIndex, out string typeName)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -483,6 +483,19 @@ public class ProbesTests : TestHelper
     [SkippableTheory]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
+    [InlineData(typeof(CaptureExpressionsMethod))]
+    [InlineData(typeof(CaptureExpressionsLine))]
+    [InlineData(typeof(CaptureExpressionsComplex))]
+    [InlineData(typeof(CaptureExpressionsMultipleProbes))]
+    public async Task CaptureExpressionProbeTest(Type testType)
+    {
+        var testDescription = DebuggerTestHelper.SpecificTestDescription(testType);
+        await RunCaptureExpressionProbeTest(testDescription);
+    }
+
+    [SkippableTheory]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
     [MemberData(nameof(SpanDecorationMemberData))]
     [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
     public async Task SpanDecorationTest(Type testType)
@@ -912,6 +925,61 @@ public class ProbesTests : TestHelper
         finally
         {
             await sample.StopSample();
+        }
+    }
+
+    private async Task RunCaptureExpressionProbeTest(ProbeTestDescription testDescription)
+    {
+        var probes = GetProbeConfiguration(testDescription.TestType, false, new DeterministicGuidGenerator());
+        var snapshotProbes = probes.Select(p => p.Probe).ToArray();
+
+        using var agent = EnvironmentHelper.GetMockAgent();
+        SetDebuggerEnvironment(agent);
+        using var logEntryWatcher = CreateLogEntryWatcher($"capture_expressions_{testDescription.TestType.Name}");
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        try
+        {
+            SetProbeConfiguration(agent, snapshotProbes);
+            await logEntryWatcher.WaitForLogEntry(AddedProbesInstrumentedLogEntry);
+
+            await sample.RunCodeSample();
+
+            var snapshots = await agent.WaitForSnapshots(snapshotProbes.Length);
+            Assert.Equal(snapshotProbes.Length, snapshots?.Length);
+            var captureExpressionNamesBySnapshot = new List<string[]>();
+            foreach (var snapshot in snapshots)
+            {
+                var token = JToken.Parse(snapshot);
+                var captureExpressionNames = GetCaptureExpressionNames(token);
+                captureExpressionNames.Should().NotBeEmpty();
+                captureExpressionNamesBySnapshot.Add(captureExpressionNames);
+                token.SelectToken("debugger.snapshot.captures.return.locals").Should().BeNull();
+                token.SelectToken("debugger.snapshot.captures.return.arguments").Should().BeNull();
+            }
+
+            if (snapshotProbes.Length > 1)
+            {
+                captureExpressionNamesBySnapshot
+                   .Select(names => string.Join(",", names))
+                   .Should()
+                   .OnlyHaveUniqueItems();
+            }
+
+            await ApproveSnapshots(snapshots, testDescription, isMultiPhase: false, phaseNumber: 1);
+        }
+        finally
+        {
+            await sample.StopSample();
+        }
+
+        static string[] GetCaptureExpressionNames(JToken token)
+        {
+            return token
+                  .SelectTokens("$..captureExpressions")
+                  .SelectMany(captureExpressions => captureExpressions.Children<JProperty>())
+                  .Select(property => property.Name)
+                  .OrderBy(name => name)
+                  .ToArray();
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -17,6 +17,7 @@ using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
 using VerifyTests;
 using VerifyXunit;
 using Xunit;
@@ -242,6 +243,59 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionEvaluator_CaptureExpressions_EvaluatesObjectValues()
+        {
+            var scopeMembers = CreateScopeMembers();
+            var evaluator = new ProbeExpressionEvaluator(
+                templates: null,
+                condition: null,
+                metric: null,
+                spanDecorations: null,
+                captureExpressions:
+                [
+                    new CaptureExpressionDefinition("inputValue", new DebuggerExpression(string.Empty, @"{""ref"":""StringArg""}", null), default),
+                    new CaptureExpressionDefinition("collection_first_element", new DebuggerExpression(string.Empty, @"{""index"":[{""ref"":""CollectionLocal""},0]}", null), default),
+                    new CaptureExpressionDefinition("dictionary_value", new DebuggerExpression(string.Empty, @"{""index"":[{""ref"":""DictionaryLocal""},""goodbye""]}", null), default),
+                    new CaptureExpressionDefinition("nested_field", new DebuggerExpression(string.Empty, @"{""getmember"":[{""ref"":""NestedObjectLocal""},""NestedString""]}", null), default)
+                ]);
+
+            ExpressionEvaluationResult result = default;
+            evaluator.EvaluateCaptureExpressions(ref result, scopeMembers);
+
+            result.CaptureExpressionCount.Should().Be(4);
+            result.CaptureExpressions.Should().HaveCountGreaterThanOrEqualTo(result.CaptureExpressionCount);
+            result.CaptureExpressions[0].Name.Should().Be("inputValue");
+            result.CaptureExpressions[0].Value.Should().Be("Hello world!");
+            result.CaptureExpressions[0].Type.Should().Be(typeof(string));
+            result.CaptureExpressions[1].Value.Should().Be("hello");
+            result.CaptureExpressions[2].Value.Should().Be("moon");
+            result.CaptureExpressions[3].Value.Should().Be("Hello from nested object");
+            result.Errors.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void ProbeExpressionEvaluator_CaptureExpressions_DoesNotCaptureParseFailures()
+        {
+            var scopeMembers = CreateScopeMembers();
+            var evaluator = new ProbeExpressionEvaluator(
+                templates: null,
+                condition: null,
+                metric: null,
+                spanDecorations: null,
+                captureExpressions:
+                [
+                    new CaptureExpressionDefinition("invalid", new DebuggerExpression(string.Empty, @"{""gt"":[{""ref"":""StringArg""},2]}", null), default)
+                ]);
+
+            ExpressionEvaluationResult result = default;
+            evaluator.EvaluateCaptureExpressions(ref result, scopeMembers);
+
+            result.CaptureExpressionCount.Should().Be(0);
+            result.CaptureExpressions.Should().BeNull();
+            result.Errors.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
         public void ProbeExpressionParser_ConstructedOpenGenericReferenceTypeParameter_CanCompileExpression()
         {
             var scopeMembers = CreateScopeMembers();
@@ -315,7 +369,7 @@ namespace Datadog.Trace.Tests.Debugger
                 scopeMembers.Exception,
                 scopeMembers.Members);
 
-            Assert.Null(result);
+            Assert.Same(UndefinedValue.Instance, result);
             var error = Assert.Single(compiled.Errors);
             Assert.Contains("generic value type parameter", error.Message);
         }
@@ -340,7 +394,7 @@ namespace Datadog.Trace.Tests.Debugger
                 scopeMembers.Exception,
                 scopeMembers.Members);
 
-            Assert.Null(result);
+            Assert.Same(UndefinedValue.Instance, result);
             var error = Assert.Single(compiled.Errors);
             Assert.Contains("recursive generic parameter constraints", error.Message);
         }
@@ -583,7 +637,7 @@ namespace Datadog.Trace.Tests.Debugger
                 throw new Exception($"{nameof(DebuggerExpressionLanguageTests)}.{nameof(GetEvaluator)}: Incorrect folder name");
             }
 
-            return (new ProbeExpressionEvaluator(templates, condition, metrics, spanDecorations), scopeMembers);
+            return (new ProbeExpressionEvaluator(templates, condition, metrics, spanDecorations, captureExpressions: null), scopeMembers);
         }
 
         private VerifySettings ConfigureVerifySettings(string expressionTestFilePath)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -167,6 +167,90 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void CaptureExpressions_AreWrittenWithoutArgumentsOrLocals()
+        {
+            var captureLimitInfo = new CaptureLimitInfo(
+                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+                MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+
+            var snapshotCreator = new DebuggerSnapshotCreator(
+                isFullSnapshot: false,
+                Datadog.Trace.Debugger.Expressions.ProbeLocation.Method,
+                hasCondition: false,
+                tags: [],
+                limitInfo: captureLimitInfo,
+                processTagsProvider: static () => null,
+                serviceNameProvider: static () => "test-service");
+
+            var evaluationResult = new ExpressionEvaluationResult
+            {
+                CaptureExpressionCount = 2,
+                CaptureExpressions =
+                [
+                    new ExpressionEvaluationResult.CaptureExpressionResult("inputValue", "testValue", typeof(string), captureLimitInfo),
+                    new ExpressionEvaluationResult.CaptureExpressionResult("localValue", 9, typeof(int), captureLimitInfo)
+                ]
+            };
+
+            snapshotCreator.StartReturn();
+            snapshotCreator.CaptureCaptureExpressions(ref evaluationResult);
+            snapshotCreator.EndReturn();
+
+            var captureInfo = new CaptureInfo<object>(
+                methodMetadataIndex: 0,
+                methodState: MethodState.ExitEnd,
+                value: new object(),
+                method: typeof(DebuggerSnapshotCreatorTests).GetMethod(nameof(DummyMethod), BindingFlags.NonPublic | BindingFlags.Static)!,
+                type: typeof(object),
+                invocationTargetType: typeof(object),
+                memberKind: ScopeMemberKind.This);
+
+            var snapshot = JObject.Parse(snapshotCreator.FinalizeMethodSnapshot("probe-id", 1, ref captureInfo));
+            var captureExpressions = snapshot.SelectToken("debugger.snapshot.captures.return.captureExpressions");
+            Assert.NotNull(captureExpressions);
+            Assert.Equal("testValue", captureExpressions!["inputValue"]?["value"]?.Value<string>());
+            Assert.Equal("9", captureExpressions["localValue"]?["value"]?.Value<string>());
+            Assert.Null(snapshot.SelectToken("debugger.snapshot.captures.return.locals"));
+            Assert.Null(snapshot.SelectToken("debugger.snapshot.captures.return.arguments"));
+        }
+
+        [Fact]
+        public void CaptureExpressions_AreSkippedWhenNoValuesWereCaptured()
+        {
+            var captureLimitInfo = new CaptureLimitInfo(
+                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+                MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+
+            var snapshotCreator = new DebuggerSnapshotCreator(
+                isFullSnapshot: false,
+                Datadog.Trace.Debugger.Expressions.ProbeLocation.Method,
+                hasCondition: false,
+                tags: [],
+                limitInfo: captureLimitInfo,
+                processTagsProvider: static () => null,
+                serviceNameProvider: static () => "test-service");
+
+            var evaluationResult = new ExpressionEvaluationResult();
+            snapshotCreator.SetEvaluationResult(ref evaluationResult);
+
+            var captureInfo = new CaptureInfo<object>(
+                methodMetadataIndex: 0,
+                methodState: MethodState.ExitEnd,
+                value: new object(),
+                method: typeof(DebuggerSnapshotCreatorTests).GetMethod(nameof(DummyMethod), BindingFlags.NonPublic | BindingFlags.Static)!,
+                type: typeof(object),
+                invocationTargetType: typeof(object),
+                memberKind: ScopeMemberKind.This);
+
+            var snapshot = JObject.Parse(snapshotCreator.FinalizeMethodSnapshot("probe-id", 1, ref captureInfo));
+            Assert.Null(snapshot.SelectToken("debugger.snapshot.captures.return"));
+        }
+
+        [Fact]
         public async Task SpecialType_StringBuilder()
         {
             await ValidateSingleValue(new StringBuilder("hi from stringbuilder"));

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationComparerTests.cs
@@ -169,6 +169,43 @@ public class ProbeConfigurationComparerTests
     }
 
     [Fact]
+    public void CurrentSnapshotsCaptureExpressionChanged_ProbeRelatedChanged()
+    {
+        var current = new ProbeConfiguration
+        {
+            LogProbes = new LogProbe[]
+            {
+                new()
+                {
+                    Id = "probe",
+                    CaptureExpressions =
+                    [
+                        new CaptureExpression { Name = "value", Expr = new SnapshotSegment(string.Empty, @"{""ref"":""value""}", null) }
+                    ]
+                }
+            }
+        };
+        var incoming = new ProbeConfiguration
+        {
+            LogProbes = new LogProbe[]
+            {
+                new()
+                {
+                    Id = "probe",
+                    CaptureExpressions =
+                    [
+                        new CaptureExpression { Name = "value", Expr = new SnapshotSegment(string.Empty, @"{""ref"":""otherValue""}", null) }
+                    ]
+                }
+            }
+        };
+
+        var comparer = new ProbeConfigurationComparer(current, incoming);
+        comparer.HasProbeRelatedChanges.Should().BeTrue();
+        comparer.HasRateLimitChanged.Should().BeTrue();
+    }
+
+    [Fact]
     public void CurrentSnaphotsWhereValue_IncomingSnapshotsWhereSameValue_ProbeRelatedChanged()
     {
         var current = new ProbeConfiguration { LogProbes = new LogProbe[] { new LogProbe() { Where = new Where() { Lines = new[] { "56" }, SourceFile = "c:/temp/temp.log" } } } };

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationFileLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeConfigurationFileLoaderTests.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Datadog.Trace.Debugger.Configurations;
+using Datadog.Trace.Debugger.Configurations.Models;
 using FluentAssertions;
 using Xunit;
 
@@ -194,6 +195,54 @@ public class ProbeConfigurationFileLoaderTests : IDisposable
         configuration.Should().NotBeNull();
         configuration!.MetricProbes.Should().BeEmpty();
         configuration.LogProbes.Should().ContainSingle().Which.Id.Should().Be("valid-log");
+    }
+
+    [Fact]
+    public async Task LoadAsync_LogProbeWithCaptureExpressions_LoadsExpressionsAndLimits()
+    {
+        var configuration = await ProbeConfigurationFileLoader.LoadAsync(
+            CreateTempProbeFile(
+                """
+                [
+                  {
+                    "id": "capture-expression-log",
+                    "language": "dotnet",
+                    "type": "LOG_PROBE",
+                    "where": { "typeName": "MyClass", "methodName": "MyMethod" },
+                    "captureSnapshot": false,
+                    "captureExpressions": [
+                      {
+                        "name": "inputValue",
+                        "expr": {
+                          "dsl": "inputValue",
+                          "json": { "ref": "inputValue" }
+                        },
+                        "capture": {
+                          "maxReferenceDepth": 1,
+                          "maxCollectionSize": 2,
+                          "maxLength": 3,
+                          "maxFieldCount": 4
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """));
+
+        configuration.Should().NotBeNull();
+        var probe = configuration!.LogProbes.Should().ContainSingle().Subject;
+        probe.CaptureExpressions.Should().ContainSingle();
+        var captureExpression = probe.CaptureExpressions![0];
+        captureExpression.Name.Should().Be("inputValue");
+        captureExpression.Expr!.Dsl.Should().Be("inputValue");
+        captureExpression.Expr.Json!.ToString(Datadog.Trace.Vendors.Newtonsoft.Json.Formatting.None).Should().Be(@"{""ref"":""inputValue""}");
+        captureExpression.Capture.Should().Be(new Capture
+        {
+            MaxReferenceDepth = 1,
+            MaxCollectionSize = 2,
+            MaxLength = 3,
+            MaxFieldCount = 4
+        });
     }
 
     public void Dispose()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -28,12 +28,11 @@ public class ProbeProcessorTests
     public void ConditionEvaluationErrorsAreDroppedWhenSamplerRejects()
     {
         var processor = CreateConditionalProbeProcessor();
-        var snapshotCreator = CreateSnapshotCreator();
         var sampler = new TestAdaptiveSampler(false);
         var probeData = new ProbeData("probe-id", sampler, processor);
         var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
 
-        Assert.True(processor.ShouldProcess(in probeData));
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
         Assert.Equal(0, sampler.SampleCalls);
 
         Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
@@ -45,12 +44,11 @@ public class ProbeProcessorTests
     public void ConditionEvaluationErrorsAreCapturedWhenSamplerKeeps()
     {
         var processor = CreateConditionalProbeProcessor();
-        var snapshotCreator = CreateSnapshotCreator();
         var sampler = new TestAdaptiveSampler(true);
         var probeData = new ProbeData("probe-id", sampler, processor);
         var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
 
-        Assert.True(processor.ShouldProcess(in probeData));
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
         Assert.Equal(0, sampler.SampleCalls);
 
         Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
@@ -62,12 +60,11 @@ public class ProbeProcessorTests
     public void ConditionEvaluationExceptionsAreDroppedWhenSamplerRejects()
     {
         var processor = CreateConditionalProbeProcessor();
-        var snapshotCreator = CreateSnapshotCreator();
         var sampler = new TestAdaptiveSampler(false);
         var probeData = new ProbeData("probe-id", sampler, processor);
         var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
 
-        Assert.True(processor.ShouldProcess(in probeData));
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
         Assert.Equal(0, sampler.SampleCalls);
 
         Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
@@ -80,9 +77,9 @@ public class ProbeProcessorTests
     public void CaptureExpressionOnlyProbeEvaluatesAndSerializesResults()
     {
         var processor = CreateCaptureExpressionProbeProcessor();
-        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
         var sampler = new TestAdaptiveSampler(true);
         var probeData = new ProbeData("probe-id", sampler, processor);
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
         var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
 
         Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
@@ -95,9 +92,9 @@ public class ProbeProcessorTests
     public void CaptureExpressionOnlyProbeIgnoresNullCaptureExpressionEntries()
     {
         var processor = CreateCaptureExpressionProbeProcessor(includeNullEntry: true);
-        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
         var sampler = new TestAdaptiveSampler(true);
         var probeData = new ProbeData("probe-id", sampler, processor);
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
         var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
 
         Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
@@ -109,9 +106,9 @@ public class ProbeProcessorTests
     public void CaptureExpressionOnlyProbeIgnoresEmptyNameCaptureExpressionEntries()
     {
         var processor = CreateCaptureExpressionProbeProcessor(includeEmptyNameEntry: true);
-        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
         var sampler = new TestAdaptiveSampler(true);
         var probeData = new ProbeData("probe-id", sampler, processor);
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
         var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
 
         Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
@@ -123,14 +120,14 @@ public class ProbeProcessorTests
     public void CaptureExpressionOnlyProbeDropsSnapshotWhenNoExpressionsCaptureValues()
     {
         var processor = CreateUndefinedCaptureExpressionProbeProcessor();
-        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
         var sampler = new TestAdaptiveSampler(true);
         var probeData = new ProbeData("probe-id", sampler, processor);
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
         var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
 
         Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
         Assert.False(ProcessExitEnd(processor, snapshotCreator, in probeData, method));
-        Assert.Equal(0, sampler.SampleCalls);
+        Assert.Equal(1, sampler.SampleCalls);
     }
 
     private static ProbeProcessor CreateConditionalProbeProcessor()
@@ -198,22 +195,10 @@ public class ProbeProcessorTests
             });
     }
 
-    private static DebuggerSnapshotCreator CreateSnapshotCreator()
+    private static DebuggerSnapshotCreator CreateSnapshotCreator(ProbeProcessor processor, in ProbeData probeData)
     {
-        var captureLimitInfo = new CaptureLimitInfo(
-            MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
-            MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
-            MaxLength: DebuggerSettings.DefaultMaxStringLength,
-            MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
-
-        return new DebuggerSnapshotCreator(
-            isFullSnapshot: false,
-            ProbeLocation.Method,
-            hasCondition: true,
-            tags: [],
-            limitInfo: captureLimitInfo,
-            processTagsProvider: static () => null,
-            serviceNameProvider: static () => "test-service");
+        Assert.True(processor.TryBeginProcess(in probeData, out var snapshotCreator));
+        return (DebuggerSnapshotCreator)snapshotCreator;
     }
 
     private static bool ProcessEntryStart(ProbeProcessor processor, DebuggerSnapshotCreator snapshotCreator, in ProbeData probeData, MethodInfo method)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -127,7 +127,26 @@ public class ProbeProcessorTests
 
         Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
         Assert.False(ProcessExitEnd(processor, snapshotCreator, in probeData, method));
+        // TryBeginProcess is the production entry gate, so non-conditional probes sample before capture-expression evaluation can drop the snapshot.
         Assert.Equal(1, sampler.SampleCalls);
+    }
+
+    [Fact]
+    public void SnapshotCreatorKeepsPublishedStateAfterProcessorUpdate()
+    {
+        var processor = CreateVersionedCaptureExpressionProbeProcessor("probe-id", version: 1, captureName: "inputValue");
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
+
+        processor.UpdateProbeProcessor(CreateVersionedCaptureExpressionProbe("probe-id", version: 2, captureName: "missingValue"));
+
+        Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessLogArg(processor, snapshotCreator, in probeData, method, "inputValue", "testValue"));
+        Assert.True(ProcessExitEnd(processor, snapshotCreator, in probeData, method));
+        Assert.Equal(1, snapshotCreator.ProbeProcessorState!.ProbeInfo.ProbeVersion);
+        Assert.Equal("probe-id", snapshotCreator.ProbeProcessorState.ProbeInfo.ProbeId);
     }
 
     private static ProbeProcessor CreateConditionalProbeProcessor()
@@ -172,6 +191,32 @@ public class ProbeProcessorTests
                             new CaptureExpression { Name = "localValue", Expr = new SnapshotSegment(string.Empty, @"{""ref"":""localValue""}", null) }
                         ]
             });
+    }
+
+    private static ProbeProcessor CreateVersionedCaptureExpressionProbeProcessor(string probeId, int version, string captureName)
+    {
+        return new ProbeProcessor(CreateVersionedCaptureExpressionProbe(probeId, version, captureName));
+    }
+
+    private static LogProbe CreateVersionedCaptureExpressionProbe(string probeId, int version, string captureName)
+    {
+        return new LogProbe
+        {
+            Id = probeId,
+            Version = version,
+            CaptureSnapshot = false,
+            EvaluateAt = EvaluateAt.Exit,
+            Tags = [],
+            Where = new Where
+            {
+                TypeName = typeof(SampleTarget).FullName!,
+                MethodName = nameof(SampleTarget.ExecuteWithValue)
+            },
+            CaptureExpressions =
+            [
+                new CaptureExpression { Name = captureName, Expr = new SnapshotSegment(string.Empty, @"{""ref"":""inputValue""}", null) }
+            ]
+        };
     }
 
     private static ProbeProcessor CreateUndefinedCaptureExpressionProbeProcessor()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Expressions;
-using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
 using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Debugger.Snapshots;
@@ -77,6 +76,63 @@ public class ProbeProcessorTests
         Assert.Equal(1, sampler.SampleCalls);
     }
 
+    [Fact]
+    public void CaptureExpressionOnlyProbeEvaluatesAndSerializesResults()
+    {
+        var processor = CreateCaptureExpressionProbeProcessor();
+        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
+
+        Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessLogArg(processor, snapshotCreator, in probeData, method, "inputValue", "testValue"));
+        Assert.True(ProcessLogLocal(processor, snapshotCreator, in probeData, method, "localValue", 9));
+        Assert.True(ProcessExitEnd(processor, snapshotCreator, in probeData, method));
+    }
+
+    [Fact]
+    public void CaptureExpressionOnlyProbeIgnoresNullCaptureExpressionEntries()
+    {
+        var processor = CreateCaptureExpressionProbeProcessor(includeNullEntry: true);
+        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
+
+        Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessLogArg(processor, snapshotCreator, in probeData, method, "inputValue", "testValue"));
+        Assert.True(ProcessExitEnd(processor, snapshotCreator, in probeData, method));
+    }
+
+    [Fact]
+    public void CaptureExpressionOnlyProbeIgnoresEmptyNameCaptureExpressionEntries()
+    {
+        var processor = CreateCaptureExpressionProbeProcessor(includeEmptyNameEntry: true);
+        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
+
+        Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessLogArg(processor, snapshotCreator, in probeData, method, "inputValue", "testValue"));
+        Assert.True(ProcessExitEnd(processor, snapshotCreator, in probeData, method));
+    }
+
+    [Fact]
+    public void CaptureExpressionOnlyProbeDropsSnapshotWhenNoExpressionsCaptureValues()
+    {
+        var processor = CreateUndefinedCaptureExpressionProbeProcessor();
+        var snapshotCreator = (DebuggerSnapshotCreator)processor.CreateSnapshotCreator();
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.ExecuteWithValue))!;
+
+        Assert.True(ProcessExitStart(processor, snapshotCreator, in probeData, method));
+        Assert.False(ProcessExitEnd(processor, snapshotCreator, in probeData, method));
+        Assert.Equal(0, sampler.SampleCalls);
+    }
+
     private static ProbeProcessor CreateConditionalProbeProcessor()
     {
         return new ProbeProcessor(
@@ -92,6 +148,53 @@ public class ProbeProcessorTests
                     MethodName = nameof(SampleTarget.Execute)
                 },
                 When = new SnapshotSegment(dsl: string.Empty, json: InvalidConditionJson, str: string.Empty)
+            });
+    }
+
+    private static ProbeProcessor CreateCaptureExpressionProbeProcessor(bool includeNullEntry = false, bool includeEmptyNameEntry = false)
+    {
+        return new ProbeProcessor(
+            new LogProbe
+            {
+                Id = "probe-id",
+                CaptureSnapshot = false,
+                EvaluateAt = EvaluateAt.Exit,
+                Tags = [],
+                Where = new Where
+                {
+                    TypeName = typeof(SampleTarget).FullName!,
+                    MethodName = nameof(SampleTarget.ExecuteWithValue)
+                },
+                CaptureExpressions =
+                    includeNullEntry
+                        ? [null, new CaptureExpression { Name = "inputValue", Expr = new SnapshotSegment(string.Empty, @"{""ref"":""inputValue""}", null) }]
+                        : includeEmptyNameEntry
+                            ? [new CaptureExpression { Name = string.Empty, Expr = new SnapshotSegment(string.Empty, @"{""ref"":""localValue""}", null) }, new CaptureExpression { Name = "inputValue", Expr = new SnapshotSegment(string.Empty, @"{""ref"":""inputValue""}", null) }]
+                        : [
+                            new CaptureExpression { Name = "inputValue", Expr = new SnapshotSegment(string.Empty, @"{""ref"":""inputValue""}", null) },
+                            new CaptureExpression { Name = "localValue", Expr = new SnapshotSegment(string.Empty, @"{""ref"":""localValue""}", null) }
+                        ]
+            });
+    }
+
+    private static ProbeProcessor CreateUndefinedCaptureExpressionProbeProcessor()
+    {
+        return new ProbeProcessor(
+            new LogProbe
+            {
+                Id = "probe-id",
+                CaptureSnapshot = false,
+                EvaluateAt = EvaluateAt.Exit,
+                Tags = [],
+                Where = new Where
+                {
+                    TypeName = typeof(SampleTarget).FullName!,
+                    MethodName = nameof(SampleTarget.ExecuteWithValue)
+                },
+                CaptureExpressions =
+                [
+                    new CaptureExpression { Name = "missingValue" }
+                ]
             });
     }
 
@@ -143,6 +246,67 @@ public class ProbeProcessorTests
         return processor.Process(ref captureInfo, snapshotCreator, in probeData);
     }
 
+    private static bool ProcessExitStart(ProbeProcessor processor, DebuggerSnapshotCreator snapshotCreator, in ProbeData probeData, MethodInfo method)
+    {
+        var captureInfo = new CaptureInfo<string>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.ExitStart,
+            value: "result",
+            name: "@return",
+            method: method,
+            type: typeof(string),
+            invocationTargetType: method.DeclaringType!,
+            memberKind: ScopeMemberKind.Return,
+            localsCount: 1,
+            argumentsCount: 1);
+
+        return processor.Process(ref captureInfo, snapshotCreator, in probeData);
+    }
+
+    private static bool ProcessLogArg<T>(ProbeProcessor processor, DebuggerSnapshotCreator snapshotCreator, in ProbeData probeData, MethodInfo method, string name, T value)
+    {
+        var captureInfo = new CaptureInfo<T>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.LogArg,
+            name: name,
+            value: value,
+            method: method,
+            type: value?.GetType() ?? typeof(T),
+            invocationTargetType: method.DeclaringType!,
+            memberKind: ScopeMemberKind.Argument);
+
+        return processor.Process(ref captureInfo, snapshotCreator, in probeData);
+    }
+
+    private static bool ProcessLogLocal<T>(ProbeProcessor processor, DebuggerSnapshotCreator snapshotCreator, in ProbeData probeData, MethodInfo method, string name, T value)
+    {
+        var captureInfo = new CaptureInfo<T>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.LogLocal,
+            name: name,
+            value: value,
+            method: method,
+            type: value?.GetType() ?? typeof(T),
+            invocationTargetType: method.DeclaringType!,
+            memberKind: ScopeMemberKind.Local);
+
+        return processor.Process(ref captureInfo, snapshotCreator, in probeData);
+    }
+
+    private static bool ProcessExitEnd(ProbeProcessor processor, DebuggerSnapshotCreator snapshotCreator, in ProbeData probeData, MethodInfo method)
+    {
+        var captureInfo = new CaptureInfo<SampleTarget>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.ExitEnd,
+            value: new SampleTarget(),
+            method: method,
+            type: typeof(SampleTarget),
+            invocationTargetType: typeof(SampleTarget),
+            memberKind: ScopeMemberKind.This);
+
+        return processor.Process(ref captureInfo, snapshotCreator, in probeData);
+    }
+
     private static void ClearMethodScopeMembers(DebuggerSnapshotCreator snapshotCreator)
     {
         typeof(DebuggerSnapshotCreator)
@@ -154,6 +318,12 @@ public class ProbeProcessorTests
     {
         public void Execute()
         {
+        }
+
+        public string ExecuteWithValue(string inputValue)
+        {
+            var localValue = inputValue.Length;
+            return localValue.ToString();
         }
     }
 

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionTestData.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionTestData.cs
@@ -1,0 +1,59 @@
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    internal static class CaptureExpressionTestData
+    {
+        internal const string BasicExpressionsJson = @"[
+    {
+        ""name"": ""inputValue"",
+        ""expr"": {
+            ""dsl"": ""inputValue"",
+            ""json"": { ""ref"": ""inputValue"" }
+        },
+        ""capture"": { ""maxReferenceDepth"": 1 }
+    },
+    {
+        ""name"": ""localValue"",
+        ""expr"": {
+            ""dsl"": ""localValue"",
+            ""json"": { ""ref"": ""localValue"" }
+        },
+        ""capture"": { ""maxReferenceDepth"": 1 }
+    },
+    {
+        ""name"": ""testStruct"",
+        ""expr"": {
+            ""dsl"": ""testStruct"",
+            ""json"": { ""ref"": ""testStruct"" }
+        },
+        ""capture"": { ""maxReferenceDepth"": 2 }
+    }
+]";
+
+        internal const string ComplexExpressionsJson = @"[
+    {
+        ""name"": ""collection_first_element"",
+        ""expr"": {
+            ""dsl"": ""testStruct.Collection[0]"",
+            ""json"": { ""index"": [{ ""getmember"": [{ ""ref"": ""testStruct"" }, ""Collection""] }, 0] }
+        },
+        ""capture"": { ""maxReferenceDepth"": 2 }
+    },
+    {
+        ""name"": ""dictionary_value"",
+        ""expr"": {
+            ""dsl"": ""testStruct.Dictionary['two']"",
+            ""json"": { ""index"": [{ ""getmember"": [{ ""ref"": ""testStruct"" }, ""Dictionary""] }, ""two""] }
+        },
+        ""capture"": { ""maxReferenceDepth"": 2 }
+    },
+    {
+        ""name"": ""nested_field"",
+        ""expr"": {
+            ""dsl"": ""testStruct.StringValue"",
+            ""json"": { ""getmember"": [{ ""ref"": ""testStruct"" }, ""StringValue""] }
+        },
+        ""capture"": { ""maxReferenceDepth"": 2 }
+    }
+]";
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsComplex.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsComplex.cs
@@ -1,0 +1,27 @@
+using System.Runtime.CompilerServices;
+using Samples.Probes.TestRuns.Shared;
+
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    public class CaptureExpressionsComplex : IRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method("testValue");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData(
+            captureSnapshot: false,
+            evaluateAt: Const.Exit,
+            returnTypeName: "System.String",
+            parametersTypeName: new[] { "System.String" },
+            CaptureExpressionsJson = CaptureExpressionTestData.ComplexExpressionsJson)]
+        public string Method(string inputValue)
+        {
+            var testStruct = new CaptureExpressionsMethod.CaptureExpressionTestStruct(inputValue);
+            return testStruct.StringValue;
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsLine.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsLine.cs
@@ -1,0 +1,22 @@
+using System.Runtime.CompilerServices;
+
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    [LogLineProbeTestData(lineNumber: 19, captureSnapshot: false, CaptureExpressionsJson = CaptureExpressionTestData.BasicExpressionsJson)]
+    public class CaptureExpressionsLine : IRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method("testValue");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string Method(string inputValue)
+        {
+            var localValue = inputValue.Length;
+            var testStruct = new CaptureExpressionsMethod.CaptureExpressionTestStruct(inputValue);
+            return $"{localValue}:{testStruct.StringValue}";
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsMethod.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsMethod.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Samples.Probes.TestRuns.Shared;
+
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    public class CaptureExpressionsMethod : IRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method("testValue");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData(
+            captureSnapshot: false,
+            evaluateAt: Const.Exit,
+            returnTypeName: "System.String",
+            parametersTypeName: new[] { "System.String" },
+            CaptureExpressionsJson = CaptureExpressionTestData.BasicExpressionsJson)]
+        public string Method(string inputValue)
+        {
+            var localValue = inputValue.Length;
+            var testStruct = new CaptureExpressionTestStruct(inputValue);
+            return $"{localValue}:{testStruct.StringValue}";
+        }
+
+        public readonly struct CaptureExpressionTestStruct
+        {
+            public CaptureExpressionTestStruct(string stringValue)
+            {
+                StringValue = stringValue;
+                Collection = new List<string> { "one", "two", "three" };
+                Dictionary = new Dictionary<string, string> { { "one", "first" }, { "two", "second" } };
+            }
+
+            public string StringValue { get; }
+
+            public List<string> Collection { get; }
+
+            public Dictionary<string, string> Dictionary { get; }
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsMultipleProbes.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/CaptureExpressionsMultipleProbes.cs
@@ -1,0 +1,34 @@
+using System.Runtime.CompilerServices;
+using Samples.Probes.TestRuns.Shared;
+
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    public class CaptureExpressionsMultipleProbes : IRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method("testValue");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData(
+            captureSnapshot: false,
+            evaluateAt: Const.Exit,
+            returnTypeName: "System.String",
+            parametersTypeName: new[] { "System.String" },
+            CaptureExpressionsJson = CaptureExpressionTestData.BasicExpressionsJson)]
+        [LogMethodProbeTestData(
+            captureSnapshot: false,
+            evaluateAt: Const.Exit,
+            returnTypeName: "System.String",
+            parametersTypeName: new[] { "System.String" },
+            CaptureExpressionsJson = CaptureExpressionTestData.ComplexExpressionsJson)]
+        public string Method(string inputValue)
+        {
+            var localValue = inputValue.Length;
+            var testStruct = new CaptureExpressionsMethod.CaptureExpressionTestStruct(inputValue);
+            return $"{localValue}:{testStruct.StringValue}";
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ProbeAttributeBase.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ProbeAttributeBase.cs
@@ -4,7 +4,7 @@ namespace Samples.Probes.TestRuns;
 
 public class ProbeAttributeBase : Attribute
 {
-    public ProbeAttributeBase(bool skip, int phase, bool unlisted, int expectedNumberOfSnapshots, string[] skipOnFrameworks, bool captureSnapshot = true, string evaluateAt = null, string conditionJson = null, string templateJson = null, string templateStr = null, string probeId = null, bool expectProbeStatusFailure = false)
+    public ProbeAttributeBase(bool skip, int phase, bool unlisted, int expectedNumberOfSnapshots, string[] skipOnFrameworks, bool captureSnapshot = true, string evaluateAt = null, string conditionJson = null, string templateJson = null, string templateStr = null, string probeId = null, bool expectProbeStatusFailure = false, string captureExpressionsJson = null)
     {
         Skip = skip;
         Phase = phase;
@@ -18,6 +18,7 @@ public class ProbeAttributeBase : Attribute
         TemplateStr = templateStr;
 		ProbeId = probeId;
         ExpectProbeStatusFailure = expectProbeStatusFailure;
+        CaptureExpressionsJson = captureExpressionsJson;
     }
 
     public bool Skip { get; }
@@ -32,4 +33,5 @@ public class ProbeAttributeBase : Attribute
     public string TemplateJson { get; set; }
     public string TemplateStr { get; set; }
     public bool ExpectProbeStatusFailure { get; set; }
+    public string CaptureExpressionsJson { get; set; }
 }


### PR DESCRIPTION
## Summary of changes

- Adds capture expressions support for non-snapshot log probes.
- Allows capture-expression probes to emit selected values without capturing full arguments or locals.
- Adds debugger integration test scenarios and approved snapshots for method, line, complex, and multi-probe capture-expression cases.
- Publishes probe processor configuration as a captured per-invocation state, so concurrent probe updates cannot mix old and new probe info, evaluator inputs, or capture-expression settings.

## Reason for change

- Enables Dynamic Instrumentation log probes to capture targeted values with lower payload size and less exposure than full snapshots.
- Supports richer expression-based capture scenarios while preserving existing log probe behavior.
- The processor state publication fix addresses a pre-existing update race, but this PR adds new capture-expression state to the same processor configuration group. Fixing it here keeps the new feature from increasing the risk of mixed old/new probe configuration during concurrent updates.
- Keeping the concurrency fix in this PR also avoids splitting tightly overlapping `ProbeProcessor` and debugger invocation changes across multiple PRs, which would likely create conflict-heavy follow-up work.


## Implementation details

- Capture expressions are compiled through the object-valued expression parser path because expressions can return arbitrary runtime values.
- `UndefinedValue` is used as a sentinel for expressions that do not produce a capturable value, so `null` can remain a valid captured value.
- Capture-expression-only log probes use snapshot serialization for selected values but skip full locals/arguments capture.
- Probe processor updates now publish an immutable `ProbeProcessorState` instead of mutating evaluator inputs, expression fields, capture-expression state, and `ProbeInfo` in place.


## Test coverage

- `ProbeProcessorTests|DebuggerExpressionLanguageTests|Debugger.DebuggerSnapshotCreatorTests|ProbeConfigurationComparerTests|ProbeConfigurationFileLoaderTests`
- `IntegrationTests.ProbesTests.CaptureExpressionProbeTest`
