### PR TITLE
Tag gitlab include refs as migration touchpoints

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,10 @@ stages:
 
 include:
   - local: .gitlab/one-pipeline.locked.yml
+  # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
+  # GitLab does not expand top-level `variables:` inside `include:` keywords,
+  # so we cannot parameterize this group path the way we do for trigger jobs
+  # and scripts below. Update this line by hand at org-split cutover.
   - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
     file: '.gitlab/ci-dotnet-aspnet-realworld-parallel.yml'
     ref: 'main'

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -1,4 +1,8 @@
 include:
+  # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
+  # GitLab does not expand top-level `variables:` inside `include:` keywords,
+  # so the group path cannot be parameterized here. Update both `project:`
+  # lines by hand at org-split cutover.
   - project: 'DataDog/benchmarking-platform-tools'
     file: 'images/templates/gitlab/check-slo-breaches.template.yml'
   - project: 'DataDog/benchmarking-platform-tools'
@@ -569,8 +573,10 @@ profiler_cpu_timer_create-arm64:
 
     RUNNER_AFTER_SCRIPT_TIMEOUT: 1h
 
-    # Allows ephemeral instances to read content from benchmarking-platform
-    DDOCTOSTS_SCOPE: "DataDog/benchmarking-platform"
+    # Allows ephemeral instances to read content from benchmarking-platform.
+    # benchmarking-platform is an internal repo on GitHub, so its org tracks
+    # GITHUB_ORG_INTERNAL (see .gitlab-ci.yml variables block).
+    DDOCTOSTS_SCOPE: "${GITHUB_ORG_INTERNAL}/benchmarking-platform"
     DDOCTOSTS_POLICY: "gitlab.github-access.read-contents"
 
     AWS_REGION: "us-east-1"

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -574,8 +574,6 @@ profiler_cpu_timer_create-arm64:
     RUNNER_AFTER_SCRIPT_TIMEOUT: 1h
 
     # Allows ephemeral instances to read content from benchmarking-platform.
-    # benchmarking-platform is an internal repo on GitHub, so its org tracks
-    # GITHUB_ORG_INTERNAL (see .gitlab-ci.yml variables block).
     DDOCTOSTS_SCOPE: "${GITHUB_ORG_INTERNAL}/benchmarking-platform"
     DDOCTOSTS_POLICY: "gitlab.github-access.read-contents"
 


### PR DESCRIPTION
## Summary of changes

Follow-up to #8426.

- Parameterize the remaining internal `DDOCTOSTS_SCOPE` in `macrobenchmarks.yml`.
- Tag the three `include: project: 'DataDog/...'` lines as `MIGRATION TOUCHPOINT`s. These can't be parameterized — GitLab evaluates `include:` before top-level `variables:` is in scope ([docs](https://docs.gitlab.com/ee/ci/yaml/includes.html)) — so the comments make them greppable at cutover.

## Reason for change

GitHub org / GitLab group split mitigation.

## Implementation details

- `.gitlab-ci.yml:14` and `.gitlab/benchmarks/macrobenchmarks.yml:1` — touchpoint comments.
- `.gitlab/benchmarks/macrobenchmarks.yml:577` — `DDOCTOSTS_SCOPE` → `"${GITHUB_ORG_INTERNAL}/benchmarking-platform"`.

## Test coverage

No behavior change: `GITHUB_ORG_INTERNAL` defaults to `DataDog`.

## Other details

Non-URL mitigations (runners, registry, `id_tokens`, schedules/secrets recreation) need infra coordination and are out of scope.
