### PR TITLE
Use latest benchmark tooling image for macrobenchmark AMI build

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -66,7 +66,7 @@ check-azure-pipeline:
 build-dd-trace-dotnet-macrobenchmarks-ami:
   stage: build-win
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:dd-trace-dotnet-macro
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
   allow_failure: true
   when: manual
   timeout: 3h


### PR DESCRIPTION
## Summary of changes

Point `build-dd-trace-dotnet-macrobenchmarks-ami` to `benchmarking-platform-tools-ubuntu:latest` instead of the `dd-trace-dotnet-macro` tag.

## Reason for change

The `dd-trace-dotnet-macro` image tag is stale and missing newer bp-infra features needed for the DD agent upgrade step.

[APMSP-2993 Allow upgrading DD agent version on Windows benchmarking AMIs](https://datadoghq.atlassian.net/browse/APMSP-2993)

## Implementation details

Single line change in `.gitlab/benchmarks/macrobenchmarks.yml`.

## Test coverage

AMI rebuild triggered manually to verify: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1679352081

## Other details