### PR TITLE
[SINT-5051] Upgrade CI Identities GitLab Job Client version to v0.6.3

### DIFF
--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -41,7 +41,7 @@ COPY install_dotnet.ps1 .
 RUN powershell -Command .\install_dotnet.ps1  -Version $ENV:DOTNET_VERSION -Sha512 $ENV:DOTNET_SHA512 $ENV:DOTNET_DOWNLOAD_URL
 
 # Copy the CI Identities GitLab Job Client
-COPY --from=registry.ddbuild.io/ci-identities/ci-identities-gitlab-job-client:v0.2.0-windows-amd64 C:/ci-identities-gitlab-job-client.exe c:/devtools/ci-identities-gitlab-job-client.exe
+COPY --from=registry.ddbuild.io/ci-identities/ci-identities-gitlab-job-client:v0.6.3-windows-amd64 C:/ci-identities-gitlab-job-client.exe c:/devtools/ci-identities-gitlab-job-client.exe
 
 # Java and code signing tool environment variables
 ENV JAVA_VERSION "25.0.1"


### PR DESCRIPTION
## Summary of changes
The goal of this PR is to update the ci-identities gitlab client to the latest version. 
## Reason for change
For better observability mostly.
See changelog : [link](https://github.com/ddoghq/ci-identities/blob/main/apps/ci-identities-gitlab-job-client/CHANGELOG.md)
