### PR TITLE
[Code Origin] Treat Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore as 3rd party

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ThirdParty/ThirdPartyModules.Names.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ThirdParty/ThirdPartyModules.Names.cs
@@ -2153,6 +2153,7 @@ internal static partial class ThirdPartyModules
         "Microsoft.Azure.Functions.Worker.ApplicationInsights",
         "Microsoft.Azure.Functions.Worker.Core",
         "Microsoft.Azure.Functions.Worker.Extensions.Abstractions",
+        "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
         "Microsoft.Azure.Functions.Worker.Extensions.Http",
         "Microsoft.Azure.Functions.Worker.Extensions.OpenApi",
         "Microsoft.Azure.Functions.Worker.Extensions.Rpc",


### PR DESCRIPTION
## Summary of changes

- Add `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore` to the embedded `ThirdPartyModules` name list.

## Reason for change

- `AssemblyFilter.ShouldSkipAssembly` (used by `SpanCodeOrigin.SetCodeOriginForEntrySpan`) consults `ThirdPartyModules.Contains` for case-sensitive exact-match membership against the assembly's simple name.
- That assembly hosts `Microsoft.AspNetCore.Http.FunctionsHttpContextExtensions`, which is what ASP.NET Core endpoint resolution surfaces for Azure Functions Isolated HTTP triggers. Because the assembly was missing from the list, Code Origin attributes the entry frame to `FunctionsHttpContextExtensions.InvokeFunctionAsync` - a framework method - instead of skipping the assembly entirely.

## Implementation details

- Single-line insertion, placed in the correct position within the `Microsoft.Azure.Functions.Worker.*` family.