### PR TITLE
Refactor remote config for ASM to fix missing config

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/ConfigurationState.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ConfigurationState.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Datadog.Trace.AppSec.Rcm.Models.Asm;
 using Datadog.Trace.AppSec.Rcm.Models.AsmData;
@@ -24,10 +25,16 @@ using Action = Datadog.Trace.AppSec.Rcm.Models.Asm.Action;
 namespace Datadog.Trace.AppSec.Rcm;
 
 /// <summary>
-/// This class represents the state of RCM for ASM.
-/// It has 2 possible status:
-/// - ASM is not activated, and _fileUpdates/_fileRemoves contain some pending non-deserialized changes to apply when ASM_FEATURES activate ASM. Every time an RC payload is received here, pending changes are reset to the last ones
-/// - ASM is activated, stored configs in _fileUpdates/_fileRemoves are applied every time.
+/// This class represents the state of RCM for ASM. `_pendingByProduct` accumulates RCM operations
+/// (updates and removes) keyed by config path, with "latest op wins" semantics. RCM only forwards
+/// deltas, so configs received while ASM is disabled must persist across polls — otherwise they'd
+/// be silently dropped when ASM finally activates.
+///
+/// Each product slot is drained by its last consumer:
+/// - ASM_FEATURES is drained inside `ApplyAsmFeatures` (the FEATURES updater is its only consumer).
+/// - ASM_DD / ASM / ASM_DATA are drained at the end of `BuildWafUpdatePayload`, which is the last
+///   reader of those slots in the cycle. When ASM is disabled and that method isn't called, the
+///   WAF-relevant slots persist across polls (which is what enables the accumulator behavior).
 /// </summary>
 internal sealed record ConfigurationState
 {
@@ -41,8 +48,13 @@ internal sealed record ConfigurationState
 
     private readonly string? _rulesPath;
     private readonly bool _canBeToggled;
-    private readonly Dictionary<string, List<RemoteConfiguration>> _fileUpdates = new();
-    private readonly Dictionary<string, List<RemoteConfigurationPath>> _fileRemoves = new();
+
+    // Pending RCM operations grouped by product. Outer key is product, inner key is the full config path.
+    // Each path can hold one pending op (later update or remove overwrites whatever was there) — the RCM
+    // "latest delta wins" semantics. Drained per-product by the last consumer: ASM_FEATURES inside
+    // ApplyAsmFeatures, WAF-relevant products at the end of BuildWafUpdatePayload.
+    private readonly Dictionary<string, Dictionary<string, PendingOperation>> _pendingByProduct = new();
+
     private bool _defaultRulesetApplied;
 
     public ConfigurationState(SecuritySettings settings, IConfigurationTelemetry telemetry, bool wafIsNull)
@@ -130,15 +142,29 @@ internal sealed record ConfigurationState
         return [.. subscriptionsKeys];
     }
 
-    internal RemoteConfigWafFiles GetWafConfigurations(bool updating = false)
+    /// <summary>
+    /// Builds the payload to push to the WAF (updates + removes) by reading pending RCM operations
+    /// and the deserialized destination dictionaries.
+    /// </summary>
+    /// <remarks>
+    /// This method is the last consumer of WAF-relevant pending entries in an RCM cycle, so it
+    /// DRAINS the ASM_DD / ASM / ASM_DATA slots of <see cref="_pendingByProduct"/> on its way out.
+    /// Calling it twice in the same cycle will return an empty delta the second time.
+    /// </remarks>
+    internal RemoteConfigWafFiles BuildWafUpdatePayload(bool updating = false)
     {
         updating &= !IncomingUpdateState.ShouldInitAppsec; // If we need to init AppSec we don't want to skip any config
         var configurations = new Dictionary<string, object>();
         List<string>? removes = null;
 
-        if (updating && _fileRemoves is { Count: > 0 })
+        if (updating && _pendingByProduct.Count > 0)
         {
-            removes = _fileRemoves.SelectMany(p => p.Value).Where(p => p.Product != RcmProducts.AsmFeatures).Select(v => v.Path).ToList();
+            removes = _pendingByProduct
+                     .Where(entry => entry.Key != RcmProducts.AsmFeatures)
+                     .SelectMany(p => p.Value.Values)
+                     .Where(op => op.IsRemove)
+                     .Select(v => v.Path.Path)
+                     .ToList();
         }
 
         if (AsmConfigs is { Count: > 0 })
@@ -190,13 +216,22 @@ internal sealed record ConfigurationState
             }
         }
 
+        // Drain WAF-relevant pending slots. ASM_FEATURES is handled separately in ApplyAsmFeatures.
+        foreach (var entry in _pendingByProduct)
+        {
+            if (entry.Key == RcmProducts.AsmFeatures) { continue; }
+            entry.Value.Clear();
+        }
+
         return new(configurations.Count > 0 ? configurations : null, removes);
 
+        // True if `path` has a pending update (not a remove) in any WAF-relevant product slot.
         bool IsNewUpdate(string path)
         {
-            foreach (var productUpdates in _fileUpdates)
+            foreach (var entry in _pendingByProduct)
             {
-                if (productUpdates.Value.Any(u => u.Path.Path == path))
+                if (entry.Key == RcmProducts.AsmFeatures) { continue; }
+                if (entry.Value.TryGetValue(path, out var op) && !op.IsRemove)
                 {
                     return true;
                 }
@@ -207,79 +242,98 @@ internal sealed record ConfigurationState
     }
 
     /// <summary>
-    /// Calls each product updater to deserialize all remote config payloads and store them properly in dictionaries which might involve various logical merges
-    /// This method deserializes everything stored in _fileUpdates. ConfigurationStatus will have a *bigger* memory footprint.
+    /// Hands each product's pending batch to its updater, which deserializes and merges into the destination
+    /// dictionaries (RulesetConfigs / AsmConfigs / AsmDataConfigs). Pending entries are NOT cleared here —
+    /// <see cref="BuildWafUpdatePayload"/> still needs to read them to know what's new in this cycle's delta,
+    /// and is responsible for draining them on the way out.
     /// </summary>
     public void ApplyStoredFiles()
     {
-        // no need to clear _fileUpdates / _fileRemoves after they've been applied, as when we receive a new config, `StoreLastConfigState` method will clear anything remaining anyway.
         foreach (var updater in _productConfigUpdaters)
         {
-            var fileRemoves = _fileRemoves.TryGetValue(updater.Key, out var removes);
-            var fileUpdates = _fileUpdates.TryGetValue(updater.Key, out var updates);
-            if (fileRemoves || fileUpdates)
+            if (_pendingByProduct.TryGetValue(updater.Key, out var pending) && pending.Count != 0)
             {
+                SplitPending(pending, out var removes, out var updates);
                 updater.Value.ProcessUpdates(this, removes, updates);
             }
         }
     }
 
     /// <summary>
-    /// This method just stores the config state without deserializing anything, this state will be ready to use and deserialized if ASM is enabled later on.
-    /// This method considers that RC sends us everything again, the whole state together. That's why it's clearing all unapplied updates / removals before processing the last ones received.
-    /// In case ASM remained disabled, we discard previous updates and removals stored here that were never applied.
+    /// Merges an incoming RCM delta into the per-product pending state without deserializing payloads.
+    /// If ASM is enabled (or this delta turns it on), the merged state is applied immediately; otherwise it stays pending until ASM activates.
     /// </summary>
-    /// <param name="configsByProduct">configsByProduct</param>
-    /// <param name="removedConfigs">removedConfigs</param>
+    /// <remarks>
+    /// Background: RCM forwards only the DELTA versus what we last acknowledged — not the full backend state.
+    /// A config received in an earlier poll is NOT re-sent on the next poll if it hasn't changed.
+    /// So while ASM is disabled, we must accumulate deltas across polls, otherwise configs received
+    /// before activation would be silently dropped (they're already in RCM's _appliedConfigurations
+    /// and won't be re-forwarded). Each path holds exactly one pending op in _pendingByProduct;
+    /// a later update or remove for the same path overwrites whatever was there.
+    /// </remarks>
     public void ReceivedNewConfig(Dictionary<string, List<RemoteConfiguration>> configsByProduct, Dictionary<string, List<RemoteConfigurationPath>>? removedConfigs)
     {
-        _fileUpdates.Clear();
-        _fileRemoves.Clear();
-        // if we just have asm features, it might only be to toggle appsec. Other products bring actual configurations to the waf.
-        var hasUpdateConfigurations = false;
         var anyChange = configsByProduct.Count > 0 || removedConfigs?.Count > 0;
         if (anyChange)
         {
-            if (removedConfigs != null)
+            // Tracks whether this delta touches any product OTHER than ASM_FEATURES. A pure ASM_FEATURES
+            // delta might only toggle AppSec on/off, it doesn't carry WAF rules, so when that's all we get,
+            // there's no reason to push a config update through to the WAF below.
+            var hasUpdateConfigurations = false;
+
+            if (removedConfigs is not null)
             {
-                foreach (var configByProductToRemove in removedConfigs)
+                foreach (var entry in removedConfigs)
                 {
-                    if (configByProductToRemove.Key != RcmProducts.AsmFeatures)
+                    var productKey = entry.Key;
+                    if (productKey != RcmProducts.AsmFeatures)
                     {
                         hasUpdateConfigurations = true;
                     }
 
-                    if (_fileRemoves.TryGetValue(configByProductToRemove.Key, out var remove))
+                    if (!_pendingByProduct.TryGetValue(productKey, out var pending))
                     {
-                        remove.AddRange(configByProductToRemove.Value);
+                        pending = new Dictionary<string, PendingOperation>();
+                        _pendingByProduct[productKey] = pending;
                     }
-                    else
+
+                    foreach (var removed in entry.Value)
                     {
-                        _fileRemoves[configByProductToRemove.Key] = configByProductToRemove.Value;
+                        // Overwrites any pending update OR pending remove for this path. Later op wins.
+                        pending[removed.Path] = new PendingOperation(removed, update: null);
                     }
                 }
             }
 
-            foreach (var configByProduct in configsByProduct)
+            foreach (var entry in configsByProduct)
             {
-                if (configByProduct.Key != RcmProducts.AsmFeatures)
+                var productKey = entry.Key;
+                if (productKey != RcmProducts.AsmFeatures)
                 {
                     hasUpdateConfigurations = true;
                 }
 
-                if (_fileUpdates.TryGetValue(configByProduct.Key, out var update))
+                if (!_pendingByProduct.TryGetValue(productKey, out var pending))
                 {
-                    update.AddRange(configByProduct.Value);
+                    pending = new Dictionary<string, PendingOperation>();
+                    _pendingByProduct[productKey] = pending;
                 }
-                else
+
+                foreach (var update in entry.Value)
                 {
-                    _fileUpdates[configByProduct.Key] = configByProduct.Value;
+                    // Same overwrite semantics — replaces any prior op for this path.
+                    pending[update.Path.Path] = new PendingOperation(update.Path, update);
                 }
             }
 
+            // ASM_FEATURES is processed eagerly because it can flip AppsecEnabled and decide whether
+            // we initialize the WAF, update an already-running WAF, or do nothing.
             ApplyAsmFeatures(AppsecEnabled);
             IncomingUpdateState.ShouldUpdateAppsec = !IncomingUpdateState.ShouldInitAppsec && AppsecEnabled && hasUpdateConfigurations;
 
+            // If ASM just turned on, or it was already on and we got real WAF config, deserialize pending
+            // state into the per-product output dictionaries (RulesetConfigs, AsmConfigs, AsmDataConfigs).
+            // The pending entries themselves stay around until BuildWafUpdatePayload drains them.
             if (IncomingUpdateState.ShouldUpdateAppsec || IncomingUpdateState.ShouldInitAppsec)
             {
                 ApplyStoredFiles();
@@ -291,15 +345,14 @@ internal sealed record ConfigurationState
     {
         // only deserialize and apply asm_features as it will decide if asm gets toggled on and if we deserialize all the others
         // (the enable of auto user instrumentation as added to asm_features)
-        var change = _fileRemoves.TryGetValue(RcmProducts.AsmFeatures, out var removals);
-        change |= _fileUpdates.TryGetValue(RcmProducts.AsmFeatures, out var updates);
-
-        if (change)
+        if (!_pendingByProduct.TryGetValue(RcmProducts.AsmFeatures, out var pending) || pending.Count == 0)
         {
-            _asmFeatureProduct.ProcessUpdates(this, removals, updates);
+            return;
         }
 
-        if (!change) { return; }
+        SplitPending(pending, out var removals, out var updates);
+        _asmFeatureProduct.ProcessUpdates(this, removals, updates);
+        pending.Clear();
 
         // normally CanBeToggled should not need a check as asm_features capacity is only sent if AppSec env var is null, but still guards it in case
         if (_canBeToggled)
@@ -339,6 +392,39 @@ internal sealed record ConfigurationState
         {
             AutoUserInstrumMode = autoUserInstrumMode?.Mode?.ToLowerInvariant();
         }
+    }
+
+    // Splits the per-product pending map into the (removes, updates) shape that IAsmConfigUpdater.ProcessUpdates expects.
+    // Either out parameter may be null when that side is empty — matching the interface contract.
+    private static void SplitPending(Dictionary<string, PendingOperation> pending, out List<RemoteConfigurationPath>? removes, out List<RemoteConfiguration>? updates)
+    {
+        removes = null;
+        updates = null;
+        foreach (var op in pending.Values)
+        {
+            if (op.IsRemove)
+            {
+                removes ??= [];
+                removes.Add(op.Path);
+            }
+            else
+            {
+                updates ??= [];
+                updates.Add(op.Update);
+            }
+        }
+    }
+
+    // A pending RCM operation for one config path: either an update carrying a fresh payload,
+    // or a removal marker. The Update field is null iff this entry represents a removal.
+    private readonly struct PendingOperation(RemoteConfigurationPath path, RemoteConfiguration? update)
+    {
+        public RemoteConfigurationPath Path { get; } = path;
+
+        public RemoteConfiguration? Update { get; } = update;
+
+        [MemberNotNullWhen(false, nameof(Update))]
+        public bool IsRemove => Update is null;
     }
 
     internal sealed record IncomingUpdateStatus : IDisposable

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -133,7 +133,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
             else
             {
                 // Apply the stored configuration
-                var configs = configurationState.GetWafConfigurations(updating);
+                var configs = configurationState.BuildWafUpdatePayload(updating);
 
                 if (configs.HasData)
                 {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ConfigurationStateTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ConfigurationStateTests.cs
@@ -1,0 +1,382 @@
+// <copyright file="ConfigurationStateTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Text;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Rcm;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+public class ConfigurationStateTests
+{
+    private const string AsmDdPath1 = "datadog/00/ASM_DD/rules1/config";
+    private const string AsmDdPath2 = "datadog/00/ASM_DD/rules2/config";
+    private const string AsmPath1 = "datadog/00/ASM/overrides1/config";
+    private const string AsmDataPath1 = "datadog/00/ASM_DATA/blocked_ips/config";
+    private const string AsmDataPath2 = "datadog/00/ASM_DATA/blocked_users/config";
+    private const string AsmFeaturesPath = "datadog/00/ASM_FEATURES/asm/config";
+
+    // Regression test for the bug where pending ASM_DD configs received while ASM is
+    // disabled were wiped by `_fileUpdates.Clear()` on every ReceivedNewConfig call.
+    // RCM only forwards deltas, so a later ASM_FEATURES-only poll wouldn't re-include
+    // the ruleset — and ASM would initialize without the custom rules.
+    [Fact]
+    public void PendingAsmDdConfig_IsApplied_WhenAsmFeaturesEnablesAsmInLaterPoll()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Poll 1: backend sends an ASM_DD ruleset; ASM still disabled so nothing is applied yet.
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath1), removedConfigs: null);
+        configurationState.RulesetConfigs.Should().BeEmpty("ASM is disabled, so nothing has been applied yet");
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeFalse();
+
+        // Poll 2: backend now sends ASM_FEATURES enabling ASM. RCM does NOT re-send the
+        // unchanged ASM_DD config — it's already in _appliedConfigurations on the RCM side.
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.RulesetConfigs.Should().ContainSingle(r => r.Key == AsmDdPath1, "the pending ASM_DD config from poll 1 must survive into the enable transition");
+    }
+
+    [Fact]
+    public void PendingRemove_CancelsEarlierPendingUpdate_ForSamePath()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Poll 1: add an ASM_DD config.
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath1), removedConfigs: null);
+
+        // Poll 2: backend removes that same config (e.g. user deleted it).
+        configurationState.ReceivedNewConfig(new(), BuildRemoves(RcmProducts.AsmDd, AsmDdPath1));
+
+        // Poll 3: ASM_FEATURES enables ASM. The earlier update + later remove for the
+        // same path must NOT result in the config being applied.
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.RulesetConfigs.Should().BeEmpty("the pending update must have been cancelled by the subsequent remove");
+    }
+
+    [Fact]
+    public void PendingUpdate_CancelsEarlierPendingRemove_ForSamePath()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Poll 1: a remove arrives (e.g. ASM was previously enabled and a config got removed).
+        configurationState.ReceivedNewConfig(new(), BuildRemoves(RcmProducts.AsmDd, AsmDdPath1));
+
+        // Poll 2: backend re-adds a config at the same path.
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath1), removedConfigs: null);
+
+        // Poll 3: ASM_FEATURES enables ASM. The remove from poll 1 must NOT wipe the update from poll 2.
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.RulesetConfigs.Should().ContainSingle(r => r.Key == AsmDdPath1, "the later update must override the earlier remove");
+    }
+
+    [Fact]
+    public void RepeatedUpdatesForSamePath_DoNotAccumulateInPendingState()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Push three updates for the same path across three polls.
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath1), removedConfigs: null);
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath1), removedConfigs: null);
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath1), removedConfigs: null);
+
+        // And one update for a different path to confirm both coexist correctly.
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath2), removedConfigs: null);
+
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+
+        configurationState.RulesetConfigs.Should().HaveCount(2);
+        configurationState.RulesetConfigs.Should().Contain(r => r.Key == AsmDdPath1);
+        configurationState.RulesetConfigs.Should().Contain(r => r.Key == AsmDdPath2);
+    }
+
+    [Fact]
+    public void PendingAsmConfig_IsApplied_WhenAsmFeaturesEnablesAsmInLaterPoll()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Same scenario as the ASM_DD regression test, but for the ASM product (rule overrides, exclusions, etc.).
+        configurationState.ReceivedNewConfig(BuildAsmUpdate(AsmPath1), removedConfigs: null);
+        configurationState.AsmConfigs.Should().BeEmpty("ASM is disabled, so nothing has been applied yet");
+
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.AsmConfigs.Should().ContainKey(AsmPath1, "the pending ASM config must survive into the enable transition");
+    }
+
+    [Fact]
+    public void PendingAsmDataConfig_IsApplied_WhenAsmFeaturesEnablesAsmInLaterPoll()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        configurationState.ReceivedNewConfig(BuildAsmDataUpdate(AsmDataPath1), removedConfigs: null);
+        configurationState.AsmDataConfigs.Should().BeEmpty("ASM is disabled, so nothing has been applied yet");
+
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.AsmDataConfigs.Should().ContainKey(AsmDataPath1, "the pending ASM_DATA config must survive into the enable transition");
+    }
+
+    // ASM can be toggled off and on via ASM_FEATURES. The deserialized destination dictionaries
+    // (RulesetConfigs / AsmConfigs / AsmDataConfigs) are not cleared when ASM is disabled, so a
+    // re-enable should restore the previously applied configs without requiring RCM to re-send them.
+    [Fact]
+    public void DisableThenReEnableCycle_PreservesAppliedConfigs()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Poll 1: enable ASM and apply a ruleset.
+        configurationState.ReceivedNewConfig(MergeProducts(BuildAsmFeaturesUpdate(enabled: true), BuildAsmDdUpdate(AsmDdPath1)), removedConfigs: null);
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.RulesetConfigs.Should().ContainSingle(r => r.Key == AsmDdPath1);
+        CompletePoll(configurationState);
+
+        // Poll 2: disable ASM via ASM_FEATURES.
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: false), removedConfigs: null);
+        configurationState.IncomingUpdateState.ShouldDisableAppsec.Should().BeTrue();
+        configurationState.RulesetConfigs.Should().ContainSingle(r => r.Key == AsmDdPath1, "deserialized state must survive a disable");
+        CompletePoll(configurationState);
+
+        // Poll 3: re-enable ASM. RCM does not re-send the ruleset (unchanged on the backend).
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.RulesetConfigs.Should().ContainSingle(r => r.Key == AsmDdPath1, "the previously applied ruleset must still be active after the disable/re-enable cycle");
+    }
+
+    // BuildWafUpdatePayload(updating: true) is the path used when ASM is already running and a new RCM
+    // delta arrives. It must only push the *changed* configs to the WAF — not the full applied state —
+    // otherwise every poll re-ships every config across the FFI boundary.
+    [Fact]
+    public void BuildWafUpdatePayload_UpdatingMode_OnlyIncludesCurrentPollDelta()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Poll 1: enable ASM with one ASM_DATA config. This is the init poll (updating=false path).
+        configurationState.ReceivedNewConfig(MergeProducts(BuildAsmFeaturesUpdate(enabled: true), BuildAsmDataUpdate(AsmDataPath1)), removedConfigs: null);
+        configurationState.IncomingUpdateState.ShouldInitAppsec.Should().BeTrue();
+        configurationState.AsmDataConfigs.Should().ContainKey(AsmDataPath1);
+        DrainAndCompletePoll(configurationState);
+
+        // Poll 2: a NEW ASM_DATA config arrives; AsmDataPath1 is unchanged so RCM does not resend it.
+        configurationState.ReceivedNewConfig(BuildAsmDataUpdate(AsmDataPath2), removedConfigs: null);
+        configurationState.IncomingUpdateState.ShouldUpdateAppsec.Should().BeTrue();
+        configurationState.AsmDataConfigs.Should().HaveCount(2, "the deserialized state retains both configs");
+
+        var wafFiles = configurationState.BuildWafUpdatePayload(updating: true);
+
+        wafFiles.Updates.Should().NotBeNull();
+        wafFiles.Updates!.Should().ContainKey(AsmDataPath2, "only the newly-changed config should be shipped to the WAF");
+        wafFiles.Updates.Should().NotContainKey(AsmDataPath1, "an unchanged config from a previous poll must not be re-pushed");
+        wafFiles.Removes.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public void BuildWafUpdatePayload_UpdatingMode_IncludesRemovesFromCurrentPoll()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Poll 1: enable + add a config.
+        configurationState.ReceivedNewConfig(MergeProducts(BuildAsmFeaturesUpdate(enabled: true), BuildAsmDataUpdate(AsmDataPath1)), removedConfigs: null);
+        DrainAndCompletePoll(configurationState);
+
+        // Poll 2: remove the config.
+        configurationState.ReceivedNewConfig(new(), BuildRemoves(RcmProducts.AsmData, AsmDataPath1));
+        configurationState.IncomingUpdateState.ShouldUpdateAppsec.Should().BeTrue();
+        configurationState.AsmDataConfigs.Should().NotContainKey(AsmDataPath1, "the remove was applied to deserialized state");
+
+        var wafFiles = configurationState.BuildWafUpdatePayload(updating: true);
+
+        wafFiles.Removes.Should().NotBeNullOrEmpty();
+        wafFiles.Removes!.Should().Contain(AsmDataPath1, "the WAF must be told about the remove on this poll");
+    }
+
+    // BuildWafUpdatePayload is a destructive read: it drains the WAF-relevant pending slots on its way out
+    // so that subsequent update polls only see the next poll's delta. Calling it twice in the same cycle
+    // returns an empty delta the second time.
+    [Fact]
+    public void BuildWafUpdatePayload_DrainsPendingAfterRead()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        configurationState.ReceivedNewConfig(MergeProducts(BuildAsmFeaturesUpdate(enabled: true), BuildAsmDataUpdate(AsmDataPath1)), removedConfigs: null);
+        DrainAndCompletePoll(configurationState);
+
+        configurationState.ReceivedNewConfig(BuildAsmDataUpdate(AsmDataPath2), removedConfigs: null);
+        configurationState.IncomingUpdateState.ShouldUpdateAppsec.Should().BeTrue();
+
+        // First call returns the delta.
+        var firstCall = configurationState.BuildWafUpdatePayload(updating: true);
+        firstCall.Updates.Should().NotBeNull();
+        firstCall.Updates!.Should().ContainKey(AsmDataPath2);
+
+        // Second call: pending was drained, so IsNewUpdate returns false for everything in the dest dicts.
+        var secondCall = configurationState.BuildWafUpdatePayload(updating: true);
+        secondCall.Updates.Should().BeNull("the destructive read drained pending; the second call sees nothing new");
+        secondCall.Removes.Should().BeNullOrEmpty();
+    }
+
+    // Verifies the drain-on-cycle-end behavior holds across consecutive update polls — configs applied
+    // in earlier polls must not bleed into later WAF update payloads.
+    [Fact]
+    public void ConsecutiveUpdatePolls_DoNotLeakBetweenPolls()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Init poll: enable + one config. Drain via BuildWafUpdatePayload (init path).
+        configurationState.ReceivedNewConfig(MergeProducts(BuildAsmFeaturesUpdate(enabled: true), BuildAsmDataUpdate(AsmDataPath1)), removedConfigs: null);
+        DrainAndCompletePoll(configurationState);
+
+        // Update poll N: a new ASM_DATA config.
+        configurationState.ReceivedNewConfig(BuildAsmDataUpdate(AsmDataPath2), removedConfigs: null);
+        var payloadN = configurationState.BuildWafUpdatePayload(updating: true);
+        payloadN.Updates!.Should().ContainKey(AsmDataPath2);
+        payloadN.Updates.Should().NotContainKey(AsmDataPath1, "configs applied during init must not appear in subsequent update payloads");
+        CompletePoll(configurationState);
+
+        // Update poll N+1: a config under a different product. Earlier polls' configs must still not leak.
+        configurationState.ReceivedNewConfig(BuildAsmUpdate(AsmPath1), removedConfigs: null);
+        var payloadN1 = configurationState.BuildWafUpdatePayload(updating: true);
+        payloadN1.Updates!.Should().ContainKey(AsmPath1);
+        payloadN1.Updates.Should().NotContainKey(AsmDataPath1);
+        payloadN1.Updates.Should().NotContainKey(AsmDataPath2, "configs applied in earlier update polls must not bleed into later update payloads");
+    }
+
+    // After a disable/re-enable cycle, a subsequent update poll must not re-push the previously-applied
+    // configs to the WAF — they're already in its state. Only the current poll's delta should ship.
+    [Fact]
+    public void DisableThenReEnable_DoesNotRePushAppliedConfigsToWaf()
+    {
+        var configurationState = CreateTogglableConfigurationState();
+
+        // Poll 1: enable + ruleset. Drain on the init WAF call.
+        configurationState.ReceivedNewConfig(MergeProducts(BuildAsmFeaturesUpdate(enabled: true), BuildAsmDdUpdate(AsmDdPath1)), removedConfigs: null);
+        DrainAndCompletePoll(configurationState);
+
+        // Poll 2: disable. Production does NOT call BuildWafUpdatePayload on disable, so use plain CompletePoll.
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: false), removedConfigs: null);
+        CompletePoll(configurationState);
+
+        // Poll 3: re-enable. Init path again — drains pending.
+        configurationState.ReceivedNewConfig(BuildAsmFeaturesUpdate(enabled: true), removedConfigs: null);
+        DrainAndCompletePoll(configurationState);
+
+        // Poll 4: a NEW ASM_DD config arrives. The WAF update payload must contain ONLY the new config.
+        configurationState.ReceivedNewConfig(BuildAsmDdUpdate(AsmDdPath2), removedConfigs: null);
+        var payload = configurationState.BuildWafUpdatePayload(updating: true);
+        payload.Updates.Should().NotBeNull();
+        payload.Updates!.Should().ContainKey(AsmDdPath2);
+        payload.Updates.Should().NotContainKey(AsmDdPath1, "configs applied before the disable cycle must not be re-pushed to the WAF on later update polls");
+    }
+
+    private static ConfigurationState CreateTogglableConfigurationState()
+    {
+        // Empty source: DD_APPSEC_ENABLED is unset, so SecuritySettings.CanBeToggled is true and AppsecEnabled is false.
+        var source = new NameValueConfigurationSource(new NameValueCollection());
+        var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
+        settings.CanBeToggled.Should().BeTrue();
+        settings.AppsecEnabled.Should().BeFalse();
+        return new ConfigurationState(settings, NullConfigurationTelemetry.Instance, wafIsNull: true);
+    }
+
+    private static Dictionary<string, List<RemoteConfiguration>> BuildAsmDdUpdate(string path)
+    {
+        // A minimal non-empty rules document. AsmDdProduct.ProcessUpdates only requires HasValues=true on the top-level JObject to take the standard parsing path.
+        var ruleSetJson = new JObject { ["version"] = "2.2" };
+        var bytes = Encoding.UTF8.GetBytes(ruleSetJson.ToString());
+        var rcPath = RemoteConfigurationPath.FromPath(path);
+        var rc = new RemoteConfiguration(rcPath, bytes, bytes.Length, new(), 1);
+        return new Dictionary<string, List<RemoteConfiguration>> { { RcmProducts.AsmDd, new List<RemoteConfiguration> { rc } } };
+    }
+
+    private static Dictionary<string, List<RemoteConfiguration>> BuildAsmFeaturesUpdate(bool enabled)
+    {
+        var featuresJson = new JObject { ["asm"] = new JObject { ["enabled"] = enabled } };
+        var bytes = Encoding.UTF8.GetBytes(featuresJson.ToString());
+        var rcPath = RemoteConfigurationPath.FromPath(AsmFeaturesPath);
+        var rc = new RemoteConfiguration(rcPath, bytes, bytes.Length, new(), 1);
+        return new Dictionary<string, List<RemoteConfiguration>> { { RcmProducts.AsmFeatures, new List<RemoteConfiguration> { rc } } };
+    }
+
+    private static Dictionary<string, List<RemoteConfiguration>> BuildAsmUpdate(string path)
+    {
+        // AsmGenericProduct stores the raw JToken keyed by path — any payload that deserializes to a JToken works.
+        var payload = new JObject { ["exclusions"] = new JArray() };
+        var bytes = Encoding.UTF8.GetBytes(payload.ToString());
+        var rcPath = RemoteConfigurationPath.FromPath(path);
+        var rc = new RemoteConfiguration(rcPath, bytes, bytes.Length, new(), 1);
+        return new Dictionary<string, List<RemoteConfiguration>> { { RcmProducts.Asm, new List<RemoteConfiguration> { rc } } };
+    }
+
+    private static Dictionary<string, List<RemoteConfiguration>> BuildAsmDataUpdate(string path)
+    {
+        var payload = new JObject { ["rules_data"] = new JArray() };
+        var bytes = Encoding.UTF8.GetBytes(payload.ToString());
+        var rcPath = RemoteConfigurationPath.FromPath(path);
+        var rc = new RemoteConfiguration(rcPath, bytes, bytes.Length, new(), 1);
+        return new Dictionary<string, List<RemoteConfiguration>> { { RcmProducts.AsmData, new List<RemoteConfiguration> { rc } } };
+    }
+
+    private static Dictionary<string, List<RemoteConfigurationPath>> BuildRemoves(string product, params string[] paths)
+    {
+        var list = new List<RemoteConfigurationPath>(paths.Length);
+        foreach (var p in paths)
+        {
+            list.Add(RemoteConfigurationPath.FromPath(p));
+        }
+
+        return new Dictionary<string, List<RemoteConfigurationPath>> { { product, list } };
+    }
+
+    // Combines per-product update dicts into a single payload (the way RCM delivers a mixed delta).
+    private static Dictionary<string, List<RemoteConfiguration>> MergeProducts(params Dictionary<string, List<RemoteConfiguration>>[] dicts)
+    {
+        var merged = new Dictionary<string, List<RemoteConfiguration>>();
+        foreach (var dict in dicts)
+        {
+            foreach (var kvp in dict)
+            {
+                merged[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return merged;
+    }
+
+    // Mirrors what Security.UpdateFromRcm does at the end of an RCM cycle when no WAF update happens
+    // (disable, or empty delta): commit the AppsecEnabled state and reset the per-poll flags.
+    private static void CompletePoll(ConfigurationState state)
+    {
+        if (state.IncomingUpdateState.ShouldInitAppsec) { state.AppsecEnabled = true; }
+        if (state.IncomingUpdateState.ShouldDisableAppsec) { state.AppsecEnabled = false; }
+        state.IncomingUpdateState.Reset();
+    }
+
+    // Mirrors a cycle where production would call _waf.Create/Update — which invokes BuildWafUpdatePayload
+    // and drains the WAF-relevant pending slots. Use after an init/update poll when you want the next poll
+    // to start with empty pending (the way production behaves between WAF-updating polls).
+    private static void DrainAndCompletePoll(ConfigurationState state)
+    {
+        var updating = state.IncomingUpdateState.ShouldUpdateAppsec;
+        _ = state.BuildWafUpdatePayload(updating);
+        CompletePoll(state);
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Fix incorrect behaviour in ASM remote config application, caused by incorrect assumptions of RCM behaviour
- Refactoring to avoid unbounded collection growth
- Associated refactoring to "simplify" (none of this is simple 😅)

## Reason for change

`ReceivedNewConfig()` is responsible for "remembering" ASM config it receives when ASM is _disabled_, so that they can be applied if/when ASM is _enabled_ via remote config. `ReceivedNewConfig()` was explictily clearing pending updates and removes as it assumed that when we receive the "full" config each time, but that's not the case. Consequently, it means that you'd "lose" any previous config when a new incremental update came in.

The "simple" fix is to stop clearing those collections. But that gives _other_ problems:

- You have an unbounded growth of the updates/removes
- You have to handle updates coming in one config, then removed in other

Consequently, a larger refactor was required.

## Implementation details

- Added a bunch of comments to try to track the flow a bit better, this stuff is super confusing 😅 
- Combine `_fileUpdates` and `_fileRemoves` into a single dictionary `_pendingByProduct`, to make tracking update then delete then update changes more easily without needing to search lists.
- Don't clear the collection of previous configs in `ReceivedNewConfig()`. This was the original bug.
- Switch to dictionary's for de-duping `Path` instead of lists (required, because we're not clearing each call, so duplicates are possible/likely, and could grow unbounded)
- Rename `GetWafConfigurations` -> `BuildWafUpdatePayload` because this mutates the `_pendingByProduct` collection

For the record, this is like the 5th iteration of this code, it's _really_ not nice to work with 😅 

## Test coverage

Added some regression tests, because there were none at all before. Can't _guarantee_ all the invariants are correct though unfortunately given the lack of existing tests 😟 
