### PR TITLE
[Code Origin] Optimize per-assembly PDB cache

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -240,7 +240,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                 }
                 catch (Exception ex)
                 {
-                    Log.Warning(ex, "Error while getting endpoints for {AssemblyName} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
+                    Log.Debug(ex, "Error while getting endpoints for {AssemblyName} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
                     sequencePoints = null;
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -240,7 +240,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Error while getting endpoints for {AssemblyName} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
+                    Log.Warning(ex, "Error while getting endpoints for {AssemblyName} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
                     sequencePoints = null;
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -240,7 +240,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Error while getting endpoints for assembly: {AssemblyName}", assembly.Location);
+                    Log.Error(ex, "Error while getting endpoints for {AssemblyName} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
                     sequencePoints = null;
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -6,12 +6,11 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
-using Datadog.Trace.Debugger.Caching;
+using System.Runtime.CompilerServices;
 using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
@@ -24,8 +23,14 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SpanCodeOrigin));
 
-        private readonly ConcurrentAdaptiveCache<Assembly, AssemblyPdbInfo?> _assemblyPdbCache = new();
-        private readonly ConcurrentDictionary<Assembly, bool> _assemblySkipCache = new();
+        // ConditionalWeakTable keys are weak, so a collectible AssemblyLoadContext can unload without being rooted by this cache.
+        // Per-assembly Lazy<T> deduplicates concurrent first-touches on the *same* assembly while allowing *different* assemblies to scan in parallel.
+
+        // Per-assembly analysis results (skip decision + sequence points), keyed weakly by Assembly.
+        private readonly ConditionalWeakTable<Assembly, Lazy<AssemblyAnalysis>> _assemblyCache = new();
+
+        // Cached factory delegate passed to ConditionalWeakTable.GetValue to avoid allocating a new delegate on each miss.
+        private readonly ConditionalWeakTable<Assembly, Lazy<AssemblyAnalysis>>.CreateValueCallback _createAnalysisLazy;
         private readonly CodeOriginTags _tags;
 
         internal SpanCodeOrigin(DebuggerSettings settings)
@@ -33,6 +38,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             Log.Information("Initializing Code Origin for Spans");
             Settings = settings;
             _tags = new CodeOriginTags(Settings.CodeOriginMaxUserFrames);
+            _createAnalysisLazy = CreateAnalysisLazy;
         }
 
         internal DebuggerSettings Settings { get; }
@@ -109,12 +115,13 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                 }
 
                 var assembly = type.Assembly;
-                if (ShouldSkipAssembly(assembly))
+                var analysis = GetOrComputeAnalysis(assembly);
+                if (analysis.ShouldSkip)
                 {
                     return;
                 }
 
-                var sp = GetPdbInfo(assembly, method);
+                var sp = TryGetSequencePoint(analysis, method);
 
                 // Add code origin tags to entry span
                 // Adds 4 tags always (type, index, method, typename) + 3 tags if PDB available (file, line, column)
@@ -162,49 +169,96 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             }
         }
 
-        private CachedSequencePoint? GetPdbInfo(Assembly assembly, MethodInfo method)
+        // Design Decision: Read ALL detected endpoint sequence points upfront per assembly (one PDB open).
+        //
+        // Alternatives considered:
+        // - Lazy per-method: Would reopen PDB once per unique endpoint (each open prefetches metadata + paying
+        //   sequence-point parse cost). Total I/O grows linearly with unique endpoints called.
+        // - Keep PDB open across calls: File handle and memory leaks, resource limits, complex lifecycle.
+        // - Background/async population: Race conditions, thundering herd, harder testing.
+        //
+        // Trade-off: Slightly higher first-request latency for simplicity, predictability, and no resource leaks.
+        // Memory cost: 50-200 endpoints x ~200 bytes = 10-40 KB per assembly.
+        //
+        // Per-assembly Lazy<T> serializes the scan for the *same* assembly only - concurrent first-touches on
+        // *different* assemblies run in parallel (unlike the previous global write-lock design).
+        //
+        // ConditionalWeakTable.GetValue already performs the lock-free fast-path lookup internally
+        // (TryGetValue first, then create-under-lock on miss), so calling GetValue directly is equivalent
+        // to an explicit TryGetValue+GetValue split and saves one redundant lookup on miss.
+        private AssemblyAnalysis GetOrComputeAnalysis(Assembly assembly)
         {
-            // Design Decision: Read ALL endpoint sequence points upfront per assembly
-            //
-            // Current approach: Opens PDB once, reads all endpoint sequence points (~50-200 methods),
-            // closes immediately. One-time cost per assembly, then instant cache hits.
-            //
-            // Alternatives considered:
-            // - Lazy loading: Would reopen PDB repeatedly (expensive I/O, unpredictable latency spikes)
-            // - Keep PDB open: File handle leaks, resource limits, complex lifecycle management
-            // - Background/async: Race conditions, thundering herd, testing complexity
-            //
-            // Trade-off: Slightly higher first-request latency for simplicity, predictability, and no resource leaks.
-            // Memory cost is negligible: 50-200 endpoints × ~150 bytes = 7.5-30 KB per assembly.
-            //
-            // Note: Will revisit if profiling shows significant performance impact.
+            return _assemblyCache.GetValue(assembly, _createAnalysisLazy).Value;
+        }
 
-            var pdbInfo = _assemblyPdbCache.GetOrAdd(
-                assembly,
-                static asm =>
+        private Lazy<AssemblyAnalysis> CreateAnalysisLazy(Assembly assembly)
+        {
+            return new Lazy<AssemblyAnalysis>(() => ComputeAnalysis(assembly));
+        }
+
+        private AssemblyAnalysis ComputeAnalysis(Assembly assembly)
+        {
+            // This method is invoked by Lazy<AssemblyAnalysis> with the default
+            // ExecutionAndPublication mode, which caches any exception the factory throws.
+            // To prevent permanently poisoning the cache entry for an assembly, the entire
+            // body is wrapped in a catch-all that falls back to AssemblyAnalysis.Skipped.
+            // The two inner try/catches stay in place so we still get diagnostic-rich logs
+            // for the two expected failure points (filter evaluation and PDB scan).
+            try
+            {
+                bool shouldSkip;
+                try
                 {
-                    using var reader = DatadogMetadataReader.CreatePdbReader(asm);
-                    if (reader is not { IsPdbExist: true })
-                    {
-                        return null;
-                    }
+                    shouldSkip = AssemblyFilter.ShouldSkipAssembly(
+                        assembly,
+                        Settings.ThirdPartyDetectionExcludes,
+                        Settings.ThirdPartyDetectionIncludes);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to evaluate assembly filter for {AssemblyName}", assembly.FullName);
+                    return AssemblyAnalysis.Skipped;
+                }
 
-                    try
+                if (shouldSkip)
+                {
+                    return AssemblyAnalysis.Skipped;
+                }
+
+                Dictionary<int, CachedSequencePoint>? sequencePoints = null;
+                try
+                {
+                    // metadataOnly: true avoids PrefetchEntireImage, which would otherwise read the full DLL into memory.
+                    // We only need MetadataReader (for type/method enumeration) and the PDB reader (for sequence points).
+                    using var reader = DatadogMetadataReader.CreatePdbReader(assembly, metadataOnly: true);
+                    if (reader is { IsPdbExist: true })
                     {
-                        // Build dictionary of sequence points for ALL detected endpoint methods in one pass
-                        // This avoids reopening the PDB file on subsequent endpoint calls.
-                        var sequencePoints = new Dictionary<int, CachedSequencePoint>();
-                        var consumer = new SequencePointTokenConsumer(reader, sequencePoints, asm);
+                        sequencePoints = new Dictionary<int, CachedSequencePoint>();
+                        var consumer = new SequencePointTokenConsumer(reader, sequencePoints, assembly);
                         EndpointDetector.GetEndpointMethodTokens(reader, ref consumer);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error while getting endpoints for assembly: {AssemblyName}", assembly.Location);
+                    sequencePoints = null;
+                }
 
-                        return new AssemblyPdbInfo(sequencePoints);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "Error while getting endpoints for assembly: {AssemblyName}", asm.Location);
-                        return null;
-                    }
-                });
+                return new AssemblyAnalysis(shouldSkip: false, sequencePoints);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Unexpected error analyzing assembly {AssemblyName}", assembly.FullName);
+                return AssemblyAnalysis.Skipped;
+            }
+        }
+
+        private CachedSequencePoint? TryGetSequencePoint(AssemblyAnalysis analysis, MethodInfo method)
+        {
+            if (analysis.SequencePoints is null)
+            {
+                return null;
+            }
 
             int metadataToken;
             try
@@ -217,9 +271,12 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                 return null;
             }
 
-            return pdbInfo is not null && pdbInfo.TryGetSequencePoint(metadataToken, out var sequencePoint)
-                       ? sequencePoint
-                       : null;
+            if (analysis.SequencePoints.TryGetValue(metadataToken, out var sp))
+            {
+                return sp;
+            }
+
+            return null;
         }
 
         private void AddExitSpanTags(Span span)
@@ -299,7 +356,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
                     continue;
                 }
 
-                if (ShouldSkipAssembly(assembly))
+                if (GetOrComputeAnalysis(assembly).ShouldSkip)
                 {
                     continue;
                 }
@@ -308,16 +365,6 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             }
 
             return count;
-        }
-
-        private bool ShouldSkipAssembly(Assembly assembly)
-        {
-            return _assemblySkipCache.GetOrAdd(
-                assembly,
-                asm => AssemblyFilter.ShouldSkipAssembly(
-                    asm,
-                    Settings.ThirdPartyDetectionExcludes,
-                    Settings.ThirdPartyDetectionIncludes));
         }
 
         private readonly record struct FrameInfo(int FrameIndex, StackFrame Frame);
@@ -368,14 +415,21 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             }
         }
 
-        private sealed class AssemblyPdbInfo(Dictionary<int, CachedSequencePoint> sequencePoints)
+        private sealed class AssemblyAnalysis
         {
-            private readonly Dictionary<int, CachedSequencePoint> _sequencePoints = sequencePoints;
+            // Singleton for "skipped" assemblies: no sequence points to remember, just the skip flag.
+            // Reuse one instance per filter decision to avoid an allocation per skipped assembly cache entry.
+            internal static readonly AssemblyAnalysis Skipped = new(shouldSkip: true, sequencePoints: null);
 
-            public bool TryGetSequencePoint(int token, out CachedSequencePoint sequencePoint)
+            internal AssemblyAnalysis(bool shouldSkip, Dictionary<int, CachedSequencePoint>? sequencePoints)
             {
-                return _sequencePoints.TryGetValue(token, out sequencePoint);
+                ShouldSkip = shouldSkip;
+                SequencePoints = sequencePoints;
             }
+
+            internal bool ShouldSkip { get; }
+
+            internal Dictionary<int, CachedSequencePoint>? SequencePoints { get; }
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
             Log.Information("Initializing Code Origin for Spans");
             Settings = settings;
             _tags = new CodeOriginTags(Settings.CodeOriginMaxUserFrames);
-            _createAnalysisLazy = CreateAnalysisLazy;
+            _createAnalysisLazy = assembly => new Lazy<AssemblyAnalysis>(() => ComputeAnalysis(assembly));
         }
 
         internal DebuggerSettings Settings { get; }
@@ -189,11 +189,6 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
         private AssemblyAnalysis GetOrComputeAnalysis(Assembly assembly)
         {
             return _assemblyCache.GetValue(assembly, _createAnalysisLazy).Value;
-        }
-
-        private Lazy<AssemblyAnalysis> CreateAnalysisLazy(Assembly assembly)
-        {
-            return new Lazy<AssemblyAnalysis>(() => ComputeAnalysis(assembly));
         }
 
         private AssemblyAnalysis ComputeAnalysis(Assembly assembly)

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -97,6 +97,9 @@ namespace Datadog.Trace.Pdb
         /// <see cref="GetDocuments"/>. Callers that expect to read IL bodies or local-variable signatures, such as
         /// <see cref="HasMethodBody"/>, <see cref="GetLocalVariableNames(int, int, bool)"/>, and
         /// <see cref="GetLocalSymbols"/>, should prefer <c>metadataOnly: false</c> so the full image is prefetched.
+        /// Callers should always dispose the returned reader promptly. This is especially important when
+        /// <paramref name="metadataOnly"/> is <c>true</c>, because <see cref="PEStreamOptions.Default"/> keeps the PE
+        /// stream open until the reader is disposed.
         /// </param>
         internal static DatadogMetadataReader? CreatePdbReader(Assembly? assembly, bool metadataOnly = false)
         {

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -44,14 +44,23 @@ namespace Datadog.Trace.Pdb
         private static readonly Guid StateMachineHoistedLocalScopes = new("6DA9A61E-F8C7-4874-BE62-68BC5630DF71");
         private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<DatadogMetadataReader>();
         private readonly PEReader _peReader;
+        private readonly MetadataReaderProvider? _pdbReaderProvider;
         private readonly bool _isDnlibPdbReader;
         private bool _disposed;
 
-        private DatadogMetadataReader(PEReader peReader, MetadataReader metadataReader, MetadataReader? pdbReader, string? pdbFullPath, Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Symbols.SymbolReader? dnlibPdbReader, Datadog.Trace.Vendors.dnlib.DotNet.ModuleDefMD? dnlibModule)
+        private DatadogMetadataReader(
+            PEReader peReader,
+            MetadataReader metadataReader,
+            MetadataReaderProvider? pdbReaderProvider,
+            MetadataReader? pdbReader,
+            string? pdbFullPath,
+            Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Symbols.SymbolReader? dnlibPdbReader,
+            Datadog.Trace.Vendors.dnlib.DotNet.ModuleDefMD? dnlibModule)
         {
             MetadataReader = metadataReader;
             PdbReader = pdbReader;
             _peReader = peReader;
+            _pdbReaderProvider = pdbReaderProvider;
             _dnlibModule = dnlibModule;
             DnlibPdbReader = dnlibPdbReader;
             PdbFullPath = pdbFullPath;
@@ -77,7 +86,19 @@ namespace Datadog.Trace.Pdb
             return MetadataTokens.MethodDefinitionHandle(RidOf(methodToken));
         }
 
-        internal static DatadogMetadataReader? CreatePdbReader(Assembly? assembly)
+        /// <summary>
+        /// Opens a <see cref="DatadogMetadataReader"/> for the given assembly.
+        /// </summary>
+        /// <param name="assembly">The assembly to open.</param>
+        /// <param name="metadataOnly">
+        /// When <c>true</c>, the PE image is opened without prefetching (<see cref="PEStreamOptions.Default"/>) to
+        /// avoid reading the whole DLL into memory. The reader can be used for metadata lookups and for PDB-only
+        /// methods such as <see cref="GetMethodSourceLocation"/>, <see cref="GetMethodSequencePoints"/>, and
+        /// <see cref="GetDocuments"/>. It must NOT be used to read IL bodies or local-variable signatures: callers
+        /// of <see cref="HasMethodBody"/>, <see cref="GetLocalVariableNames(int, int, bool)"/>, and
+        /// <see cref="GetLocalSymbols"/> require the full image and must pass <c>metadataOnly: false</c>.
+        /// </param>
+        internal static DatadogMetadataReader? CreatePdbReader(Assembly? assembly, bool metadataOnly = false)
         {
             if (assembly == null || string.IsNullOrEmpty(assembly.Location))
             {
@@ -85,16 +106,44 @@ namespace Datadog.Trace.Pdb
                 return null;
             }
 
+            // We track each owned resource locally and only null it out when ownership is
+            // transferred to a successfully constructed DatadogMetadataReader. The finally
+            // block disposes anything still owned, which guarantees that the underlying
+            // FileStream held by the PEReader (under PEStreamOptions.Default, see below) and
+            // by the sidecar-PDB MetadataReaderProvider are released even if a later step
+            // throws or short-circuits to a partial result.
+            PEReader? peReader = null;
+            MetadataReaderProvider? pdbReaderProvider = null;
+            Datadog.Trace.Vendors.dnlib.DotNet.ModuleDefMD? dnlibModule = null;
+            Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Symbols.SymbolReader? dnlibReader = null;
+
             try
             {
-                // For metadata we are always using System.Reflection.Metadata
-                // For PDB, Reflection.Metadata for portable and embedded PDB and dnlib for windows PDB
-                var peReader = new PEReader(File.OpenRead(assembly.Location), PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage);
+                // For metadata we are always using System.Reflection.Metadata.
+                // For PDB, Reflection.Metadata for portable and embedded PDB and dnlib for Windows PDB.
+                //
+                // When metadataOnly is true the caller only needs MetadataReader + PdbReader (no IL bodies),
+                // so we avoid PrefetchEntireImage which would otherwise read the full DLL into memory.
+                // We use PEStreamOptions.Default rather than PrefetchMetadata alone because PrefetchMetadata
+                // reads the metadata blob and then disposes the PE stream, but TryOpenAssociatedPortablePdb
+                // still needs to read the PE Debug Directory (in a non-metadata section) and would fail.
+                // With Default, the PEReader keeps the stream open and reads only the bytes it needs;
+                // the stream is closed when the PEReader is disposed.
+                var peOptions = metadataOnly
+                                    ? PEStreamOptions.Default
+                                    : PEStreamOptions.PrefetchMetadata | PEStreamOptions.PrefetchEntireImage;
+                peReader = new PEReader(File.OpenRead(assembly.Location), peOptions);
                 MetadataReader metadataReader = peReader.GetMetadataReader(MetadataReaderOptions.Default);
-                if (peReader.TryOpenAssociatedPortablePdb(assembly.Location, File.OpenRead, out var metadataReaderProvider, out var pdbPath))
+                if (peReader.TryOpenAssociatedPortablePdb(assembly.Location, File.OpenRead, out pdbReaderProvider, out var pdbPath))
                 {
-                    var pdbReader = metadataReaderProvider!.GetMetadataReader(MetadataReaderOptions.Default, MetadataStringDecoder.DefaultUTF8);
-                    return new DatadogMetadataReader(peReader, metadataReader, pdbReader, pdbPath ?? assembly.Location, null, null);
+                    // For sidecar portable PDBs, pdbReaderProvider owns a FileStream (opened by the File.OpenRead
+                    // callback) that is only released when the provider is disposed. Transfer ownership to the
+                    // DatadogMetadataReader so Dispose() releases the handle.
+                    var pdbReader = pdbReaderProvider!.GetMetadataReader(MetadataReaderOptions.Default, MetadataStringDecoder.DefaultUTF8);
+                    var portableResult = new DatadogMetadataReader(peReader, metadataReader, pdbReaderProvider, pdbReader, pdbPath ?? assembly.Location, null, null);
+                    peReader = null;
+                    pdbReaderProvider = null;
+                    return portableResult;
                 }
 
                 Logger.Debug("No associated portable or embedded PDB was found for {Assembly} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
@@ -102,21 +151,29 @@ namespace Datadog.Trace.Pdb
                 if (!TryFindPdbFile(assembly.Location, out var pdbFullPath))
                 {
                     Logger.Debug("No standalone PDB file was found for {Assembly} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
-                    return new DatadogMetadataReader(peReader, metadataReader, null, null, null, null);
+                    var noPdbResult = new DatadogMetadataReader(peReader, metadataReader, null, null, null, null, null);
+                    peReader = null;
+                    return noPdbResult;
                 }
 
-                var module = Datadog.Trace.Vendors.dnlib.DotNet.ModuleDefMD.Load(assembly.ManifestModule, new Datadog.Trace.Vendors.dnlib.DotNet.ModuleCreationOptions { TryToLoadPdbFromDisk = false });
+                dnlibModule = Datadog.Trace.Vendors.dnlib.DotNet.ModuleDefMD.Load(assembly.ManifestModule, new Datadog.Trace.Vendors.dnlib.DotNet.ModuleCreationOptions { TryToLoadPdbFromDisk = false });
                 var pdbStream = Datadog.Trace.Vendors.dnlib.IO.DataReaderFactoryFactory.Create(pdbFullPath, false);
-                var dnlibReader = Datadog.Trace.Vendors.dnlib.DotNet.Pdb.SymbolReaderFactory.Create(Datadog.Trace.Vendors.dnlib.DotNet.ModuleCreationOptions.DefaultPdbReaderOptions, module.Metadata, pdbStream);
+                dnlibReader = Datadog.Trace.Vendors.dnlib.DotNet.Pdb.SymbolReaderFactory.Create(Datadog.Trace.Vendors.dnlib.DotNet.ModuleCreationOptions.DefaultPdbReaderOptions, dnlibModule.Metadata, pdbStream);
                 if (dnlibReader == null)
                 {
                     Logger.Debug("A standalone PDB file was found for {Assembly} but a dnlib PDB reader could not be created. AssemblyLocation={AssemblyLocation}, PdbPath={PdbPath}", assembly.FullName, assembly.Location, pdbFullPath);
-                    return new DatadogMetadataReader(peReader, metadataReader, null, null, null, null);
+                    var noDnlibReaderResult = new DatadogMetadataReader(peReader, metadataReader, null, null, null, null, null);
+                    peReader = null; // ownership transferred; dnlibModule will be disposed in finally
+                    return noDnlibReaderResult;
                 }
 
-                dnlibReader.Initialize(module);
-                module.LoadPdb(dnlibReader);
-                return new DatadogMetadataReader(peReader, metadataReader, null, pdbFullPath, dnlibReader, module);
+                dnlibReader.Initialize(dnlibModule);
+                dnlibModule.LoadPdb(dnlibReader);
+                var dnlibResult = new DatadogMetadataReader(peReader, metadataReader, null, null, pdbFullPath, dnlibReader, dnlibModule);
+                peReader = null;
+                dnlibModule = null;
+                dnlibReader = null;
+                return dnlibResult;
             }
             catch (UnauthorizedAccessException e)
             {
@@ -132,6 +189,16 @@ namespace Datadog.Trace.Pdb
             {
                 Logger.Error(e, "Error while trying to get a pdb for {Assembly} in location: {AssemblyLocation}", assembly.FullName, assembly.Location);
                 return null;
+            }
+            finally
+            {
+                // Any resource still owned here was not transferred to a DatadogMetadataReader,
+                // so it must be released to avoid leaking the underlying file handles (PEReader and
+                // sidecar-PDB MetadataReaderProvider) and the dnlib module / symbol reader.
+                dnlibReader?.Dispose();
+                dnlibModule?.Dispose();
+                pdbReaderProvider?.Dispose();
+                peReader?.Dispose();
             }
         }
 
@@ -982,6 +1049,7 @@ namespace Datadog.Trace.Pdb
             }
 
             DnlibPdbReader?.Dispose();
+            _pdbReaderProvider?.Dispose();
             _peReader?.Dispose();
             _dnlibModule?.Dispose();
             _disposed = true;

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -92,11 +92,11 @@ namespace Datadog.Trace.Pdb
         /// <param name="assembly">The assembly to open.</param>
         /// <param name="metadataOnly">
         /// When <c>true</c>, the PE image is opened without prefetching (<see cref="PEStreamOptions.Default"/>) to
-        /// avoid reading the whole DLL into memory. The reader can be used for metadata lookups and for PDB-only
-        /// methods such as <see cref="GetMethodSourceLocation"/>, <see cref="GetMethodSequencePoints"/>, and
-        /// <see cref="GetDocuments"/>. It must NOT be used to read IL bodies or local-variable signatures: callers
-        /// of <see cref="HasMethodBody"/>, <see cref="GetLocalVariableNames(int, int, bool)"/>, and
-        /// <see cref="GetLocalSymbols"/> require the full image and must pass <c>metadataOnly: false</c>.
+        /// avoid reading the whole DLL into memory. This is intended for callers that only need metadata lookups and
+        /// PDB-only methods such as <see cref="GetMethodSourceLocation"/>, <see cref="GetMethodSequencePoints"/>, and
+        /// <see cref="GetDocuments"/>. Callers that expect to read IL bodies or local-variable signatures, such as
+        /// <see cref="HasMethodBody"/>, <see cref="GetLocalVariableNames(int, int, bool)"/>, and
+        /// <see cref="GetLocalSymbols"/>, should prefer <c>metadataOnly: false</c> so the full image is prefetched.
         /// </param>
         internal static DatadogMetadataReader? CreatePdbReader(Assembly? assembly, bool metadataOnly = false)
         {

--- a/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Pdb/DatadogMetadataReaderTests.cs
@@ -87,4 +87,23 @@ public class DatadogMetadataReaderTests
             localTypes.IsDefault.Should().BeTrue();
         }
     }
+
+    [Fact]
+    public void CreatePdbReader_MetadataOnly_StillReadsPdb()
+    {
+        // Regression guard: metadataOnly: true must still find the associated PDB.
+        // The PE Debug Directory lives outside the metadata blob, so PEStreamOptions.PrefetchMetadata alone would close
+        // the underlying stream and break TryOpenAssociatedPortablePdb. PEStreamOptions.Default keeps the stream open.
+        //
+        // We compare metadataOnly:true against the default (full-prefetch) path on the same assembly so the test asserts
+        // equivalence rather than a platform-specific outcome. If the default path can find a PDB for the test assembly,
+        // the metadata-only path must too. On targets where the default path can't find a PDB either (e.g. .NET Framework
+        // running on a build where the standalone .pdb cannot be located), the test still passes because both paths agree.
+        using var baseline = DatadogMetadataReader.CreatePdbReader(typeof(DatadogMetadataReaderTests).Assembly, metadataOnly: false);
+        using var metadataOnly = DatadogMetadataReader.CreatePdbReader(typeof(DatadogMetadataReaderTests).Assembly, metadataOnly: true);
+
+        baseline.Should().NotBeNull();
+        metadataOnly.Should().NotBeNull();
+        metadataOnly!.IsPdbExist.Should().Be(baseline!.IsPdbExist);
+    }
 }


### PR DESCRIPTION
## Summary of changes

- Optimizes Span Code Origin PDB analysis by replacing the old per-assembly `ConcurrentAdaptiveCache` / separate skip-cache path with a weakly-keyed `ConditionalWeakTable<Assembly, Lazy<AssemblyAnalysis>>`.
- Deduplicates concurrent first-touch analysis for the same assembly while allowing different assemblies to be analyzed in parallel.
- Combines the assembly skip decision and endpoint sequence-point cache into one per-assembly analysis result.
- Adds a metadata-only PDB reader mode for code-origin endpoint discovery, avoiding full PE image prefetch when IL bodies are not needed.
- Ensures metadata/PDB reader resources are disposed correctly, including sidecar portable PDB providers.

## Reason for change

- The previous cache population path used a global write lock, so concurrent cold-cache analysis for different assemblies could block each other.
- Code-origin PDB lookup only needs metadata and PDB sequence points, not the full PE image, so full-image prefetching added unnecessary cold-path cost.
- Weak assembly keys avoid keeping collectible assembly load contexts alive through the cache.

## Implementation details

- `SpanCodeOrigin` now stores a `Lazy<AssemblyAnalysis>` per `Assembly`, keyed by `ConditionalWeakTable`, so:
  - repeated lookups hit an already-computed analysis result;
  - concurrent first touches for the same assembly are deduplicated;
  - first touches for different assemblies are no longer serialized by the old global cache write lock.
- `AssemblyAnalysis` stores both the skip decision and the endpoint token-to-sequence-point dictionary.
- `DatadogMetadataReader.CreatePdbReader()` now supports `metadataOnly: true`.
  - For this mode it uses `PEStreamOptions.Default` instead of `PrefetchMetadata | PrefetchEntireImage`.
  - This avoids reading the full DLL image while still keeping the stream available for portable PDB discovery.
- Resource ownership is now explicit during PDB reader creation so `PEReader`, `MetadataReaderProvider`, dnlib module, and dnlib symbol reader are disposed if construction exits early.

## Test coverage

- Added unit coverage for `CreatePdbReader(metadataOnly: true)` to verify it still discovers the same PDB availability as the full-prefetch path.

- Ran local BenchmarkDotNet comparison on Windows, .NET 10.0.7, BenchmarkDotNet 0.15.8:

| Case | master | this branch | Change |
|---|---:|---:|---:|
| Cold first-touch | 546.389 us, 31,480 B | 421.000 us, 35,744 B | ~23% faster, +4.3 KB managed allocation |
| Warm cache | 278.472 ns, 584 B | 277.088 ns, 584 B | effectively unchanged |


## Other details
- The measured cold first-touch improvement is single-threaded. In a multi-threaded environment, the benefit is expected to be higher when multiple assemblies are first analyzed concurrently, because this branch removes the previous global cache write-lock bottleneck.
- Warm-cache performance is unchanged because both implementations converge to the same steady-state work: cache lookup, method-token dictionary lookup, and tag writes.
- The cold-path managed allocation is slightly higher due to the new Lazy<AssemblyAnalysis> / analysis wrapper objects, but BenchmarkDotNet managed allocation does not capture the reduced PE image prefetching, I/O, native memory, or handle lifetime improvements.