### PR TITLE
Fix attempt-to-fix final status precedence

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -75,7 +75,7 @@ public sealed class Test
         tags.CapabilitiesAutoTestRetries = "1";
         tags.CapabilitiesTestManagementQuarantine = "1";
         tags.CapabilitiesTestManagementDisable = "1";
-        tags.CapabilitiesTestManagementAttemptToFix = "4";
+        tags.CapabilitiesTestManagementAttemptToFix = "5";
 
         CurrentTest.Value = this;
         lock (OpenedTests)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -293,8 +293,8 @@ internal static class Common
     /// <summary>
     /// Calculates the final status for a test based on execution results and test management tags.
     /// Priority order (first match wins):
-    /// 1. Quarantined/disabled -> skip (always mask to skip)
-    /// 2. For ATF tests: any execution failed -> fail (flaky test = fix didn't work)
+    /// 1. For ATF tests: any execution failed -> fail (flaky test = fix didn't work)
+    /// 2. Quarantined/disabled -> skip (always mask non-ATF tests to skip)
     /// 3. Any execution passed -> pass
     /// 4. Skip/inconclusive AND no pass -> skip
     /// 5. All executions failed -> fail
@@ -306,17 +306,31 @@ internal static class Common
     /// <returns>The final status string: "pass", "fail", or "skip".</returns>
     internal static string CalculateFinalStatus(bool anyExecutionPassed, bool anyExecutionFailed, bool isSkippedOrInconclusive, TestSpanTags? testTags)
     {
-        // Priority 1: Quarantined/disabled tests always mask to skip
+        // Priority 1: ATF tests ignore quarantine/disabled when reporting final status
+        if (testTags?.IsAttemptToFix == "true")
+        {
+            if (anyExecutionFailed)
+            {
+                return TestTags.StatusFail;
+            }
+
+            if (anyExecutionPassed)
+            {
+                return TestTags.StatusPass;
+            }
+
+            if (isSkippedOrInconclusive)
+            {
+                return TestTags.StatusSkip;
+            }
+
+            return TestTags.StatusFail;
+        }
+
+        // Priority 2: Quarantined/disabled tests always mask to skip
         if (testTags?.IsQuarantined == "true" || testTags?.IsDisabled == "true")
         {
             return TestTags.StatusSkip;
-        }
-
-        // Priority 2: For ATF tests, any failure means fix didn't work (test is still flaky)
-        // This must be checked BEFORE anyPassed for ATF tests
-        if (testTags?.IsAttemptToFix == "true" && anyExecutionFailed)
-        {
-            return TestTags.StatusFail;
         }
 
         // Priority 3: Any execution passed -> pass (pass takes precedence over skip)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -253,6 +253,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                                                 "attempt_to_fix": true
                                                             }
                                                         },
+                                                        "SimpleErrorParameterizedTest": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -265,7 +270,72 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     1,
                     38,
                     40,
-                    "quarantined_tests");
+                    "quarantined_and_disabled");
+
+                yield return row.Concat(
+                    new MockData(
+                        GetSettingsJson("false", "false", "true", "10"),
+                        string.Empty,
+                        """
+                        {
+                            "data": {
+                                "id": "878448902e138d339eb9f26a778851f35582b5ea3622ae8ab446209d232399af",
+                                "type": "ci_app_libraries_tests",
+                                "attributes": {
+                                    "modules": {
+                                        "Samples.MSTestTests": {
+                                            "suites": {
+                                                "Samples.MSTestTests.TestSuite": {
+                                                    "tests": {
+                                                        "SimplePassTest": {
+                                                            "properties": {
+                                                                "quarantined": true,
+                                                                "attempt_to_fix": true
+                                                            }
+                                                        },
+                                                        "TraitPassTest": {
+                                                            "properties": {
+                                                                "disabled": true,
+                                                                "attempt_to_fix": true
+                                                            }
+                                                        },
+                                                        "TraitErrorTest": {
+                                                            "properties": {
+                                                                "quarantined": true
+                                                            }
+                                                        },
+                                                        "SimpleErrorTest": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        },
+                                                        "SimpleErrorParameterizedTest": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Samples.MSTestTests.ClassInitializeExceptionTestSuite": {
+                                                    "tests": {
+                                                        "ClassInitializeExceptionTestMethod": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        """),
+                    0,
+                    38,
+                    40,
+                    "quarantined_and_disabled_attempt_to_fix_passes");
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -262,6 +262,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                                                 "attempt_to_fix": true
                                                             }
                                                         },
+                                                        "SimpleErrorParameterizedTest": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -274,6 +279,131 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     1,
                     ExpectedTestCount + 9 + 9,
                     "quarantined_and_disabled");
+
+                yield return row.Concat(
+                    new MockData(
+                        GetSettingsJson("false", "false", "true", "10"),
+                        string.Empty,
+                        """
+                        {
+                            "data": {
+                                "id": "878448902e138d339eb9f26a778851f35582b5ea3622ae8ab446209d232399af",
+                                "type": "ci_app_libraries_tests",
+                                "attributes": {
+                                    "modules": {
+                                        "Samples.NUnitTests": {
+                                            "suites": {
+                                                "Samples.NUnitTests.TestSuite": {
+                                                    "tests": {
+                                                        "SimplePassTest": {
+                                                            "properties": {
+                                                                "quarantined": true,
+                                                                "attempt_to_fix": true
+                                                            }
+                                                        },
+                                                        "TraitPassTest": {
+                                                            "properties": {
+                                                                "disabled": true,
+                                                                "attempt_to_fix": true
+                                                            }
+                                                        },
+                                                        "TraitErrorTest": {
+                                                            "properties": {
+                                                                "quarantined": true
+                                                            }
+                                                        },
+                                                        "SimpleErrorTest": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        },
+                                                        "SimpleErrorParameterizedTest": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Samples.NUnitTests.TestFixtureSetupError(\"Test01\")": {
+                                                    "tests": {
+                                                        "Test": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Samples.NUnitTests.TestFixtureSetupError(\"Test02\")": {
+                                                    "tests": {
+                                                        "Test": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Samples.NUnitTests.TestSetupError": {
+                                                    "tests": {
+                                                        "IsNull": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        },
+                                                        "Test01": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        },
+                                                        "Test02": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        },
+                                                        "Test03": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        },
+                                                        "Test04": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        },
+                                                        "Test05": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Samples.NUnitTests.TestTearDownError": {
+                                                    "tests": {
+                                                        "IsNull": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "Samples.NUnitTests.TestTearDown2Error": {
+                                                    "tests": {
+                                                        "IsNull": {
+                                                            "properties": {
+                                                                "disabled": true
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        """),
+                    0,
+                    ExpectedTestCount + 9 + 9,
+                    "quarantined_and_disabled_attempt_to_fix_passes");
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -359,6 +359,11 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
                                                             "attempt_to_fix": true
                                                         }
                                                     },
+                                                    "SimpleErrorParameterizedTest": {
+                                                        "properties": {
+                                                            "disabled": true
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -371,6 +376,61 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
                 1,
                 34,
                 "quarantined_and_disabled");
+
+            yield return row.Concat(
+                new MockData(
+                    GetSettingsJson("false", "false", "true", "10"),
+                    string.Empty,
+                    """
+                    {
+                        "data": {
+                            "id": "878448902e138d339eb9f26a778851f35582b5ea3622ae8ab446209d232399af",
+                            "type": "ci_app_libraries_tests",
+                            "attributes": {
+                                "modules": {
+                                    "Samples.XUnitTests": {
+                                        "suites": {
+                                            "Samples.XUnitTests.TestSuite": {
+                                                "tests": {
+                                                    "SimplePassTest": {
+                                                        "properties": {
+                                                            "quarantined": true,
+                                                            "attempt_to_fix": true
+                                                        }
+                                                    },
+                                                    "TraitPassTest": {
+                                                        "properties": {
+                                                            "disabled": true,
+                                                            "attempt_to_fix": true
+                                                        }
+                                                    },
+                                                    "TraitErrorTest": {
+                                                        "properties": {
+                                                            "quarantined": true
+                                                        }
+                                                    },
+                                                    "SimpleErrorTest": {
+                                                        "properties": {
+                                                            "disabled": true
+                                                        }
+                                                    },
+                                                    "SimpleErrorParameterizedTest": {
+                                                        "properties": {
+                                                            "disabled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    """),
+                0,
+                34,
+                "quarantined_and_disabled_attempt_to_fix_passes");
         }
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
@@ -258,6 +258,11 @@ public class XUnitEvpTestsV3 : TestingFrameworkEvpTest
                                                             "attempt_to_fix": true
                                                         }
                                                     },
+                                                    "SimpleErrorParameterizedTest": {
+                                                        "properties": {
+                                                            "disabled": true
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
@@ -270,6 +275,61 @@ public class XUnitEvpTestsV3 : TestingFrameworkEvpTest
                 1,
                 34,
                 "quarantined_and_disabled");
+
+            yield return row.Concat(
+                new MockData(
+                    GetSettingsJson("false", "false", "true", "10"),
+                    string.Empty,
+                    """
+                    {
+                        "data": {
+                            "id": "878448902e138d339eb9f26a778851f35582b5ea3622ae8ab446209d232399af",
+                            "type": "ci_app_libraries_tests",
+                            "attributes": {
+                                "modules": {
+                                    "Samples.XUnitTestsV3": {
+                                        "suites": {
+                                            "Samples.XUnitTestsV3.TestSuite": {
+                                                "tests": {
+                                                    "SimplePassTest": {
+                                                        "properties": {
+                                                            "quarantined": true,
+                                                            "attempt_to_fix": true
+                                                        }
+                                                    },
+                                                    "TraitPassTest": {
+                                                        "properties": {
+                                                            "disabled": true,
+                                                            "attempt_to_fix": true
+                                                        }
+                                                    },
+                                                    "TraitErrorTest": {
+                                                        "properties": {
+                                                            "quarantined": true
+                                                        }
+                                                    },
+                                                    "SimpleErrorTest": {
+                                                        "properties": {
+                                                            "disabled": true
+                                                        }
+                                                    },
+                                                    "SimpleErrorParameterizedTest": {
+                                                        "properties": {
+                                                            "disabled": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    """),
+                0,
+                34,
+                "quarantined_and_disabled_attempt_to_fix_passes");
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestFinalStatusTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestFinalStatusTests.cs
@@ -48,7 +48,7 @@ public class TestFinalStatusTests
         result.Should().Be(TestTags.StatusPass);
     }
 
-    // Priority 1: Quarantined/Disabled Tests
+    // Quarantined/Disabled Tests
 
     [Fact]
     public void CalculateFinalStatus_Quarantined_AnyPassed_ReturnsSkip()
@@ -83,31 +83,38 @@ public class TestFinalStatusTests
     }
 
     [Fact]
-    public void CalculateFinalStatus_QuarantinedWithATF_Passed_ReturnsSkip()
+    public void CalculateFinalStatus_QuarantinedWithATF_Passed_ReturnsPass()
     {
-        // Quarantine always masks to skip, even with ATF enabled
         var tags = new TestSpanTags { IsQuarantined = "true", IsAttemptToFix = "true" };
         var result = Common.CalculateFinalStatus(anyExecutionPassed: true, anyExecutionFailed: false, isSkippedOrInconclusive: false, testTags: tags);
-        result.Should().Be(TestTags.StatusSkip, "quarantined tests with ATF still return skip");
+        result.Should().Be(TestTags.StatusPass, "ATF takes precedence over quarantine when all attempts pass");
     }
 
     [Fact]
-    public void CalculateFinalStatus_QuarantinedWithATF_AllFailed_ReturnsSkip()
+    public void CalculateFinalStatus_QuarantinedWithATF_AllFailed_ReturnsFail()
     {
         var tags = new TestSpanTags { IsQuarantined = "true", IsAttemptToFix = "true" };
         var result = Common.CalculateFinalStatus(anyExecutionPassed: false, anyExecutionFailed: true, isSkippedOrInconclusive: false, testTags: tags);
-        result.Should().Be(TestTags.StatusSkip, "quarantined tests with ATF still return skip");
+        result.Should().Be(TestTags.StatusFail, "ATF takes precedence over quarantine when any attempt fails");
     }
 
     [Fact]
-    public void CalculateFinalStatus_DisabledWithATF_Passed_ReturnsSkip()
+    public void CalculateFinalStatus_DisabledWithATF_Passed_ReturnsPass()
     {
         var tags = new TestSpanTags { IsDisabled = "true", IsAttemptToFix = "true" };
         var result = Common.CalculateFinalStatus(anyExecutionPassed: true, anyExecutionFailed: false, isSkippedOrInconclusive: false, testTags: tags);
-        result.Should().Be(TestTags.StatusSkip, "disabled tests with ATF still return skip");
+        result.Should().Be(TestTags.StatusPass, "ATF takes precedence over disabled when all attempts pass");
     }
 
-    // Priority 2: For ATF - Any Execution Failed
+    [Fact]
+    public void CalculateFinalStatus_DisabledWithATF_AllFailed_ReturnsFail()
+    {
+        var tags = new TestSpanTags { IsDisabled = "true", IsAttemptToFix = "true" };
+        var result = Common.CalculateFinalStatus(anyExecutionPassed: false, anyExecutionFailed: true, isSkippedOrInconclusive: false, testTags: tags);
+        result.Should().Be(TestTags.StatusFail, "ATF takes precedence over disabled when any attempt fails");
+    }
+
+    // Priority 1: Attempt-to-Fix Tests
 
     [Fact]
     public void CalculateFinalStatus_ATF_AnyFailed_ReturnsFail()
@@ -605,21 +612,21 @@ public class TestFinalStatusTests
     }
 
     [Fact]
-    public void CalculateFinalStatus_ATF_Quarantined_Passes_ReturnsSkip()
+    public void CalculateFinalStatus_ATF_Quarantined_Passes_ReturnsPass()
     {
-        // Test 59: MsTest ATF on quarantined test (passes) -> skip
+        // Test 59: MsTest ATF on quarantined test (passes) -> pass
         var tags = new TestSpanTags { IsAttemptToFix = "true", IsQuarantined = "true" };
         var result = Common.CalculateFinalStatus(anyExecutionPassed: true, anyExecutionFailed: false, isSkippedOrInconclusive: false, testTags: tags);
-        result.Should().Be(TestTags.StatusSkip, "quarantined always takes precedence");
+        result.Should().Be(TestTags.StatusPass, "ATF takes precedence over quarantine");
     }
 
     [Fact]
-    public void CalculateFinalStatus_ATF_Disabled_Fails_ReturnsSkip()
+    public void CalculateFinalStatus_ATF_Disabled_Fails_ReturnsFail()
     {
-        // Test 60: MsTest ATF on disabled test (fails) -> skip
+        // Test 60: MsTest ATF on disabled test (fails) -> fail
         var tags = new TestSpanTags { IsAttemptToFix = "true", IsDisabled = "true" };
         var result = Common.CalculateFinalStatus(anyExecutionPassed: false, anyExecutionFailed: true, isSkippedOrInconclusive: false, testTags: tags);
-        result.Should().Be(TestTags.StatusSkip, "disabled always takes precedence");
+        result.Should().Be(TestTags.StatusFail, "ATF takes precedence over disabled");
     }
 
     // ATR with FlakyRetryCount=0 Edge Cases - Tests 63-65
@@ -965,12 +972,12 @@ public class TestFinalStatusTests
     }
 
     [Fact]
-    public void CalculateFinalStatus_QuarantinedDisabledAndATF_AllSet_ReturnsSkip()
+    public void CalculateFinalStatus_QuarantinedDisabledAndATF_AllSet_ReturnsPass()
     {
         // Edge case: all flags set
         var tags = new TestSpanTags { IsQuarantined = "true", IsDisabled = "true", IsAttemptToFix = "true" };
         var result = Common.CalculateFinalStatus(anyExecutionPassed: true, anyExecutionFailed: false, isSkippedOrInconclusive: false, testTags: tags);
-        result.Should().Be(TestTags.StatusSkip, "quarantined/disabled always takes precedence over ATF");
+        result.Should().Be(TestTags.StatusPass, "ATF takes precedence over quarantine/disabled");
     }
 
     // EFD + New Test Combinations


### PR DESCRIPTION
## Summary

Test Management attempt-to-fix should take precedence over quarantine and disabled status. This updates final status calculation so attempt-to-fix tests report `fail` when any attempt fails and `pass` only when all attempts pass, even when the test is also quarantined or disabled.

Non-attempt-to-fix quarantined and disabled tests continue to be masked as `skip`. The attempt-to-fix capability is also updated to version `5`, and unit/EVP coverage is updated for xUnit, NUnit, and MSTest.

## Testing

- `git diff --check`
- Parsed updated EVP JSON blocks successfully.
- `./tracer/build.sh BuildAndRunManagedUnitTests --filter "FullyQualifiedName~Datadog.Trace.Tests.Ci.TestFinalStatusTests"` was not able to run locally because this checkout requires .NET SDK `10.0.100`, while the local machine has SDK `8.0.400`.