### PR TITLE
[Code Origin] Skip exit-span hook in Tracer.StartSpan

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SpanCodeOrigin/SpanCodeOrigin.cs
@@ -69,7 +69,8 @@ namespace Datadog.Trace.Debugger.SpanCodeOrigin
         private bool ShouldSkipExitSpan()
         {
             // Exit span code origin has been disabled since tracer version 3.28.0.
-            // when it will be enabled, update SpanCodeOriginTests.ExitSpanTests
+            // The call from Tracer.StartSpan was also removed to avoid per-span overhead.
+            // When re-enabling, restore the call in Tracer.StartSpan and update SpanCodeOriginTests.ExitSpanTests.
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -442,8 +442,6 @@ namespace Datadog.Trace
             // write them directly to the <see cref="TraceChunkModel"/>.
             TracerManager.GitMetadataTagsProvider.TryExtractGitMetadata(out _);
 
-            DebuggerManager.Instance.CodeOrigin?.SetCodeOriginForExitSpan(span);
-
             return span;
         }
     }


### PR DESCRIPTION
## Summary of changes

- Removed the `DebuggerManager.Instance.CodeOrigin?.SetCodeOriginForExitSpan(span)` call from `Tracer.StartSpan` so the exit-span Code Origin hook is no longer invoked on every span.
- Refreshed the breadcrumb comment in `SpanCodeOrigin.ShouldSkipExitSpan()` so re-enablers know to restore the call site in `Tracer.StartSpan` in addition to updating the existing tests.

## Reason for change

- Exit-span Code Origin has been hard-disabled since 3.28.0 (`ShouldSkipExitSpan()` returns `true`), so `SetCodeOriginForExitSpan` is a behavioral no-op today.
- It was still invoked on every `StartSpan`, paying a virtual call + `WebTags` type/property check on every span, plus a structured `Log.Debug` on every server entry span. Per-span overhead with no observable effect.
- The cost becomes more relevant in the upcoming default-on configuration where Code Origin for Spans is enabled by default.

## Implementation details

- Pure call-site removal. The implementation (`SetCodeOriginForExitSpan`, `AddExitSpanTags`, `PopulateUserFrames`, `ShouldSkipExitSpan`) is intentionally left in place so:
  - `SpanCodeOriginTests.ExitSpanTests` (which invokes the method directly) stays green.
  - Re-enabling exit-side Code Origin in the future is a small revert (restore the line in `Tracer.StartSpan` and flip `ShouldSkipExitSpan`).
- No production call sites remain; the only references to `SetCodeOriginForExitSpan` are now the method definition itself and the direct test callers.
