### PR TITLE
Use `ArtifactsOutput` in more places in the tracer build

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -13,3 +13,7 @@
 !**/obj/**
 !packages/**
 !artifacts/**
+
+# Re-exclude .git/ — the AzDO matcher otherwise re-includes refs whose branch
+# names contain "bin" or "obj" as a substring (e.g. refs/.../andrew/move-bin-and-obj).
+.git/**

--- a/.azure-pipelines/steps/restore-working-directory.yml
+++ b/.azure-pipelines/steps/restore-working-directory.yml
@@ -7,6 +7,6 @@ steps:
 - template: download-artifact.yml
   parameters:
     artifact: ${{ parameters.artifact }}
-    patterns: "**/@(bin|obj|packages)/**"
+    patterns: "**/@(bin|obj|packages|artifacts)/**"
     path: $(System.DefaultWorkingDirectory)
     retryCountOnTaskFailure: 5

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -293,7 +293,7 @@ stages:
       displayName: Upload working directory after the managed build
       artifact: build-windows-working-directory
 
-    - publish: $(System.DefaultWorkingDirectory)/tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll
+    - publish: $(System.DefaultWorkingDirectory)/artifacts/bin/Datadog.Trace.Manual/release_netcoreapp3.1/Datadog.Trace.Manual.dll
       displayName: Upload Datadog.Trace.Manual.dll for external CI
       artifact: Datadog.Trace.Manual.dll
 

--- a/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
+++ b/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
@@ -95,7 +95,7 @@
 
   # Skip if benchmark project DLL not built.
   # Some projects (e.g., Benchmarks.OpenTelemetry.Api) are not built on PRs. See Build.cs GetBenchmarkProjectsWithSettings().
-  $dllPattern = "$env:CODE_SRC\tracer\test\benchmarks\$env:BENCHMARK_PROJECT\bin\Release\*\$env:BENCHMARK_PROJECT.dll"
+  $dllPattern = "$env:CODE_SRC\artifacts\bin\$env:BENCHMARK_PROJECT\release_*\$env:BENCHMARK_PROJECT.dll"
   if (-not (Test-Path $dllPattern)) {
     Write-Output "Skipping: $env:BENCHMARK_PROJECT not built (DLL not found matching $dllPattern)"
     exit 0

--- a/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
@@ -84,8 +84,10 @@ $hostFramework = "net6.0"
 # Matches Build.cs: on Windows, benchmarks run against net472, netcoreapp3.1, net6.0
 $runtimes = @("net472", "netcoreapp3.1", "net6.0")
 
-# Source bin folder (built by Nuke in how_to_fetch_release)
-$sourceBinDir = "$benchmarkProjectDir\bin\Release\$hostFramework"
+# Source bin folder (built by Nuke in how_to_fetch_release).
+# Under UseArtifactsOutput (set in tracer/Directory.Build.props) the per-project
+# bin output lives at <repo>/artifacts/bin/<Project>/<config>_<tfm>/.
+$sourceBinDir = "$env:CODE_SRC\artifacts\bin\$Project\release_$hostFramework"
 
 if (-not (Test-Path "$sourceBinDir\$Project.exe")) {
     Write-Error "Benchmark executable not found at: $sourceBinDir\$Project.exe"

--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -4,6 +4,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths (e.g. GenerateBundle's dedupe) don't trip on the `tracer\..\` segment -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\artifacts'))</ArtifactsPath>
 
     <!-- Strong name signature -->
     <SignAssembly>true</SignAssembly>

--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -56,10 +56,10 @@ partial class Build
        .Before(PackNuGet, BuildMsi, ZipMonitoringHome)
        .Executes(() =>
         {
-            // also sign the NuGet package "bin" folder, as they are what gets packed in the NuGet
+            // also sign the per-project bin output, since these are what gets packed in the NuGet.
+            // Under UseArtifactsOutput (tracer/Directory.Build.props) the bin lives at artifacts/bin/<Project>/<pivot>/.
             var dllsInBin = ProjectsToPack
-                           .Select(project => project.Directory)
-                           .SelectMany(projectDir => projectDir.GlobFiles("**/bin/**/Datadog*.dll"));
+                           .SelectMany(project => (ArtifactsBinDirectory / project.Name).GlobFiles("**/Datadog*.dll"));
             var homeDlls = MonitoringHomeDirectory.GlobFiles("**/Datadog*.dll");
             var waf = MonitoringHomeDirectory.GlobFiles("**/ddwaf.dll");
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -46,6 +46,12 @@ partial class Build
     AbsolutePath ProfilerDirectory => RootDirectory / "profiler";
     AbsolutePath MsBuildProject => TracerDirectory / "Datadog.Trace.proj";
     AbsolutePath BuildArtifactsDirectory => RootDirectory / "artifacts";
+    AbsolutePath ArtifactsBinDirectory => BuildArtifactsDirectory / "bin";
+
+    // Resolves the bin output directory of a managed tracer project under the UseArtifactsOutput layout
+    // (set in tracer/Directory.Build.props). Pivot is "{config}_{tfm}" lower-cased.
+    AbsolutePath GetProjectBinDirectory(string projectName, string tfm) =>
+        ArtifactsBinDirectory / projectName / $"{BuildConfiguration.ToString().ToLowerInvariant()}_{tfm.ToLowerInvariant()}";
 
     AbsolutePath OutputDirectory => TracerDirectory / "bin";
     AbsolutePath SymbolsDirectory => OutputDirectory / "symbols";
@@ -485,8 +491,8 @@ partial class Build
             DotnetBuild(toBuild, noDependencies: false);
 
             var nativeGeneratedFilesOutputPath = NativeTracerProject.Directory / "Generated";
-            CallSitesGenerator.GenerateCallSites(TargetFrameworks, tfm => DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath);
-            CallTargetsGenerator.GenerateCallTargets(TargetFrameworks, tfm => DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath, Version, BuildDirectory);
+            CallSitesGenerator.GenerateCallSites(TargetFrameworks, tfm => GetProjectBinDirectory(Projects.DatadogTrace, tfm) / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath);
+            CallTargetsGenerator.GenerateCallTargets(TargetFrameworks, tfm => GetProjectBinDirectory(Projects.DatadogTrace, tfm) / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath, Version, BuildDirectory);
         });
 
     Target CompileTracerNativeTestsWindows => _ => _
@@ -735,8 +741,6 @@ partial class Build
                     frameworks = frameworks.Where(x=> x == Framework).ToList();
                 }
 
-                var testBinFolder = testDir / "bin" / BuildConfiguration;
-
                 var (ext, source, libdatadog) = Platform switch
                 {
                     PlatformFamily.Windows => ("dll", MonitoringHomeDirectory / $"win-{TargetPlatform}", "datadog_profiling_ffi.dll"),
@@ -753,9 +757,10 @@ partial class Build
 
                 foreach (var framework in frameworks)
                 {
+                    var testBinFolder = GetProjectBinDirectory(project.Name, framework);
                     foreach (var lib in libs)
                     {
-                        var dest = testBinFolder / framework / lib.Item2;
+                        var dest = testBinFolder / lib.Item2;
                         CopyFile(source / lib.Item1, dest, FileExistsPolicy.Overwrite);
                     }
                 }
@@ -769,10 +774,7 @@ partial class Build
                 .Executes(async () =>
                 {
                     var project = Solution.GetProject(Projects.AppSecUnitTests);
-                    var testDir = project.Directory;
                     var frameworks = project.GetTargetFrameworks();
-
-                    var testBinFolder = testDir / "bin" / BuildConfiguration;
 
                     // dotnet test runs under x86 for net461, even on x64 platforms
                     // so copy both, just to be safe
@@ -788,7 +790,7 @@ partial class Build
                                 var source = MonitoringHomeDirectory / arch;
                                 foreach (var framework in frameworks)
                                 {
-                                    var dest = testBinFolder / framework / arch;
+                                    var dest = GetProjectBinDirectory(project.Name, framework) / arch;
                                     CopyDirectoryRecursively(source, dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
                                     CopyFile(oldVersionPath, dest / $"ddwaf-{olderLibDdwafVersion}.dll", FileExistsPolicy.Overwrite);
                                 }
@@ -816,7 +818,7 @@ partial class Build
                                     // - The native tracer must be side-by-side with the running dll
                                     // As this is a managed-only unit test, the native tracer _must_ be in the root folder
                                     // For simplicity, we just copy all the native dlls there
-                                    var dest = testBinFolder / framework;
+                                    var dest = GetProjectBinDirectory(project.Name, framework);
 
                                     // use the files from the monitoring native folder
                                     CopyDirectoryRecursively(MonitoringHomeDirectory / (IsOsx ? "osx" : arch), dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
@@ -2379,7 +2381,7 @@ partial class Build
             List<(string Assembly, string Type)> datadogTraceTypes = new();
             foreach (var tfm in AppTrimmingTFMs)
             {
-                datadogTraceTypes.AddRange(GetTypeReferences(DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll"));
+                datadogTraceTypes.AddRange(GetTypeReferences(GetProjectBinDirectory(Projects.DatadogTrace, tfm) / Projects.DatadogTrace + ".dll"));
             }
 
             // add Datadog projects to the root descriptors file
@@ -2690,8 +2692,7 @@ partial class Build
 
         // Not sure if/why this is necessary, and we can't just point to the correct output location
         var src = MonitoringHomeDirectory;
-        var testProject = Solution.GetProject(project).Directory;
-        var dest = testProject / "bin" / BuildConfiguration / Framework / "profiler-lib";
+        var dest = GetProjectBinDirectory(project, Framework) / "profiler-lib";
         CopyDirectoryRecursively(src, dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
 
         // not sure exactly where this is supposed to go, may need to change the original build

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -677,7 +677,7 @@ partial class Build : NukeBuild
                 Logger.Information("Debugging...");
                 // Execute whatever you want to debug here
                 var nativeGeneratedFilesOutputPath = NativeTracerProject.Directory / "Generated";
-                CallTargetsGenerator.GenerateCallTargets(TargetFrameworks, tfm => DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath, Version);
+                CallTargetsGenerator.GenerateCallTargets(TargetFrameworks, tfm => GetProjectBinDirectory(Projects.DatadogTrace, tfm) / Projects.DatadogTrace + ".dll", nativeGeneratedFilesOutputPath, Version);
             });
     //*/
 }

--- a/tracer/src/Datadog.FeatureFlags.OpenFeature/Datadog.FeatureFlags.OpenFeature.csproj
+++ b/tracer/src/Datadog.FeatureFlags.OpenFeature/Datadog.FeatureFlags.OpenFeature.csproj
@@ -8,7 +8,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
     <NoWarn>$(NoWarn);NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == '' ">bin\$(Configuration)\packages</PackageOutputPath>
     <SignAssembly>False</SignAssembly>
     <!-- Note, this version should mirror the version of the OpenFeature package where possible -->
     <!-- When making patch version updates, you should use ".NET SDK" style version numbers -->

--- a/tracer/src/Datadog.InstrumentedAssemblyVerification/Directory.Build.props
+++ b/tracer/src/Datadog.InstrumentedAssemblyVerification/Directory.Build.props
@@ -1,7 +1,14 @@
 ﻿<Project>
-  <!-- 
-       Only here so that the default Directory.Build.props will not be used. 
-       This is neccessary because of a conflict between StrongNamer and our ThreadAbortAnalyzer, 
-       which causes the following issue: https://github.com/dsplaisted/strongnamer/issues/42 
+  <!--
+       Only here so that the default Directory.Build.props will not be used.
+       This is neccessary because of a conflict between StrongNamer and our ThreadAbortAnalyzer,
+       which causes the following issue: https://github.com/dsplaisted/strongnamer/issues/42
   -->
+
+  <PropertyGroup>
+    <!-- Send obj/ output to the repo-root artifacts/ tree, matching the rest of the tracer. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths (e.g. GenerateBundle's dedupe in BuildStandaloneTool) don't trip on `tracer\..\` segments -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\artifacts'))</ArtifactsPath>
+  </PropertyGroup>
 </Project>

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -15,7 +15,6 @@
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
     <NoWarn>$(NoWarn);NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == '' ">bin\$(Configuration)\packages</PackageOutputPath>
     <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>
   </PropertyGroup>
 

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -8,7 +8,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
     <NoWarn>$(NoWarn);NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == '' ">bin\$(Configuration)\packages</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -3,7 +3,11 @@
   <PropertyGroup>
     <RootNamespace>Datadog.Trace.ClrProfiler.Managed.Loader</RootNamespace>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-    <OutputPath>..\bin\ProfilerResources\</OutputPath>
+
+    <!-- The output path is referenced as a relative path by the native tracer's Resource.rc and -->
+    <!-- by build/cmake/FindManagedLoader.cmake; this explicit value wins over UseArtifactsOutput (set in tracer/Directory.Build.props). -->
+    <!-- $(TargetFramework) is appended manually because the SDK only auto-appends it when UseArtifactsOutput is false. -->
+    <OutputPath>..\bin\ProfilerResources\$(TargetFramework)\</OutputPath>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -32,7 +32,8 @@
       <PropertyGroup>
         <!-- When building standalone we have to exclude <netcoreapp3.1 from the targets otherwise the SDK has a fit -->
         <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;</TargetFrameworks>
-        <OutputPath>bin\$(Configuration)\Console</OutputPath>
+        <!-- $(TargetFramework) is appended manually because the SDK only auto-appends it when UseArtifactsOutput is false. -->
+        <OutputPath>bin\$(Configuration)\Console\$(TargetFramework)\</OutputPath>
         <PublishDir Condition="'$(PublishDir)' == '' ">bin\$(Configuration)\Console\publish\$(RuntimeIdentifier)</PublishDir>
         <AssemblyName>dd-trace</AssemblyName>
         <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-musl-x64;osx-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
@@ -131,7 +132,8 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <PackageId>dd-trace</PackageId>
-        <OutputPath>bin\$(Configuration)\Tool</OutputPath>
+        <!-- $(TargetFramework) is appended manually because the SDK only auto-appends it when UseArtifactsOutput is false. -->
+        <OutputPath>bin\$(Configuration)\Tool\$(TargetFramework)\</OutputPath>
       </PropertyGroup>
       <ItemGroup>
         <Content Include="..\Datadog.Trace.Bundle\home\**\*.*" Pack="true" PackagePath="\home" LinkBase="home">
@@ -170,10 +172,12 @@
   <Target Name="RemoveDuplicate" AfterTargets="ComputeFilesToPublish" BeforeTargets="_HandleFileConflictsForPublish">
 
     <!-- Required for StrongNamer: https://github.com/dsplaisted/strongnamer/issues/61 -->
+    <!-- $(IntermediateOutputPath) is the fully-resolved obj path (with pivot/TFM/RID applied), -->
+    <!-- so it works for both the legacy obj\<Config>\<TFM>\<RID>\ layout and UseArtifactsOutput. -->
     <Message Text="Removing $(DuplicateFileToRemove) from publish output" Importance="high" />
     <ItemGroup>
-      <ResolvedFileToPublish Remove="$(MSBuildThisFileDirectory)$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\SignedAssemblies\Spectre.Console.dll" />
-      <ResolvedFileToPublish Remove="$(MSBuildThisFileDirectory)$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\SignedAssemblies\ILVerification.dll" />
+      <ResolvedFileToPublish Remove="$(IntermediateOutputPath)SignedAssemblies\Spectre.Console.dll" />
+      <ResolvedFileToPublish Remove="$(IntermediateOutputPath)SignedAssemblies\ILVerification.dll" />
     </ItemGroup>
   </Target>
 

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -80,10 +80,12 @@
   <Target Name="RemoveDuplicate" AfterTargets="ComputeFilesToPublish" BeforeTargets="_HandleFileConflictsForPublish">
 
     <!-- Required for StrongNamer: https://github.com/dsplaisted/strongnamer/issues/61 -->
+    <!-- $(IntermediateOutputPath) is the fully-resolved obj path (with pivot/TFM/RID applied), -->
+    <!-- so it works for both the legacy obj\<Config>\<TFM>\<RID>\ layout and UseArtifactsOutput. -->
     <Message Text="Removing $(DuplicateFileToRemove) from publish output" Importance="high" />
     <ItemGroup>
-      <ResolvedFileToPublish Remove="$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\linked\Spectre.Console.dll" />
-      <ResolvedFileToPublish Remove="$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\linked\ILVerification.dll" />
+      <ResolvedFileToPublish Remove="$(IntermediateOutputPath)linked\Spectre.Console.dll" />
+      <ResolvedFileToPublish Remove="$(IntermediateOutputPath)linked\ILVerification.dll" />
     </ItemGroup>
   </Target>
 </Project>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/DataHelpers.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/DataHelpers.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         /// <returns>The path to the CI/Data directory</returns>
         public static string GetCiDataDirectory()
         {
-            static string BuildPath(string basePath) => Path.Combine(basePath, "CI", "Data");
+            static string BuildPath(string basePath) => Path.Combine(basePath, "tracer", "test", "Datadog.Trace.ClrProfiler.IntegrationTests", "CI", "Data");
 
             var currentDirectory = Environment.CurrentDirectory;
 

--- a/tracer/test/benchmarks/Benchmarks.OpenTelemetry.Api/Directory.Build.props
+++ b/tracer/test/benchmarks/Benchmarks.OpenTelemetry.Api/Directory.Build.props
@@ -1,3 +1,10 @@
 ﻿<Project>
   <!-- Only here so that the default Directory.Build.props will not be used. -->
+
+  <PropertyGroup>
+    <!-- Send obj/ output to the repo-root artifacts/ tree, matching the rest of the tracer. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths don't trip on `tracer\..\` segments -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\artifacts'))</ArtifactsPath>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/benchmarks/Benchmarks.OpenTelemetry.InstrumentedApi/Directory.Build.props
+++ b/tracer/test/benchmarks/Benchmarks.OpenTelemetry.InstrumentedApi/Directory.Build.props
@@ -1,3 +1,10 @@
 ﻿<Project>
   <!-- Only here so that the default Directory.Build.props will not be used. -->
+
+  <PropertyGroup>
+    <!-- Send obj/ output to the repo-root artifacts/ tree, matching the rest of the tracer. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths don't trip on `tracer\..\` segments -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\artifacts'))</ArtifactsPath>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/benchmarks/Benchmarks.Trace/Directory.Build.props
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Directory.Build.props
@@ -1,3 +1,10 @@
 ﻿<Project>
   <!-- Only here so that the default Directory.Build.props will not be used. -->
+
+  <PropertyGroup>
+    <!-- Send obj/ output to the repo-root artifacts/ tree, matching the rest of the tracer. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths don't trip on `tracer\..\` segments -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\artifacts'))</ArtifactsPath>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.Abstractions/Directory.Build.props
+++ b/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.Abstractions/Directory.Build.props
@@ -3,4 +3,11 @@
   This file intentionally left blank...
   to stop msbuild from looking up the folder hierarchy
   -->
+
+  <PropertyGroup>
+    <!-- Send obj/ output to the repo-root artifacts/ tree, matching the rest of the tracer. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths don't trip on `tracer\..\` segments -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\..\..\artifacts'))</ArtifactsPath>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Directory.Build.props
+++ b/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Directory.Build.props
@@ -7,5 +7,10 @@
   <PropertyGroup>
     <!-- Stop complaining about obsolete/vulnerable packages, we know they are -->
     <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
+
+    <!-- Send obj/ output to the repo-root artifacts/ tree, matching the rest of the tracer. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths don't trip on `tracer\..\` segments -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\..\..\artifacts'))</ArtifactsPath>
   </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Directory.Build.props
+++ b/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Directory.Build.props
@@ -7,5 +7,10 @@
   <PropertyGroup>
     <!-- Stop complaining about obsolete/vulnerable packages, we know they are -->
     <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
+
+    <!-- Send obj/ output to the repo-root artifacts/ tree, matching the rest of the tracer. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <!-- Normalize so that downstream tools that string-compare paths don't trip on `tracer\..\` segments -->
+    <ArtifactsPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\..\..\artifacts'))</ArtifactsPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes

Set `UseArtifactsOutput` for all `tracer/` libraries

## Reason for change

`UseArtifactsOutput` puts all the build output [nested in a top-level directory](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output). We are already using this for samples and in _some_ places. This PR extends it to use in more of the tracer build.

```
📁 artifacts
    └──📂 <Type of output>
        └──📂 <Project name>
            └──📂 <Pivot>
```

The advantage of this approach is it neatly scopes the output of a stage in the `artifacts/bin`, `artifacts/obj` or `artifacts/packages` folder (for example). This is convenient in _general_ (I use artifact layout in personal projects wherever possible), but it's particularly useful in CI, especially if/when we need to migrate the build to gitlab.

## Implementation details

Get the 🤖 to make the change. As long as CI keeps working, we can still build locally, and the artifacts look the same, ultimately, we're good 👍 

## Test coverage

This is the test. Also had the agent do some analysis of the artifacts to make sure it's ok, and tested locally.

## Other details

Stacked on:
- https://github.com/DataDog/dd-trace-dotnet/pull/8610

Will add more to the stack (e.g. profiling assets later)

Requires:
- https://github.com/DataDog/serverless-tools/pull/126