### PR TITLE
Fix off-by-one error in ASM Encoder

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -308,7 +308,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                     var idx = 0;
                     foreach (var val in enumerable)
                     {
-                        if (idx > childrenCount)
+                        if (idx >= childrenCount)
                         {
                             break;
                         }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/EncoderUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/EncoderUnitTests.cs
@@ -126,6 +126,11 @@ public class EncoderUnitTests : WafLibraryRequiredTest
     [InlineData(WafConstants.MaxContainerSize + 10000, WafConstants.MaxContainerSize)]
     public void TestNonIListEnumerableLength(int length, int expectedLength)
     {
+        // The legacy encoder's type switch has no case for IEnumerable<object>;
+        // it falls through to EncodeUnknownType which calls ToString() on the
+        // enumerable, so this test only applies to the new Encoder.
+        Skip.If(_encoder is not Encoder, "Test only applies to the new (unsafe) Encoder");
+
         // Lazy LINQ enumerable: RepeatIterator<T> implements IEnumerable<T> but
         // not IList, so this exercises the non-IList branch of ProcessIEnumerable
         var target = Enumerable.Repeat((object)"test", length);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/EncoderUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/EncoderUnitTests.cs
@@ -124,6 +124,26 @@ public class EncoderUnitTests : WafLibraryRequiredTest
     [InlineData(WafConstants.MaxContainerSize - 1, WafConstants.MaxContainerSize - 1)]
     [InlineData(WafConstants.MaxContainerSize, WafConstants.MaxContainerSize)]
     [InlineData(WafConstants.MaxContainerSize + 10000, WafConstants.MaxContainerSize)]
+    public void TestNonIListEnumerableLength(int length, int expectedLength)
+    {
+        // Lazy LINQ enumerable: RepeatIterator<T> implements IEnumerable<T> but
+        // not IList, so this exercises the non-IList branch of ProcessIEnumerable
+        var target = Enumerable.Repeat((object)"test", length);
+
+        using var intermediate = _encoder.Encode(target, applySafetyLimits: true);
+
+        intermediate.ResultDdwafObject.NbEntries.Should().Be((ulong)expectedLength);
+
+        var result = intermediate.ResultDdwafObject.Decode() as List<object>;
+        result.Should().NotBeNull();
+        result.Should().HaveCount(expectedLength);
+        result.Should().AllBeEquivalentTo("test");
+    }
+
+    [SkippableTheory]
+    [InlineData(WafConstants.MaxContainerSize - 1, WafConstants.MaxContainerSize - 1)]
+    [InlineData(WafConstants.MaxContainerSize, WafConstants.MaxContainerSize)]
+    [InlineData(WafConstants.MaxContainerSize + 10000, WafConstants.MaxContainerSize)]
     public void TestMapLength(int length, int expectedLength)
     {
         var target = Enumerable.Range(0, length).ToDictionary(x => x.ToString(), _ => (object)"test");


### PR DESCRIPTION
## Summary of changes

Fix off-by-one error in the `Encoder` when encoding an `IEnumerable` that doesn't implement `IList`

## Reason for change

There's an off by one error in the encoder

## Implementation details

- Create a PR to repro
- Fix the off-by-one error

## Test coverage

Added a unit test to demonstrate the error and fix it.

Note that the legacy encoder's switch has no `IEnumerable<object>` case, it falls through to `EncodeUnknownType` (which just calls `.ToString()`), so the tests are skipped for that case.
