### PR TITLE
Serialize RuntimeIdTests and HttpHeaderHelperTests to remove telemetry header flake

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/HttpHeaderHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/HttpHeaderHelperTests.cs
@@ -18,6 +18,11 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.HttpOverStreams;
 
+// Reads RuntimeId.GetRootSessionId() (via TelemetryAgentHttpHeaderHelper.DefaultHeaders) and the lazy-cached
+// TelemetryHttpHeaderNames._httpSerializedDefaultAgentHeaders. Must serialize with RuntimeIdTests, which
+// transiently mutates _rootSessionId — otherwise the fresh DefaultHeaders read and the cached serialized
+// headers can disagree on whether DD-Root-Session-ID is present.
+[Collection(nameof(EnvironmentVariablesTestCollection))]
 public class HttpHeaderHelperTests
 {
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/HttpHeaderHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/HttpHeaderHelperTests.cs
@@ -18,11 +18,6 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.HttpOverStreams;
 
-// Reads RuntimeId.GetRootSessionId() (via TelemetryAgentHttpHeaderHelper.DefaultHeaders) and the lazy-cached
-// TelemetryHttpHeaderNames._httpSerializedDefaultAgentHeaders. Must serialize with RuntimeIdTests, which
-// transiently mutates _rootSessionId — otherwise the fresh DefaultHeaders read and the cached serialized
-// headers can disagree on whether DD-Root-Session-ID is present.
-[Collection(nameof(EnvironmentVariablesTestCollection))]
 public class HttpHeaderHelperTests
 {
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Util/RuntimeIdTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RuntimeIdTests.cs
@@ -12,6 +12,11 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.Util
 {
+    // Mutates the _DD_ROOT_DOTNET_SESSION_ID env var and the lazy-cached RuntimeId._rootSessionId. Must run
+    // serially with anything that reads RuntimeId.GetRootSessionId() — notably HttpHeaderHelperTests, which
+    // compares fresh TelemetryHttpHeaderNames.GetDefaultAgentHeaders() output against the lazy-cached
+    // _httpSerializedDefaultAgentHeaders and will flake if either is read during this test's mutation window.
+    [Collection(nameof(EnvironmentVariablesTestCollection))]
     [EnvironmentRestorer(ConfigurationKeys.Telemetry.RootSessionId)]
     public class RuntimeIdTests
     {

--- a/tracer/test/Datadog.Trace.Tests/Util/RuntimeIdTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RuntimeIdTests.cs
@@ -13,9 +13,7 @@ using Xunit;
 namespace Datadog.Trace.Tests.Util
 {
     // Mutates the _DD_ROOT_DOTNET_SESSION_ID env var and the lazy-cached RuntimeId._rootSessionId. Must run
-    // serially with anything that reads RuntimeId.GetRootSessionId() — notably HttpHeaderHelperTests, which
-    // compares fresh TelemetryHttpHeaderNames.GetDefaultAgentHeaders() output against the lazy-cached
-    // _httpSerializedDefaultAgentHeaders and will flake if either is read during this test's mutation window.
+    // serially with anything that reads RuntimeId.GetRootSessionId(), which is basically everything
     [Collection(nameof(EnvironmentVariablesTestCollection))]
     [EnvironmentRestorer(ConfigurationKeys.Telemetry.RootSessionId)]
     public class RuntimeIdTests


### PR DESCRIPTION
## Summary of changes

Add `[Collection(nameof(EnvironmentVariablesTestCollection))]` to `RuntimeIdTests` so they cannot run in parallel.

## Reason for change

`HttpHeaderHelperTests.TelemetryAgentHttpHeaderHelper_WritesExpectedHeaders` flaked in [build 201656](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=201656&view=logs&j=9e99876c-cf2a-524e-ab4f-fe5fda2d14e0&t=3f315e10-b9e0-5188-8254-af235fd7d13d&s=3aa6981d-8091-5a76-864f-2e4cd27a2640): `expected` included `DD-Root-Session-ID: inherited-root-session-id`, `actual` did not.

`RuntimeIdTests` transiently sets `RuntimeId._rootSessionId = "inherited-root-session-id"` before restoring it in `finally`. xUnit runs test classes in parallel, and the log confirms `RuntimeIdTests` (6ms) ran inside `HttpHeaderHelperTests`'s 146ms window. The race:

1. `helper.DefaultHeaders` read fresh during the mutation window → `expected` includes the root header.
2. `helper.WriteLeadingHeaders` populated the once-per-process cache `TelemetryHttpHeaderNames._httpSerializedDefaultAgentHeaders` after `RuntimeIdTests` restored state → `actual` lacks it.

## Implementation details

- `RuntimeIdTests.cs` — gains `[Collection(...)]`. It already mutates `_DD_ROOT_DOTNET_SESSION_ID`, so it belongs here anyway.

Production code is unchanged: the lazy cache and static field are fine because `_rootSessionId` is set once at startup in real runs.

## Test coverage

No new tests — existing coverage is preserved, just no longer racing.

## Other details