### PR TITLE
fix(debugger): apply redaction to dictionary iterator key/value

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -7,12 +7,54 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Datadog.Trace.Debugger.Helpers;
+using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Debugger.Expressions;
 
 internal sealed partial class ProbeExpressionParser<T>
 {
+    private static bool SafeEquals(object left, object right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        var leftType = left.GetType();
+        var rightType = right.GetType();
+        if (leftType != rightType || !IsSafeToCallEquals(leftType))
+        {
+            return false;
+        }
+
+        return left.Equals(right);
+    }
+
+    private static bool IsSafeToCallEquals(Type type)
+    {
+        var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
+        if (TypeExtensions.IsSimple(effectiveType))
+        {
+            return true;
+        }
+
+        foreach (var allowedType in Redaction.AllowedTypesSafeToCallToString)
+        {
+            if (allowedType == effectiveType)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private Expression NotEqual(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         return BinaryOperation(reader, parameters, itParameter, "!=");
@@ -133,11 +175,11 @@ internal sealed partial class ProbeExpressionParser<T>
             {
                 var leftAsObject = left.Type == typeof(object) ? left : Expression.Convert(left, typeof(object));
                 var rightAsObject = right.Type == typeof(object) ? right : Expression.Convert(right, typeof(object));
-                var objectEquals = Expression.Call(
-                    ProbeExpressionParserHelper.GetMethodByReflection(typeof(object), nameof(object.Equals), new[] { typeof(object), typeof(object) }),
+                var safeEquals = Expression.Call(
+                    ProbeExpressionParserHelper.GetMethodByReflection(typeof(ProbeExpressionParser<T>), nameof(SafeEquals), new[] { typeof(object), typeof(object) }),
                     leftAsObject,
                     rightAsObject);
-                return operand == "==" ? objectEquals : Expression.Not(objectEquals);
+                return operand == "==" ? safeEquals : Expression.Not(safeEquals);
             }
 
             return operand == "==" ? Expression.Equal(left, right) : Expression.NotEqual(left, right);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -62,14 +62,14 @@ internal sealed partial class ProbeExpressionParser<T>
 
             if (left.Type == typeof(string) && right.Type == typeof(string))
             {
-                return StringLexicographicComparison(left, right, operand);
+                return RedactDictionaryBinaryOperation(left, right, StringLexicographicComparison(left, right, operand));
             }
 
             HandleDurationBinaryOperation(ref left, ref right);
 
             NumericImplicitConversion(ref left, ref right);
 
-            return operand switch
+            var comparison = operand switch
             {
                 ">" => Expression.GreaterThan(left, right),
                 ">=" => Expression.GreaterThanOrEqual(left, right),
@@ -78,6 +78,7 @@ internal sealed partial class ProbeExpressionParser<T>
                 "==" or "!=" => EqualExpression(),
                 _ => throw new ArgumentException("Unknown operand" + operand, nameof(operand))
             };
+            return RedactDictionaryBinaryOperation(left, right, comparison);
         }
         catch (Exception e)
         {
@@ -126,6 +127,17 @@ internal sealed partial class ProbeExpressionParser<T>
                 return operand == "=="
                     ? Expression.ReferenceEqual(Expression.Constant(null, typeof(object)), rightAsObject)
                     : Expression.Not(Expression.ReferenceEqual(Expression.Constant(null, typeof(object)), rightAsObject));
+            }
+
+            if (left.Type == typeof(object) || right.Type == typeof(object))
+            {
+                var leftAsObject = left.Type == typeof(object) ? left : Expression.Convert(left, typeof(object));
+                var rightAsObject = right.Type == typeof(object) ? right : Expression.Convert(right, typeof(object));
+                var objectEquals = Expression.Call(
+                    ProbeExpressionParserHelper.GetMethodByReflection(typeof(object), nameof(object.Equals), new[] { typeof(object), typeof(object) }),
+                    leftAsObject,
+                    rightAsObject);
+                return operand == "==" ? objectEquals : Expression.Not(objectEquals);
             }
 
             return operand == "==" ? Expression.Equal(left, right) : Expression.NotEqual(left, right);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Type = System.Type;
@@ -17,6 +18,8 @@ namespace Datadog.Trace.Debugger.Expressions;
 
 internal partial class ProbeExpressionParser<T>
 {
+    private Dictionary<Expression, RedactedDictionaryValueExpression> _redactedDictionaryValues;
+
     private Expression HasAny(JsonTextReader reader, List<ParameterExpression> parameters)
     {
         var any = typeof(Enumerable).GetMethods().Single(m => m.Name == nameof(Enumerable.Any) && m.GetParameters().Length == 2);
@@ -255,11 +258,10 @@ internal partial class ProbeExpressionParser<T>
         if (itParameter.Type == typeof(DictionaryEntry))
         {
             var property = Expression.Property(itParameter, propertyName);
-            var keyProperty = Expression.Property(itParameter, nameof(DictionaryEntry.Key));
             propertyExpression = propertyName switch
             {
-                nameof(KeyValuePair<int, int>.Key) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
-                nameof(KeyValuePair<int, int>.Value) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
+                nameof(KeyValuePair<int, int>.Key) => property,
+                nameof(KeyValuePair<int, int>.Value) when TryRedactDictionaryValueMember(itParameter, out var redactedValue) => redactedValue,
                 _ => property,
             };
             return true;
@@ -268,11 +270,10 @@ internal partial class ProbeExpressionParser<T>
         if (itParameter.Type.IsGenericType && itParameter.Type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
         {
             var property = Expression.Property(itParameter, propertyName);
-            var keyProperty = Expression.Property(itParameter, nameof(KeyValuePair<int, int>.Key));
             propertyExpression = propertyName switch
             {
-                nameof(KeyValuePair<int, int>.Key) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
-                nameof(KeyValuePair<int, int>.Value) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
+                nameof(KeyValuePair<int, int>.Key) => property,
+                nameof(KeyValuePair<int, int>.Value) when TryRedactDictionaryValueMember(itParameter, out var redactedValue) => redactedValue,
                 _ => property,
             };
             return true;
@@ -281,26 +282,106 @@ internal partial class ProbeExpressionParser<T>
         return false;
     }
 
-    private ConditionalExpression RedactDictionaryValueWhenKeyMatches(MemberExpression valueExpression, Expression keyExpression)
+    private bool TryRedactDictionaryValueMember(Expression dictionaryEntryExpression, out Expression redactedValue)
+    {
+        redactedValue = null;
+
+        if (dictionaryEntryExpression.Type != typeof(DictionaryEntry) &&
+            (!dictionaryEntryExpression.Type.IsGenericType || dictionaryEntryExpression.Type.GetGenericTypeDefinition() != typeof(KeyValuePair<,>)))
+        {
+            return false;
+        }
+
+        var valueExpression = Expression.Property(dictionaryEntryExpression, nameof(KeyValuePair<int, int>.Value));
+        var keyExpression = Expression.Property(dictionaryEntryExpression, nameof(KeyValuePair<int, int>.Key));
+        redactedValue = TrackRedactedDictionaryValue(valueExpression, keyExpression);
+        return true;
+    }
+
+    private MemberExpression TrackRedactedDictionaryValue(MemberExpression valueExpression, MemberExpression keyExpression)
     {
         var shouldRedactKeyMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(ProbeExpressionParser<T>), nameof(ShouldRedactDictionaryKey), [typeof(object)]);
         var shouldRedactCall = Expression.Call(Expression.Constant(this), shouldRedactKeyMethod, Expression.Convert(keyExpression, typeof(object)));
-        return Expression.Condition(shouldRedactCall, RedactedDictionaryValue(valueExpression.Type), valueExpression);
+        (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
+           .Add(valueExpression, new RedactedDictionaryValueExpression(shouldRedactCall, valueExpression));
+        return valueExpression;
     }
 
-    private Expression RedactedDictionaryValue(Type valueType)
+    private bool TryGetRedactedDictionaryValue(Expression expression, out RedactedDictionaryValueExpression redactedDictionaryValue)
     {
-        if (valueType == typeof(string))
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression)
         {
-            return RedactedValue();
+            expression = unaryExpression.Operand;
         }
 
-        if (valueType == typeof(object))
+        if (_redactedDictionaryValues != null && _redactedDictionaryValues.TryGetValue(expression, out redactedDictionaryValue))
         {
-            return Expression.Convert(RedactedValue(), typeof(object));
+            return true;
         }
 
-        return Expression.Default(valueType);
+        redactedDictionaryValue = default;
+        return false;
+    }
+
+    private MemberExpression RedactedDictionaryValueMember(RedactedDictionaryValueExpression redactedDictionaryValue, string propertyOrFieldValue)
+    {
+        var valueExpression = redactedDictionaryValue.ValueExpression;
+        var memberExpression = Expression.PropertyOrField(valueExpression, propertyOrFieldValue);
+        (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
+           .Add(memberExpression, new RedactedDictionaryValueExpression(redactedDictionaryValue.ShouldRedactExpression, memberExpression));
+        return memberExpression;
+    }
+
+    private Expression RedactDictionaryBinaryOperation(Expression left, Expression right, Expression comparison)
+    {
+        Expression shouldRedact = null;
+        if (TryGetRedactedDictionaryValue(left, out var leftRedactedDictionaryValue))
+        {
+            shouldRedact = leftRedactedDictionaryValue.ShouldRedactExpression;
+        }
+
+        if (TryGetRedactedDictionaryValue(right, out var rightRedactedDictionaryValue))
+        {
+            shouldRedact = shouldRedact == null
+                               ? rightRedactedDictionaryValue.ShouldRedactExpression
+                               : Expression.OrElse(shouldRedact, rightRedactedDictionaryValue.ShouldRedactExpression);
+        }
+
+        return shouldRedact == null
+                   ? comparison
+                   : Expression.Condition(shouldRedact, Expression.Constant(false), comparison);
+    }
+
+    private Expression RedactDictionaryValueForReturn(RedactedDictionaryValueExpression redactedDictionaryValue, Expression finalExpr, List<ParameterExpression> scopeMembers)
+    {
+        var redactedValue = RedactedValue();
+        if (typeof(T) == typeof(object))
+        {
+            return Expression.Condition(
+                redactedDictionaryValue.ShouldRedactExpression,
+                Expression.Convert(redactedValue, typeof(object)),
+                Expression.Convert(finalExpr, typeof(object)));
+        }
+
+        if (typeof(T) == typeof(string))
+        {
+            var valueAsString = finalExpr.Type == typeof(string)
+                                    ? finalExpr
+                                    : DumpExpression(finalExpr, scopeMembers);
+            return Expression.Condition(redactedDictionaryValue.ShouldRedactExpression, redactedValue, valueAsString);
+        }
+
+        if (typeof(T) == typeof(bool) && finalExpr.Type == typeof(bool))
+        {
+            return Expression.Condition(redactedDictionaryValue.ShouldRedactExpression, Expression.Constant(false), finalExpr);
+        }
+
+        if (typeof(T).IsNumeric() && TryConvertToNumericType<T>(finalExpr, out var numericResult))
+        {
+            return Expression.Condition(redactedDictionaryValue.ShouldRedactExpression, Expression.Constant(default(T), typeof(T)), numericResult);
+        }
+
+        return finalExpr;
     }
 
     private bool ShouldRedactDictionaryKey(object key)
@@ -384,5 +465,12 @@ internal partial class ProbeExpressionParser<T>
 
         assignableFrom = null;
         return false;
+    }
+
+    private readonly struct RedactedDictionaryValueExpression(Expression shouldRedactExpression, Expression valueExpression)
+    {
+        internal Expression ShouldRedactExpression { get; } = shouldRedactExpression;
+
+        internal Expression ValueExpression { get; } = valueExpression;
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -20,6 +20,32 @@ internal partial class ProbeExpressionParser<T>
 {
     private Dictionary<Expression, RedactedDictionaryValueExpression> _redactedDictionaryValues;
 
+    private static bool ShouldRedactDictionaryKey(object key)
+    {
+        var type = key?.GetType() ?? typeof(object);
+        var name = key switch
+        {
+            string stringKey => stringKey,
+            null => null,
+            _ when Redaction.IsSafeToCallToString(type) => key.ToString(),
+            _ => null
+        };
+
+        return Redaction.Instance.ShouldRedact(name, type, out _);
+    }
+
+    private static Expression RedactedDictionaryOperationDefault(Type type)
+    {
+        if (type == typeof(bool))
+        {
+            return Expression.Constant(false);
+        }
+
+        return type == typeof(string)
+                   ? Expression.Constant("{REDACTED}")
+                   : Expression.Default(type);
+    }
+
     private Expression HasAny(JsonTextReader reader, List<ParameterExpression> parameters)
     {
         var any = typeof(Enumerable).GetMethods().Single(m => m.Name == nameof(Enumerable.Any) && m.GetParameters().Length == 2);
@@ -180,7 +206,7 @@ internal partial class ProbeExpressionParser<T>
                 return ReturnDefaultValueExpression();
             }
 
-            return CollectionAndStringLengthExpression(source);
+            return RedactDictionaryOperation(source, CollectionAndStringLengthExpression(source));
         }
         catch (Exception e)
         {
@@ -301,7 +327,7 @@ internal partial class ProbeExpressionParser<T>
     private MemberExpression TrackRedactedDictionaryValue(MemberExpression valueExpression, MemberExpression keyExpression)
     {
         var shouldRedactKeyMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(ProbeExpressionParser<T>), nameof(ShouldRedactDictionaryKey), [typeof(object)]);
-        var shouldRedactCall = Expression.Call(Expression.Constant(this), shouldRedactKeyMethod, Expression.Convert(keyExpression, typeof(object)));
+        var shouldRedactCall = Expression.Call(null, shouldRedactKeyMethod, Expression.Convert(keyExpression, typeof(object)));
         (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
            .Add(valueExpression, new RedactedDictionaryValueExpression(shouldRedactCall, valueExpression));
         return valueExpression;
@@ -347,9 +373,27 @@ internal partial class ProbeExpressionParser<T>
                                : Expression.OrElse(shouldRedact, rightRedactedDictionaryValue.ShouldRedactExpression);
         }
 
-        return shouldRedact == null
-                   ? comparison
-                   : Expression.Condition(shouldRedact, Expression.Constant(false), comparison);
+        return RedactDictionaryOperationWithGuard(shouldRedact, comparison);
+    }
+
+    private Expression RedactDictionaryOperation(Expression source, Expression operation)
+    {
+        return TryGetRedactedDictionaryValue(source, out var redactedDictionaryValue)
+                   ? RedactDictionaryOperationWithGuard(redactedDictionaryValue.ShouldRedactExpression, operation)
+                   : operation;
+    }
+
+    private Expression RedactDictionaryOperationWithGuard(Expression shouldRedact, Expression operation)
+    {
+        if (shouldRedact == null)
+        {
+            return operation;
+        }
+
+        var redactedOperation = Expression.Condition(shouldRedact, RedactedDictionaryOperationDefault(operation.Type), operation);
+        (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
+           .Add(redactedOperation, new RedactedDictionaryValueExpression(shouldRedact, redactedOperation));
+        return redactedOperation;
     }
 
     private Expression RedactDictionaryValueForReturn(RedactedDictionaryValueExpression redactedDictionaryValue, Expression finalExpr, List<ParameterExpression> scopeMembers)
@@ -382,20 +426,6 @@ internal partial class ProbeExpressionParser<T>
         }
 
         return finalExpr;
-    }
-
-    private bool ShouldRedactDictionaryKey(object key)
-    {
-        var type = key?.GetType() ?? typeof(object);
-        var name = key switch
-        {
-            string stringKey => stringKey,
-            null => null,
-            _ when Redaction.IsSafeToCallToString(type) => key.ToString(),
-            _ => null
-        };
-
-        return Redaction.Instance.ShouldRedact(name, type, out _);
     }
 
     private bool IsSafeCollection(Type type)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -46,6 +46,12 @@ internal partial class ProbeExpressionParser<T>
                    : Expression.Default(type);
     }
 
+    private static bool IsDictionaryEntryType(Type type)
+    {
+        return type == typeof(DictionaryEntry) ||
+               (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
+    }
+
     private Expression HasAny(JsonTextReader reader, List<ParameterExpression> parameters)
     {
         var any = typeof(Enumerable).GetMethods().Single(m => m.Name == nameof(Enumerable.Any) && m.GetParameters().Length == 2);
@@ -187,12 +193,19 @@ internal partial class ProbeExpressionParser<T>
         }
 
         var getItemCall = Expression.Call(source, getItemMethod, indexOrKey);
+        Expression result;
         if (getItemCall.Type == convertToType)
         {
-            return getItemCall;
+            result = getItemCall;
+        }
+        else
+        {
+            result = Expression.Convert(getItemCall, convertToType);
         }
 
-        return Expression.Convert(getItemCall, convertToType);
+        return IsDictionaryEntryType(result.Type)
+                   ? TrackRedactedDictionaryEntry(result)
+                   : result;
     }
 
     private Expression Length(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
@@ -312,8 +325,7 @@ internal partial class ProbeExpressionParser<T>
     {
         redactedValue = null;
 
-        if (dictionaryEntryExpression.Type != typeof(DictionaryEntry) &&
-            (!dictionaryEntryExpression.Type.IsGenericType || dictionaryEntryExpression.Type.GetGenericTypeDefinition() != typeof(KeyValuePair<,>)))
+        if (!IsDictionaryEntryType(dictionaryEntryExpression.Type))
         {
             return false;
         }
@@ -324,25 +336,42 @@ internal partial class ProbeExpressionParser<T>
         return true;
     }
 
+    private Expression TrackRedactedDictionaryEntry(Expression dictionaryEntryExpression)
+    {
+        var keyExpression = Expression.Property(dictionaryEntryExpression, nameof(KeyValuePair<int, int>.Key));
+        TrackRedactedDictionaryExpression(dictionaryEntryExpression, keyExpression);
+        return dictionaryEntryExpression;
+    }
+
     private MemberExpression TrackRedactedDictionaryValue(MemberExpression valueExpression, MemberExpression keyExpression)
+    {
+        TrackRedactedDictionaryExpression(valueExpression, keyExpression);
+        return valueExpression;
+    }
+
+    private void TrackRedactedDictionaryExpression(Expression expression, Expression keyExpression)
     {
         var shouldRedactKeyMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(ProbeExpressionParser<T>), nameof(ShouldRedactDictionaryKey), [typeof(object)]);
         var shouldRedactCall = Expression.Call(null, shouldRedactKeyMethod, Expression.Convert(keyExpression, typeof(object)));
         (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
-           .Add(valueExpression, new RedactedDictionaryValueExpression(shouldRedactCall, valueExpression));
-        return valueExpression;
+           .Add(expression, new RedactedDictionaryValueExpression(shouldRedactCall, expression));
     }
 
     private bool TryGetRedactedDictionaryValue(Expression expression, out RedactedDictionaryValueExpression redactedDictionaryValue)
     {
-        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression)
+        while (expression != null)
         {
-            expression = unaryExpression.Operand;
-        }
+            if (_redactedDictionaryValues != null && _redactedDictionaryValues.TryGetValue(expression, out redactedDictionaryValue))
+            {
+                return true;
+            }
 
-        if (_redactedDictionaryValues != null && _redactedDictionaryValues.TryGetValue(expression, out redactedDictionaryValue))
-        {
-            return true;
+            if (expression is not UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unaryExpression)
+            {
+                break;
+            }
+
+            expression = unaryExpression.Operand;
         }
 
         redactedDictionaryValue = default;

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -281,17 +281,39 @@ internal partial class ProbeExpressionParser<T>
         return false;
     }
 
-    private ConditionalExpression RedactDictionaryValueWhenKeyMatches(Expression valueExpression, Expression keyExpression)
+    private ConditionalExpression RedactDictionaryValueWhenKeyMatches(MemberExpression valueExpression, Expression keyExpression)
     {
         var shouldRedactKeyMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(ProbeExpressionParser<T>), nameof(ShouldRedactDictionaryKey), [typeof(object)]);
         var shouldRedactCall = Expression.Call(Expression.Constant(this), shouldRedactKeyMethod, Expression.Convert(keyExpression, typeof(object)));
-        return Expression.Condition(shouldRedactCall, RedactedValue(), valueExpression);
+        return Expression.Condition(shouldRedactCall, RedactedDictionaryValue(valueExpression.Type), valueExpression);
+    }
+
+    private Expression RedactedDictionaryValue(Type valueType)
+    {
+        if (valueType == typeof(string))
+        {
+            return RedactedValue();
+        }
+
+        if (valueType == typeof(object))
+        {
+            return Expression.Convert(RedactedValue(), typeof(object));
+        }
+
+        return Expression.Default(valueType);
     }
 
     private bool ShouldRedactDictionaryKey(object key)
     {
-        var name = key?.ToString();
         var type = key?.GetType() ?? typeof(object);
+        var name = key switch
+        {
+            string stringKey => stringKey,
+            null => null,
+            _ when Redaction.IsSafeToCallToString(type) => key.ToString(),
+            _ => null
+        };
+
         return Redaction.Instance.ShouldRedact(name, type, out _);
     }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -248,23 +248,51 @@ internal partial class ProbeExpressionParser<T>
         return Expression.Call(null, castMethod, source);
     }
 
-    private bool TryGetCollectionIteratorProperty(ParameterExpression itParameter, string propertyName, out MemberExpression propertyExpression)
+    private bool TryGetCollectionIteratorProperty(ParameterExpression itParameter, string propertyName, out Expression propertyExpression)
     {
         propertyExpression = null;
 
         if (itParameter.Type == typeof(DictionaryEntry))
         {
-            propertyExpression = Expression.Property(itParameter, propertyName);
+            var property = Expression.Property(itParameter, propertyName);
+            var keyProperty = Expression.Property(itParameter, nameof(DictionaryEntry.Key));
+            propertyExpression = propertyName switch
+            {
+                nameof(KeyValuePair<int, int>.Key) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
+                nameof(KeyValuePair<int, int>.Value) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
+                _ => property,
+            };
             return true;
         }
 
         if (itParameter.Type.IsGenericType && itParameter.Type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
         {
-            propertyExpression = Expression.Property(itParameter, propertyName);
+            var property = Expression.Property(itParameter, propertyName);
+            var keyProperty = Expression.Property(itParameter, nameof(KeyValuePair<int, int>.Key));
+            propertyExpression = propertyName switch
+            {
+                nameof(KeyValuePair<int, int>.Key) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
+                nameof(KeyValuePair<int, int>.Value) => RedactDictionaryValueWhenKeyMatches(property, keyProperty),
+                _ => property,
+            };
             return true;
         }
 
         return false;
+    }
+
+    private ConditionalExpression RedactDictionaryValueWhenKeyMatches(Expression valueExpression, Expression keyExpression)
+    {
+        var shouldRedactKeyMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(ProbeExpressionParser<T>), nameof(ShouldRedactDictionaryKey), [typeof(object)]);
+        var shouldRedactCall = Expression.Call(Expression.Constant(this), shouldRedactKeyMethod, Expression.Convert(keyExpression, typeof(object)));
+        return Expression.Condition(shouldRedactCall, RedactedValue(), valueExpression);
+    }
+
+    private bool ShouldRedactDictionaryKey(object key)
+    {
+        var name = key?.ToString();
+        var type = key?.GetType() ?? typeof(object);
+        return Redaction.Instance.ShouldRedact(name, type, out _);
     }
 
     private bool IsSafeCollection(Type type)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -270,27 +270,29 @@ internal partial class ProbeExpressionParser<T>
             return Expression.Constant(false);
         }
 
-        return Expression.TypeIs(value, type);
+        return RedactDictionaryOperation(value, Expression.TypeIs(value, type));
     }
 
-    private MemberExpression GetTypeName(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
+    private Expression GetTypeName(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
-        return Expression.Property(
+        var source = ParseTree(reader, parameters, itParameter);
+        return RedactDictionaryOperation(source, Expression.Property(
             Expression.Call(
-                ParseTree(reader, parameters, itParameter),
+                source,
                 ProbeExpressionParserHelper.GetMethodByReflection(typeof(object), "GetType", Type.EmptyTypes)),
-            nameof(Type.FullName));
+            nameof(Type.FullName)));
     }
 
-    private TypeBinaryExpression IsUndefined(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
+    private Expression IsUndefined(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         var value = ParseTree(reader, parameters, itParameter);
-        return Expression.TypeEqual(value, ProbeExpressionParserHelper.UndefinedValueType);
+        return RedactDictionaryOperation(value, Expression.TypeEqual(value, ProbeExpressionParserHelper.UndefinedValueType));
     }
 
-    private UnaryExpression IsDefined(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
+    private Expression IsDefined(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
-        return Expression.Not(IsUndefined(reader, parameters, itParameter));
+        var value = ParseTree(reader, parameters, itParameter);
+        return RedactDictionaryOperation(value, Expression.Not(Expression.TypeEqual(value, ProbeExpressionParserHelper.UndefinedValueType)));
     }
 
     private Expression GetMember(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -353,6 +353,17 @@ internal partial class ProbeExpressionParser<T>
                 return RedactedValue();
             }
 
+            if (propertyOrFieldValue == nameof(KeyValuePair<int, int>.Value) &&
+                TryRedactDictionaryValueMember(expression, out var redactedValue))
+            {
+                return redactedValue;
+            }
+
+            if (TryGetRedactedDictionaryValue(expression, out var redactedDictionaryValue))
+            {
+                return RedactedDictionaryValueMember(redactedDictionaryValue, propertyOrFieldValue);
+            }
+
             var memberInfo = expression.Type.GetMember(propertyOrFieldValue, GetMemberFlags).FirstOrDefault();
 
             if (memberInfo == null)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.String.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.String.cs
@@ -16,8 +16,15 @@ internal partial class ProbeExpressionParser<T>
 {
     private Expression RegexMatches(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
-        var matchesMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(Regex), nameof(Regex.Matches), new[] { typeof(string), typeof(string) });
-        return CallStringMethod(reader, parameters, itParameter, matchesMethod);
+        var matchesMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(Regex), nameof(Regex.IsMatch), new[] { typeof(string), typeof(string) });
+        var source = ParseTree(reader, parameters, itParameter);
+        if (source.Type == ProbeExpressionParserHelper.UndefinedValueType)
+        {
+            return source;
+        }
+
+        var pattern = ParseTree(reader, parameters, itParameter);
+        return RedactDictionaryOperation(source, Expression.Call(null, matchesMethod, source, pattern));
     }
 
     private Expression Contains(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
@@ -50,7 +57,7 @@ internal partial class ProbeExpressionParser<T>
         var startIndex = ParseTree(reader, parameters, itParameter);
         var endIndex = ParseTree(reader, parameters, itParameter);
         var lengthExpr = Expression.Subtract(endIndex, startIndex);
-        return Expression.Call(source, substringMethod, startIndex, lengthExpr);
+        return RedactDictionaryOperation(source, Expression.Call(source, substringMethod, startIndex, lengthExpr));
     }
 
     private Expression IsEmpty(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
@@ -64,13 +71,13 @@ internal partial class ProbeExpressionParser<T>
         if (source.Type == typeof(string))
         {
             var emptyMethod = ProbeExpressionParserHelper.GetMethodByReflection(typeof(string), nameof(string.IsNullOrEmpty), [typeof(string)]);
-            return Expression.Call(null, emptyMethod, source);
+            return RedactDictionaryOperation(source, Expression.Call(null, emptyMethod, source));
         }
 
         try
         {
             var collectionCount = CollectionAndStringLengthExpression(source);
-            return Expression.Equal(collectionCount, Expression.Constant(0));
+            return RedactDictionaryOperation(source, Expression.Equal(collectionCount, Expression.Constant(0)));
         }
         catch (InvalidOperationException e)
         {
@@ -88,6 +95,6 @@ internal partial class ProbeExpressionParser<T>
         }
 
         var parameter = ParseTree(reader, parameters, itParameter);
-        return Expression.Call(source, method, parameter);
+        return RedactDictionaryOperation(source, Expression.Call(source, method, parameter));
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Unary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Unary.cs
@@ -11,9 +11,9 @@ namespace Datadog.Trace.Debugger.Expressions;
 
 internal partial class ProbeExpressionParser<T>
 {
-    private UnaryExpression Not(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
+    private Expression Not(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         var ex = ParseTree(reader, parameters, itParameter);
-        return Expression.Not(ex);
+        return RedactDictionaryOperation(ex, Expression.Not(ex));
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -482,6 +482,11 @@ internal partial class ProbeExpressionParser<T>
 
     private Expression HandleReturnType(Expression finalExpr, List<ParameterExpression> scopeMembers)
     {
+        if (TryGetRedactedDictionaryValue(finalExpr, out var redactedDictionaryValue))
+        {
+            return RedactDictionaryValueForReturn(redactedDictionaryValue, finalExpr, scopeMembers);
+        }
+
         if (typeof(T).IsAssignableFrom(finalExpr.Type))
         {
             // If the expression type is already exactly T, return as-is.

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -625,6 +625,7 @@ internal partial class ProbeExpressionParser<T>
             body = body.ReduceAndCheck();
         }
 
+        _redactedDictionaryValues = null;
         return new ExpressionBodyAndParameters(body, thisParameterExpression, returnParameterExpression, durationParameterExpression, exceptionParameterExpression, argsOrLocalsParameterExpression);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -294,9 +294,9 @@ namespace Datadog.Trace.Tests.Debugger
             result.CaptureExpressions.Should().BeNull();
             result.Errors.Should().NotBeNullOrEmpty();
         }
-		
-		[Fact]
-        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeys()
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorKeyAndValue_RedactsSensitiveKeys()
         {
             var scopeMembers = CreateScopeMembers();
             const string secret = "TOP_SECRET_VALUE";
@@ -305,31 +305,25 @@ namespace Datadog.Trace.Tests.Debugger
                 typeof(Dictionary<string, string>),
                 new Dictionary<string, string>
                 {
-                    { "password", secret },
-                    { "public", "hello" },
+                    { "password", secret }
                 },
                 ScopeMemberKind.Local));
 
             const string json = """
                                 {
-                                  "getmember": [
+                                  "any": [
+                                    { "ref": "SafeDictionaryLocal" },
                                     {
-                                      "index": [
-                                        {
-                                          "filter": [
-                                            { "ref": "SafeDictionaryLocal" },
-                                            { "eq": [ { "ref": "@key" }, "password" ] }
-                                          ]
-                                        },
-                                        0
+                                      "and": [
+                                        { "eq": [ { "ref": "@key" }, "{REDACTED}" ] },
+                                        { "eq": [ { "ref": "@value" }, "{REDACTED}" ] }
                                       ]
-                                    },
-                                    "Value"
+                                    }
                                   ]
                                 }
                                 """;
 
-            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
             var result = compiled.Delegate(
                 scopeMembers.InvocationTarget,
                 scopeMembers.Return,
@@ -337,9 +331,8 @@ namespace Datadog.Trace.Tests.Debugger
                 scopeMembers.Exception,
                 scopeMembers.Members);
 
-            Assert.NotEqual(secret, result);
-            var error = Assert.Single(compiled.Errors);
-            Assert.Equal("The property or field is redacted.", error.Message);
+            Assert.True(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -336,6 +336,79 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeysWithoutChangingValueType()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, int>),
+                new Dictionary<string, int>
+                {
+                    { "password", 42 },
+                    { "public", 10 }
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "any": [
+                                    { "ref": "SafeDictionaryLocal" },
+                                    {
+                                      "eq": [ { "ref": "@value" }, 10 ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_DoesNotCallUnsafeKeyToString()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<ThrowsOnToStringKey, string>),
+                new Dictionary<ThrowsOnToStringKey, string>
+                {
+                    { new ThrowsOnToStringKey(), "visible" }
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "any": [
+                                    { "ref": "SafeDictionaryLocal" },
+                                    {
+                                      "eq": [ { "ref": "@value" }, "visible" ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
         public void ProbeExpressionParser_ConstructedOpenGenericReferenceTypeParameter_CanCompileExpression()
         {
             var scopeMembers = CreateScopeMembers();
@@ -1004,6 +1077,14 @@ namespace Datadog.Trace.Tests.Debugger
             {
                 { "hello", null },
             };
+        }
+
+        private sealed class ThrowsOnToStringKey
+        {
+            public override string ToString()
+            {
+                throw new InvalidOperationException("Dictionary key ToString should not be called.");
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -80,6 +80,46 @@ namespace Datadog.Trace.Tests.Debugger
             yield return [new Hashtable { { "password", secret }, { "public", "hello" } }];
         }
 
+        public static IEnumerable<object[]> SensitiveDictionaryValueOperations()
+        {
+            yield return
+            [
+                """
+                { "contains": [ "@value", "TOP_SECRET" ] }
+                """
+            ];
+            yield return
+            [
+                """
+                { "startsWith": [ "@value", "TOP" ] }
+                """
+            ];
+            yield return
+            [
+                """
+                { "endsWith": [ "@value", "VALUE" ] }
+                """
+            ];
+            yield return
+            [
+                """
+                { "matches": [ "@value", "TOP_.*" ] }
+                """
+            ];
+            yield return
+            [
+                """
+                { "eq": [ { "substring": [ "@value", 0, 10 ] }, "TOP_SECRET" ] }
+                """
+            ];
+            yield return
+            [
+                """
+                { "gt": [ { "len": "@value" }, 10 ] }
+                """
+            ];
+        }
+
         public static IEnumerable<object[]> TemplatesResources()
         {
             var sourceFilePath = GetSourceFilePath();
@@ -662,6 +702,72 @@ namespace Datadog.Trace.Tests.Debugger
                 scopeMembers.Members);
 
             Assert.Equal(publicValue, publicResult);
+        }
+
+        [Theory]
+        [MemberData(nameof(SensitiveDictionaryValueOperations))]
+        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeysBeforeDerivedOperations(string operationJson)
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, string>),
+                new Dictionary<string, string>
+                {
+                    { "password", "TOP_SECRET_VALUE" },
+                    { "public", "TOP_SECRET_VALUE" },
+                },
+                ScopeMemberKind.Local));
+
+            var publicJson = $$"""
+                               {
+                                 "any": [
+                                   {
+                                     "filter": [
+                                       { "ref": "SafeDictionaryLocal" },
+                                       { "eq": [ { "ref": "@key" }, "public" ] }
+                                     ]
+                                   },
+                                   {{operationJson}}
+                                 ]
+                               }
+                               """;
+
+            var sensitiveJson = $$"""
+                                  {
+                                    "any": [
+                                      {
+                                        "filter": [
+                                          { "ref": "SafeDictionaryLocal" },
+                                          { "eq": [ { "ref": "@key" }, "password" ] }
+                                        ]
+                                      },
+                                      {{operationJson}}
+                                    ]
+                                  }
+                                  """;
+
+            var publicCompiled = ProbeExpressionParser<bool>.ParseExpression(publicJson, scopeMembers);
+            var publicResult = publicCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(publicResult);
+            Assert.True(publicCompiled.Errors == null || publicCompiled.Errors.Length == 0);
+
+            var sensitiveCompiled = ProbeExpressionParser<bool>.ParseExpression(sensitiveJson, scopeMembers);
+            var sensitiveResult = sensitiveCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.False(sensitiveResult);
+            Assert.True(sensitiveCompiled.Errors == null || sensitiveCompiled.Errors.Length == 0);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -389,6 +389,45 @@ namespace Datadog.Trace.Tests.Debugger
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
         }
 
+        [Theory]
+        [MemberData(nameof(SupportedSensitiveDictionaries))]
+        public void ProbeExpressionParser_DictionaryIteratorEntry_RedactsSensitiveKeys(object dictionary)
+        {
+            var scopeMembers = CreateScopeMembers();
+            const string secret = "TOP_SECRET_VALUE";
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                dictionary.GetType(),
+                dictionary,
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "index": [
+                                    {
+                                      "filter": [
+                                        { "ref": "SafeDictionaryLocal" },
+                                        { "eq": [ { "ref": "@key" }, "password" ] }
+                                      ]
+                                    },
+                                    0
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.NotEqual(secret, result);
+            Assert.Equal("{REDACTED}", result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
         [Fact]
         public void ProbeExpressionParser_DictionaryIteratorValue_DoesNotCallUnsafeKeyToString()
         {
@@ -421,6 +460,74 @@ namespace Datadog.Trace.Tests.Debugger
 
             Assert.True(result);
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_UsesSafeObjectEquality()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Hashtable),
+                new Hashtable
+                {
+                    { "public", "hello" },
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "any": [
+                                    { "ref": "SafeDictionaryLocal" },
+                                    { "eq": [ "@value", "hello" ] }
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_DoesNotCallUnsafeObjectEquals()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Hashtable),
+                new Hashtable
+                {
+                    { "public", new ThrowsOnEqualsValue() },
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "any": [
+                                    { "ref": "SafeDictionaryLocal" },
+                                    { "eq": [ "@value", "public" ] }
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0, string.Join(Environment.NewLine, compiled.Errors?.Select(e => $"{e.Expression}: {e.Message}") ?? []));
+            Assert.False(result);
         }
 
         [Fact]
@@ -1446,6 +1553,19 @@ namespace Datadog.Trace.Tests.Debugger
             public override string ToString()
             {
                 throw new InvalidOperationException("Dictionary key ToString should not be called.");
+            }
+        }
+
+        private sealed class ThrowsOnEqualsValue
+        {
+            public override bool Equals(object obj)
+            {
+                throw new InvalidOperationException("Dictionary value Equals should not be called.");
+            }
+
+            public override int GetHashCode()
+            {
+                return 0;
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -69,6 +70,15 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         internal TestStruct TestObject { get; set; }
+
+        public static IEnumerable<object[]> SupportedSensitiveDictionaries()
+        {
+            const string secret = "TOP_SECRET_VALUE";
+            yield return [new Dictionary<string, string> { { "password", secret }, { "public", "hello" } }];
+            yield return [new SortedDictionary<string, string> { { "password", secret }, { "public", "hello" } }];
+            yield return [new ConcurrentDictionary<string, string>(new[] { new KeyValuePair<string, string>("password", secret), new KeyValuePair<string, string>("public", "hello") })];
+            yield return [new Hashtable { { "password", secret }, { "public", "hello" } }];
+        }
 
         public static IEnumerable<object[]> TemplatesResources()
         {
@@ -295,35 +305,38 @@ namespace Datadog.Trace.Tests.Debugger
             result.Errors.Should().NotBeNullOrEmpty();
         }
 
-        [Fact]
-        public void ProbeExpressionParser_DictionaryIteratorKeyAndValue_RedactsSensitiveKeys()
+        [Theory]
+        [MemberData(nameof(SupportedSensitiveDictionaries))]
+        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeys(object dictionary)
         {
             var scopeMembers = CreateScopeMembers();
             const string secret = "TOP_SECRET_VALUE";
             scopeMembers.AddMember(new ScopeMember(
                 "SafeDictionaryLocal",
-                typeof(Dictionary<string, string>),
-                new Dictionary<string, string>
-                {
-                    { "password", secret }
-                },
+                dictionary.GetType(),
+                dictionary,
                 ScopeMemberKind.Local));
 
             const string json = """
                                 {
-                                  "any": [
-                                    { "ref": "SafeDictionaryLocal" },
+                                  "getmember": [
                                     {
-                                      "and": [
-                                        { "eq": [ { "ref": "@key" }, "{REDACTED}" ] },
-                                        { "eq": [ { "ref": "@value" }, "{REDACTED}" ] }
+                                      "index": [
+                                        {
+                                          "filter": [
+                                            { "ref": "SafeDictionaryLocal" },
+                                            { "eq": [ { "ref": "@key" }, "password" ] }
+                                          ]
+                                        },
+                                        0
                                       ]
-                                    }
+                                    },
+                                    "Value"
                                   ]
                                 }
                                 """;
 
-            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
             var result = compiled.Delegate(
                 scopeMembers.InvocationTarget,
                 scopeMembers.Return,
@@ -331,44 +344,8 @@ namespace Datadog.Trace.Tests.Debugger
                 scopeMembers.Exception,
                 scopeMembers.Members);
 
-            Assert.True(result);
-            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
-        }
-
-        [Fact]
-        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeysWithoutChangingValueType()
-        {
-            var scopeMembers = CreateScopeMembers();
-            scopeMembers.AddMember(new ScopeMember(
-                "SafeDictionaryLocal",
-                typeof(Dictionary<string, int>),
-                new Dictionary<string, int>
-                {
-                    { "password", 42 },
-                    { "public", 10 }
-                },
-                ScopeMemberKind.Local));
-
-            const string json = """
-                                {
-                                  "any": [
-                                    { "ref": "SafeDictionaryLocal" },
-                                    {
-                                      "eq": [ { "ref": "@value" }, 10 ]
-                                    }
-                                  ]
-                                }
-                                """;
-
-            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
-            var result = compiled.Delegate(
-                scopeMembers.InvocationTarget,
-                scopeMembers.Return,
-                scopeMembers.Duration,
-                scopeMembers.Exception,
-                scopeMembers.Members);
-
-            Assert.True(result);
+            Assert.NotEqual(secret, result);
+            Assert.Equal("{REDACTED}", result);
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
         }
 
@@ -381,7 +358,7 @@ namespace Datadog.Trace.Tests.Debugger
                 typeof(Dictionary<ThrowsOnToStringKey, string>),
                 new Dictionary<ThrowsOnToStringKey, string>
                 {
-                    { new ThrowsOnToStringKey(), "visible" }
+                    { new ThrowsOnToStringKey(), "hello" },
                 },
                 ScopeMemberKind.Local));
 
@@ -389,9 +366,7 @@ namespace Datadog.Trace.Tests.Debugger
                                 {
                                   "any": [
                                     { "ref": "SafeDictionaryLocal" },
-                                    {
-                                      "eq": [ { "ref": "@value" }, "visible" ]
-                                    }
+                                    { "eq": [ "@value", "hello" ] }
                                   ]
                                 }
                                 """;
@@ -406,6 +381,287 @@ namespace Datadog.Trace.Tests.Debugger
 
             Assert.True(result);
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsStringPredicatesWithSensitiveKeys()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, string>),
+                new Dictionary<string, string>
+                {
+                    { "password", "hello" },
+                    { "public", "hello" },
+                },
+                ScopeMemberKind.Local));
+
+            const string publicJson = """
+                                      {
+                                        "any": [
+                                          {
+                                            "filter": [
+                                              { "ref": "SafeDictionaryLocal" },
+                                              { "eq": [ { "ref": "@key" }, "public" ] }
+                                            ]
+                                          },
+                                          { "eq": [ "@value", "hello" ] }
+                                        ]
+                                      }
+                                      """;
+
+            const string sensitiveJson = """
+                                         {
+                                           "any": [
+                                             {
+                                               "filter": [
+                                                 { "ref": "SafeDictionaryLocal" },
+                                                 { "eq": [ { "ref": "@key" }, "password" ] }
+                                               ]
+                                             },
+                                             { "eq": [ "@value", "hello" ] }
+                                           ]
+                                         }
+                                         """;
+
+            var publicCompiled = ProbeExpressionParser<bool>.ParseExpression(publicJson, scopeMembers);
+            var publicResult = publicCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(publicResult);
+            Assert.True(publicCompiled.Errors == null || publicCompiled.Errors.Length == 0);
+
+            var sensitiveCompiled = ProbeExpressionParser<bool>.ParseExpression(sensitiveJson, scopeMembers);
+            var sensitiveResult = sensitiveCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.False(sensitiveResult);
+            Assert.True(sensitiveCompiled.Errors == null || sensitiveCompiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_PreservesNumericValueTypeForComparisons()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, int>),
+                new Dictionary<string, int>
+                {
+                    { "password", 42 },
+                    { "public", 42 },
+                },
+                ScopeMemberKind.Local));
+
+            const string publicJson = """
+                                      {
+                                        "any": [
+                                          {
+                                            "filter": [
+                                              { "ref": "SafeDictionaryLocal" },
+                                              { "eq": [ { "ref": "@key" }, "public" ] }
+                                            ]
+                                          },
+                                          { "gt": [ "@value", 10 ] }
+                                        ]
+                                      }
+                                      """;
+
+            const string sensitiveJson = """
+                                         {
+                                           "any": [
+                                             {
+                                               "filter": [
+                                                 { "ref": "SafeDictionaryLocal" },
+                                                 { "eq": [ { "ref": "@key" }, "password" ] }
+                                               ]
+                                             },
+                                             { "gt": [ "@value", 10 ] }
+                                           ]
+                                         }
+                                         """;
+
+            var publicCompiled = ProbeExpressionParser<bool>.ParseExpression(publicJson, scopeMembers);
+            var publicResult = publicCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(publicResult);
+            Assert.True(publicCompiled.Errors == null || publicCompiled.Errors.Length == 0);
+
+            var sensitiveCompiled = ProbeExpressionParser<bool>.ParseExpression(sensitiveJson, scopeMembers);
+            var sensitiveResult = sensitiveCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.False(sensitiveResult);
+            Assert.True(sensitiveCompiled.Errors == null || sensitiveCompiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_PreservesRedactionAfterNumericConversion()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, int>),
+                new Dictionary<string, int>
+                {
+                    { "password", 42 },
+                    { "public", 42 },
+                },
+                ScopeMemberKind.Local));
+
+            const string publicJson = """
+                                      {
+                                        "any": [
+                                          {
+                                            "filter": [
+                                              { "ref": "SafeDictionaryLocal" },
+                                              { "eq": [ { "ref": "@key" }, "public" ] }
+                                            ]
+                                          },
+                                          { "gt": [ "@value", 10.5 ] }
+                                        ]
+                                      }
+                                      """;
+
+            const string sensitiveJson = """
+                                         {
+                                           "any": [
+                                             {
+                                               "filter": [
+                                                 { "ref": "SafeDictionaryLocal" },
+                                                 { "eq": [ { "ref": "@key" }, "password" ] }
+                                               ]
+                                             },
+                                             { "gt": [ "@value", 10.5 ] }
+                                           ]
+                                         }
+                                         """;
+
+            var publicCompiled = ProbeExpressionParser<bool>.ParseExpression(publicJson, scopeMembers);
+            var publicResult = publicCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.True(publicResult);
+            Assert.True(publicCompiled.Errors == null || publicCompiled.Errors.Length == 0);
+
+            var sensitiveCompiled = ProbeExpressionParser<bool>.ParseExpression(sensitiveJson, scopeMembers);
+            var sensitiveResult = sensitiveCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.False(sensitiveResult);
+            Assert.True(sensitiveCompiled.Errors == null || sensitiveCompiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsNestedValuesBeforeMemberAccess()
+        {
+            var scopeMembers = CreateScopeMembers();
+            const string secret = "TOP_SECRET_VALUE";
+            const string publicValue = "hello";
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, SensitiveValueHolder>),
+                new Dictionary<string, SensitiveValueHolder>
+                {
+                    { "password", new SensitiveValueHolder { Data = secret } },
+                    { "public", new SensitiveValueHolder { Data = publicValue } },
+                },
+                ScopeMemberKind.Local));
+
+            const string sensitiveJson = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "getmember": [
+                                        {
+                                          "index": [
+                                            {
+                                              "filter": [
+                                                { "ref": "SafeDictionaryLocal" },
+                                                { "eq": [ { "ref": "@key" }, "password" ] }
+                                              ]
+                                            },
+                                            0
+                                          ]
+                                        },
+                                        "Value"
+                                      ]
+                                    },
+                                    "Data"
+                                  ]
+                                }
+                                """;
+
+            const string publicJson = """
+                                      {
+                                        "getmember": [
+                                          {
+                                            "getmember": [
+                                              {
+                                                "index": [
+                                                  {
+                                                    "filter": [
+                                                      { "ref": "SafeDictionaryLocal" },
+                                                      { "eq": [ { "ref": "@key" }, "public" ] }
+                                                    ]
+                                                  },
+                                                  0
+                                                ]
+                                              },
+                                              "Value"
+                                            ]
+                                          },
+                                          "Data"
+                                        ]
+                                      }
+                                      """;
+
+            var sensitiveCompiled = ProbeExpressionParser<object>.ParseExpression(sensitiveJson, scopeMembers);
+            var sensitiveResult = sensitiveCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.NotEqual(secret, sensitiveResult);
+            Assert.Equal("{REDACTED}", sensitiveResult);
+
+            var publicCompiled = ProbeExpressionParser<object>.ParseExpression(publicJson, scopeMembers);
+            var publicResult = publicCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Equal(publicValue, publicResult);
         }
 
         [Fact]
@@ -1085,6 +1341,11 @@ namespace Datadog.Trace.Tests.Debugger
             {
                 throw new InvalidOperationException("Dictionary key ToString should not be called.");
             }
+        }
+
+        private class SensitiveValueHolder
+        {
+            public string Data { get; set; }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -294,6 +294,53 @@ namespace Datadog.Trace.Tests.Debugger
             result.CaptureExpressions.Should().BeNull();
             result.Errors.Should().NotBeNullOrEmpty();
         }
+		
+		[Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeys()
+        {
+            var scopeMembers = CreateScopeMembers();
+            const string secret = "TOP_SECRET_VALUE";
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, string>),
+                new Dictionary<string, string>
+                {
+                    { "password", secret },
+                    { "public", "hello" },
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "index": [
+                                        {
+                                          "filter": [
+                                            { "ref": "SafeDictionaryLocal" },
+                                            { "eq": [ { "ref": "@key" }, "password" ] }
+                                          ]
+                                        },
+                                        0
+                                      ]
+                                    },
+                                    "Value"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.NotEqual(secret, result);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Equal("The property or field is redacted.", error.Message);
+        }
 
         [Fact]
         public void ProbeExpressionParser_ConstructedOpenGenericReferenceTypeParameter_CanCompileExpression()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashAnyKeyValueAnd.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashAnyKeyValueAnd.verified.txt
@@ -59,7 +59,9 @@ Expression: (
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
     var $dd_el_result = DictionaryLocal.Any(
-        stringStringKeyValuePair => (stringStringKeyValuePair.Key == "hello") && (stringStringKeyValuePair.Value == "world"));
+        stringStringKeyValuePair => (stringStringKeyValuePair.Key == "hello") && (ProbeExpressionParser<bool>.ShouldRedactDictionaryKey(stringStringKeyValuePair.Key)
+            ? false
+            : stringStringKeyValuePair.Value == "world"));
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashFilterKeyValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashFilterKeyValue.verified.txt
@@ -61,7 +61,10 @@ Expression: (
     var $dd_el_result = DictionaryLocal
         .Where(stringStringKeyValuePair1 => stringStringKeyValuePair1.Key == "hello")
         .ToList()
-        .Any(stringStringKeyValuePair2 => stringStringKeyValuePair2.Value == "world");
+        .Any(
+            stringStringKeyValuePair2 => ProbeExpressionParser<bool>.ShouldRedactDictionaryKey(stringStringKeyValuePair2.Key)
+                ? false
+                : stringStringKeyValuePair2.Value == "world");
 
     return $dd_el_result;
 }


### PR DESCRIPTION
### Motivation

- The debugger expression language added `@key`/`@value` for dictionary iteration but exposed a bypass that allowed reading values stored under redacted keys without applying the existing redaction rules.

### Description

- Apply redaction checks to dictionary iterator projections by updating `TryGetCollectionIteratorProperty` to return an `Expression` and wrap `Key`/`Value` projections with a conditional that returns `RedactedValue()` when the entry key matches redaction rules in `tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs`.
- Add helper functions `RedactDictionaryValueWhenKeyMatches` and `ShouldRedactDictionaryKey` to centralize the key redaction lookup and produce an `Expression.Condition` for the redaction decision.
- Add a regression test `ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeys` in `tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs` that verifies a dictionary entry under the key `"password"` is surfaced as redacted when accessed through the iterator/filter/index/member path.

### Testing

- Added the unit test `ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeys` and executed focused `dotnet test` runs against the test project with a filter for the new test (`dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj -f net10.0 --filter "ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeys"`), iterating until the parsing code produced the expected redaction behavior locally.
- Full cross-TFM test runs in this environment were unreliable due to test-host/runtime environment issues (ICU/libssl), so CI should validate the change across all target frameworks; targeted runs during development validated the regression fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0300aad35483278effab8a4674d080)