### PR TITLE
fix(debugger): redact nullable wrappers of configured types

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -249,11 +249,17 @@ namespace Datadog.Trace.Debugger.Snapshots
                 return false;
             }
 
-            var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
-            return _redactedTypesCache.GetOrAdd(effectiveType, CheckForRedactedType);
+            return _redactedTypesCache.GetOrAdd(type, CheckForRedactedType);
         }
 
         private bool CheckForRedactedType(Type type)
+        {
+            return CheckForRedactedTypeCore(type) ||
+                   (Nullable.GetUnderlyingType(type) is { } underlyingType &&
+                    CheckForRedactedTypeCore(underlyingType));
+        }
+
+        private bool CheckForRedactedTypeCore(Type type)
         {
             Type? genericDefinition = null;
             if (type.IsGenericType)

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -249,7 +249,8 @@ namespace Datadog.Trace.Debugger.Snapshots
                 return false;
             }
 
-            return _redactedTypesCache.GetOrAdd(type, CheckForRedactedType);
+            var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
+            return _redactedTypesCache.GetOrAdd(effectiveType, CheckForRedactedType);
         }
 
         private bool CheckForRedactedType(Type type)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/RedactionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/RedactionTests.cs
@@ -195,6 +195,19 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void IsRedactedType_WithConfiguredNullableWrapperType_Test()
+        {
+            // Arrange
+            Redaction.Instance.SetConfig(
+                new HashSet<string>(),
+                new HashSet<string>(),
+                new HashSet<string> { "System.Nullable*" });
+
+            // Act & Assert
+            Assert.True(Redaction.Instance.IsRedactedType(typeof(Guid?)));
+        }
+
+        [Fact]
         public void IsRedactedType_WithWildcardMatch_Test()
         {
             // Arrange

--- a/tracer/test/Datadog.Trace.Tests/Debugger/RedactionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/RedactionTests.cs
@@ -182,6 +182,19 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void IsRedactedType_WithConfiguredUnderlyingNullableType_Test()
+        {
+            // Arrange
+            Redaction.Instance.SetConfig(
+                new HashSet<string>(),
+                new HashSet<string>(),
+                new HashSet<string> { "System.Guid" });
+
+            // Act & Assert
+            Assert.True(Redaction.Instance.IsRedactedType(typeof(Guid?)));
+        }
+
+        [Fact]
         public void IsRedactedType_WithWildcardMatch_Test()
         {
             // Arrange
@@ -224,6 +237,7 @@ namespace Datadog.Trace.Tests.Debugger
         [Theory]
         [InlineData("password", typeof(System.Security.SecureString), RedactionReason.Identifier)]
         [InlineData("no-password", typeof(System.Security.SecureString), RedactionReason.Type)]
+        [InlineData("nullable-guid", typeof(Guid?), RedactionReason.Type)]
         [InlineData("api_key", typeof(string), RedactionReason.Identifier)]
         [InlineData("normal", typeof(string), RedactionReason.None)]
         internal void ShouldRedact_CombinedScenarios_Test(string name, Type type, RedactionReason expectedReason)
@@ -232,7 +246,7 @@ namespace Datadog.Trace.Tests.Debugger
             Redaction.Instance.SetConfig(
                 new HashSet<string> { "api_key" },
                 new HashSet<string>(),
-                new HashSet<string> { "System.Security.SecureString" });
+                new HashSet<string> { "System.Security.SecureString", "System.Guid" });
 
             // Act
             bool result = Redaction.Instance.ShouldRedact(name, type, out var reason);


### PR DESCRIPTION
### Motivation
- Unwrapping `Nullable<T>` was added to `IsSafeToCallToString`, but type-redaction checks still used the original wrapper type, allowing configured redacted underlying types (e.g., `System.Guid`) to be bypassed when serialized as `Guid?`.
- This caused a confidentiality regression where nullable forms of allow-listed safe-to-`ToString` value types could be emitted without redaction.

### Description
- Unwrap `Nullable<T>` before checking/caching in `Redaction.IsRedactedType` so configured redacted underlying types apply to nullable wrappers as well (`tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs`).
- Add `IsRedactedType_WithConfiguredUnderlyingNullableType_Test` to assert `Guid?` is redacted when `System.Guid` is configured as redacted (`tracer/test/Datadog.Trace.Tests/Debugger/RedactionTests.cs`).
- Extend the combined `ShouldRedact` theory to include a `Guid?` case and include `System.Guid` in the test configuration to cover the end-to-end decision path.

### Testing
- Ran the focused test command `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj --filter "FullyQualifiedName~Datadog.Trace.Tests.Debugger.RedactionTests" --no-restore`, and the modified redaction tests passed on supported TFMs in this environment.
- Some test host processes for other TFMs aborted due to missing system runtime dependencies (ICU/libssl) in this environment, which is unrelated to the change and did not affect the targeted redaction test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03061e489c83278e4111bf66bfde1e)