### PR TITLE
Load native loader in profiler via absolute path on Windows

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
@@ -34,16 +34,10 @@ bool RuntimeIdStore::StartImpl()
     {    // variable not set - try to infer the location instead
         Log::Debug("DD_INTERNAL_NATIVE_LOADER_PATH variable not found. Inferring native loader path");
 
-        // the native loader is always available in the same directory
-#ifdef _WINDOWS
-        auto nativeLoaderFilename = NativeLoaderFilename;
-#else
+        // the native loader is always available in the same directory as the current module
         auto currentModulePath = fs::path(shared::GetCurrentModuleFileName());
-        // the native loader is in the parent directory
         auto nativeLoaderPath = currentModulePath.parent_path() / NativeLoaderFilename;
-        auto nativeLoaderFilename = nativeLoaderPath.string();
-#endif
-        _instance = LoadDynamicLibrary(nativeLoaderFilename);
+        _instance = LoadDynamicLibrary(nativeLoaderPath.string());
     }
 
 


### PR DESCRIPTION
## Summary of changes

Updates the fallback path when loading the native loader (runtime ID store) to use an absolute path

## Reason for change

By default, we load the native loader using an env var set by the loader itself. This is the default approach, but there's also a fallback in case this is not set for some reason.

On Windows only, we were using just the filename to load the library, which can be ambiguous depending on dll search paths. This changes the Windows lookup to use an absolute path like we do on Linux

## Implementation details

Remove the `#ifdef` for Windows, and construct the full path in both cases.

## Test coverage

Should be covered by existing tests

## Other details

Note that the old comment of "the native loader is in the parent directory" has been incorrect since #3060 (v2.14.0, back in 2022 😅)