### PR TITLE
Refactor GraphQL error response building and add pre-emptive truncation

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommonBase.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommonBase.cs
@@ -23,6 +23,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
 
         protected const string ServiceName = "graphql";
 
+        protected const string Tab = "    ";
+
         protected static Scope CreateScopeFromExecuteAsync(Tracer tracer, IntegrationId integrationId, GraphQLTags tags, string serviceName, string queryOperationName, string source, string queryOperationType)
         {
             var (resolvedServiceName, serviceNameSource) = tracer.CurrentTraceSettings.GetServiceNameMetadata(serviceName);
@@ -58,20 +60,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
 
         protected static void ConstructErrorLocationsMessage(StringBuilder builder, IEnumerable locations)
         {
-            const string tab = "    ";
-            builder.AppendLine($"{tab + tab}\"locations\": [");
+            builder.AppendLine($"{Tab + Tab}\"locations\": [");
             foreach (var location in locations)
             {
                 if (location.TryDuckCast<ErrorLocationStruct>(out var locationProxy))
                 {
-                    builder.AppendLine($"{tab + tab + tab}{{");
-                    builder.Append($"{tab + tab + tab + tab}\"line\": ").Append(locationProxy.Line).AppendLine(",");
-                    builder.Append($"{tab + tab + tab + tab}\"column\": ").Append(locationProxy.Column).AppendLine(",");
-                    builder.AppendLine($"{tab + tab + tab}}},");
+                    builder.AppendLine($"{Tab + Tab + Tab}{{");
+                    builder.Append($"{Tab + Tab + Tab + Tab}\"line\": ").Append(locationProxy.Line).AppendLine(",");
+                    builder.Append($"{Tab + Tab + Tab + Tab}\"column\": ").Append(locationProxy.Column).AppendLine();
+                    builder.AppendLine($"{Tab + Tab + Tab}}},");
                 }
             }
 
-            builder.AppendLine($"{tab + tab}]");
+            builder.AppendLine($"{Tab + Tab}]");
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommonBase.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommonBase.cs
@@ -56,16 +56,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
             }
         }
 
-        protected static void ConstructErrorLocationsMessage(StringBuilder builder, string tab, IEnumerable locations)
+        protected static void ConstructErrorLocationsMessage(StringBuilder builder, IEnumerable locations)
         {
+            const string tab = "    ";
             builder.AppendLine($"{tab + tab}\"locations\": [");
             foreach (var location in locations)
             {
                 if (location.TryDuckCast<ErrorLocationStruct>(out var locationProxy))
                 {
                     builder.AppendLine($"{tab + tab + tab}{{");
-                    builder.AppendLine($"{tab + tab + tab + tab}\"line\": {locationProxy.Line},");
-                    builder.AppendLine($"{tab + tab + tab + tab}\"column\": {locationProxy.Column}");
+                    builder.Append($"{tab + tab + tab + tab}\"line\": ").Append(locationProxy.Line).AppendLine(",");
+                    builder.Append($"{tab + tab + tab + tab}\"column\": ").Append(locationProxy.Column).AppendLine(",");
                     builder.AppendLine($"{tab + tab + tab}}},");
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommonBase.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommonBase.cs
@@ -61,18 +61,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
         protected static void ConstructErrorLocationsMessage(StringBuilder builder, IEnumerable locations)
         {
             builder.AppendLine($"{Tab + Tab}\"locations\": [");
+            var i = 0;
             foreach (var location in locations)
             {
                 if (location.TryDuckCast<ErrorLocationStruct>(out var locationProxy))
                 {
+                    if (i != 0)
+                    {
+                        builder.AppendLine(",");
+                    }
+
                     builder.AppendLine($"{Tab + Tab + Tab}{{");
                     builder.Append($"{Tab + Tab + Tab + Tab}\"line\": ").Append(locationProxy.Line).AppendLine(",");
                     builder.Append($"{Tab + Tab + Tab + Tab}\"column\": ").Append(locationProxy.Column).AppendLine();
-                    builder.AppendLine($"{Tab + Tab + Tab}}},");
+                    builder.Append($"{Tab + Tab + Tab}}}");
+                    i++;
                 }
             }
 
-            builder.AppendLine($"{Tab + Tab}]");
+            builder.AppendLine().AppendLine($"{Tab + Tab}]");
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
@@ -130,19 +130,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
 
             try
             {
-                const string tab = "    ";
                 builder.AppendLine("errors: [");
 
                 for (int i = 0; i < executionErrors.Count; i++)
                 {
                     var executionError = executionErrors[i];
 
-                    builder.AppendLine($"{tab}{{");
+                    builder.AppendLine($"{Tab}{{");
 
                     var message = executionError.Message;
                     if (message != null)
                     {
-                        builder.Append($"{tab + tab}\"message\": \"")
+                        builder.Append($"{Tab + Tab}\"message\": \"")
                                .Append(message.Replace("\r", "\\r").Replace("\n", "\\n"))
                                .AppendLine("\",");
                     }
@@ -153,7 +152,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
                         ConstructErrorLocationsMessage(builder, locations);
                     }
 
-                    builder.AppendLine($"{tab}}},");
+                    builder.AppendLine($"{Tab}}},");
                 }
 
                 builder.AppendLine("]");

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Processors;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
 {
@@ -120,7 +121,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
             }
         }
 
-        private static string ConstructErrorMessage(List<IError> executionErrors)
+        [TestingAndPrivateOnly]
+        internal static string ConstructErrorMessage(List<IError> executionErrors)
         {
             if (executionErrors == null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Processors;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
 {
@@ -147,7 +148,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
                     }
 
                     var locations = executionError.Locations;
-                    if (locations != null)
+                    if (locations != null && builder.Length < TruncatorTagsProcessor.MaxMetaValLen)
                     {
                         ConstructErrorLocationsMessage(builder, locations);
                     }
@@ -164,7 +165,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
                 return "errors: []";
             }
 
-            return Util.StringBuilderCache.GetStringAndRelease(builder);
+            if (builder.Length < TruncatorTagsProcessor.MaxMetaValLen)
+            {
+                return Util.StringBuilderCache.GetStringAndRelease(builder);
+            }
+
+            // pre-truncate if we got too large
+            var result = builder.ToString(startIndex: 0, length: TruncatorTagsProcessor.MaxMetaValLen);
+            Util.StringBuilderCache.Release(builder);
+            return result;
         }
 
         private static List<SpanEvent> ConstructErrorEvents(List<IError> executionErrors)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
@@ -137,6 +137,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
 
                 for (int i = 0; i < executionErrors.Count; i++)
                 {
+                    if (builder.Length >= TruncatorTagsProcessor.MaxMetaValLen)
+                    {
+                        // Too big, give up
+                        break;
+                    }
+
+                    if (i > 0)
+                    {
+                        builder.Append(',').AppendLine();
+                    }
+
                     var executionError = executionErrors[i];
 
                     builder.AppendLine($"{Tab}{{");
@@ -155,9 +166,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
                         ConstructErrorLocationsMessage(builder, locations);
                     }
 
-                    builder.AppendLine($"{Tab}}},");
+                    builder.Append($"{Tab}}}");
                 }
 
+                builder.AppendLine();
                 builder.AppendLine("]");
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommon.cs
@@ -137,18 +137,20 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
                 {
                     var executionError = executionErrors[i];
 
-                    builder.Append(tab).AppendLine("{");
+                    builder.AppendLine($"{tab}{{");
 
                     var message = executionError.Message;
                     if (message != null)
                     {
-                        builder.AppendLine($"{tab + tab}\"message\": \"{message.Replace("\r", "\\r").Replace("\n", "\\n")}\",");
+                        builder.Append($"{tab + tab}\"message\": \"")
+                               .Append(message.Replace("\r", "\\r").Replace("\n", "\\n"))
+                               .AppendLine("\",");
                     }
 
                     var locations = executionError.Locations;
                     if (locations != null)
                     {
-                        ConstructErrorLocationsMessage(builder, tab, locations);
+                        ConstructErrorLocationsMessage(builder, locations);
                     }
 
                     builder.AppendLine($"{tab}}},");

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
@@ -151,6 +151,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
 
                 for (int i = 0; i < executionErrors.Count; i++)
                 {
+                    if (builder.Length >= TruncatorTagsProcessor.MaxMetaValLen)
+                    {
+                        // Too big, give up
+                        break;
+                    }
+
+                    if (i > 0)
+                    {
+                        builder.Append(',').AppendLine();
+                    }
+
                     var executionError = executionErrors[i];
 
                     builder.AppendLine($"{Tab}{{");
@@ -196,9 +207,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                         ConstructErrorLocationsMessage(builder, locations);
                     }
 
-                    builder.AppendLine($"{Tab}}},");
+                    builder.Append($"{Tab}}}");
                 }
 
+                builder.AppendLine();
                 builder.AppendLine("]");
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Processors;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
 {
@@ -161,7 +162,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                     }
 
                     var paths = executionError.Path;
-                    if (paths != null)
+                    if (paths != null && builder.Length < TruncatorTagsProcessor.MaxMetaValLen)
                     {
                         builder.Append($"{Tab + Tab}\"path\": \"");
                         var addSeparator = false;
@@ -188,7 +189,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                     }
 
                     var locations = executionError.Locations;
-                    if (locations != null)
+                    if (locations != null && builder.Length < TruncatorTagsProcessor.MaxMetaValLen)
                     {
                         ConstructErrorLocationsMessage(builder, locations);
                     }
@@ -205,7 +206,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                 return "errors: []";
             }
 
-            return Util.StringBuilderCache.GetStringAndRelease(builder);
+            if (builder.Length < TruncatorTagsProcessor.MaxMetaValLen)
+            {
+                return Util.StringBuilderCache.GetStringAndRelease(builder);
+            }
+
+            // pre-truncate if we got too large
+            var result = builder.ToString(startIndex: 0, length: TruncatorTagsProcessor.MaxMetaValLen);
+            Util.StringBuilderCache.Release(builder);
+            return result;
         }
 
         private static List<SpanEvent> ConstructErrorEvents(IExecutionErrors executionErrors)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
 
             try
             {
-                var tab = "    ";
+                const string tab = "    ";
                 builder.AppendLine("errors: [");
 
                 for (int i = 0; i < executionErrors.Count; i++)
@@ -156,25 +156,42 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                     var message = executionError.Message;
                     if (message != null)
                     {
-                        builder.AppendLine($"{tab + tab}\"message\": \"{message.Replace("\r", "\\r").Replace("\n", "\\n")}\",");
+                        builder.Append($"{tab + tab}\"message\": \"")
+                               .Append(message.Replace("\r", "\\r").Replace("\n", "\\n"))
+                               .AppendLine("\",");
                     }
 
                     var paths = executionError.Path;
                     if (paths != null)
                     {
-                        builder.AppendLine($"{tab + tab}\"path\": \"{string.Join(".", paths)}\",");
+                        builder.Append($"{tab + tab}\"path\": \"{string.Join(".", paths)}\",");
+                        var addSeparator = false;
+                        foreach (var path in paths)
+                        {
+                            if (addSeparator)
+                            {
+                                builder.Append('.');
+                            }
+
+                            builder.Append(path);
+                            addSeparator = true;
+                        }
+
+                        builder.AppendLine("\",");
                     }
 
                     var code = executionError.Code;
                     if (code != null)
                     {
-                        builder.AppendLine($"{tab + tab}\"code\": \"{code}\",");
+                        builder.Append($"{tab + tab}\"code\": \"")
+                               .Append(code)
+                               .AppendLine("\",");
                     }
 
                     var locations = executionError.Locations;
                     if (locations != null)
                     {
-                        ConstructErrorLocationsMessage(builder, tab, locations);
+                        ConstructErrorLocationsMessage(builder, locations);
                     }
 
                     builder.AppendLine($"{tab}}},");

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Processors;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
 {
@@ -134,7 +135,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
             }
         }
 
-        private static string ConstructErrorMessage(IExecutionErrors executionErrors)
+        [TestingAndPrivateOnly]
+        internal static string ConstructErrorMessage(IExecutionErrors executionErrors)
         {
             if (executionErrors == null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommon.cs
@@ -144,19 +144,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
 
             try
             {
-                const string tab = "    ";
                 builder.AppendLine("errors: [");
 
                 for (int i = 0; i < executionErrors.Count; i++)
                 {
                     var executionError = executionErrors[i];
 
-                    builder.AppendLine($"{tab}{{");
+                    builder.AppendLine($"{Tab}{{");
 
                     var message = executionError.Message;
                     if (message != null)
                     {
-                        builder.Append($"{tab + tab}\"message\": \"")
+                        builder.Append($"{Tab + Tab}\"message\": \"")
                                .Append(message.Replace("\r", "\\r").Replace("\n", "\\n"))
                                .AppendLine("\",");
                     }
@@ -164,7 +163,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                     var paths = executionError.Path;
                     if (paths != null)
                     {
-                        builder.Append($"{tab + tab}\"path\": \"{string.Join(".", paths)}\",");
+                        builder.Append($"{Tab + Tab}\"path\": \"");
                         var addSeparator = false;
                         foreach (var path in paths)
                         {
@@ -183,7 +182,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                     var code = executionError.Code;
                     if (code != null)
                     {
-                        builder.Append($"{tab + tab}\"code\": \"")
+                        builder.Append($"{Tab + Tab}\"code\": \"")
                                .Append(code)
                                .AppendLine("\",");
                     }
@@ -194,7 +193,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
                         ConstructErrorLocationsMessage(builder, locations);
                     }
 
-                    builder.AppendLine($"{tab}}},");
+                    builder.AppendLine($"{Tab}}},");
                 }
 
                 builder.AppendLine("]");

--- a/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/HotChocolateCommonTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="HotChocolateCommonTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate;
+using Datadog.Trace.Processors;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
+{
+    public class HotChocolateCommonTests
+    {
+        private const int MaxLen = TruncatorTagsProcessor.MaxMetaValLen;
+
+        [Fact]
+        public void ConstructErrorMessage_SmallError_NotTruncated()
+        {
+            var errors = new List<IError>
+            {
+                new TestError
+                {
+                    Message = "boom",
+                    Locations = new object[] { new TestLocation { Line = 3, Column = 7 } },
+                },
+            };
+
+            var result = HotChocolateCommon.ConstructErrorMessage(errors);
+
+            result.Length.Should().BeLessThan(MaxLen);
+            result.Should().Contain("boom");
+            result.Should().Contain("\"line\": 3");
+            result.Should().Contain("\"column\": 7");
+        }
+
+        [Fact]
+        public void ConstructErrorMessage_LongMessage_TruncatedToMaxLen()
+        {
+            var errors = new List<IError>
+            {
+                new TestError
+                {
+                    Message = new string('x', MaxLen + 100),
+                    Locations = new object[] { new TestLocation { Line = 1, Column = 1 } },
+                },
+            };
+
+            var result = HotChocolateCommon.ConstructErrorMessage(errors);
+
+            result.Length.Should().Be(MaxLen);
+        }
+
+        private sealed class TestError : IError
+        {
+            public string? Code { get; set; }
+
+            public IEnumerable? Locations { get; set; }
+
+            public string? Message { get; set; }
+
+            public IPath? Path { get; set; }
+
+            public Exception? Exception { get; set; }
+
+            public IReadOnlyDictionary<string, object>? Extensions { get; set; }
+        }
+
+        private sealed class TestLocation
+        {
+            public int Line { get; set; }
+
+            public int Column { get; set; }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/GraphQL/Net/GraphQLCommonTests.cs
@@ -1,0 +1,102 @@
+// <copyright file="GraphQLCommonTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net;
+using Datadog.Trace.Processors;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ClrProfiler.AutoInstrumentation.GraphQL.Net
+{
+    public class GraphQLCommonTests
+    {
+        private const int MaxLen = TruncatorTagsProcessor.MaxMetaValLen;
+
+        [Fact]
+        public void ConstructErrorMessage_SmallError_NotTruncated()
+        {
+            var errors = new TestExecutionErrors(
+                new TestExecutionError
+                {
+                    Message = "boom",
+                    Code = "MY_CODE",
+                    Path = new object[] { "user", "name" },
+                    Locations = new object[] { new TestLocation { Line = 3, Column = 7 } },
+                });
+
+            var result = GraphQLCommon.ConstructErrorMessage(errors);
+
+            result.Length.Should().BeLessThan(MaxLen);
+            result.Should().Contain("boom");
+            result.Should().Contain("\"code\": \"MY_CODE\"");
+            result.Should().Contain("user.name");
+            result.Should().Contain("\"line\": 3");
+            result.Should().Contain("\"column\": 7");
+        }
+
+        [Fact]
+        public void ConstructErrorMessage_LongMessage_TruncatedToMaxLen()
+        {
+            var errors = new TestExecutionErrors(
+                new TestExecutionError
+                {
+                    Message = new string('x', MaxLen + 100),
+                    Path = new object[] { "user", "name" },
+                    Locations = new object[] { new TestLocation { Line = 1, Column = 1 } },
+                });
+
+            var result = GraphQLCommon.ConstructErrorMessage(errors);
+
+            result.Length.Should().Be(MaxLen);
+        }
+
+        private sealed class TestExecutionErrors : IExecutionErrors
+        {
+            private readonly IExecutionError[] _errors;
+
+            public TestExecutionErrors(params IExecutionError[] errors)
+            {
+                _errors = errors;
+            }
+
+            public int Count => _errors.Length;
+
+            public IExecutionError this[int index] => _errors[index];
+        }
+
+        private sealed class TestExecutionError : IExecutionError
+        {
+            public string? Code { get; set; }
+
+            public IEnumerable? Locations { get; set; }
+
+            public string? Message { get; set; }
+
+            public IEnumerable? Path { get; set; }
+
+            public string? StackTrace { get; set; }
+
+            public object? Instance => this;
+
+            public Type Type => GetType();
+
+            public ref TReturn? GetInternalDuckTypedInstance<TReturn>()
+                => throw new NotImplementedException();
+
+            public override string ToString() => string.Empty;
+        }
+
+        private sealed class TestLocation
+        {
+            public int Line { get; set; }
+
+            public int Column { get; set; }
+        }
+    }
+}

--- a/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.SchemaV0.verified.txt
@@ -366,7 +366,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -376,9 +376,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -433,15 +433,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve throwNotImplementedException.",
-"path": "System.String[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.SchemaV1.verified.txt
@@ -326,7 +326,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -336,9 +336,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -383,15 +383,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve throwNotImplementedException.",
-"path": "System.String[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.netfx.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.netfx.SchemaV0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -116,7 +116,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -126,9 +126,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -290,15 +290,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve throwNotImplementedException.",
-"path": "System.String[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.netfx.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GraphQL2Tests.SubmitsTraces.netfx.SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -112,7 +112,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -122,9 +122,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -280,15 +280,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve throwNotImplementedException.",
-"path": "System.String[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.SchemaV0.verified.txt
@@ -366,7 +366,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -376,9 +376,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -433,15 +433,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve field 'throwNotImplementedException'.",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.SchemaV1.verified.txt
@@ -326,7 +326,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -336,9 +336,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -383,15 +383,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve field 'throwNotImplementedException'.",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.netfx.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.netfx.SchemaV0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -116,7 +116,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -126,9 +126,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -290,15 +290,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve field 'throwNotImplementedException'.",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.netfx.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GraphQL3Tests.SubmitsTraces.netfx.SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -112,7 +112,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -122,9 +122,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -280,15 +280,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve field 'throwNotImplementedException'.",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL4Tests.SubmitsTraces.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GraphQL4Tests.SubmitsTraces.SchemaV0.verified.txt
@@ -366,7 +366,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -376,9 +376,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -433,15 +433,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve field 'throwNotImplementedException'.",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL4Tests.SubmitsTraces.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GraphQL4Tests.SubmitsTraces.SchemaV1.verified.txt
@@ -326,7 +326,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -336,9 +336,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -383,15 +383,15 @@ errors: [
 errors: [
 {
 "message": "Error trying to resolve field 'throwNotImplementedException'.",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,

--- a/tracer/test/snapshots/GraphQL7Tests.SubmitsTraces.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GraphQL7Tests.SubmitsTraces.SchemaV0.verified.txt
@@ -320,9 +320,9 @@ errors: [
 {
 "line": 1,
 "column": 1
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -360,7 +360,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -370,9 +370,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -410,9 +410,9 @@ errors: [
 {
 "line": 1,
 "column": 1
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,

--- a/tracer/test/snapshots/GraphQL7Tests.SubmitsTraces.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GraphQL7Tests.SubmitsTraces.SchemaV1.verified.txt
@@ -290,9 +290,9 @@ errors: [
 {
 "line": 1,
 "column": 1
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -325,7 +325,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -335,9 +335,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,
@@ -370,9 +370,9 @@ errors: [
 {
 "line": 1,
 "column": 1
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,

--- a/tracer/test/snapshots/GraphQL7Tests.SubmitsTracesWebsockets.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GraphQL7Tests.SubmitsTracesWebsockets.SchemaV0.verified.txt
@@ -188,15 +188,15 @@
 errors: [
 {
 "message": "This API purposely throws a NotImplementedException",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,
@@ -236,7 +236,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -246,9 +246,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,

--- a/tracer/test/snapshots/GraphQL7Tests.SubmitsTracesWebsockets.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GraphQL7Tests.SubmitsTracesWebsockets.SchemaV1.verified.txt
@@ -173,15 +173,15 @@
 errors: [
 {
 "message": "This API purposely throws a NotImplementedException",
-"path": "System.Object[]",
+"path": "throwNotImplementedException",
 "code": "NOT_IMPLEMENTED",
 "locations": [
 {
 "line": 1,
 "column": 32
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.ExecutionError,
@@ -216,7 +216,7 @@ errors: [
 {
 "line": 1,
 "column": 24
-},
+}
 ]
 },
 {
@@ -226,9 +226,9 @@ errors: [
 {
 "line": 1,
 "column": 35
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: GraphQL.Validation.ValidationError,

--- a/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV0.Pre_13_1_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV0.Pre_13_1_0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -294,9 +294,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -342,9 +342,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -386,9 +386,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV0.Pre_16_0_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV0.Pre_16_0_0.verified.txt
@@ -294,9 +294,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -342,9 +342,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -386,9 +386,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV0.verified.txt
@@ -294,9 +294,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -338,7 +338,7 @@ errors: [
 errors: [
 {
 "message": "Unexpected Execution Error",
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -376,7 +376,7 @@ query ErrorQuery {
 errors: [
 {
 "message": "Unexpected Execution Error",
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV1.Pre_13_1_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV1.Pre_13_1_0.verified.txt
@@ -279,9 +279,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -322,9 +322,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -361,9 +361,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV1.Pre_16_0_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV1.Pre_16_0_0.verified.txt
@@ -279,9 +279,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -322,9 +322,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -361,9 +361,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTests.SubmitsTraces.SchemaV1.verified.txt
@@ -279,9 +279,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -318,7 +318,7 @@ errors: [
 errors: [
 {
 "message": "Unexpected Execution Error",
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -351,7 +351,7 @@ query ErrorQuery {
 errors: [
 {
 "message": "Unexpected Execution Error",
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV0.Pre_13_1_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV0.Pre_13_1_0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -199,9 +199,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -243,9 +243,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV0.Pre_16_0_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV0.Pre_16_0_0.verified.txt
@@ -199,9 +199,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -243,9 +243,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV0.verified.txt
@@ -195,7 +195,7 @@ mutation m {
 errors: [
 {
 "message": "Unexpected Execution Error",
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -237,9 +237,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV1.Pre_13_1_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV1.Pre_13_1_0.verified.txt
@@ -189,9 +189,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -228,9 +228,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV1.Pre_16_0_0.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV1.Pre_16_0_0.verified.txt
@@ -189,9 +189,9 @@ errors: [
 {
 "line": 1,
 "column": 18
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -228,9 +228,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,

--- a/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/HotChocolateTestsWebsockets.SubmitsTraces.SchemaV1.verified.txt
@@ -185,7 +185,7 @@ mutation m {
 errors: [
 {
 "message": "Unexpected Execution Error",
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,
@@ -222,9 +222,9 @@ errors: [
 {
 "line": 1,
 "column": 2
-},
+}
 ]
-},
+}
 ]
 ,
       error.type: HotChocolate.Error,


### PR DESCRIPTION
## Summary of changes

- Reduce allocations by avoiding string interpolation when using `StringBuilder` 
- Use `const` instead of parameter to reduce allocations on concat
- Bail out of building error tag if it gets too large

## Reason for change

Technically the building of the error tag could become very large. This PR bails out of building the error response if it gets too large. The bail out is not super strict, as this is on a hot path, we just stop adding errors etc if the value exceeds the truncation threshold (25k chars, so pretty unlikely).

While I was in there, I noticed a bunch of places we were not using constants where we could have been, and places where we were using interpolation, which allocates a string, before adding the result to a `StringBuilder`, so cleaned that up at the same time.

## Implementation details

- Make `Tab` a constant on the common base, so we don't have to pass it to functions as a variable, meaning we have compile-time constants added to the builder.
- Remove  interpolation for any non-constant strings
- Fix invalid trailing comma in the JSON
- Add checks at various points for exceeding tag truncation limit. Checks are quick and rough
- If we do exceed the count, only create a string of the final correct size, as it would be truncated in the agent/backend anyway

## Test coverage

Add a couple of simple checks for the basic truncation.

https://datadoghq.atlassian.net/browse/APMSP-3519