### PR TITLE
Stabilize benchmarks

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
+++ b/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
@@ -158,7 +158,7 @@ experiments:
             *RedisBenchmark*
             *SpanBenchmark*
             *TraceAnnotationsBenchmark*
-          cpus_per_item: 1
+          cpus_per_item: 2
 
         env:
           BATCH_PREFIX: "trace"
@@ -187,7 +187,7 @@ experiments:
             *Log4netBenchmark*
             *SerilogBenchmark*
             *StringAspectsBenchmark*
-          cpus_per_item: 1
+          cpus_per_item: 2
 
         env:
           BATCH_PREFIX: "trace-unstable"
@@ -202,14 +202,14 @@ experiments:
         repo: DataDog/dd-trace-dotnet
         baseline_branch: ""
 
-        cpus: "0,0xE00000"
+        cpus: "0,0x3F000000"
         parallelize:
-          # OpenTelemetry InstrumentedApi benchmarks (CPUs 21-23 on NUMA node 0)
+          # OpenTelemetry InstrumentedApi benchmarks (CPUs 24-29 on NUMA node 0)
           items: >-
             *ActivityBenchmark*
             *TelemetrySpanBenchmark*
             *TracerBenchmark*
-          cpus_per_item: 1
+          cpus_per_item: 2
 
         env:
           BATCH_PREFIX: "otel-instr-api"
@@ -230,14 +230,14 @@ experiments:
         repo: DataDog/dd-trace-dotnet
         baseline_branch: ""
 
-        cpus: "1,0xE00000"
+        cpus: "1,0x3F000000"
         parallelize:
-          # OpenTelemetry Api benchmarks (CPUs 21-23 on NUMA node 1, skipped on PRs since Nuke doesn't build them)
+          # OpenTelemetry Api benchmarks (CPUs 24-29 on NUMA node 1, skipped on PRs since Nuke doesn't build them)
           items: >-
             *ActivityBenchmark*
             *TelemetrySpanBenchmark*
             *TracerBenchmark*
-          cpus_per_item: 1
+          cpus_per_item: 2
 
         env:
           BATCH_PREFIX: "otel-api"

--- a/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
+++ b/.gitlab/benchmarks/microbenchmarks/scripts/run-benchmarks.ps1
@@ -135,7 +135,7 @@ $arguments = @("-r") + $runtimes + @(
     # We change this manually on benchmark methods from 200 ms to 500 ms on 
     # less stable benchmarks with "[IterationTime(500)]"
     "--iterationTime", "200",
-    "--launchCount", "5",
+    "--launchCount", "10",
     "--warmupCount", "10",
     "--iterationCount", "10",
     "--buildTimeout", "3600",


### PR DESCRIPTION
## Summary of changes

Partially revert the methodology changes from #8559 that introduced .NET 6-specific instability in the microbenchmarks:

- restore `--launchCount` from `5` back to `10`.
- restore/change `cpus_per_item` from `1` back to `2` on all four batches (`trace`, `trace-unstable`, `otel-instr-api`, `otel-api`).
- widen the OTel batch CPU masks from `0xE00000` (3 CPUs, bits 21–23) to `0x3F000000` (6 CPUs, bits 24–29) so `cpus_per_item: 2` still fits the 3 OTel items in a single parallel wave instead of serializing them.

The new OpenTelemetry batches added in #8559 are retained.

## Reason for change

Since #8559 merged, the microbenchmarks dashboard showed two distinct .NET 6-only regressions:

1. **Systematic execution-time shift across basically all .NET 6 benchmarks.** Other runtimes (net472, netcoreapp3.1) were unaffected.
2. **Erratic allocation metrics on the OTel .NET 6 benchmarks.** 

Root cause is the combination of `cpus_per_item: 1` and `launchCount: 5`

## Implementation details

The two levers target different symptoms:
- **`cpus_per_item: 2`** addresses the *systematic shift* by giving the runtime a second core for background work.
- **`launchCount: 10`** addresses the *variance* by tightening confidence intervals.

## Test coverage

## Other details


Related: #8559 (the PR being partially reverted).

<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->