### PR TITLE
Handle invalid timestamps in Kafka consume integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -268,10 +268,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                         var produceTime = message.Timestamp.UtcDateTime;
                         tags.MessageQueueTimeMs = Math.Max(0, (consumeTime - produceTime).TotalMilliseconds);
                     }
-                    catch (OverflowException)
+                    catch (Exception)
                     {
                         // The stored timestamp resulted in an out-of-range value when converting to DateTime;
                         // likely due to an invalid timestamp. Skip the tag rather than abort the whole scope.
+                        // Using Exception here, because the method could throw ArgumentOutOfRangeException or OverflowException
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -262,9 +262,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                 if (message?.Instance is not null && message.Timestamp.Type != 0)
                 {
-                    var consumeTime = span.StartTime.UtcDateTime;
-                    var produceTime = message.Timestamp.UtcDateTime;
-                    tags.MessageQueueTimeMs = Math.Max(0, (consumeTime - produceTime).TotalMilliseconds);
+                    try
+                    {
+                        var consumeTime = span.StartTime.UtcDateTime;
+                        var produceTime = message.Timestamp.UtcDateTime;
+                        tags.MessageQueueTimeMs = Math.Max(0, (consumeTime - produceTime).TotalMilliseconds);
+                    }
+                    catch (OverflowException)
+                    {
+                        // The stored timestamp resulted in an out-of-range value when converting to DateTime;
+                        // likely due to an invalid timestamp. Skip the tag rather than abort the whole scope.
+                    }
                 }
 
                 if (message?.Instance is not null && message.Value is null)


### PR DESCRIPTION
## Summary of changes

Add try-catch when grabbing the timestamp from a Kafka message

## Reason for change

We have seen [some cases](https://app.datadoghq.com/error-tracking/issue/921d8bbc-5065-11f1-8e66-da7ad0900002) where the conversion from a timestamp to a `DateTime` ([in the Confluent.Kafka library](https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.3.0/src/Confluent.Kafka/Timestamp.cs#L221)) was throwing an `OverflowException`. Likely due to an "invalid" value associated with the stored message.

## Implementation details


Throwing here would mean a lot of details would be lost (including DSM) so wrap in a try-catch to handle it. Other options are changing to grab the raw timestamp and detecting this issue before triggering it, but the net effect is the same (the tag can't be set) and it's a niche issue caused by an invalid scenario, so not worth the effort IMO

## Test coverage

Meh, it's just a try-catch

## Other details

Fixes [error tracking issue](https://app.datadoghq.com/error-tracking/issue/921d8bbc-5065-11f1-8e66-da7ad0900002)