### PR TITLE
Fix race condition in IpcTests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
@@ -21,7 +21,8 @@ public class IpcTests
         using var server = new IpcServer(name);
         using var client = new IpcClient(name);
 
-        TestMessage? finalValue = null;
+        var finalServerValue = 0;
+        var finalClientValue = 0;
         var serverTaskCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var clientTaskCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -39,7 +40,7 @@ public class IpcTests
                 }
             }
 
-            Interlocked.Exchange(ref finalValue, value);
+            Interlocked.Exchange(ref finalServerValue, value.ServerValue);
             if (value.ServerValue == maxNumber)
             {
                 serverTaskCompletion.TrySetResult(true);
@@ -58,7 +59,7 @@ public class IpcTests
                 }
             }
 
-            Interlocked.Exchange(ref finalValue, value);
+            Interlocked.Exchange(ref finalClientValue, value.ClientValue);
             if (value.ClientValue == maxNumber)
             {
                 clientTaskCompletion.TrySetResult(true);
@@ -71,12 +72,11 @@ public class IpcTests
         var ipcTasks = Task.WhenAll(serverTaskCompletion.Task, clientTaskCompletion.Task);
         if (await Task.WhenAny(ipcTasks, delayTask) == delayTask)
         {
-            throw new TimeoutException($"Timeout waiting for messages. Values went up to [{finalValue?.ServerValue}, {finalValue?.ClientValue}]");
+            throw new TimeoutException($"Timeout waiting for messages. Values went up to [{finalServerValue}, {finalClientValue}]");
         }
 
-        finalValue.Should().NotBeNull();
-        finalValue!.ServerValue.Should().Be(maxNumber);
-        finalValue.ClientValue.Should().Be(maxNumber);
+        finalServerValue.Should().Be(maxNumber);
+        finalClientValue.Should().Be(maxNumber);
     }
 
     private class TestMessage(int serverValue, int clientValue)


### PR DESCRIPTION
## Summary of changes

Fixes a race condition in IpcTests that is causing a lot of flake

## Reason for change

There's a race condition between the client and server loops. Both callbacks call `Interlocked.Exchange(ref finalValue, value)` _after_ sending the message. During the final exchange, the server's callback for `(19, 19)` would send `(20, 19)` to the client, then the client could process it, send `(20, 20)` back, write `finalValue=(20, 20)`, and set `clientTaskCompletion`. That all happens _before_ the server callback writes `finalValue`, so the server overwrites with `(20, 19)`.

The table below (from 🤖) summarizes it: 

| time | server polling thread                                 | client polling thread                                 | finalValue |
| ---- | ----------------------------------------------------- | ----------------------------------------------------- | ---------- |
| t0   | receives `(19, 19)` → increments → value = `(20, 19)` |                                                       | …          |
| t1   | sends `(20, 19)` to client (mutex released)           |                                                       | …          |
| t2   |                                                       | receives `(20, 19)` → increments → value = `(20, 20)` | …          |
| t3   |                                                       | sends `(20, 20)` to server                            | …          |
| t4   |                                                       | `Interlocked.Exchange(finalValue, (20, 20))`          | `(20, 20)` |
| t5   |                                                       | sets `clientTaskCompletion`                           | `(20, 20)` |
| t6   | `Interlocked.Exchange(finalValue, (20, 19))` ← stale! |                                                       | `(20, 19)` |
| t7   | sets `serverTaskCompletion`                           |                                                       | `(20, 19)` |

## Implementation details

Track `finalServerValue` and `finalClientValue` independently so that each callback writes its own value. As there's now only one writer, the race has gone.

## Test coverage

This is the test

## Other details

The bug is only in the test, not in the production code