### PR TITLE
Invalidate libdatadog FetchContent cache on version bump

### DIFF
--- a/build/cmake/FindLibdatadog.cmake
+++ b/build/cmake/FindLibdatadog.cmake
@@ -6,6 +6,33 @@ include(FetchContent)
 
 set(LIBDATADOG_VERSION "v32.0.0" CACHE STRING "libdatadog version")
 
+# FetchContent only validates URL_HASH on the initial download and skips
+# re-fetching whenever SOURCE_DIR already exists.  On persistent CI workers
+# (e.g. Azure DevOps with build caching) that means bumping LIBDATADOG_VERSION
+# here can be silently ignored — the cached binary from a previous run keeps
+# being used.  Use a sibling stamp file to detect version changes and wipe
+# the cached directory so FetchContent re-downloads and re-validates.
+function(_libdatadog_invalidate_cache_if_version_changed dir_basename)
+    set(_dir "${CMAKE_CURRENT_BINARY_DIR}/${dir_basename}")
+    set(_stamp "${CMAKE_CURRENT_BINARY_DIR}/${dir_basename}.version")
+    set(_cached "")
+    if(EXISTS "${_stamp}")
+        file(READ "${_stamp}" _cached)
+        string(STRIP "${_cached}" _cached)
+    endif()
+    if(NOT "${_cached}" STREQUAL "${LIBDATADOG_VERSION}")
+        if(EXISTS "${_dir}")
+            message(STATUS "libdatadog version changed (${_cached} -> ${LIBDATADOG_VERSION}); clearing ${_dir}")
+            file(REMOVE_RECURSE "${_dir}")
+        endif()
+        file(WRITE "${_stamp}" "${LIBDATADOG_VERSION}\n")
+    endif()
+endfunction()
+
+_libdatadog_invalidate_cache_if_version_changed(libdatadog-install)
+_libdatadog_invalidate_cache_if_version_changed(libdatadog-install-arm64)
+_libdatadog_invalidate_cache_if_version_changed(libdatadog-install-x86_64)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     # For Darwin, we'll download both architectures and combine them
     set(SHA256_LIBDATADOG_ARM64 "3f87294f613290c4946899f02a3944f75d6b6077f156d105bb1a90bbbfeffa9d" CACHE STRING "libdatadog arm64 sha256")


### PR DESCRIPTION
## Summary of changes

Adds a stamp-file check at the top of `build/cmake/FindLibdatadog.cmake` that deletes any cached `libdatadog-install*` directory whose recorded version doesn't match the current `LIBDATADOG_VERSION`. FetchContent then re-downloads and re-validates `URL_HASH` against the freshly-published tarball.

## Reason for change

CMake's `FetchContent` only validates `URL_HASH` on the **initial** download and skips re-fetching whenever `SOURCE_DIR` already exists. On persistent CI workers (e.g. Azure DevOps with build caching), bumping `LIBDATADOG_VERSION` was silently ignored — the cached binary from a previous run kept being used.

We hit this concretely when upgrading libdatadog and the `ValidateNativeProfilerGlibcCompatibility` target failed against a stale binary with `Maximum required glibc version for libdatadog_profiling is 2.16` even though the new version's binary has no `GLIBC_2.16` references at all. The validation was running against the cached previous-version binary.

## Implementation details

A small helper function checks for a `<dir>.version` stamp file next to the cached `SOURCE_DIR`. If the stamp doesn't match the current `LIBDATADOG_VERSION`:
- `file(REMOVE_RECURSE)` the cached directory
- Write a new stamp file with the current version

Stamp files live **outside** the SOURCE_DIR (sibling to it), so they survive `FetchContent_Populate` re-extraction. The helper is invoked once per cached directory: `libdatadog-install`, `libdatadog-install-arm64`, `libdatadog-install-x86_64` (the latter two are used to build the macOS universal binary).

Behavior:
- First run on a worker: no stamp → write stamp → FetchContent does its normal download → cached.
- Version-bump run: stamp doesn't match → wipe dir → write new stamp → FetchContent re-downloads.
- No-bump run: stamp matches → no-op → FetchContent skip-because-cached, same as before.

## Test coverage

No behavior change for users on the happy path (single version, no bumps, fresh workers). The fix is exercised any time `LIBDATADOG_VERSION` changes; CI runs that perform a libdatadog bump are the natural test surface.

## Other details

Purely additive change to one file — no other files touched.