### PR TITLE
[Code Origin] Fix smoke test path mismatches on macOS and Windows IIS

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5543,7 +5543,7 @@ stages:
 
         - script: |
             cd $(smokeTestAppDir)
-            dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $(publishFramework) -o $(smokeTestAppDir)/publish
+            dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $(publishFramework) /p:PathMap=$(smokeTestAppDir)=/src -o $(smokeTestAppDir)/publish
           displayName: Build app
           failOnStderr: true
 

--- a/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json
@@ -133,7 +133,7 @@
         "_dd.code_origin.frames.0.index": "0",
         "_dd.code_origin.frames.0.method": "Get",
         "_dd.code_origin.frames.0.type": "AspNetCoreSmokeTest.ValuesController",
-        "_dd.code_origin.frames.0.file": "C:\\src\\ValuesController.cs",
+        "_dd.code_origin.frames.0.file": "/src/ValuesController.cs",
         "_dd.code_origin.frames.0.line": "19",
         "_dd.code_origin.frames.0.column": "13"
       },


### PR DESCRIPTION
## Summary of changes

- Add `/p:PathMap=$(smokeTestAppDir)=/src` to the macOS smoke-test publish step in `.azure-pipelines/ultimate-pipeline.yml`, mirroring the `PathMap` already used by every Linux/Windows smoke-test Dockerfile.
- Update `tracer/build/smoke_test_snapshots/smoke_test_iis_snapshots.json` so `_dd.code_origin.frames.0.file` is `/src/ValuesController.cs` (the value the Windows IIS Fleet Dockerfile actually emits).

## Reason for change

- After #8272 (Code Origin on by default), `smoke_macos_tool_tests` failed on master for all 13 `macos*` jobs because the macOS pipeline builds `AspNetCoreSmokeTest` directly on the host (no Docker, no `PathMap`), so PDB sequence points contained `/Users/runner/work/1/s/tracer/test/test-applications/regression/AspNetCoreSmokeTest/ValuesController.cs` instead of the snapshot's expected `/src/ValuesController.cs`.
- The same PR added `/p:PathMap=C:\src=/src` to `smoke.windows.iis.fleet-installer.dockerfile`, so the runtime now emits `/src/ValuesController.cs`, but `smoke_test_iis_snapshots.json` was approved with `C:\\src\\ValuesController.cs`, breaking `smoke_win_fleet_tests`.

## Implementation details

- macOS: `$(smokeTestAppDir)` resolves to `$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest`, so `PathMap=$(smokeTestAppDir)=/src` rewrites every embedded source path under that directory to `/src/...`. This matches the layout produced by the Linux `WORKDIR /src` Dockerfiles, keeping a single shared `smoke_test_snapshots.json` for all Linux/macOS smoke tests.
- IIS: only `WindowsFleetInstallerIisScenario` reads `smoke_test_iis_snapshots`, and its Dockerfile already applies `PathMap=C:\src=/src`, so updating the snapshot to `/src/ValuesController.cs` aligns the expected value with actual runtime output rather than re-introducing a divergent path.
- No tracer code or runtime behavior changes; this is purely a CI/snapshot fix limited to two files (`+2 / -2`).