### PR TITLE
Prevent invalid JSON in AWS Lambda payloads

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Util.Json;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
 {
@@ -101,7 +102,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
         {
             public void Set(StringBuilder carrier, string key, string value)
             {
-                carrier.AppendFormat("\"{0}\":\"{1}\",", key, value);
+                carrier.Append('"').Append(key).Append("\":\"");
+                JsonHelper.WriteEscapedJavaScriptString(carrier, value);
+                carrier.Append("\",");
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
@@ -62,8 +62,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
                 detailBuilder.Append(','); // Add comma if the original detail is not empty
             }
 
-            var traceContext = BuildContextJson(tracer, context, entry.EventBusName);
-            detailBuilder.Append($"\"{DatadogKey}\":{traceContext}").Append('}');
+            detailBuilder.Append($"\"{DatadogKey}\":");
+            AppendContextJson(tracer, context, entry.EventBusName, detailBuilder);
+            detailBuilder.Append('}');
 
             // Check new detail size
             var updatedDetail = Util.StringBuilderCache.GetStringAndRelease(detailBuilder);
@@ -77,25 +78,24 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
             entry.Detail = updatedDetail;
         }
 
-        // Builds a JSON string containing Datadog trace context
-        private static string BuildContextJson(Tracer tracer, PropagationContext context, string? eventBusName)
+        // Appends the body of the Datadog trace-context JSON object (without surrounding braces) to the supplied builder.
+        private static void AppendContextJson(Tracer tracer, PropagationContext context, string? eventBusName, StringBuilder jsonBuilder)
         {
-            // Inject trace context
-            var jsonBuilder = Util.StringBuilderCache.Acquire();
             jsonBuilder.Append('{');
 
             tracer.TracerManager.SpanContextPropagator.Inject(context, jsonBuilder, new StringBuilderCarrierSetter());
 
-            // Inject start time and bus name
             var startTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            jsonBuilder.Append($"\"{StartTimeKey}\":\"{startTime}\"");
+            jsonBuilder.Append($"\"{StartTimeKey}\":\"").Append(startTime).Append('"');
+
             if (eventBusName != null)
             {
-                jsonBuilder.Append($",\"{ResourceNameKey}\":\"{eventBusName}\"");
+                jsonBuilder.Append($",\"{ResourceNameKey}\":\"");
+                JsonHelper.WriteEscapedJavaScriptString(jsonBuilder, eventBusName);
+                jsonBuilder.Append('"');
             }
 
             jsonBuilder.Append('}');
-            return Util.StringBuilderCache.GetStringAndRelease(jsonBuilder);
         }
 
         private struct StringBuilderCarrierSetter : ICarrierSetter<StringBuilder>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
             jsonBuilder.Append('}');
         }
 
-        private struct StringBuilderCarrierSetter : ICarrierSetter<StringBuilder>
+        private readonly struct StringBuilderCarrierSetter : ICarrierSetter<StringBuilder>
         {
             public void Set(StringBuilder carrier, string key, string value)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Shared/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Shared/ContextPropagation.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Text;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Util.Json;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Shared
 {
@@ -89,7 +90,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Shared
         {
             public void Set(StringBuilder carrier, string key, string value)
             {
-                carrier.AppendFormat("\"{0}\":\"{1}\",", key, value);
+                carrier.Append('"').Append(key).Append("\":\"");
+                JsonHelper.WriteEscapedJavaScriptString(carrier, value);
+                carrier.Append("\",");
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/ContextPropagation.cs
@@ -7,6 +7,7 @@
 
 using System.Text;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Util.Json;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
 {
@@ -56,7 +57,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
         {
             public void Set(StringBuilder carrier, string key, string value)
             {
-                carrier.AppendFormat("\"{0}\":\"{1}\",", key, value);
+                carrier.Append('"').Append(key).Append("\":\"");
+                JsonHelper.WriteEscapedJavaScriptString(carrier, value);
+                carrier.Append("\",");
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/StepFunctions/ContextPropagation.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions
                 sb.Append(','); // Add a comma if it's not an empty object
             }
 
-            sb.AppendFormat(" \"{0}\": {{", StepFunctionsKey); // Add _datadog:" {
+            sb.Append($$""" "{{StepFunctionsKey}}": {"""); // Add _datadog:" {
             tracer.TracerManager.SpanContextPropagator.Inject(context, sb, default(StringBuilderCarrierSetter));
             sb.Remove(sb.Length - 1, 1); // remove trailing comma
             sb.Append("}}"); // re-add both closing braces one for original JSON and one for context

--- a/tracer/src/Datadog.Trace/Util/Json/JsonHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/Json/JsonHelper.cs
@@ -5,11 +5,13 @@
 
 #nullable enable
 
+using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Utilities;
 
 namespace Datadog.Trace.Util.Json;
 
@@ -131,5 +133,126 @@ internal static class JsonHelper
         // differs from the vendored version, in that we use an array pool
         using var reader = new JsonTextReader(new StringReader(value)) { ArrayPool = JsonArrayPool.Shared };
         return jsonSerializer.Deserialize(reader, type);
+    }
+
+    /// <summary>
+    /// Appends <paramref name="value"/> to <paramref name="sb"/> with JSON-string escaping applied,
+    /// without surrounding quotes (the caller writes its own delimiters).
+    /// Escapes <c>"</c>, <c>\</c>, control chars (U+0000..U+001F), and the three JS-string-breaking
+    /// chars U+0085, U+2028, U+2029 — matching the output of
+    /// <see cref="Vendors.Newtonsoft.Json.Utilities.JavaScriptUtils.WriteEscapedJavaScriptString"/>
+    /// in its default double-quote mode.
+    /// </summary>
+    public static void WriteEscapedJavaScriptString(StringBuilder sb, string? value)
+    {
+        var escapeFlags = JavaScriptUtils.DoubleQuoteCharEscapeFlags;
+        if (StringUtil.IsNullOrEmpty(value))
+        {
+            return;
+        }
+
+        var firstEscape = FirstCharToEscape(value, escapeFlags);
+        if (firstEscape == -1)
+        {
+            // fast path: nothing to escape, append in one call
+            sb.Append(value);
+            return;
+        }
+
+        if (firstEscape != 0)
+        {
+            sb.Append(value, 0, firstEscape);
+        }
+
+        var lastWritePosition = firstEscape;
+        for (var i = firstEscape; i < value.Length; i++)
+        {
+            var c = value[i];
+
+            // skip chars that don't need escaping
+            if (c < escapeFlags.Length)
+            {
+                if (!escapeFlags[c])
+                {
+                    continue;
+                }
+            }
+            else if (c != '\u0085' && c != '\u2028' && c != '\u2029')
+            {
+                continue;
+            }
+
+            // flush the unescaped chunk between lastWritePosition and i
+            if (i > lastWritePosition)
+            {
+                sb.Append(value, lastWritePosition, i - lastWritePosition);
+            }
+
+            switch (c)
+            {
+                case '"':
+                    sb.Append("\\\"");
+                    break;
+                case '\\':
+                    sb.Append("\\\\");
+                    break;
+                case '\b':
+                    sb.Append("\\b");
+                    break;
+                case '\f':
+                    sb.Append("\\f");
+                    break;
+                case '\n':
+                    sb.Append("\\n");
+                    break;
+                case '\r':
+                    sb.Append("\\r");
+                    break;
+                case '\t':
+                    sb.Append("\\t");
+                    break;
+                case '\u0085':
+                    sb.Append("\\u0085");
+                    break;
+                case '\u2028':
+                    sb.Append("\\u2028");
+                    break;
+                case '\u2029':
+                    sb.Append("\\u2029");
+                    break;
+                default:
+                    // Not very efficient, but likely to be pretty rare
+                    sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                    break;
+            }
+
+            lastWritePosition = i + 1;
+        }
+
+        if (lastWritePosition < value.Length)
+        {
+            sb.Append(value, lastWritePosition, value.Length - lastWritePosition);
+        }
+    }
+
+    private static int FirstCharToEscape(string value, bool[] escapeFlags)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c < escapeFlags.Length)
+            {
+                if (escapeFlags[c])
+                {
+                    return i;
+                }
+            }
+            else if (c == '\u0085' || c == '\u2028' || c == '\u2029')
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
@@ -78,7 +78,7 @@ public class ContextPropagationTests
     public async Task InjectTracingContext_ExistingDetail_AddsTraceContext()
     {
         var request = GeneratePutEventsRequest([
-            new PutEventsRequestEntry { Detail = "{\"foo\":\"bar\"}", EventBusName = EventBusName }
+            new PutEventsRequestEntry { Detail = """{"foo":"bar"}""", EventBusName = EventBusName }
         ]);
 
         var proxy = request.DuckCast<IPutEventsRequest>();
@@ -167,7 +167,7 @@ public class ContextPropagationTests
     {
         var request = GeneratePutEventsRequest([
             new PutEventsRequestEntry { Detail = "{}", EventBusName = EventBusName },
-            new PutEventsRequestEntry { Detail = "{\"foo\":\"bar\"}", EventBusName = EventBusName }
+            new PutEventsRequestEntry { Detail = """{"foo":"bar"}""", EventBusName = EventBusName }
         ]);
 
         var proxy = request.DuckCast<IPutEventsRequest>();
@@ -280,6 +280,40 @@ public class ContextPropagationTests
 
         var byteSize = Encoding.UTF8.GetByteCount(entry.Detail);
         byteSize.Should().BeLessThan(MaxSizeBytes);
+    }
+
+    [Theory]
+    [InlineData("bad\"value")]
+    [InlineData("back\\slash")]
+    [InlineData("\"closing-brace\"}")]
+    [InlineData("\"},\"injected\":\"true")]
+    [InlineData("tab\there")]
+    [InlineData("nel\u0085char")]
+    public async Task InjectTracingContext_MaliciousOrigin_ProducesParseableJsonAndRoundTrips(string maliciousOrigin)
+    {
+        var spanContext = new SpanContext(
+            new TraceId(Upper: 1234567890123456789UL, Lower: 9876543210987654321UL),
+            spanId: 6766950223540265769UL,
+            samplingPriority: 1,
+            serviceName: "test-eventbridge",
+            origin: maliciousOrigin);
+
+        var entry = new PutEventsRequestEntry { Detail = """{"foo":"bar"}""", EventBusName = EventBusName };
+        var request = GeneratePutEventsRequest([entry]);
+        var proxy = request.DuckCast<IPutEventsRequest>();
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(spanContext, baggage: null));
+
+        // detail must be parseable JSON (no syntax break)
+        var detail = JsonConvert.DeserializeObject<Dictionary<string, object>>(entry.Detail)!;
+        // should have both keys
+        detail.Keys.Should().BeEquivalentTo("foo", DatadogKey);
+        detail["foo"].Should().Be("bar");
+
+        // origin round-trips through the _datadog object
+        var datadog = JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(detail[DatadogKey]))!;
+        datadog["x-datadog-origin"].Should().Be(maliciousOrigin);
     }
 
     private static PutEventsRequest GeneratePutEventsRequest(List<PutEventsRequestEntry> entries)

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SQS/SqsContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/SQS/SqsContextPropagationTests.cs
@@ -106,4 +106,32 @@ public class SqsContextPropagationTests
         extractedTraceContext["x-datadog-parent-id"].Should().Be(_spanContext.SpanId.ToString());
         extractedTraceContext["x-datadog-trace-id"].Should().Be(_spanContext.TraceId.ToString());
     }
+
+    [Theory]
+    [InlineData("bad\"value")]
+    [InlineData("back\\slash")]
+    [InlineData("\"},\"injected\":\"true")]
+    internal async Task MaliciousOrigin_AttributeValueIsParseableAndRoundTrips(string maliciousOrigin)
+    {
+        var spanContext = new SpanContext(
+            new TraceId(1234567890123456789UL, 9876543210987654321UL),
+            spanId: 6766950223540265769UL,
+            samplingPriority: 1,
+            serviceName: "test-sqs",
+            origin: maliciousOrigin);
+
+        var request = new SendMessageRequest { MessageBody = "msg" };
+        var proxy = request.DuckCast<IContainsMessageAttributes>();
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        ContextPropagation.InjectHeadersIntoMessage(tracer, proxy, spanContext, dataStreamsManager: null, CachedMessageHeadersHelper<SendMessageRequest>.Instance);
+
+        var messageAttributes = (Dictionary<string, MessageAttributeValue>)proxy.MessageAttributes;
+        messageAttributes.TryGetValue(DatadogKey, out var datadogAttr).Should().BeTrue();
+
+        // the _datadog attribute string must be parseable JSON despite the malicious origin
+        var parsed = JsonConvert.DeserializeObject<Dictionary<string, string>>(datadogAttr.StringValue);
+        parsed.Should().NotBeNull();
+        parsed["x-datadog-origin"].Should().Be(maliciousOrigin);
+    }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/StepFunctions/ContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/StepFunctions/ContextPropagationTests.cs
@@ -1,0 +1,132 @@
+// <copyright file="ContextPropagationTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.StepFunctions.Model;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.StepFunctions;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
+using Datadog.Trace.TestHelpers.TestTracer;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.AWS.StepFunctions;
+
+public class ContextPropagationTests
+{
+    private const string DatadogKey = "_datadog";
+
+    [Fact]
+    public async Task InjectContextIntoInput_EmptyInput_ProducesParseableJson()
+    {
+        var spanContext = CreateSpanContext(origin: null);
+        var request = new StartExecutionRequest { Input = "{}" };
+        var proxy = request.DuckCast<StartExecutionIntegration.IStartExecutionRequest>();
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        ContextPropagation.InjectContextIntoInput<object, StartExecutionIntegration.IStartExecutionRequest>(
+            tracer, proxy, new PropagationContext(spanContext, baggage: null));
+
+        var parsed = JsonConvert.DeserializeObject<Dictionary<string, object>>(proxy.Input!)!;
+        parsed.Should().ContainKey(DatadogKey);
+
+        var datadog = JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(parsed[DatadogKey]))!;
+        datadog["x-datadog-trace-id"].Should().Be(spanContext.TraceId.ToString());
+        datadog["x-datadog-parent-id"].Should().Be(spanContext.SpanId.ToString());
+    }
+
+    [Fact]
+    public async Task InjectContextIntoInput_NonEmptyInput_PreservesExistingKeys()
+    {
+        var spanContext = CreateSpanContext(origin: null);
+        var request = new StartExecutionRequest { Input = """{"foo":"bar"}""" };
+        var proxy = request.DuckCast<StartExecutionIntegration.IStartExecutionRequest>();
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        ContextPropagation.InjectContextIntoInput<object, StartExecutionIntegration.IStartExecutionRequest>(
+            tracer, proxy, new PropagationContext(spanContext, baggage: null));
+
+        var parsed = JsonConvert.DeserializeObject<Dictionary<string, object>>(proxy.Input!)!;
+        parsed.Should().ContainKey("foo");
+        parsed["foo"].Should().Be("bar");
+        parsed.Should().ContainKey(DatadogKey);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not-json")]
+    public async Task InjectContextIntoInput_InvalidInput_DoesNothing(string? input)
+    {
+        var spanContext = CreateSpanContext(origin: null);
+        var request = new StartExecutionRequest { Input = input };
+        var proxy = request.DuckCast<StartExecutionIntegration.IStartExecutionRequest>();
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        ContextPropagation.InjectContextIntoInput<object, StartExecutionIntegration.IStartExecutionRequest>(
+            tracer, proxy, new PropagationContext(spanContext, baggage: null));
+
+        proxy.Input.Should().Be(input);
+    }
+
+    [Theory]
+    [InlineData("bad\"value")]
+    [InlineData("back\\slash")]
+    [InlineData("\"closing-brace\"}")]
+    [InlineData("\"},\"injected\":\"true")]
+    [InlineData("tab\there")]
+    [InlineData("nel\u0085char")]
+    public async Task InjectContextIntoInput_MaliciousOrigin_ProducesParseableJsonAndRoundTrips(string maliciousOrigin)
+    {
+        var spanContext = CreateSpanContext(origin: maliciousOrigin);
+        var request = new StartExecutionRequest { Input = """{"foo":"bar"}""" };
+        var proxy = request.DuckCast<StartExecutionIntegration.IStartExecutionRequest>();
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        ContextPropagation.InjectContextIntoInput<object, StartExecutionIntegration.IStartExecutionRequest>(
+            tracer, proxy, new PropagationContext(spanContext, baggage: null));
+
+        // result must be parseable JSON (no syntax break)
+        var parsed = JsonConvert.DeserializeObject<Dictionary<string, object>>(proxy.Input!)!;
+        parsed.Should().ContainKey("foo");
+        parsed["foo"].Should().Be("bar");
+
+        // no injection at the top level beyond the original keys and _datadog
+        parsed.Keys.Should().BeEquivalentTo("foo", DatadogKey);
+
+        // origin round-trips
+        var datadog = JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(parsed[DatadogKey]))!;
+        datadog["x-datadog-origin"].Should().Be(maliciousOrigin);
+    }
+
+    [Theory]
+    [InlineData("bad\"v")]
+    [InlineData("back\\slash")]
+    [InlineData("v\"},\"injected\":\"true")]
+    public async Task InjectContextIntoInput_MaliciousBaggage_ProducesParseableJsonAndDoesNotInjectAtTopLevel(string maliciousValue)
+    {
+        var spanContext = CreateSpanContext(origin: null);
+        var baggage = new Baggage { ["safe-key"] = maliciousValue };
+        var request = new StartExecutionRequest { Input = """{"foo":"bar"}""" };
+        var proxy = request.DuckCast<StartExecutionIntegration.IStartExecutionRequest>();
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        ContextPropagation.InjectContextIntoInput<object, StartExecutionIntegration.IStartExecutionRequest>(
+            tracer, proxy, new PropagationContext(spanContext, baggage));
+
+        var parsed = JsonConvert.DeserializeObject<Dictionary<string, object>>(proxy.Input!)!;
+        parsed.Keys.Should().BeEquivalentTo("foo", DatadogKey);
+        parsed["foo"].Should().Be("bar");
+    }
+
+    private static SpanContext CreateSpanContext(string? origin)
+    {
+        var traceId = new TraceId(Upper: 1234567890123456789UL, Lower: 9876543210987654321UL);
+        return new SpanContext(traceId, spanId: 6766950223540265769UL, samplingPriority: 1, serviceName: "test", origin: origin!);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/Json/JsonHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Json/JsonHelperTests.cs
@@ -167,6 +167,74 @@ public class JsonHelperTests
         deserialized.Should().BeEquivalentTo(original);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("hello world")]
+    [InlineData("plain-trace-id-1234567890")]
+    [InlineData("with\"quote")]
+    [InlineData("with\\backslash")]
+    [InlineData("a\"b\\c\"d")]
+    [InlineData("tab\there")]
+    [InlineData("new\nline")]
+    [InlineData("carriage\rreturn")]
+    [InlineData("back\bspace")]
+    [InlineData("form\ffeed")]
+    [InlineData("control\u0001char")]
+    [InlineData("nel\u0085char")]
+    [InlineData("lsep\u2028char")]
+    [InlineData("psep\u2029char")]
+    [InlineData("emoji 😀 here")]
+    [InlineData("accents éè")]
+    [InlineData("\"leading-quote")]
+    [InlineData("trailing-backslash\\")]
+    [InlineData("\"\"\"")]
+    [InlineData("multi\"esc\\seq\nhere\t")]
+    public void WriteEscapedJavaScriptString_MatchesNewtonsoftEscaping(string value)
+    {
+        var sb = new StringBuilder();
+        sb.Append('"');
+        JsonHelper.WriteEscapedJavaScriptString(sb, value);
+        sb.Append('"');
+
+        var expected = JsonConvert.ToString(value);
+        sb.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void WriteEscapedJavaScriptString_NullOrEmptyInput_AppendsNothing(string input)
+    {
+        var sb = new StringBuilder("prefix");
+        JsonHelper.WriteEscapedJavaScriptString(sb, input);
+        sb.ToString().Should().Be("prefix");
+    }
+
+    [Fact]
+    public void WriteEscapedJavaScriptString_NoEscapeNeeded_AppendsSourceUnchanged()
+    {
+        // covers the FirstCharToEscape == -1 fast path
+        var sb = new StringBuilder();
+        JsonHelper.WriteEscapedJavaScriptString(sb, "abc123-_/.:;");
+        sb.ToString().Should().Be("abc123-_/.:;");
+    }
+
+    [Fact]
+    public void WriteEscapedJavaScriptString_ProducesParseableJsonWhenWrappedInObject()
+    {
+        // simulates the AWS Step Functions / EventBridge call pattern: build a JSON object
+        // by concatenation, with the escape helper handling untrusted values
+        var malicious = "_dd.p.foo=bad\"v\\}";
+        var sb = new StringBuilder();
+        sb.Append("{\"x-datadog-tags\":\"");
+        JsonHelper.WriteEscapedJavaScriptString(sb, malicious);
+        sb.Append("\"}");
+
+        var parsed = JsonConvert.DeserializeObject<Dictionary<string, string>>(sb.ToString());
+        parsed.Should().NotBeNull();
+        parsed["x-datadog-tags"].Should().Be(malicious);
+    }
+
     private static object[] GetDataToSerialize() =>
     [
         null,


### PR DESCRIPTION
## Summary of changes

- Add helper for automatically escaping `string` for inclusion in JSON
- Update serverless injection to use the new helper
- Refactor serverless usages of `StringBuilder` to avoid allocation

## Reason for change

The serverless context injection has to modify JSON to add additional headers. It's currently doing that using a `StringBuilder` approach, but it's not currently accounting for any potential characters in the injected payloads that might need escaping. This is rare and unlikely, but theoretically possible.

Additionally, there's some inefficiencies in how the `StringBuilder` is used in some cases, which is doing more allocation than necessary (e.g. using multiple `StringBuilder`s, using interpolation, using `AppendFormat`)

## Implementation details

- Created a new `JsonHelper.WriteEscapedJavaScriptString()` based on the vendored `Newtonsoft.JSon` version
  - The vendored version is more generalised than we need, and potentially allocates `char[]`, which the new version avoids.
  - The simple iteration of the input string is generally sub optimal, but these are generally going to be small strings, so it's likely as good as anything, given no SearchValues availability
- Updated the `ContextPropagation` implementations to use it
- Fix the `ContextPropagation` implementation usages of `StringBuilder`

## Test coverage

- Added unit tests for the helper + behaviour of context propagation
- Covered by existing integration tests
