### PR TITLE
Allocate 2 CPUs per microbenchmark item

### DIFF
--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -101,7 +101,7 @@ run-benchmarks:
     # Set to "true" to skip actual benchmarks and use _latest results (for testing the pipeline)
     BP_INFRA_TEST: "false"
     # Set to "true" to run OpenTelemetry.Api benchmarks outside of "master" (for testing the pipeline)
-    RUN_OTEL_API_BENCHMARKS_ON_PR: "true"
+    RUN_OTEL_API_BENCHMARKS_ON_PR: "false"
 
   before_script:
     - !reference [.dd-octo-sts-setup, before_script]

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -100,6 +100,9 @@ run-benchmarks:
     CLEANUP: "true"
     # Set to "true" to skip actual benchmarks and use _latest results (for testing the pipeline)
     BP_INFRA_TEST: "false"
+    # Set to "true" to run OpenTelemetry.Api benchmarks outside of "master" (for testing the pipeline)
+    RUN_OTEL_API_BENCHMARKS_ON_PR: "true"
+
   before_script:
     - !reference [.dd-octo-sts-setup, before_script]
   script:
@@ -111,7 +114,7 @@ run-benchmarks:
     # Nuke's BuildBenchmarks target (see Build.cs) checks PR_NUMBER to skip building
     # Benchmarks.OpenTelemetry.Api on PRs. Only int.TryParse is used (boolean check),
     # so any integer works. The actual PR number is not needed in this code path.
-    - if [ "$CI_COMMIT_REF_NAME" != "master" ]; then export PR_NUMBER=1; fi
+    - if [ "$CI_COMMIT_REF_NAME" != "master" ] && [ "$RUN_OTEL_API_BENCHMARKS_ON_PR" = "false" ]; then export PR_NUMBER=1; fi
     # Run benchmarks on ephemeral instance
     - |
       bp-infra launch \

--- a/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
+++ b/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
@@ -1,23 +1,23 @@
 # bp-runner config for dd-trace-dotnet microbenchmarks on Windows.
 #
-# Instance: Intel Xeon 8259CL bare metal, 2 NUMA nodes × 24 cores each (48 total, HT disabled).
-#
 # Three experiments run in parallel:
 #   - trace-0: Benchmarks.Trace (9 benchmarks) on NUMA node 0, cores 0-17
 #   - trace-1: Benchmarks.Trace (11 benchmarks) on NUMA node 1, cores 0-21
 #   - otel:    OpenTelemetry benchmarks on NUMA node 0, cores 18-23
-#              Step 1: InstrumentedApi (always), Step 2: Api (master only, sequential)
+#              Step 1: InstrumentedApi (always), Step 2: Api (master only, after InstrumentedApi finishes)
 #
 # trace-0 clones and builds; others wait for .build-complete marker file.
 # Artifact dirs are prefixed with batch name to avoid collisions.
 #
-# Each benchmark item gets 2 CPUs for reduced noise.
+# Each benchmark item gets 2 CPUs. We empirically verified noise was too high for .NET 6.0 on single CPUs.
 #
-# bp-runner keywords (enable parallel benchmark execution on isolated CPU sets):
+# bp-runner uses the "run: run_microbenchmarks" template on each "experiment step". 
+# This template orchestrates running microbenchmarks in parallel. It requires the following fields:
 #   - how_to_fetch_release: script to clone/build the repo for baseline/candidate
 #   - how_to_run_benchmarks: script invoked for each parallel item
 #   - cpus: CPU affinity mask for NUMA node isolation
 #   - parallelize.items: benchmark filters, each run in parallel within the batch
+#
 #
 # YAML anchors (&name/*name) define reusable script blocks referenced below.
 

--- a/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
+++ b/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
@@ -1,13 +1,17 @@
 # bp-runner config for dd-trace-dotnet microbenchmarks on Windows.
 #
-# Four batches run in parallel on separate NUMA nodes:
-#   - trace (stable benchmarks) on NUMA node 0
-#   - trace-unstable (less stable benchmarks) on NUMA node 1
-#   - otel-instr-api (OpenTelemetry InstrumentedApi) on NUMA node 0
-#   - otel-api (OpenTelemetry Api, skipped on PRs) on NUMA node 1
+# Instance: Intel Xeon 8259CL bare metal, 2 NUMA nodes × 24 cores each (48 total, HT disabled).
 #
-# trace batch clones and builds; others wait for .build-complete marker file.
+# Three experiments run in parallel:
+#   - trace-0: Benchmarks.Trace (9 benchmarks) on NUMA node 0, cores 0-17
+#   - trace-1: Benchmarks.Trace (11 benchmarks) on NUMA node 1, cores 0-21
+#   - otel:    OpenTelemetry benchmarks on NUMA node 0, cores 18-23
+#              Step 1: InstrumentedApi (always), Step 2: Api (master only, sequential)
+#
+# trace-0 clones and builds; others wait for .build-complete marker file.
 # Artifact dirs are prefixed with batch name to avoid collisions.
+#
+# Each benchmark item gets 2 CPUs for reduced noise.
 #
 # bp-runner keywords (enable parallel benchmark execution on isolated CPU sets):
 #   - how_to_fetch_release: script to clone/build the repo for baseline/candidate
@@ -127,26 +131,20 @@
 
   Write-Output "=== Benchmarks completed for filter: $env:PARALLEL_ITEM ==="
 
-# Run experiments in parallel (each on different NUMA node)
+# Run experiments in parallel
 parallelize: true
 
-# Benchmarks are split into batches:
-# - trace: stable Benchmarks.Trace benchmarks (low variance)
-# - trace-unstable: less stable Benchmarks.Trace benchmarks (higher variance)
-# - otel-instr-api: OpenTelemetry InstrumentedApi benchmarks
-# - otel-api: OpenTelemetry Api benchmarks (skipped on PRs since Nuke doesn't build them)
-
 experiments:
-  - name: trace
+  - name: trace-0
     steps:
-      - name: trace
+      - name: trace-0
         run: run_microbenchmarks
         repo: DataDog/dd-trace-dotnet
         baseline_branch: ""
 
-        cpus: "0,0xFFC00"
+        cpus: "0,0x3FFFF"
         parallelize:
-          # Stable benchmarks (CPUs 10-19 on NUMA node 0)
+          # 9 Benchmarks.Trace benchmarks on NUMA node 0, cores 0-17 (9 × 2 = 18 CPUs)
           items: >-
             *ActivityBenchmark*
             *AppSecBodyBenchmark*
@@ -157,25 +155,24 @@ experiments:
             *NLogBenchmark*
             *RedisBenchmark*
             *SpanBenchmark*
-            *TraceAnnotationsBenchmark*
-          cpus_per_item: 1
+          cpus_per_item: 2
 
         env:
-          BATCH_PREFIX: "trace"
+          BATCH_PREFIX: "trace-0"
           BENCHMARK_PROJECT: "Benchmarks.Trace"
         how_to_fetch_release: *how_to_fetch_release_build
         how_to_run_benchmarks: *how_to_run_benchmarks
 
-  - name: trace-unstable
+  - name: trace-1
     steps:
-      - name: trace-unstable
+      - name: trace-1
         run: run_microbenchmarks
         repo: DataDog/dd-trace-dotnet
         baseline_branch: ""
 
-        cpus: "1,0xFFC00"
+        cpus: "1,0x3FFFFF"
         parallelize:
-          # Less stable benchmarks (CPUs 10-19 on NUMA node 1)
+          # 11 Benchmarks.Trace benchmarks on NUMA node 1, cores 0-21 (11 × 2 = 22 CPUs)
           items: >-
             *AgentWriterBenchmark*
             *AppSecEncoderBenchmark*
@@ -187,29 +184,30 @@ experiments:
             *Log4netBenchmark*
             *SerilogBenchmark*
             *StringAspectsBenchmark*
-          cpus_per_item: 1
+            *TraceAnnotationsBenchmark*
+          cpus_per_item: 2
 
         env:
-          BATCH_PREFIX: "trace-unstable"
+          BATCH_PREFIX: "trace-1"
           BENCHMARK_PROJECT: "Benchmarks.Trace"
         how_to_fetch_release: *how_to_fetch_release_wait
         how_to_run_benchmarks: *how_to_run_benchmarks
 
-  - name: otel-instr-api
+  - name: otel
     steps:
       - name: otel-instr-api
         run: run_microbenchmarks
         repo: DataDog/dd-trace-dotnet
         baseline_branch: ""
 
-        cpus: "0,0xE00000"
+        cpus: "0,0xFC0000"
         parallelize:
-          # OpenTelemetry InstrumentedApi benchmarks (CPUs 21-23 on NUMA node 0)
+          # OpenTelemetry InstrumentedApi benchmarks on NUMA node 0, cores 18-23 (3 × 2 = 6 CPUs)
           items: >-
             *ActivityBenchmark*
             *TelemetrySpanBenchmark*
             *TracerBenchmark*
-          cpus_per_item: 1
+          cpus_per_item: 2
 
         env:
           BATCH_PREFIX: "otel-instr-api"
@@ -223,21 +221,20 @@ experiments:
         how_to_fetch_release: *how_to_fetch_release_wait
         how_to_run_benchmarks: *how_to_run_benchmarks
 
-  - name: otel-api
-    steps:
       - name: otel-api
         run: run_microbenchmarks
         repo: DataDog/dd-trace-dotnet
         baseline_branch: ""
 
-        cpus: "1,0xE00000"
+        cpus: "0,0xFC0000"
         parallelize:
-          # OpenTelemetry Api benchmarks (CPUs 21-23 on NUMA node 1, skipped on PRs since Nuke doesn't build them)
+          # OpenTelemetry Api benchmarks, same cores as otel-instr-api (runs sequentially after it).
+          # Skipped on PRs since Nuke doesn't build them (see Build.cs GetBenchmarkProjectsWithSettings()).
           items: >-
             *ActivityBenchmark*
             *TelemetrySpanBenchmark*
             *TracerBenchmark*
-          cpus_per_item: 1
+          cpus_per_item: 2
 
         env:
           BATCH_PREFIX: "otel-api"

--- a/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
+++ b/.gitlab/benchmarks/microbenchmarks/bp-runner.windows.yml
@@ -1,16 +1,5 @@
 # bp-runner config for dd-trace-dotnet microbenchmarks on Windows.
 #
-# Three experiments run in parallel:
-#   - trace-0: Benchmarks.Trace (9 benchmarks) on NUMA node 0, cores 0-17
-#   - trace-1: Benchmarks.Trace (11 benchmarks) on NUMA node 1, cores 0-21
-#   - otel:    OpenTelemetry benchmarks on NUMA node 0, cores 18-23
-#              Step 1: InstrumentedApi (always), Step 2: Api (master only, after InstrumentedApi finishes)
-#
-# trace-0 clones and builds; others wait for .build-complete marker file.
-# Artifact dirs are prefixed with batch name to avoid collisions.
-#
-# Each benchmark item gets 2 CPUs. We empirically verified noise was too high for .NET 6.0 on single CPUs.
-#
 # bp-runner uses the "run: run_microbenchmarks" template on each "experiment step". 
 # This template orchestrates running microbenchmarks in parallel. It requires the following fields:
 #   - how_to_fetch_release: script to clone/build the repo for baseline/candidate
@@ -18,8 +7,18 @@
 #   - cpus: CPU affinity mask for NUMA node isolation
 #   - parallelize.items: benchmark filters, each run in parallel within the batch
 #
+# Three experiments run in parallel:
+#   - trace-0: Benchmarks.Trace (9 benchmarks) on NUMA node 0, cores 0-17
+#   - trace-1: Benchmarks.Trace (11 benchmarks) on NUMA node 1, cores 0-21
+#   - otel:    OpenTelemetry benchmarks on NUMA node 0, cores 18-23
+#     - This experiment has two experiment steps that run sequentially (because we don't have enough CPUs): 
+#         - Step 1: InstrumentedApi (always);
+#         - Step 2: Api (master only, after InstrumentedApi finishes)
 #
-# YAML anchors (&name/*name) define reusable script blocks referenced below.
+# trace-0 clones and builds; others wait for .build-complete marker file.
+# Artifact dirs are prefixed with batch name to avoid collisions.
+#
+# Each benchmark item gets 2 CPUs. We empirically verified noise was too high for .NET 6.0 on single CPUs.
 
 .how_to_fetch_release_build: &how_to_fetch_release_build |
   $ErrorActionPreference = "Stop"


### PR DESCRIPTION
- [x] Set `RUN_OTEL_API_BENCHMARKS_ON_PR` to `"false"` before merging

## Summary of changes

- Increase `cpus_per_item` from 1 to 2 for all microbenchmark experiments
- Rename experiments: `trace` to `trace-0`, `trace-unstable` to `trace-1`. Using "unstable" doesn't reflect the split we're currently doing across NUMA nodes.
- Rebalance trace benchmarks into 9/11 split to fit NUMA constraints
- Merge `otel-instr-api` and `otel-api` into single `otel` experiment with two sequential steps
- Update CPU affinity masks to cover wider core ranges

## Reason for change

Allocating 2 CPUs per benchmark item should reduce variance for .NET 6.0 benchmarks.

## Implementation details

48-core bare metal instance (2 NUMA nodes × 24 cores, HT disabled):
- `trace-0` (NUMA 0): 9 items × 2 CPUs = 18 cores (0-17)
- `trace-1` (NUMA 1): 11 items × 2 CPUs = 22 cores (0-21)
- `otel` (NUMA 0): 3 items × 2 CPUs = 6 cores (18-23), InstrumentedApi then Api sequentially

## Test coverage

## Other details