### PR TITLE
Handle dotnet/runtime#127957 in integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -135,56 +135,39 @@ namespace Datadog.Trace.TestHelpers
                     WriteToOutput("Timeout while waiting for the proces to start");
                 }
 
-                if (port != null)
+                if (port == null)
                 {
-                    HttpPort = port.Value;
-                    WriteToOutput($"Started aspnetcore sample, listening on {HttpPort}");
-                    break;
+                    if (await CheckRaceAndCleanupForRetryAsync(attempt, maxAttempts, capturedStderr, helper))
+                    {
+                        continue;
+                    }
+
+                    WriteToOutput("Unable to determine port application is listening on");
+                    throw new Exception("Unable to determine port application is listening on");
                 }
 
-                // Give a slow runtime abort (e.g. createdump in flight) up to 5s to finish
-                // before reading the exit code; defaults to -1 on any read failure.
-                int exitCode = -1;
+                HttpPort = port.Value;
+                WriteToOutput($"Started aspnetcore sample, listening on {HttpPort}");
+
                 try
                 {
-                    Process.WaitForExit(5000);
-                    if (Process.HasExited)
-                    {
-                        exitCode = Process.ExitCode;
-                    }
+                    await EnsureServerStarted(sendHealthCheck);
                 }
                 catch
                 {
-                    // best-effort
-                }
-
-                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
-                {
-                    try
+                    // Sample bound a port but never served the health check — could be the race
+                    // firing post-bind (gate thread dies after Kestrel is up).
+                    if (await CheckRaceAndCleanupForRetryAsync(attempt, maxAttempts, capturedStderr, helper))
                     {
-                        if (!Process.HasExited)
-                        {
-                            Process.Kill();
-                        }
-                    }
-                    catch
-                    {
-                        // best-effort cleanup
+                        continue;
                     }
 
-                    Process.Dispose();
-                    Process = null;
-                    Agent.Dispose();
-                    Agent = null;
-                    continue;
+                    throw;
                 }
 
-                WriteToOutput("Unable to determine port application is listening on");
-                throw new Exception("Unable to determine port application is listening on");
+                Agent.SpanFilters.Add(IsNotServerLifeCheck);
+                return;
             }
-
-            await EnsureServerStarted(sendHealthCheck);
-            Agent.SpanFilters.Add(IsNotServerLifeCheck);
         }
 
         public void Dispose()
@@ -261,6 +244,51 @@ namespace Datadog.Trace.TestHelpers
                        count: 1,
                        minDateTime: now,
                        returnAllOperations: true);
+        }
+
+        // Returns true when a known race fingerprint was detected in the captured stderr and the
+        // caller should retry the launch (process and agent have been torn down). Returns false
+        // when no fingerprint matched. Throws if the fingerprint persisted past the retry budget.
+        private async Task<bool> CheckRaceAndCleanupForRetryAsync(int attempt, int maxAttempts, StringBuilder capturedStderr, TestHelper helper)
+        {
+            // Give a slow runtime abort (e.g. createdump in flight) up to 5s to finish before
+            // reading the exit code; defaults to -1 on any read failure.
+            int exitCode = -1;
+            try
+            {
+                Process.WaitForExit(5000);
+                if (Process.HasExited)
+                {
+                    exitCode = Process.ExitCode;
+                }
+            }
+            catch
+            {
+                // best-effort
+            }
+
+            if (!await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!Process.HasExited)
+                {
+                    Process.Kill();
+                }
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+
+            Process.Dispose();
+            Process = null;
+            Agent.Dispose();
+            Agent = null;
+            return true;
         }
 
         private async Task EnsureServerStarted(bool sendHealthCheck)

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -158,9 +158,7 @@ namespace Datadog.Trace.TestHelpers
                     // best-effort
                 }
 
-                var outcome = await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput);
-
-                if (outcome == RuntimeErrorOutcome.Retry)
+                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
                 {
                     try
                     {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -11,8 +11,10 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers
@@ -78,8 +80,14 @@ namespace Datadog.Trace.TestHelpers
                 return;
             }
 
-            if (Process is null)
+            // Allow one retry if startup crashes with the dotnet/runtime#127957 fingerprint.
+            // The race fires during runtime startup before user code, so a fresh launch
+            // almost always succeeds. If it crashes the same way twice, skip the test.
+            const int maxAttempts = 2;
+
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
+                var capturedStderr = new StringBuilder();
                 var initialAgentPort = TcpPortProvider.GetOpenPort();
 
                 Agent = MockTracerAgent.Create(_currentOutput, initialAgentPort, agentConfiguration: agentConfiguration, useTelemetry: useTelemetry);
@@ -118,6 +126,7 @@ namespace Datadog.Trace.TestHelpers
                 {
                     if (args.Data != null)
                     {
+                        capturedStderr.AppendLine(args.Data);
                         WriteToOutput($"[webserver][stderr] {args.Data}");
                     }
                 };
@@ -130,14 +139,49 @@ namespace Datadog.Trace.TestHelpers
                     WriteToOutput("Timeout while waiting for the proces to start");
                 }
 
-                if (port == null)
+                if (port != null)
                 {
-                    WriteToOutput("Unable to determine port application is listening on");
-                    throw new Exception("Unable to determine port application is listening on");
+                    HttpPort = port.Value;
+                    WriteToOutput($"Started aspnetcore sample, listening on {HttpPort}");
+                    break;
                 }
 
-                HttpPort = port.Value;
-                WriteToOutput($"Started aspnetcore sample, listening on {HttpPort}");
+                var exitCode = Process.HasExited ? Process.ExitCode : -1;
+                var isRuntime127957Race = ErrorHelpers.IsRuntime127957Race(exitCode, capturedStderr.ToString());
+
+                if (isRuntime127957Race && attempt < maxAttempts)
+                {
+                    WriteToOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
+                    await helper.SendCIMetricAsync("dd_trace_dotnet.ci.tests.retried_due_to_runtime_127957");
+
+                    try
+                    {
+                        if (!Process.HasExited)
+                        {
+                            Process.Kill();
+                        }
+                    }
+                    catch
+                    {
+                        // best-effort cleanup
+                    }
+
+                    Process.Dispose();
+                    Process = null;
+                    Agent.Dispose();
+                    Agent = null;
+                    continue;
+                }
+
+                if (isRuntime127957Race)
+                {
+                    // Race persisted through retry — skip as last resort.
+                    await helper.SendCIMetricAsync("dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957");
+                    throw new SkipException("Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)");
+                }
+
+                WriteToOutput("Unable to determine port application is listening on");
+                throw new Exception("Unable to determine port application is listening on");
             }
 
             await EnsureServerStarted(sendHealthCheck);

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -145,7 +145,26 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                var exitCode = Process.HasExited ? Process.ExitCode : -1;
+                // Give the process a moment to finish exiting in case it's crashing — the
+                // port-bind mutex can time out before a slow runtime abort completes (createdump
+                // can take several seconds to write a dump before the process actually dies).
+                // Reading HasExited/ExitCode can also throw if the process is in an
+                // indeterminate state; defaulting to -1 lets the race-fingerprint check fail
+                // cleanly and the "Unable to determine port" path fire instead of an unhandled
+                // exception.
+                int exitCode = -1;
+                try
+                {
+                    Process.WaitForExit(5000);
+                    if (Process.HasExited)
+                    {
+                        exitCode = Process.ExitCode;
+                    }
+                }
+                catch
+                {
+                    // best-effort
+                }
 
                 if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -147,7 +147,7 @@ namespace Datadog.Trace.TestHelpers
 
                 var exitCode = Process.HasExited ? Process.ExitCode : -1;
 
-                if (await ErrorHelpers.HandleRuntime127957AttemptAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
+                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
                 {
                     try
                     {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -14,7 +14,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers
@@ -147,13 +146,9 @@ namespace Datadog.Trace.TestHelpers
                 }
 
                 var exitCode = Process.HasExited ? Process.ExitCode : -1;
-                var isRuntime127957Race = ErrorHelpers.IsRuntime127957Race(exitCode, capturedStderr.ToString());
 
-                if (isRuntime127957Race && attempt < maxAttempts)
+                if (await ErrorHelpers.HandleRuntime127957AttemptAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
                 {
-                    WriteToOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
-                    await helper.SendCIMetricAsync("dd_trace_dotnet.ci.tests.retried_due_to_runtime_127957");
-
                     try
                     {
                         if (!Process.HasExited)
@@ -171,13 +166,6 @@ namespace Datadog.Trace.TestHelpers
                     Agent.Dispose();
                     Agent = null;
                     continue;
-                }
-
-                if (isRuntime127957Race)
-                {
-                    // Race persisted through retry — skip as last resort.
-                    await helper.SendCIMetricAsync("dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957");
-                    throw new SkipException("Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)");
                 }
 
                 WriteToOutput("Unable to determine port application is listening on");

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -79,10 +79,6 @@ namespace Datadog.Trace.TestHelpers
                 return;
             }
 
-            // Retry sample launch up to (maxAttempts - 1) times if startup crashes with the
-            // dotnet/runtime#127957 fingerprint. The race fires during runtime startup before
-            // user code, so a fresh launch almost always succeeds. If the fingerprint persists
-            // across all attempts it's no longer credibly a flake — let the test fail.
             const int maxAttempts = 3;
 
             for (int attempt = 1; attempt <= maxAttempts; attempt++)
@@ -146,13 +142,8 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                // Give the process a moment to finish exiting in case it's crashing — the
-                // port-bind mutex can time out before a slow runtime abort completes (createdump
-                // can take several seconds to write a dump before the process actually dies).
-                // Reading HasExited/ExitCode can also throw if the process is in an
-                // indeterminate state; defaulting to -1 lets the race-fingerprint check fail
-                // cleanly and the "Unable to determine port" path fire instead of an unhandled
-                // exception.
+                // Give a slow runtime abort (e.g. createdump in flight) up to 5s to finish
+                // before reading the exit code; defaults to -1 on any read failure.
                 int exitCode = -1;
                 try
                 {
@@ -190,9 +181,6 @@ namespace Datadog.Trace.TestHelpers
                     continue;
                 }
 
-                // Proceed (no race detected) and Persistent (race fingerprint persisted past
-                // retry budget) both fall through to the same loud failure here. The helper
-                // already emitted the corresponding metric in the Persistent case.
                 WriteToOutput("Unable to determine port application is listening on");
                 throw new Exception("Unable to determine port application is listening on");
             }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -251,14 +251,19 @@ namespace Datadog.Trace.TestHelpers
         // when no fingerprint matched. Throws if the fingerprint persisted past the retry budget.
         private async Task<bool> CheckRaceAndCleanupForRetryAsync(int attempt, int maxAttempts, StringBuilder capturedStderr, TestHelper helper)
         {
-            // Give a slow runtime abort (e.g. createdump in flight) up to 5s to finish before
-            // reading the exit code; defaults to -1 on any read failure.
+            // Reset HttpPort up-front: whether we retry or rethrow, the port we bound earlier
+            // is now stale (process died) and Dispose() must not target it.
+            HttpPort = 0;
+
+            // 5s grace for createdump. Parameterless WaitForExit() after a successful timed
+            // wait drains async stdout/stderr handlers — otherwise capturedStderr may miss
+            // the final lines that carry the fingerprint.
             int exitCode = -1;
             try
             {
-                Process.WaitForExit(5000);
-                if (Process.HasExited)
+                if (Process.WaitForExit(5000))
                 {
+                    Process.WaitForExit();
                     exitCode = Process.ExitCode;
                 }
             }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -79,10 +79,11 @@ namespace Datadog.Trace.TestHelpers
                 return;
             }
 
-            // Allow one retry if startup crashes with the dotnet/runtime#127957 fingerprint.
-            // The race fires during runtime startup before user code, so a fresh launch
-            // almost always succeeds. If it crashes the same way twice, skip the test.
-            const int maxAttempts = 2;
+            // Retry sample launch up to (maxAttempts - 1) times if startup crashes with the
+            // dotnet/runtime#127957 fingerprint. The race fires during runtime startup before
+            // user code, so a fresh launch almost always succeeds. If the fingerprint persists
+            // across all attempts it's no longer credibly a flake — let the test fail.
+            const int maxAttempts = 3;
 
             for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
@@ -166,7 +167,9 @@ namespace Datadog.Trace.TestHelpers
                     // best-effort
                 }
 
-                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
+                var outcome = await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput);
+
+                if (outcome == RuntimeErrorOutcome.Retry)
                 {
                     try
                     {
@@ -187,6 +190,9 @@ namespace Datadog.Trace.TestHelpers
                     continue;
                 }
 
+                // Proceed (no race detected) and Persistent (race fingerprint persisted past
+                // retry budget) both fall through to the same loud failure here. The helper
+                // already emitted the corresponding metric in the Persistent case.
                 WriteToOutput("Unable to determine port application is listening on");
                 throw new Exception("Unable to determine port application is listening on");
             }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -20,6 +20,37 @@ namespace Datadog.Trace.TestHelpers;
 
 public static class ErrorHelpers
 {
+    private const string Runtime127957SkipMessage = "Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)";
+    private const string Runtime127957RetryMetric = "dd_trace_dotnet.ci.tests.retried_due_to_runtime_127957";
+    private const string Runtime127957SkipMetric = "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957";
+
+    /// <summary>
+    /// Inspects a sample-launch attempt for the dotnet/runtime#127957 race fingerprint and
+    /// applies the retry-once-then-skip policy. Returns true if the caller should retry the
+    /// launch (race detected, not the final attempt); returns false if no race fingerprint was
+    /// detected and the caller should proceed with normal validation. Throws SkipException if
+    /// the race fingerprint matched on the final attempt — the test is skipped rather than
+    /// failed since #127957 is an upstream runtime bug.
+    /// </summary>
+    public static async Task<bool> HandleRuntime127957AttemptAsync(
+        int attempt, int maxAttempts, int exitCode, string stderr, TestHelper helper, Action<string> writeOutput)
+    {
+        if (!IsRuntime127957Race(exitCode, stderr))
+        {
+            return false;
+        }
+
+        if (attempt < maxAttempts)
+        {
+            writeOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
+            await helper.SendCIMetricAsync(Runtime127957RetryMetric);
+            return true;
+        }
+
+        await helper.SendCIMetricAsync(Runtime127957SkipMetric);
+        throw new SkipException(Runtime127957SkipMessage);
+    }
+
     public static bool IsRuntime127957Race(int exitCode, string standardError)
     {
         // Both fingerprints of dotnet/runtime#127957 surface as a SIGABRT (exit 134) caused by
@@ -74,10 +105,10 @@ public static class ErrorHelpers
         {
             // dotnet/runtime#127957 — race in MDInternalRW where ExpandTables() invalidates
             // pointers returned by unlocked metadata readers while the profiler emits tokens.
-            // See IsRuntime127957Race for the supported fingerprints.
-            // Reached here only if retries were exhausted (see RunSampleAndWaitForExit / AspNetCoreTestFixture.TryStartApp).
-            SendMetric(output, "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957", environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
-            throw new SkipException("Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)");
+            // Reached when CheckForKnownSkipConditions is called directly (e.g. SmokeTestBase),
+            // outside the retry-aware paths that already call HandleRuntime127957AttemptAsync.
+            SendMetric(output, Runtime127957SkipMetric, environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
+            throw new SkipException(Runtime127957SkipMessage);
         }
 
 #if NETCOREAPP2_1

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -22,13 +22,35 @@ public static class ErrorHelpers
 {
     public static bool IsRuntime127957Race(int exitCode, string standardError)
     {
-        // Fingerprint of dotnet/runtime#127957: a SIGABRT carrying a TypeLoadException whose
-        // message is the "Undefined resource string ID" fallback. The fallback only fires when
-        // the runtime asks the localization layer for a string ID that doesn't exist, which
-        // happens when corrupted metadata bytes flow into the throw site.
-        return exitCode == 134
-            && standardError?.Contains("System.TypeLoadException") == true
-            && standardError?.Contains("Undefined resource string ID") == true;
+        // Both fingerprints of dotnet/runtime#127957 surface as a SIGABRT (exit 134) caused by
+        // an unhandled exception on a runtime worker thread that read corrupted metadata.
+        if (exitCode != 134 || standardError is null)
+        {
+            return false;
+        }
+
+        // Fingerprint A — TypeLoadException with the "Undefined resource string ID" fallback:
+        // garbage flowed into the IDS_* argument of the throw site, so the localization
+        // layer was asked for a string ID that doesn't exist.
+        if (standardError.Contains("System.TypeLoadException")
+            && standardError.Contains("Undefined resource string ID"))
+        {
+            return true;
+        }
+
+        // Fingerprint B — MissingMethodException for ConcurrentDictionary.TryGetValue:
+        // the canonical example in the runtime issue. A method signature read returns
+        // garbage from a freed metadata buffer, so the runtime concludes the method
+        // doesn't exist. Commonly hit during ASP.NET HostBuilder.Build() via
+        // Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.
+        if (standardError.Contains("System.MissingMethodException: Method not found:")
+            && standardError.Contains("ConcurrentDictionary")
+            && standardError.Contains("TryGetValue"))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     public static void CheckForKnownSkipConditions(ITestOutputHelper output, int exitCode, string standardError, EnvironmentHelper environmentHelper)
@@ -52,10 +74,10 @@ public static class ErrorHelpers
         {
             // dotnet/runtime#127957 — race in MDInternalRW where ExpandTables() invalidates
             // pointers returned by unlocked metadata readers while the profiler emits tokens.
-            // Manifests as a TypeLoadException with no localized message (unlocalized HRESULT).
-            // Reached here only if retries were exhausted (see RunSampleAndWaitForExit).
+            // See IsRuntime127957Race for the supported fingerprints.
+            // Reached here only if retries were exhausted (see RunSampleAndWaitForExit / AspNetCoreTestFixture.TryStartApp).
             SendMetric(output, "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957", environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
-            throw new SkipException("TypeLoadException due to dotnet/runtime#127957 (MDInternalRW race)");
+            throw new SkipException("Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)");
         }
 
 #if NETCOREAPP2_1

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -27,14 +27,8 @@ public static class ErrorHelpers
     private const string RuntimeMetadataRaceSkipMetric = "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_metadata_race";
 
     /// <summary>
-    /// Inspects a sample-launch attempt for known upstream/runtime-level error fingerprints
-    /// (currently dotnet/runtime#127957) and applies a retry-once-then-skip policy.
-    /// Returns true if the caller should retry the launch (a known error was detected, not
-    /// on the final attempt). Returns false if no known fingerprint was detected and the
-    /// caller should proceed with its normal validation. Throws SkipException if a known
-    /// fingerprint matched on the final attempt — the test is skipped rather than failed,
-    /// since these errors come from upstream bugs we can't fix here.
-    /// New fingerprints should be added as additional branches in this method.
+    /// Inspects a sample-launch attempt for known upstream/runtime-level error fingerprints.
+    /// Returns true if the caller should retry the launch.
     /// </summary>
     public static async Task<bool> HandleRuntimeSkippableErrorsAsync(
         int attempt, int maxAttempts, int exitCode, string stderr, TestHelper helper, Action<string> writeOutput)
@@ -75,9 +69,7 @@ public static class ErrorHelpers
 
         // Fingerprint B — MissingMethodException for ConcurrentDictionary.TryGetValue:
         // the canonical example in the runtime issue. A method signature read returns
-        // garbage from a freed metadata buffer, so the runtime concludes the method
-        // doesn't exist. Commonly hit during ASP.NET HostBuilder.Build() via
-        // Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.
+        // garbage from a freed metadata buffer, so the runtime concludes the method doesn't exist.
         if (standardError.Contains("System.MissingMethodException: Method not found:")
             && standardError.Contains("ConcurrentDictionary")
             && standardError.Contains("TryGetValue"))
@@ -107,10 +99,6 @@ public static class ErrorHelpers
 
         if (IsRuntime127957Race(exitCode, standardError))
         {
-            // dotnet/runtime#127957 — race in MDInternalRW where ExpandTables() invalidates
-            // pointers returned by unlocked metadata readers while the profiler emits tokens.
-            // Reached when CheckForKnownSkipConditions is called directly (e.g. SmokeTestBase),
-            // outside the retry-aware paths that already call HandleRuntimeSkippableErrorsAsync.
             SendMetric(output, RuntimeMetadataRaceSkipMetric, environmentHelper, Runtime127957IssueTag).ConfigureAwait(false).GetAwaiter().GetResult();
             throw new SkipException(Runtime127957SkipMessage);
         }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -21,8 +22,9 @@ namespace Datadog.Trace.TestHelpers;
 public static class ErrorHelpers
 {
     private const string Runtime127957SkipMessage = "Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)";
-    private const string Runtime127957RetryMetric = "dd_trace_dotnet.ci.tests.retried_due_to_runtime_127957";
-    private const string Runtime127957SkipMetric = "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957";
+    private const string Runtime127957IssueTag = "runtime_issue:127957";
+    private const string RuntimeMetadataRaceRetryMetric = "dd_trace_dotnet.ci.tests.retried_due_to_runtime_metadata_race";
+    private const string RuntimeMetadataRaceSkipMetric = "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_metadata_race";
 
     /// <summary>
     /// Inspects a sample-launch attempt for known upstream/runtime-level error fingerprints
@@ -42,11 +44,11 @@ public static class ErrorHelpers
             if (attempt < maxAttempts)
             {
                 writeOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
-                await helper.SendCIMetricAsync(Runtime127957RetryMetric);
+                await helper.SendCIMetricAsync(RuntimeMetadataRaceRetryMetric, Runtime127957IssueTag);
                 return true;
             }
 
-            await helper.SendCIMetricAsync(Runtime127957SkipMetric);
+            await helper.SendCIMetricAsync(RuntimeMetadataRaceSkipMetric, Runtime127957IssueTag);
             throw new SkipException(Runtime127957SkipMessage);
         }
 
@@ -109,7 +111,7 @@ public static class ErrorHelpers
             // pointers returned by unlocked metadata readers while the profiler emits tokens.
             // Reached when CheckForKnownSkipConditions is called directly (e.g. SmokeTestBase),
             // outside the retry-aware paths that already call HandleRuntimeSkippableErrorsAsync.
-            SendMetric(output, Runtime127957SkipMetric, environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
+            SendMetric(output, RuntimeMetadataRaceSkipMetric, environmentHelper, Runtime127957IssueTag).ConfigureAwait(false).GetAwaiter().GetResult();
             throw new SkipException(Runtime127957SkipMessage);
         }
 
@@ -132,7 +134,7 @@ public static class ErrorHelpers
         SkipKnownCrashes(environmentHelper.PathToCrashReport, output).Wait();
     }
 
-    public static async Task SendMetric(ITestOutputHelper outputHelper, string metricName, EnvironmentHelper environmentHelper)
+    public static async Task SendMetric(ITestOutputHelper outputHelper, string metricName, EnvironmentHelper environmentHelper, params string[] extraTags)
     {
         const int maxTestFullNameLength = 200;
 
@@ -166,6 +168,11 @@ public static class ErrorHelpers
                          "test.name:{{SanitizeTagValue(testFullName)}}",
                          "git.branch:{{SanitizeTagValue(srcBranch)}}"
                      """;
+
+        if (extraTags is { Length: > 0 })
+        {
+            tags += ", " + string.Join(", ", extraTags.Select(t => $"\"{t}\""));
+        }
 
         var payload = $$"""
                             {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -25,30 +25,32 @@ public static class ErrorHelpers
     private const string Runtime127957SkipMetric = "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957";
 
     /// <summary>
-    /// Inspects a sample-launch attempt for the dotnet/runtime#127957 race fingerprint and
-    /// applies the retry-once-then-skip policy. Returns true if the caller should retry the
-    /// launch (race detected, not the final attempt); returns false if no race fingerprint was
-    /// detected and the caller should proceed with normal validation. Throws SkipException if
-    /// the race fingerprint matched on the final attempt — the test is skipped rather than
-    /// failed since #127957 is an upstream runtime bug.
+    /// Inspects a sample-launch attempt for known upstream/runtime-level error fingerprints
+    /// (currently dotnet/runtime#127957) and applies a retry-once-then-skip policy.
+    /// Returns true if the caller should retry the launch (a known error was detected, not
+    /// on the final attempt). Returns false if no known fingerprint was detected and the
+    /// caller should proceed with its normal validation. Throws SkipException if a known
+    /// fingerprint matched on the final attempt — the test is skipped rather than failed,
+    /// since these errors come from upstream bugs we can't fix here.
+    /// New fingerprints should be added as additional branches in this method.
     /// </summary>
-    public static async Task<bool> HandleRuntime127957AttemptAsync(
+    public static async Task<bool> HandleRuntimeSkippableErrorsAsync(
         int attempt, int maxAttempts, int exitCode, string stderr, TestHelper helper, Action<string> writeOutput)
     {
-        if (!IsRuntime127957Race(exitCode, stderr))
+        if (IsRuntime127957Race(exitCode, stderr))
         {
-            return false;
+            if (attempt < maxAttempts)
+            {
+                writeOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
+                await helper.SendCIMetricAsync(Runtime127957RetryMetric);
+                return true;
+            }
+
+            await helper.SendCIMetricAsync(Runtime127957SkipMetric);
+            throw new SkipException(Runtime127957SkipMessage);
         }
 
-        if (attempt < maxAttempts)
-        {
-            writeOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
-            await helper.SendCIMetricAsync(Runtime127957RetryMetric);
-            return true;
-        }
-
-        await helper.SendCIMetricAsync(Runtime127957SkipMetric);
-        throw new SkipException(Runtime127957SkipMessage);
+        return false;
     }
 
     public static bool IsRuntime127957Race(int exitCode, string standardError)
@@ -106,7 +108,7 @@ public static class ErrorHelpers
             // dotnet/runtime#127957 — race in MDInternalRW where ExpandTables() invalidates
             // pointers returned by unlocked metadata readers while the profiler emits tokens.
             // Reached when CheckForKnownSkipConditions is called directly (e.g. SmokeTestBase),
-            // outside the retry-aware paths that already call HandleRuntime127957AttemptAsync.
+            // outside the retry-aware paths that already call HandleRuntimeSkippableErrorsAsync.
             SendMetric(output, Runtime127957SkipMetric, environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
             throw new SkipException(Runtime127957SkipMessage);
         }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -19,18 +19,6 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers;
 
-public enum RuntimeErrorOutcome
-{
-    /// <summary>No known fingerprint detected; proceed with normal validation.</summary>
-    Proceed,
-
-    /// <summary>Known fingerprint detected, retry budget remaining; caller should retry.</summary>
-    Retry,
-
-    /// <summary>Known fingerprint persisted past retry budget; caller should let the test fail.</summary>
-    Persistent,
-}
-
 public static class ErrorHelpers
 {
     private const string Runtime127957IssueTag = "runtime_issue:127957";
@@ -38,53 +26,61 @@ public static class ErrorHelpers
     private const string RuntimeMetadataRacePersistentMetric = "dd_trace_dotnet.ci.tests.persistent_runtime_metadata_race";
 
     /// <summary>
-    /// Dispatch helper for known transient runtime crashes. Returns whether the caller should
-    /// retry, fail, or proceed normally. New fingerprints should be added as branches here.
+    /// Dispatch helper for known transient runtime crashes. Returns true when the caller should
+    /// retry, false when no known fingerprint matched. Throws when the fingerprint persisted
+    /// across the retry budget (test must fail loudly — exit code alone can't be trusted to
+    /// surface the failure, e.g. Windows FailFast paths sometimes report exit 0).
     /// </summary>
-    public static async Task<RuntimeErrorOutcome> HandleRuntimeSkippableErrorsAsync(
+    public static async Task<bool> HandleRuntimeSkippableErrorsAsync(
         int attempt, int maxAttempts, int exitCode, string stderr, TestHelper helper, Action<string> writeOutput)
     {
         if (!IsRuntime127957Race(exitCode, stderr))
         {
-            return RuntimeErrorOutcome.Proceed;
+            return false;
         }
 
         if (attempt < maxAttempts)
         {
             writeOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
             await helper.SendCIMetricAsync(RuntimeMetadataRaceRetryMetric, Runtime127957IssueTag);
-            return RuntimeErrorOutcome.Retry;
+            return true;
         }
 
-        writeOutput($"dotnet/runtime#127957 fingerprint persisted across {maxAttempts} attempts; letting the test fail.");
         await helper.SendCIMetricAsync(RuntimeMetadataRacePersistentMetric, Runtime127957IssueTag);
-        return RuntimeErrorOutcome.Persistent;
+        throw new Exception($"dotnet/runtime#127957 fingerprint persisted across {maxAttempts} attempts; failing the test.");
     }
 
     public static bool IsRuntime127957Race(int exitCode, string standardError)
     {
-        // Both fingerprints of dotnet/runtime#127957 surface as a SIGABRT (exit 134) caused by
-        // an unhandled exception on a runtime worker thread that read corrupted metadata.
-        if (exitCode != 134 || standardError is null)
+        if (standardError is null)
         {
             return false;
         }
 
-        // Fingerprint A — TypeLoadException with the "Undefined resource string ID" fallback:
-        // garbage flowed into the IDS_* argument of the throw site, so the localization
-        // layer was asked for a string ID that doesn't exist.
-        if (standardError.Contains("System.TypeLoadException")
+        // Linux/SIGABRT — TypeLoadException with the "Undefined resource string ID" fallback.
+        if (exitCode == 134
+            && standardError.Contains("System.TypeLoadException")
             && standardError.Contains("Undefined resource string ID"))
         {
             return true;
         }
 
-        // Fingerprint B — MissingMethodException for ConcurrentDictionary.TryGetValue:
-        // the canonical example in the runtime issue. A method signature read returns
-        // garbage from a freed metadata buffer, so the runtime concludes the method doesn't exist.
-        if (standardError.Contains("System.MissingMethodException: Method not found:")
+        // Linux/SIGABRT — MissingMethodException for ConcurrentDictionary.TryGetValue
+        // (the canonical example from the runtime issue).
+        if (exitCode == 134
+            && standardError.Contains("System.MissingMethodException: Method not found:")
             && standardError.Contains("ConcurrentDictionary")
             && standardError.Contains("TryGetValue"))
+        {
+            return true;
+        }
+
+        // Windows — CLR FailFast with HRESULT 0x80131506 (COR_E_EXECUTIONENGINE) on the
+        // threadpool gate thread. Exit code is unreliable here (we've seen 0 in CI even though
+        // the runtime died), so we don't gate on it.
+        if (standardError.Contains("Fatal error. Internal CLR error. (0x80131506)")
+            && standardError.Contains("PortableThreadPool")
+            && standardError.Contains("GateThread"))
         {
             return true;
         }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -19,34 +19,68 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers;
 
+public enum RuntimeErrorOutcome
+{
+    /// <summary>
+    /// No known transient error fingerprint detected. The caller should apply its normal
+    /// validation path (including <see cref="ErrorHelpers.CheckForKnownSkipConditions"/>).
+    /// </summary>
+    Proceed,
+
+    /// <summary>
+    /// A known transient error fingerprint was detected and the retry budget is not yet
+    /// exhausted. The caller should clean up and retry the launch.
+    /// </summary>
+    Retry,
+
+    /// <summary>
+    /// A known transient error fingerprint was detected on every attempt — past the retry
+    /// budget. The error is no longer credibly a flake. The caller should let the test fail
+    /// loudly and must NOT call <see cref="ErrorHelpers.CheckForKnownSkipConditions"/>, which
+    /// would re-skip the same fingerprint.
+    /// </summary>
+    Persistent,
+}
+
 public static class ErrorHelpers
 {
     private const string Runtime127957SkipMessage = "Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)";
     private const string Runtime127957IssueTag = "runtime_issue:127957";
     private const string RuntimeMetadataRaceRetryMetric = "dd_trace_dotnet.ci.tests.retried_due_to_runtime_metadata_race";
     private const string RuntimeMetadataRaceSkipMetric = "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_metadata_race";
+    private const string RuntimeMetadataRacePersistentMetric = "dd_trace_dotnet.ci.tests.persistent_runtime_metadata_race";
 
     /// <summary>
-    /// Inspects a sample-launch attempt for known upstream/runtime-level error fingerprints.
-    /// Returns true if the caller should retry the launch.
+    /// Inspects a sample-launch attempt for known upstream/runtime-level error fingerprints
+    /// (currently dotnet/runtime#127957) and decides whether the caller should retry, proceed
+    /// with normal validation, or treat the failure as a persistent (non-flake) error.
     /// </summary>
-    public static async Task<bool> HandleRuntimeSkippableErrorsAsync(
+    /// <returns>
+    /// <see cref="RuntimeErrorOutcome.Retry"/> when a known transient error is detected and
+    /// the retry budget isn't exhausted; <see cref="RuntimeErrorOutcome.Persistent"/> when a
+    /// known fingerprint matched on every attempt (no longer a flake — caller should let the
+    /// test fail loudly without consulting <see cref="CheckForKnownSkipConditions"/>, which
+    /// would otherwise skip the same fingerprint); <see cref="RuntimeErrorOutcome.Proceed"/>
+    /// when no known fingerprint was detected and the caller should proceed normally.
+    /// </returns>
+    public static async Task<RuntimeErrorOutcome> HandleRuntimeSkippableErrorsAsync(
         int attempt, int maxAttempts, int exitCode, string stderr, TestHelper helper, Action<string> writeOutput)
     {
-        if (IsRuntime127957Race(exitCode, stderr))
+        if (!IsRuntime127957Race(exitCode, stderr))
         {
-            if (attempt < maxAttempts)
-            {
-                writeOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
-                await helper.SendCIMetricAsync(RuntimeMetadataRaceRetryMetric, Runtime127957IssueTag);
-                return true;
-            }
-
-            await helper.SendCIMetricAsync(RuntimeMetadataRaceSkipMetric, Runtime127957IssueTag);
-            throw new SkipException(Runtime127957SkipMessage);
+            return RuntimeErrorOutcome.Proceed;
         }
 
-        return false;
+        if (attempt < maxAttempts)
+        {
+            writeOutput($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
+            await helper.SendCIMetricAsync(RuntimeMetadataRaceRetryMetric, Runtime127957IssueTag);
+            return RuntimeErrorOutcome.Retry;
+        }
+
+        writeOutput($"dotnet/runtime#127957 fingerprint persisted across {maxAttempts} attempts — not a flake. Letting the test fail.");
+        await helper.SendCIMetricAsync(RuntimeMetadataRacePersistentMetric, Runtime127957IssueTag);
+        return RuntimeErrorOutcome.Persistent;
     }
 
     public static bool IsRuntime127957Race(int exitCode, string standardError)

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -20,6 +20,17 @@ namespace Datadog.Trace.TestHelpers;
 
 public static class ErrorHelpers
 {
+    public static bool IsRuntime127957Race(int exitCode, string standardError)
+    {
+        // Fingerprint of dotnet/runtime#127957: a SIGABRT carrying a TypeLoadException whose
+        // message is the "Undefined resource string ID" fallback. The fallback only fires when
+        // the runtime asks the localization layer for a string ID that doesn't exist, which
+        // happens when corrupted metadata bytes flow into the throw site.
+        return exitCode == 134
+            && standardError?.Contains("System.TypeLoadException") == true
+            && standardError?.Contains("Undefined resource string ID") == true;
+    }
+
     public static void CheckForKnownSkipConditions(ITestOutputHelper output, int exitCode, string standardError, EnvironmentHelper environmentHelper)
     {
 #if NETCOREAPP2_1
@@ -35,6 +46,16 @@ public static class ErrorHelpers
         {
             // Coverlet occasionally throws AbandonedMutexException during clean up
             throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
+        }
+
+        if (IsRuntime127957Race(exitCode, standardError))
+        {
+            // dotnet/runtime#127957 — race in MDInternalRW where ExpandTables() invalidates
+            // pointers returned by unlocked metadata readers while the profiler emits tokens.
+            // Manifests as a TypeLoadException with no localized message (unlocalized HRESULT).
+            // Reached here only if retries were exhausted (see RunSampleAndWaitForExit).
+            SendMetric(output, "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_127957", environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
+            throw new SkipException("TypeLoadException due to dotnet/runtime#127957 (MDInternalRW race)");
         }
 
 #if NETCOREAPP2_1

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -21,48 +21,26 @@ namespace Datadog.Trace.TestHelpers;
 
 public enum RuntimeErrorOutcome
 {
-    /// <summary>
-    /// No known transient error fingerprint detected. The caller should apply its normal
-    /// validation path (including <see cref="ErrorHelpers.CheckForKnownSkipConditions"/>).
-    /// </summary>
+    /// <summary>No known fingerprint detected; proceed with normal validation.</summary>
     Proceed,
 
-    /// <summary>
-    /// A known transient error fingerprint was detected and the retry budget is not yet
-    /// exhausted. The caller should clean up and retry the launch.
-    /// </summary>
+    /// <summary>Known fingerprint detected, retry budget remaining; caller should retry.</summary>
     Retry,
 
-    /// <summary>
-    /// A known transient error fingerprint was detected on every attempt — past the retry
-    /// budget. The error is no longer credibly a flake. The caller should let the test fail
-    /// loudly and must NOT call <see cref="ErrorHelpers.CheckForKnownSkipConditions"/>, which
-    /// would re-skip the same fingerprint.
-    /// </summary>
+    /// <summary>Known fingerprint persisted past retry budget; caller should let the test fail.</summary>
     Persistent,
 }
 
 public static class ErrorHelpers
 {
-    private const string Runtime127957SkipMessage = "Crash matching dotnet/runtime#127957 fingerprint (MDInternalRW race)";
     private const string Runtime127957IssueTag = "runtime_issue:127957";
     private const string RuntimeMetadataRaceRetryMetric = "dd_trace_dotnet.ci.tests.retried_due_to_runtime_metadata_race";
-    private const string RuntimeMetadataRaceSkipMetric = "dd_trace_dotnet.ci.tests.skipped_due_to_runtime_metadata_race";
     private const string RuntimeMetadataRacePersistentMetric = "dd_trace_dotnet.ci.tests.persistent_runtime_metadata_race";
 
     /// <summary>
-    /// Inspects a sample-launch attempt for known upstream/runtime-level error fingerprints
-    /// (currently dotnet/runtime#127957) and decides whether the caller should retry, proceed
-    /// with normal validation, or treat the failure as a persistent (non-flake) error.
+    /// Dispatch helper for known transient runtime crashes. Returns whether the caller should
+    /// retry, fail, or proceed normally. New fingerprints should be added as branches here.
     /// </summary>
-    /// <returns>
-    /// <see cref="RuntimeErrorOutcome.Retry"/> when a known transient error is detected and
-    /// the retry budget isn't exhausted; <see cref="RuntimeErrorOutcome.Persistent"/> when a
-    /// known fingerprint matched on every attempt (no longer a flake — caller should let the
-    /// test fail loudly without consulting <see cref="CheckForKnownSkipConditions"/>, which
-    /// would otherwise skip the same fingerprint); <see cref="RuntimeErrorOutcome.Proceed"/>
-    /// when no known fingerprint was detected and the caller should proceed normally.
-    /// </returns>
     public static async Task<RuntimeErrorOutcome> HandleRuntimeSkippableErrorsAsync(
         int attempt, int maxAttempts, int exitCode, string stderr, TestHelper helper, Action<string> writeOutput)
     {
@@ -78,7 +56,7 @@ public static class ErrorHelpers
             return RuntimeErrorOutcome.Retry;
         }
 
-        writeOutput($"dotnet/runtime#127957 fingerprint persisted across {maxAttempts} attempts — not a flake. Letting the test fail.");
+        writeOutput($"dotnet/runtime#127957 fingerprint persisted across {maxAttempts} attempts; letting the test fail.");
         await helper.SendCIMetricAsync(RuntimeMetadataRacePersistentMetric, Runtime127957IssueTag);
         return RuntimeErrorOutcome.Persistent;
     }
@@ -129,12 +107,6 @@ public static class ErrorHelpers
         {
             // Coverlet occasionally throws AbandonedMutexException during clean up
             throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
-        }
-
-        if (IsRuntime127957Race(exitCode, standardError))
-        {
-            SendMetric(output, RuntimeMetadataRaceSkipMetric, environmentHelper, Runtime127957IssueTag).ConfigureAwait(false).GetAwaiter().GetResult();
-            throw new SkipException(Runtime127957SkipMessage);
         }
 
 #if NETCOREAPP2_1

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -178,9 +178,9 @@ namespace Datadog.Trace.TestHelpers
             {
                 var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID, dotnetRuntimeArgs: dotnetRuntimeArgs);
                 using var processHelper = new ProcessHelper(process);
-                var result = WaitForProcessResultCore(processHelper);
+                var result = WaitForProcessResultRaw(processHelper);
 
-                if (await ErrorHelpers.HandleRuntime127957AttemptAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine))
+                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine))
                 {
                     continue;
                 }
@@ -195,7 +195,7 @@ namespace Datadog.Trace.TestHelpers
 
         public ProcessResult WaitForProcessResult(ProcessHelper helper, int expectedExitCode = 0, bool dumpChildProcesses = false)
         {
-            var result = WaitForProcessResultCore(helper, dumpChildProcesses);
+            var result = WaitForProcessResultRaw(helper, dumpChildProcesses);
             ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
             ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode, result.StandardError);
             return result;
@@ -677,7 +677,7 @@ namespace Datadog.Trace.TestHelpers
             Assert.Equal(expectedServiceVersion, span.Tags.GetValueOrDefault(Tags.Version));
         }
 
-        private ProcessResult WaitForProcessResultCore(ProcessHelper helper, bool dumpChildProcesses = false)
+        private ProcessResult WaitForProcessResultRaw(ProcessHelper helper, bool dumpChildProcesses = false)
         {
             // this is _way_ too long, but we want to be v. safe
             // the goal is just to make sure we kill the test before

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -168,10 +168,6 @@ namespace Datadog.Trace.TestHelpers
 
         public async Task<ProcessResult> RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool usePublishWithRID = false, string dotnetRuntimeArgs = null)
         {
-            // Retry the sample launch up to (maxAttempts - 1) times when it crashes with the
-            // dotnet/runtime#127957 fingerprint. The race fires during runtime startup before
-            // user code runs, so a clean restart almost always succeeds. If the fingerprint
-            // persists across all attempts it's no longer credibly a flake — let the test fail.
             const int maxAttempts = 3;
             var attempt = 1;
 
@@ -191,9 +187,6 @@ namespace Datadog.Trace.TestHelpers
 
                 if (outcome == RuntimeErrorOutcome.Proceed)
                 {
-                    // No known fingerprint matched — apply the standard skip-condition checks.
-                    // Skipped on Persistent because CheckForKnownSkipConditions would otherwise
-                    // re-skip the same race fingerprint we've decided to fail on.
                     ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
                 }
 
@@ -210,8 +203,6 @@ namespace Datadog.Trace.TestHelpers
             return result;
         }
 
-        // Exposes ErrorHelpers.SendMetric to callers that don't have access to EnvironmentHelper
-        // (which is protected). Used by AspNetCoreTestFixture for runtime#127957 retry telemetry.
         public Task SendCIMetricAsync(string metricName, params string[] extraTags)
             => ErrorHelpers.SendMetric(Output, metricName, EnvironmentHelper, extraTags);
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -114,10 +114,25 @@ namespace Datadog.Trace.TestHelpers
 
         public async Task<ProcessResult> RunDotnetTestSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", bool forceVsTestParam = false, int expectedExitCode = 0, bool useDotnetExec = false)
         {
-            var process = await StartDotnetTestSample(agent, arguments, packageVersion, aspNetCorePort: 5000, framework: framework, forceVsTestParam: forceVsTestParam, useDotnetExec);
+            const int maxAttempts = 3;
+            var attempt = 1;
 
-            using var helper = new ProcessHelper(process);
-            return WaitForProcessResult(helper, expectedExitCode, dumpChildProcesses: true);
+            while (true)
+            {
+                var process = await StartDotnetTestSample(agent, arguments, packageVersion, aspNetCorePort: 5000, framework: framework, forceVsTestParam: forceVsTestParam, useDotnetExec);
+                using var processHelper = new ProcessHelper(process);
+                var result = WaitForProcessResultRaw(processHelper, dumpChildProcesses: true);
+
+                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine))
+                {
+                    attempt++;
+                    continue;
+                }
+
+                ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
+                ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode, result.StandardError);
+                return result;
+            }
         }
 
         public async Task<Process> StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false, string dotnetRuntimeArgs = null)

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -177,13 +177,11 @@ namespace Datadog.Trace.TestHelpers
             for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
                 var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID, dotnetRuntimeArgs: dotnetRuntimeArgs);
-                using var helper = new ProcessHelper(process);
-                var result = WaitForProcessResultCore(helper);
+                using var processHelper = new ProcessHelper(process);
+                var result = WaitForProcessResultCore(processHelper);
 
-                if (attempt < maxAttempts && ErrorHelpers.IsRuntime127957Race(result.ExitCode, result.StandardError))
+                if (await ErrorHelpers.HandleRuntime127957AttemptAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine))
                 {
-                    Output.WriteLine($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
-                    await ErrorHelpers.SendMetric(Output, "dd_trace_dotnet.ci.tests.retried_due_to_runtime_127957", EnvironmentHelper);
                     continue;
                 }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -168,52 +168,39 @@ namespace Datadog.Trace.TestHelpers
 
         public async Task<ProcessResult> RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool usePublishWithRID = false, string dotnetRuntimeArgs = null)
         {
-            var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID, dotnetRuntimeArgs: dotnetRuntimeArgs);
-            using var helper = new ProcessHelper(process);
+            // Allow a single retry when the sample crashes with the dotnet/runtime#127957 fingerprint.
+            // The race fires during runtime startup before user code runs, so a clean restart almost
+            // always succeeds. If it crashes the same way twice, fall through to the standard validation,
+            // which will skip the test via ErrorHelpers.CheckForKnownSkipConditions as a last resort.
+            const int maxAttempts = 2;
 
-            return WaitForProcessResult(helper);
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID, dotnetRuntimeArgs: dotnetRuntimeArgs);
+                using var helper = new ProcessHelper(process);
+                var result = WaitForProcessResultCore(helper);
+
+                if (attempt < maxAttempts && ErrorHelpers.IsRuntime127957Race(result.ExitCode, result.StandardError))
+                {
+                    Output.WriteLine($"Detected dotnet/runtime#127957 race on attempt {attempt}/{maxAttempts}, retrying.");
+                    await ErrorHelpers.SendMetric(Output, "dd_trace_dotnet.ci.tests.retried_due_to_runtime_127957", EnvironmentHelper);
+                    continue;
+                }
+
+                ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
+                ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode: 0, result.StandardError);
+                return result;
+            }
+
+            throw new InvalidOperationException("Retry loop exited without returning a result.");
         }
 
         public ProcessResult WaitForProcessResult(ProcessHelper helper, int expectedExitCode = 0, bool dumpChildProcesses = false)
         {
-            // this is _way_ too long, but we want to be v. safe
-            // the goal is just to make sure we kill the test before
-            // the whole CI run times out
-            var process = helper.Process;
-            var timeoutMs = (int)TimeSpan.FromMinutes(10).TotalMilliseconds;
-            var ranToCompletion = process.WaitForExit(timeoutMs) && helper.Drain(timeoutMs / 2);
-
-            var standardOutput = helper.StandardOutput;
-
-            if (!string.IsNullOrWhiteSpace(standardOutput))
-            {
-                Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
-            }
-
-            var standardError = helper.ErrorOutput;
-
-            if (!string.IsNullOrWhiteSpace(standardError))
-            {
-                Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
-            }
-
-            if (!ranToCompletion && !process.HasExited)
-            {
-                var tookMemoryDump = MemoryDumpHelper.CaptureMemoryDump(process, includeChildProcesses: dumpChildProcesses);
-                process.Kill();
-                throw new Exception($"The sample did not exit in {timeoutMs}ms. Memory dump taken: {tookMemoryDump}. Killing process.");
-            }
-
-            var exitCode = process.ExitCode;
-
-            Output.WriteLine($"ProcessId: " + process.Id);
-            Output.WriteLine($"Exit Code: " + exitCode);
-
-            ErrorHelpers.CheckForKnownSkipConditions(Output, exitCode, standardError, EnvironmentHelper);
-
-            ExitCodeException.ThrowIfNonExpected(exitCode, expectedExitCode, standardError);
-
-            return new ProcessResult(process, standardOutput, standardError, exitCode);
+            var result = WaitForProcessResultCore(helper, dumpChildProcesses);
+            ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
+            ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode, result.StandardError);
+            return result;
         }
 
         public async Task<(ProcessHelper Process, string ConfigFile)> StartIISExpress(
@@ -686,6 +673,44 @@ namespace Datadog.Trace.TestHelpers
             // other tags
             Assert.Equal(SpanKinds.Server, span.Tags.GetValueOrDefault(Tags.SpanKind));
             Assert.Equal(expectedServiceVersion, span.Tags.GetValueOrDefault(Tags.Version));
+        }
+
+        private ProcessResult WaitForProcessResultCore(ProcessHelper helper, bool dumpChildProcesses = false)
+        {
+            // this is _way_ too long, but we want to be v. safe
+            // the goal is just to make sure we kill the test before
+            // the whole CI run times out
+            var process = helper.Process;
+            var timeoutMs = (int)TimeSpan.FromMinutes(10).TotalMilliseconds;
+            var ranToCompletion = process.WaitForExit(timeoutMs) && helper.Drain(timeoutMs / 2);
+
+            var standardOutput = helper.StandardOutput;
+
+            if (!string.IsNullOrWhiteSpace(standardOutput))
+            {
+                Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+            }
+
+            var standardError = helper.ErrorOutput;
+
+            if (!string.IsNullOrWhiteSpace(standardError))
+            {
+                Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+            }
+
+            if (!ranToCompletion && !process.HasExited)
+            {
+                var tookMemoryDump = MemoryDumpHelper.CaptureMemoryDump(process, includeChildProcesses: dumpChildProcesses);
+                process.Kill();
+                throw new Exception($"The sample did not exit in {timeoutMs}ms. Memory dump taken: {tookMemoryDump}. Killing process.");
+            }
+
+            var exitCode = process.ExitCode;
+
+            Output.WriteLine($"ProcessId: " + process.Id);
+            Output.WriteLine($"Exit Code: " + exitCode);
+
+            return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
         private bool IsServerSpan(MockSpan span) =>

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -177,19 +177,13 @@ namespace Datadog.Trace.TestHelpers
                 using var processHelper = new ProcessHelper(process);
                 var result = WaitForProcessResultRaw(processHelper);
 
-                var outcome = await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine);
-
-                if (outcome == RuntimeErrorOutcome.Retry)
+                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine))
                 {
                     attempt++;
                     continue;
                 }
 
-                if (outcome == RuntimeErrorOutcome.Proceed)
-                {
-                    ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
-                }
-
+                ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
                 ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode: 0, result.StandardError);
                 return result;
             }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -168,11 +168,11 @@ namespace Datadog.Trace.TestHelpers
 
         public async Task<ProcessResult> RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool usePublishWithRID = false, string dotnetRuntimeArgs = null)
         {
-            // Allow a single retry when the sample crashes with the dotnet/runtime#127957 fingerprint.
-            // The race fires during runtime startup before user code runs, so a clean restart almost
-            // always succeeds. If it crashes the same way twice, fall through to the standard validation,
-            // which will skip the test via ErrorHelpers.CheckForKnownSkipConditions as a last resort.
-            const int maxAttempts = 2;
+            // Retry the sample launch up to (maxAttempts - 1) times when it crashes with the
+            // dotnet/runtime#127957 fingerprint. The race fires during runtime startup before
+            // user code runs, so a clean restart almost always succeeds. If the fingerprint
+            // persists across all attempts it's no longer credibly a flake — let the test fail.
+            const int maxAttempts = 3;
             var attempt = 1;
 
             while (true)
@@ -181,13 +181,22 @@ namespace Datadog.Trace.TestHelpers
                 using var processHelper = new ProcessHelper(process);
                 var result = WaitForProcessResultRaw(processHelper);
 
-                if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine))
+                var outcome = await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine);
+
+                if (outcome == RuntimeErrorOutcome.Retry)
                 {
                     attempt++;
                     continue;
                 }
 
-                ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
+                if (outcome == RuntimeErrorOutcome.Proceed)
+                {
+                    // No known fingerprint matched — apply the standard skip-condition checks.
+                    // Skipped on Persistent because CheckForKnownSkipConditions would otherwise
+                    // re-skip the same race fingerprint we've decided to fail on.
+                    ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
+                }
+
                 ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode: 0, result.StandardError);
                 return result;
             }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -203,6 +203,10 @@ namespace Datadog.Trace.TestHelpers
             return result;
         }
 
+        // Exposes ErrorHelpers.SendMetric to callers that don't have access to EnvironmentHelper
+        // (which is protected). Used by AspNetCoreTestFixture for runtime#127957 retry telemetry.
+        public Task SendCIMetricAsync(string metricName) => ErrorHelpers.SendMetric(Output, metricName, EnvironmentHelper);
+
         public async Task<(ProcessHelper Process, string ConfigFile)> StartIISExpress(
             MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath, bool usePartialTrust, bool useLegacyCasModel)
         {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -173,8 +173,9 @@ namespace Datadog.Trace.TestHelpers
             // always succeeds. If it crashes the same way twice, fall through to the standard validation,
             // which will skip the test via ErrorHelpers.CheckForKnownSkipConditions as a last resort.
             const int maxAttempts = 2;
+            var attempt = 1;
 
-            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            while (true)
             {
                 var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID, dotnetRuntimeArgs: dotnetRuntimeArgs);
                 using var processHelper = new ProcessHelper(process);
@@ -182,6 +183,7 @@ namespace Datadog.Trace.TestHelpers
 
                 if (await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, result.ExitCode, result.StandardError, this, Output.WriteLine))
                 {
+                    attempt++;
                     continue;
                 }
 
@@ -189,8 +191,6 @@ namespace Datadog.Trace.TestHelpers
                 ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode: 0, result.StandardError);
                 return result;
             }
-
-            throw new InvalidOperationException("Retry loop exited without returning a result.");
         }
 
         public ProcessResult WaitForProcessResult(ProcessHelper helper, int expectedExitCode = 0, bool dumpChildProcesses = false)
@@ -203,7 +203,8 @@ namespace Datadog.Trace.TestHelpers
 
         // Exposes ErrorHelpers.SendMetric to callers that don't have access to EnvironmentHelper
         // (which is protected). Used by AspNetCoreTestFixture for runtime#127957 retry telemetry.
-        public Task SendCIMetricAsync(string metricName) => ErrorHelpers.SendMetric(Output, metricName, EnvironmentHelper);
+        public Task SendCIMetricAsync(string metricName, params string[] extraTags)
+            => ErrorHelpers.SendMetric(Output, metricName, EnvironmentHelper, extraTags);
 
         public async Task<(ProcessHelper Process, string ConfigFile)> StartIISExpress(
             MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath, bool usePartialTrust, bool useLegacyCasModel)


### PR DESCRIPTION
## Summary of changes

Retry sample launches that crash with the [dotnet/runtime#127957](https://github.com/dotnet/runtime/issues/127957) fingerprint (a race in `MDInternalRW` between unlocked metadata readers and the profiler emitting tokens). Up to 2 retries; if the fingerprint persists across all 3 attempts, throw a clear exception to fail the test — at that point it's not a flake.

## Reason for change

Integration tests intermittently crash during runtime startup with one of three platform-specific shapes — all documented manifestations of the issue:

- **Linux/SIGABRT:** `TypeLoadException: [Undefined resource string ID:0x...]` from `PortableThreadPool.GateThread`
- **Linux/SIGABRT:** `MissingMethodException: Method not found: 'Boolean ConcurrentDictionary'2.TryGetValue(...)'` during `HostBuilder.Build()`
- **Windows:** `Fatal error. Internal CLR error. (0x80131506)` (COR_E_EXECUTIONENGINE FailFast) on `PortableThreadPool.GateThread`. The Windows variant is more annoying — the host can report exit code 0 even though the runtime died, and the sample can emit partial output before dying, so downstream test assertions fail with misleading messages.

All three fingerprints are structurally unique to corrupted-metadata throws — unreachable through normal product or user code.

## Implementation details

- `ErrorHelpers.HandleRuntimeSkippableErrorsAsync` — central decision helper. Returns `true` to retry, `false` to proceed normally, **throws** when the fingerprint persists past the retry budget (exit code can't be trusted to surface the failure on Windows). Wired into the three "run sample" entry points: `TestHelper.RunSampleAndWaitForExit`, `TestHelper.RunDotnetTestSampleAndWaitForExit` (CI Visibility / VSTest path), and `AspNetCoreTestFixture.TryStartApp`.
- Two metrics tagged with `runtime_issue:127957`:
  - `dd_trace_dotnet.ci.tests.retried_due_to_runtime_metadata_race` (recovered via retry)
  - `dd_trace_dotnet.ci.tests.persistent_runtime_metadata_race` (failed after all retries)
- Fixture path retries on either failure point (port-bind timeout *and* `EnsureServerStarted` health-check failure) — the Windows manifestation often binds Kestrel before the gate thread dies, so the crash surfaces during health-check rather than at port-bind. Both detection paths share a `CheckRaceAndCleanupForRetryAsync` helper.
- Fixture also waits up to 5s for the process to finish exiting before reading the exit code, so a slow `createdump` doesn't slip past detection.

## Test coverage

Existing suite. Retry/fail only fires on the narrow fingerprints, so other failures surface normally.

## Other details

Revisit when dotnet/runtime#127957 is fixed upstream (currently open).
