### PR TITLE
[CI Visibility] Fix coverage resolver assembly file locks

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -103,17 +103,9 @@ namespace Datadog.Trace.Coverage.Collector
                     return;
                 }
 
-                // The target assembly stays open for in-place rewriting, so hold the per-path write lock
-                // until Cecil has disposed the target file stream.
-                using var assemblyLock = CoverageAssemblyPathLock.EnterWrite(_assemblyFilePath);
                 using var assemblyResolver = new CoverageAssemblyResolver(_logger, _assemblyFilePath);
                 assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(_assemblyFilePath));
-                using var assemblyDefinition = AssemblyDefinition.ReadAssembly(_assemblyFilePath, new ReaderParameters
-                {
-                    ReadSymbols = true,
-                    ReadWrite = true,
-                    AssemblyResolver = assemblyResolver,
-                });
+                using var assemblyDefinition = ReadTargetAssembly(_assemblyFilePath, assemblyResolver);
 
                 var hasInternalsVisibleAttribute = false;
                 foreach (var cAttr in assemblyDefinition.CustomAttributes)
@@ -734,11 +726,7 @@ namespace Datadog.Trace.Coverage.Collector
                     var tracerAssemblyLocation = CopyRequiredAssemblies(assemblyDefinition, tracerTarget);
                     assemblyResolver.SetTracerAssemblyLocation(tracerAssemblyLocation);
 
-                    assemblyDefinition.Write(new WriterParameters
-                    {
-                        WriteSymbols = true,
-                        StrongNameKeyBlob = _strongNameKeyBlob
-                    });
+                    WriteTargetAssembly(assemblyDefinition, _assemblyFilePath, _strongNameKeyBlob);
                 }
 
                 _logger.Debug($"Done: {_assemblyFilePath} [Modified:{isDirty}]");
@@ -751,6 +739,39 @@ namespace Datadog.Trace.Coverage.Collector
             {
                 Ci.Coverage.Exceptions.PdbNotFoundException.Throw();
             }
+        }
+
+        /// <summary>
+        /// Reads the target assembly into memory while holding only the target-path read lock.
+        /// </summary>
+        /// <param name="assemblyFilePath">The assembly path to read.</param>
+        /// <param name="assemblyResolver">The resolver used for Cecil metadata resolution.</param>
+        /// <returns>The in-memory assembly definition to rewrite.</returns>
+        internal static AssemblyDefinition ReadTargetAssembly(string assemblyFilePath, IAssemblyResolver assemblyResolver)
+        {
+            using var assemblyLock = CoverageAssemblyPathLock.EnterRead(assemblyFilePath);
+            return AssemblyDefinition.ReadAssembly(assemblyFilePath, new ReaderParameters
+            {
+                ReadSymbols = true,
+                InMemory = true,
+                AssemblyResolver = assemblyResolver,
+            });
+        }
+
+        /// <summary>
+        /// Writes the rewritten target assembly while holding the target-path write lock.
+        /// </summary>
+        /// <param name="assemblyDefinition">The rewritten assembly definition.</param>
+        /// <param name="assemblyFilePath">The assembly path to overwrite.</param>
+        /// <param name="strongNameKeyBlob">The optional strong-name key used when rewriting signed assemblies.</param>
+        internal static void WriteTargetAssembly(AssemblyDefinition assemblyDefinition, string assemblyFilePath, byte[]? strongNameKeyBlob)
+        {
+            using var assemblyLock = CoverageAssemblyPathLock.EnterWrite(assemblyFilePath);
+            assemblyDefinition.Write(assemblyFilePath, new WriterParameters
+            {
+                WriteSymbols = true,
+                StrongNameKeyBlob = strongNameKeyBlob
+            });
         }
 
         private static void RemoveShortOpCodes(Instruction instruction)

--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -103,14 +103,16 @@ namespace Datadog.Trace.Coverage.Collector
                     return;
                 }
 
-                // Open the assembly
-                var customResolver = new CustomResolver(_logger, _assemblyFilePath);
-                customResolver.AddSearchDirectory(Path.GetDirectoryName(_assemblyFilePath));
+                // The target assembly stays open for in-place rewriting, so hold the per-path write lock
+                // until Cecil has disposed the target file stream.
+                using var assemblyLock = CoverageAssemblyPathLock.EnterWrite(_assemblyFilePath);
+                using var assemblyResolver = new CoverageAssemblyResolver(_logger, _assemblyFilePath);
+                assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(_assemblyFilePath));
                 using var assemblyDefinition = AssemblyDefinition.ReadAssembly(_assemblyFilePath, new ReaderParameters
                 {
                     ReadSymbols = true,
                     ReadWrite = true,
-                    AssemblyResolver = customResolver,
+                    AssemblyResolver = assemblyResolver,
                 });
 
                 var hasInternalsVisibleAttribute = false;
@@ -191,7 +193,10 @@ namespace Datadog.Trace.Coverage.Collector
 
                 // We open the exact datadog assembly to be copied to the target, this is because the AssemblyReference lists
                 // differs depends on the target runtime. (netstandard, .NET 5.0 or .NET 4.6.2)
-                using var datadogTracerAssembly = AssemblyDefinition.ReadAssembly(GetDatadogTracer(tracerTarget));
+                using var datadogTracerAssembly = AssemblyDefinition.ReadAssembly(GetDatadogTracer(tracerTarget), new ReaderParameters
+                {
+                    InMemory = true
+                });
 
                 var isDirty = false;
                 var fileMetadataIndex = 0;
@@ -727,7 +732,7 @@ namespace Datadog.Trace.Coverage.Collector
 
                     // Create backup for dll and pdb and copy the Datadog.Trace assembly
                     var tracerAssemblyLocation = CopyRequiredAssemblies(assemblyDefinition, tracerTarget);
-                    customResolver.SetTracerAssemblyLocation(tracerAssemblyLocation);
+                    assemblyResolver.SetTracerAssemblyLocation(tracerAssemblyLocation);
 
                     assemblyDefinition.Write(new WriterParameters
                     {
@@ -947,126 +952,6 @@ namespace Datadog.Trace.Coverage.Collector
 
             _logger.Debug("GetTracerTarget: Returning TracerTarget.Net461");
             return TracerTarget.Net461;
-        }
-
-        private class CustomResolver : BaseAssemblyResolver
-        {
-            private readonly ICollectorLogger _logger;
-            private DefaultAssemblyResolver _defaultResolver;
-            private string _tracerAssemblyLocation;
-            private string _assemblyFilePath;
-
-            public CustomResolver(ICollectorLogger logger, string assemblyFilePath)
-            {
-                _tracerAssemblyLocation = string.Empty;
-                _logger = logger;
-                _assemblyFilePath = assemblyFilePath;
-                _defaultResolver = new DefaultAssemblyResolver();
-            }
-
-            public override AssemblyDefinition? Resolve(AssemblyNameReference name)
-            {
-                AssemblyDefinition? assembly = null;
-                try
-                {
-                    assembly = _defaultResolver.Resolve(name);
-                }
-                catch (AssemblyResolutionException arEx)
-                {
-                    var tracerAssemblyName = TracerAssembly.GetName();
-                    if (name.Name == tracerAssemblyName.Name && name.Version == tracerAssemblyName.Version)
-                    {
-                        var cAssemblyLocation = !string.IsNullOrEmpty(_tracerAssemblyLocation) ? _tracerAssemblyLocation : TracerAssembly.Location;
-                        try
-                        {
-                            assembly = AssemblyDefinition.ReadAssembly(cAssemblyLocation);
-                        }
-                        catch (Exception innerAssemblyException)
-                        {
-                            _logger.Error(innerAssemblyException, $"Error reading the tracer assembly: {cAssemblyLocation}");
-                            throw;
-                        }
-                    }
-                    else
-                    {
-                        var folder = Path.GetDirectoryName(_assemblyFilePath);
-                        var pathTest = Path.Combine(folder ?? string.Empty, name.Name + ".dll");
-                        _logger.Debug($"Looking for: {pathTest}");
-                        if (File.Exists(pathTest))
-                        {
-                            try
-                            {
-                                return AssemblyDefinition.ReadAssembly(pathTest);
-                            }
-                            catch (Exception innerAssemblyException)
-                            {
-                                _logger.Error(innerAssemblyException, $"Error reading the assembly: {pathTest}");
-                                throw;
-                            }
-                        }
-
-                        if (name.Name == "mscorlib")
-                        {
-                            var path = GetMscorlibBasePath(name.Version);
-                            var file = Path.Combine(path, "mscorlib.dll");
-                            if (File.Exists(file))
-                            {
-                                return AssemblyDefinition.ReadAssembly(file);
-                            }
-                        }
-
-                        _logger.Error(arEx, $"Error in the Custom Resolver processing '{_assemblyFilePath}' for: {name.FullName}");
-                        throw;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.Error(ex, $"Error in the custom resolver when trying to resolve assembly: {name.FullName}");
-                }
-
-                return assembly;
-            }
-
-            public void SetTracerAssemblyLocation(string assemblyLocation)
-            {
-                _tracerAssemblyLocation = assemblyLocation;
-            }
-
-            private string GetMscorlibBasePath(Version version)
-            {
-                string? GetSubFolderForVersion()
-                    => version.Major switch
-                    {
-                        1 when version.MajorRevision == 3300 => "v1.0.3705",
-                        1 => "v1.1.4322",
-                        2 => "v2.0.50727",
-                        4 => "v4.0.30319",
-                        _ => throw new NotSupportedException("Version not supported: " + version),
-                    };
-
-                var rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Microsoft.NET");
-                string[] frameworkPaths =
-                [
-                    Path.Combine(rootPath, "Framework"),
-                    Path.Combine(rootPath, "Framework64")
-                ];
-
-                var folder = GetSubFolderForVersion();
-
-                if (folder != null)
-                {
-                    foreach (var path in frameworkPaths)
-                    {
-                        var basePath = Path.Combine(path, folder);
-                        if (Directory.Exists(basePath))
-                        {
-                            return basePath;
-                        }
-                    }
-                }
-
-                throw new NotSupportedException("Version not supported: " + version);
-            }
         }
 
 #pragma warning disable SA1201

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyPathLock.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyPathLock.cs
@@ -16,10 +16,16 @@ namespace Datadog.Trace.Coverage.Collector
     /// </summary>
     internal static class CoverageAssemblyPathLock
     {
-        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
-        private static readonly object RegistryLock = new();
         // Keep lock entries for the collector process lifetime so every same-path access shares one lock object.
-        private static readonly Dictionary<string, ReaderWriterLockSlim> Locks = new(GetPathComparer());
+        private static readonly Dictionary<string, ReaderWriterLockSlim> Locks;
+        private static readonly TimeSpan DefaultTimeout;
+
+        static CoverageAssemblyPathLock()
+        {
+            DefaultTimeout = TimeSpan.FromSeconds(5);
+            var pathComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            Locks = new(pathComparer);
+        }
 
         /// <summary>
         /// Acquires shared read access for a dependency assembly path.
@@ -80,7 +86,7 @@ namespace Datadog.Trace.Coverage.Collector
 
         private static ReaderWriterLockSlim GetLock(string normalizedPath)
         {
-            lock (RegistryLock)
+            lock (Locks)
             {
                 if (!Locks.TryGetValue(normalizedPath, out var pathLock))
                 {
@@ -92,14 +98,11 @@ namespace Datadog.Trace.Coverage.Collector
             }
         }
 
-        private static StringComparer GetPathComparer()
-            => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-
         private sealed class LockScope : IDisposable
         {
             private readonly ReaderWriterLockSlim _pathLock;
             private readonly bool _isWriteLock;
-            private bool _disposed;
+            private int _disposed;
 
             public LockScope(ReaderWriterLockSlim pathLock, bool isWriteLock)
             {
@@ -109,12 +112,11 @@ namespace Datadog.Trace.Coverage.Collector
 
             public void Dispose()
             {
-                if (_disposed)
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
                 {
                     return;
                 }
 
-                _disposed = true;
                 if (_isWriteLock)
                 {
                     _pathLock.ExitWriteLock();

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyPathLock.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyPathLock.cs
@@ -1,0 +1,128 @@
+// <copyright file="CoverageAssemblyPathLock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Datadog.Trace.Coverage.Collector
+{
+    /// <summary>
+    /// Coordinates coverage reads and rewrites for individual assembly paths inside the current process.
+    /// </summary>
+    internal static class CoverageAssemblyPathLock
+    {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+        private static readonly object RegistryLock = new();
+        private static readonly Dictionary<string, ReaderWriterLockSlim> Locks = new(GetPathComparer());
+
+        /// <summary>
+        /// Acquires shared read access for a dependency assembly path.
+        /// </summary>
+        /// <param name="path">The assembly path to protect.</param>
+        /// <returns>A disposable lock scope.</returns>
+        public static IDisposable EnterRead(string path) => EnterRead(path, DefaultTimeout);
+
+        /// <summary>
+        /// Acquires shared read access for a dependency assembly path.
+        /// </summary>
+        /// <param name="path">The assembly path to protect.</param>
+        /// <param name="timeout">The maximum time to wait before failing with an <see cref="IOException"/>.</param>
+        /// <returns>A disposable lock scope.</returns>
+        internal static IDisposable EnterRead(string path, TimeSpan timeout)
+        {
+            var normalizedPath = NormalizePath(path);
+            var pathLock = GetLock(normalizedPath);
+            if (!pathLock.TryEnterReadLock(timeout))
+            {
+                throw new IOException($"Timed out waiting for read access to assembly: {normalizedPath}");
+            }
+
+            return new LockScope(pathLock, isWriteLock: false);
+        }
+
+        /// <summary>
+        /// Acquires exclusive write access for a target assembly path.
+        /// </summary>
+        /// <param name="path">The assembly path to protect.</param>
+        /// <returns>A disposable lock scope.</returns>
+        public static IDisposable EnterWrite(string path) => EnterWrite(path, DefaultTimeout);
+
+        /// <summary>
+        /// Acquires exclusive write access for a target assembly path.
+        /// </summary>
+        /// <param name="path">The assembly path to protect.</param>
+        /// <param name="timeout">The maximum time to wait before failing with an <see cref="IOException"/>.</param>
+        /// <returns>A disposable lock scope.</returns>
+        internal static IDisposable EnterWrite(string path, TimeSpan timeout)
+        {
+            var normalizedPath = NormalizePath(path);
+            var pathLock = GetLock(normalizedPath);
+            if (!pathLock.TryEnterWriteLock(timeout))
+            {
+                throw new IOException($"Timed out waiting for write access to assembly: {normalizedPath}");
+            }
+
+            return new LockScope(pathLock, isWriteLock: true);
+        }
+
+        /// <summary>
+        /// Normalizes an assembly path to the key used by the lock registry.
+        /// </summary>
+        /// <param name="path">The path to normalize.</param>
+        /// <returns>The full path used as the lock key.</returns>
+        internal static string NormalizePath(string path) => Path.GetFullPath(path);
+
+        private static ReaderWriterLockSlim GetLock(string normalizedPath)
+        {
+            lock (RegistryLock)
+            {
+                if (!Locks.TryGetValue(normalizedPath, out var pathLock))
+                {
+                    pathLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+                    Locks[normalizedPath] = pathLock;
+                }
+
+                return pathLock;
+            }
+        }
+
+        private static StringComparer GetPathComparer()
+            => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        private sealed class LockScope : IDisposable
+        {
+            private readonly ReaderWriterLockSlim _pathLock;
+            private readonly bool _isWriteLock;
+            private bool _disposed;
+
+            public LockScope(ReaderWriterLockSlim pathLock, bool isWriteLock)
+            {
+                _pathLock = pathLock;
+                _isWriteLock = isWriteLock;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                if (_isWriteLock)
+                {
+                    _pathLock.ExitWriteLock();
+                }
+                else
+                {
+                    _pathLock.ExitReadLock();
+                }
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyPathLock.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyPathLock.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.Coverage.Collector
     {
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
         private static readonly object RegistryLock = new();
+        // Keep lock entries for the collector process lifetime so every same-path access shares one lock object.
         private static readonly Dictionary<string, ReaderWriterLockSlim> Locks = new(GetPathComparer());
 
         /// <summary>

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -1,0 +1,307 @@
+// <copyright file="CoverageAssemblyResolver.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Datadog.Trace.Ci.Coverage;
+using Mono.Cecil;
+
+namespace Datadog.Trace.Coverage.Collector
+{
+    /// <summary>
+    /// Resolves coverage rewrite dependencies without keeping file handles open on resolved assemblies.
+    /// </summary>
+    internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
+    {
+        private static readonly Assembly TracerAssembly = typeof(CoverageReporter).Assembly;
+        private readonly Dictionary<string, AssemblyDefinition> _cache = new(StringComparer.Ordinal);
+        private readonly ICollectorLogger _logger;
+        private readonly string _assemblyFilePath;
+        private readonly string _preferredSearchDirectory;
+        private string _tracerAssemblyLocation;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CoverageAssemblyResolver"/> class.
+        /// </summary>
+        /// <param name="logger">Logger used to report resolution failures.</param>
+        /// <param name="assemblyFilePath">The target assembly currently being rewritten.</param>
+        public CoverageAssemblyResolver(ICollectorLogger logger, string assemblyFilePath)
+        {
+            _logger = logger;
+            _assemblyFilePath = assemblyFilePath;
+            _preferredSearchDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
+            _tracerAssemblyLocation = string.Empty;
+        }
+
+        /// <inheritdoc />
+        public override AssemblyDefinition Resolve(AssemblyNameReference name)
+            => Resolve(name, new ReaderParameters());
+
+        /// <inheritdoc />
+        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            ThrowIfDisposed();
+            if (_cache.TryGetValue(name.FullName, out var cachedAssembly))
+            {
+                return cachedAssembly;
+            }
+
+            try
+            {
+                return ResolveAndCache(name);
+            }
+            catch (AssemblyResolutionException arEx)
+            {
+                _logger.Error(arEx, $"Error in the custom resolver processing '{_assemblyFilePath}' for: {name.FullName}");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, $"Error in the custom resolver when trying to resolve assembly: {name.FullName}");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Sets the Datadog.Trace assembly path that should be preferred for later resolutions.
+        /// </summary>
+        /// <param name="assemblyLocation">The copied Datadog.Trace assembly path.</param>
+        public void SetTracerAssemblyLocation(string assemblyLocation)
+        {
+            ThrowIfDisposed();
+            assemblyLocation ??= string.Empty;
+            if (string.Equals(_tracerAssemblyLocation, assemblyLocation, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            InvalidateTracerCache();
+            _tracerAssemblyLocation = assemblyLocation;
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing)
+            {
+                var assemblies = _cache.Values.Distinct().ToArray();
+                _cache.Clear();
+                foreach (var assembly in assemblies)
+                {
+                    assembly.Dispose();
+                }
+            }
+
+            _disposed = true;
+            base.Dispose(disposing);
+        }
+
+        private AssemblyDefinition ResolveAndCache(AssemblyNameReference name)
+        {
+            var tracerAssemblyName = TracerAssembly.GetName();
+            if (IsTracerAssembly(name, tracerAssemblyName) && !string.IsNullOrEmpty(_tracerAssemblyLocation))
+            {
+                return ReadAndCache(name.FullName, _tracerAssemblyLocation);
+            }
+
+            var assemblyFromSearchDirectory = ResolveFromSearchDirectories(name);
+            if (assemblyFromSearchDirectory is not null)
+            {
+                return assemblyFromSearchDirectory;
+            }
+
+            if (IsTracerAssembly(name, tracerAssemblyName))
+            {
+                return ReadAndCache(name.FullName, TracerAssembly.Location);
+            }
+
+            if (name.Name == "mscorlib")
+            {
+                var mscorlibPath = Path.Combine(GetMscorlibBasePath(name.Version), "mscorlib.dll");
+                if (File.Exists(mscorlibPath))
+                {
+                    return ReadAndCache(name.FullName, mscorlibPath);
+                }
+            }
+
+            var assembly = ResolveWithoutDirectoryFallback(name);
+            return CacheAssembly(name.FullName, assembly);
+        }
+
+        private AssemblyDefinition? ResolveFromSearchDirectories(AssemblyNameReference name)
+        {
+            var extensions = name.IsWindowsRuntime ? new[] { ".winmd", ".dll" } : new[] { ".exe", ".dll" };
+            foreach (var directory in GetSearchDirectoryCandidates())
+            {
+                foreach (var extension in extensions)
+                {
+                    var path = Path.Combine(directory, name.Name + extension);
+                    _logger.Debug($"Looking for: {path}");
+                    if (!File.Exists(path))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        return ReadAndCache(name.FullName, path);
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private IEnumerable<string> GetSearchDirectoryCandidates()
+        {
+            if (!string.IsNullOrEmpty(_preferredSearchDirectory))
+            {
+                yield return _preferredSearchDirectory;
+            }
+
+            foreach (var directory in GetSearchDirectories())
+            {
+                if (!string.Equals(directory, _preferredSearchDirectory, StringComparison.Ordinal))
+                {
+                    yield return directory;
+                }
+            }
+        }
+
+        private AssemblyDefinition ReadAndCache(string requestedFullName, string assemblyPath)
+        {
+            try
+            {
+                using var assemblyLock = CoverageAssemblyPathLock.EnterRead(assemblyPath);
+                var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, CreateDependencyReaderParameters());
+                return CacheAssembly(requestedFullName, assembly);
+            }
+            catch (Exception ex) when (ex is not AssemblyResolutionException)
+            {
+                _logger.Error(ex, $"Error reading the assembly: {assemblyPath}");
+                throw;
+            }
+        }
+
+        private AssemblyDefinition CacheAssembly(string requestedFullName, AssemblyDefinition assembly)
+        {
+            _cache[requestedFullName] = assembly;
+            _cache[assembly.Name.FullName] = assembly;
+            return assembly;
+        }
+
+        private AssemblyDefinition ResolveWithoutDirectoryFallback(AssemblyNameReference name)
+        {
+            // Directory probing is handled by ResolveFromSearchDirectories so every output-folder read
+            // goes through CoverageAssemblyPathLock. The base resolver is only used for platform/TPA
+            // fallback paths that are not rewritten by the coverage collector.
+            var searchDirectories = GetSearchDirectories();
+            foreach (var directory in searchDirectories)
+            {
+                RemoveSearchDirectory(directory);
+            }
+
+            try
+            {
+                return base.Resolve(name, CreateDependencyReaderParameters());
+            }
+            finally
+            {
+                foreach (var directory in searchDirectories)
+                {
+                    AddSearchDirectory(directory);
+                }
+            }
+        }
+
+        private ReaderParameters CreateDependencyReaderParameters()
+            => new()
+            {
+                InMemory = true,
+                AssemblyResolver = this
+            };
+
+        private void InvalidateTracerCache()
+        {
+            var tracerAssemblyName = TracerAssembly.GetName();
+            var cacheEntries = _cache.ToArray();
+            var assembliesToDispose = new HashSet<AssemblyDefinition>();
+
+            foreach (var entry in cacheEntries)
+            {
+                if (IsTracerAssembly(entry.Value.Name, tracerAssemblyName))
+                {
+                    _cache.Remove(entry.Key);
+                    assembliesToDispose.Add(entry.Value);
+                }
+            }
+
+            foreach (var assembly in assembliesToDispose)
+            {
+                assembly.Dispose();
+            }
+        }
+
+        private bool IsTracerAssembly(AssemblyNameReference name, AssemblyName tracerAssemblyName)
+            => name.Name == tracerAssemblyName.Name && name.Version == tracerAssemblyName.Version;
+
+        private string GetMscorlibBasePath(Version version)
+        {
+            string? GetSubFolderForVersion()
+                => version.Major switch
+                {
+                    1 when version.MajorRevision == 3300 => "v1.0.3705",
+                    1 => "v1.1.4322",
+                    2 => "v2.0.50727",
+                    4 => "v4.0.30319",
+                    _ => throw new NotSupportedException("Version not supported: " + version),
+                };
+
+            var rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Microsoft.NET");
+            string[] frameworkPaths =
+            [
+                Path.Combine(rootPath, "Framework"),
+                Path.Combine(rootPath, "Framework64")
+            ];
+
+            var folder = GetSubFolderForVersion();
+
+            if (folder != null)
+            {
+                foreach (var path in frameworkPaths)
+                {
+                    var basePath = Path.Combine(path, folder);
+                    if (Directory.Exists(basePath))
+                    {
+                        return basePath;
+                    }
+                }
+            }
+
+            throw new NotSupportedException("Version not supported: " + version);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(CoverageAssemblyResolver));
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -63,12 +63,12 @@ namespace Datadog.Trace.Coverage.Collector
             }
             catch (AssemblyResolutionException arEx)
             {
-                _logger.Error(arEx, $"Error in the custom resolver processing '{_assemblyFilePath}' for: {name.FullName}");
+                _logger.Error(arEx, $"{nameof(CoverageAssemblyResolver)} failed to resolve dependency '{name.FullName}' while processing target assembly '{_assemblyFilePath}'.");
                 throw;
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, $"Error in the custom resolver when trying to resolve assembly: {name.FullName}");
+                _logger.Error(ex, $"{nameof(CoverageAssemblyResolver)} failed to resolve dependency '{name.FullName}' while processing target assembly '{_assemblyFilePath}'.");
                 throw;
             }
         }
@@ -185,17 +185,9 @@ namespace Datadog.Trace.Coverage.Collector
 
         private AssemblyDefinition ReadAndCache(string requestedFullName, string assemblyPath)
         {
-            try
-            {
-                using var assemblyLock = CoverageAssemblyPathLock.EnterRead(assemblyPath);
-                var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, CreateDependencyReaderParameters());
-                return CacheAssembly(requestedFullName, assembly);
-            }
-            catch (Exception ex) when (ex is not AssemblyResolutionException)
-            {
-                _logger.Error(ex, $"Error reading the assembly: {assemblyPath}");
-                throw;
-            }
+            using var assemblyLock = CoverageAssemblyPathLock.EnterRead(assemblyPath);
+            var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, CreateDependencyReaderParameters());
+            return CacheAssembly(requestedFullName, assembly);
         }
 
         private AssemblyDefinition CacheAssembly(string requestedFullName, AssemblyDefinition assembly)

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -8,292 +8,299 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Datadog.Trace.Ci.Coverage;
 using Mono.Cecil;
 
-namespace Datadog.Trace.Coverage.Collector
+namespace Datadog.Trace.Coverage.Collector;
+
+/// <summary>
+/// Resolves coverage rewrite dependencies without keeping file handles open on resolved assemblies.
+/// </summary>
+internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
 {
+    private static readonly Assembly TracerAssembly = typeof(CoverageReporter).Assembly;
+    private static readonly StringComparison PathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    private static readonly string[] ManagedAssemblyExtensions = [".exe", ".dll"];
+    private static readonly string[] WindowsRuntimeAssemblyExtensions = [".winmd", ".dll"];
+    private readonly Dictionary<string, AssemblyDefinition> _cache = new(StringComparer.Ordinal);
+    private readonly ICollectorLogger _logger;
+    private readonly string _assemblyFilePath;
+    private readonly string _preferredSearchDirectory;
+    private string _tracerAssemblyLocation;
+    private bool _disposed;
+
     /// <summary>
-    /// Resolves coverage rewrite dependencies without keeping file handles open on resolved assemblies.
+    /// Initializes a new instance of the <see cref="CoverageAssemblyResolver"/> class.
     /// </summary>
-    internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
+    /// <param name="logger">Logger used to report resolution failures.</param>
+    /// <param name="assemblyFilePath">The target assembly currently being rewritten.</param>
+    public CoverageAssemblyResolver(ICollectorLogger logger, string assemblyFilePath)
     {
-        private static readonly Assembly TracerAssembly = typeof(CoverageReporter).Assembly;
-        private readonly Dictionary<string, AssemblyDefinition> _cache = new(StringComparer.Ordinal);
-        private readonly ICollectorLogger _logger;
-        private readonly string _assemblyFilePath;
-        private readonly string _preferredSearchDirectory;
-        private string _tracerAssemblyLocation;
-        private bool _disposed;
+        _logger = logger;
+        _assemblyFilePath = assemblyFilePath;
+        _preferredSearchDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
+        _tracerAssemblyLocation = string.Empty;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CoverageAssemblyResolver"/> class.
-        /// </summary>
-        /// <param name="logger">Logger used to report resolution failures.</param>
-        /// <param name="assemblyFilePath">The target assembly currently being rewritten.</param>
-        public CoverageAssemblyResolver(ICollectorLogger logger, string assemblyFilePath)
+    /// <inheritdoc />
+    public override AssemblyDefinition Resolve(AssemblyNameReference name)
+        => Resolve(name, new ReaderParameters());
+
+    /// <inheritdoc />
+    public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+    {
+        if (name is null)
         {
-            _logger = logger;
-            _assemblyFilePath = assemblyFilePath;
-            _preferredSearchDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
-            _tracerAssemblyLocation = string.Empty;
+            throw new ArgumentNullException(nameof(name));
         }
 
-        /// <inheritdoc />
-        public override AssemblyDefinition Resolve(AssemblyNameReference name)
-            => Resolve(name, new ReaderParameters());
-
-        /// <inheritdoc />
-        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        ThrowIfDisposed();
+        if (_cache.TryGetValue(name.FullName, out var cachedAssembly))
         {
-            if (name is null)
+            return cachedAssembly;
+        }
+
+        try
+        {
+            return ResolveAndCache(name);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, $"{nameof(CoverageAssemblyResolver)} failed to resolve dependency '{name.FullName}' while processing target assembly '{_assemblyFilePath}'.");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Sets the Datadog.Trace assembly path that should be preferred for later resolutions.
+    /// </summary>
+    /// <param name="assemblyLocation">The copied Datadog.Trace assembly path.</param>
+    public void SetTracerAssemblyLocation(string assemblyLocation)
+    {
+        ThrowIfDisposed();
+        assemblyLocation ??= string.Empty;
+        if (string.Equals(_tracerAssemblyLocation, assemblyLocation, PathComparison))
+        {
+            return;
+        }
+
+        InvalidateTracerCache();
+        _tracerAssemblyLocation = assemblyLocation;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (!_disposed && disposing)
+        {
+            foreach (var assembly in _cache.Values.Distinct())
             {
-                throw new ArgumentNullException(nameof(name));
+                assembly.Dispose();
             }
 
-            ThrowIfDisposed();
-            if (_cache.TryGetValue(name.FullName, out var cachedAssembly))
-            {
-                return cachedAssembly;
-            }
+            _cache.Clear();
+        }
 
-            try
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+
+    private AssemblyDefinition ResolveAndCache(AssemblyNameReference name)
+    {
+        var tracerAssemblyName = TracerAssembly.GetName();
+        if (IsTracerAssembly(name, tracerAssemblyName) && !string.IsNullOrEmpty(_tracerAssemblyLocation))
+        {
+            return ReadAndCache(name.FullName, _tracerAssemblyLocation);
+        }
+
+        var assemblyFromSearchDirectory = ResolveFromSearchDirectories(name);
+        if (assemblyFromSearchDirectory is not null)
+        {
+            return assemblyFromSearchDirectory;
+        }
+
+        if (IsTracerAssembly(name, tracerAssemblyName))
+        {
+            return ReadAndCache(name.FullName, TracerAssembly.Location);
+        }
+
+        if (name.Name == "mscorlib")
+        {
+            var mscorlibPath = Path.Combine(GetMscorlibBasePath(name.Version), "mscorlib.dll");
+            if (File.Exists(mscorlibPath))
             {
-                return ResolveAndCache(name);
-            }
-            catch (AssemblyResolutionException arEx)
-            {
-                _logger.Error(arEx, $"{nameof(CoverageAssemblyResolver)} failed to resolve dependency '{name.FullName}' while processing target assembly '{_assemblyFilePath}'.");
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, $"{nameof(CoverageAssemblyResolver)} failed to resolve dependency '{name.FullName}' while processing target assembly '{_assemblyFilePath}'.");
-                throw;
+                return ReadAndCache(name.FullName, mscorlibPath);
             }
         }
 
-        /// <summary>
-        /// Sets the Datadog.Trace assembly path that should be preferred for later resolutions.
-        /// </summary>
-        /// <param name="assemblyLocation">The copied Datadog.Trace assembly path.</param>
-        public void SetTracerAssemblyLocation(string assemblyLocation)
-        {
-            ThrowIfDisposed();
-            assemblyLocation ??= string.Empty;
-            if (string.Equals(_tracerAssemblyLocation, assemblyLocation, StringComparison.Ordinal))
-            {
-                return;
-            }
+        var assembly = ResolveWithoutDirectoryFallback(name);
+        return CacheAssembly(name.FullName, assembly);
+    }
 
-            InvalidateTracerCache();
-            _tracerAssemblyLocation = assemblyLocation;
-        }
-
-        /// <inheritdoc />
-        protected override void Dispose(bool disposing)
+    private AssemblyDefinition? ResolveFromSearchDirectories(AssemblyNameReference name)
+    {
+        var extensions = name.IsWindowsRuntime ? WindowsRuntimeAssemblyExtensions : ManagedAssemblyExtensions;
+        foreach (var directory in GetSearchDirectoryCandidates())
         {
-            if (!_disposed && disposing)
+            foreach (var extension in extensions)
             {
-                var assemblies = _cache.Values.Distinct().ToArray();
-                _cache.Clear();
-                foreach (var assembly in assemblies)
+                var path = Path.Combine(directory, name.Name + extension);
+                _logger.Debug($"Looking for: {path}");
+                if (!File.Exists(path))
                 {
-                    assembly.Dispose();
+                    continue;
                 }
-            }
 
-            _disposed = true;
-            base.Dispose(disposing);
-        }
-
-        private AssemblyDefinition ResolveAndCache(AssemblyNameReference name)
-        {
-            var tracerAssemblyName = TracerAssembly.GetName();
-            if (IsTracerAssembly(name, tracerAssemblyName) && !string.IsNullOrEmpty(_tracerAssemblyLocation))
-            {
-                return ReadAndCache(name.FullName, _tracerAssemblyLocation);
-            }
-
-            var assemblyFromSearchDirectory = ResolveFromSearchDirectories(name);
-            if (assemblyFromSearchDirectory is not null)
-            {
-                return assemblyFromSearchDirectory;
-            }
-
-            if (IsTracerAssembly(name, tracerAssemblyName))
-            {
-                return ReadAndCache(name.FullName, TracerAssembly.Location);
-            }
-
-            if (name.Name == "mscorlib")
-            {
-                var mscorlibPath = Path.Combine(GetMscorlibBasePath(name.Version), "mscorlib.dll");
-                if (File.Exists(mscorlibPath))
+                try
                 {
-                    return ReadAndCache(name.FullName, mscorlibPath);
+                    return ReadAndCache(name.FullName, path);
                 }
-            }
-
-            var assembly = ResolveWithoutDirectoryFallback(name);
-            return CacheAssembly(name.FullName, assembly);
-        }
-
-        private AssemblyDefinition? ResolveFromSearchDirectories(AssemblyNameReference name)
-        {
-            var extensions = name.IsWindowsRuntime ? new[] { ".winmd", ".dll" } : new[] { ".exe", ".dll" };
-            foreach (var directory in GetSearchDirectoryCandidates())
-            {
-                foreach (var extension in extensions)
+                catch (BadImageFormatException)
                 {
-                    var path = Path.Combine(directory, name.Name + extension);
-                    _logger.Debug($"Looking for: {path}");
-                    if (!File.Exists(path))
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        return ReadAndCache(name.FullName, path);
-                    }
-                    catch (BadImageFormatException)
-                    {
-                        continue;
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private IEnumerable<string> GetSearchDirectoryCandidates()
-        {
-            if (!string.IsNullOrEmpty(_preferredSearchDirectory))
-            {
-                yield return _preferredSearchDirectory;
-            }
-
-            foreach (var directory in GetSearchDirectories())
-            {
-                if (!string.Equals(directory, _preferredSearchDirectory, StringComparison.Ordinal))
-                {
-                    yield return directory;
+                    continue;
                 }
             }
         }
 
-        private AssemblyDefinition ReadAndCache(string requestedFullName, string assemblyPath)
+        return null;
+    }
+
+    private IEnumerable<string> GetSearchDirectoryCandidates()
+    {
+        if (!string.IsNullOrEmpty(_preferredSearchDirectory))
         {
-            using var assemblyLock = CoverageAssemblyPathLock.EnterRead(assemblyPath);
-            var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, CreateDependencyReaderParameters());
-            return CacheAssembly(requestedFullName, assembly);
+            yield return _preferredSearchDirectory;
         }
 
-        private AssemblyDefinition CacheAssembly(string requestedFullName, AssemblyDefinition assembly)
+        foreach (var directory in GetSearchDirectories())
         {
-            _cache[requestedFullName] = assembly;
-            _cache[assembly.Name.FullName] = assembly;
-            return assembly;
+            if (!string.Equals(directory, _preferredSearchDirectory, PathComparison))
+            {
+                yield return directory;
+            }
+        }
+    }
+
+    private AssemblyDefinition ReadAndCache(string requestedFullName, string assemblyPath)
+    {
+        using var assemblyLock = CoverageAssemblyPathLock.EnterRead(assemblyPath);
+        var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, CreateDependencyReaderParameters());
+        return CacheAssembly(requestedFullName, assembly);
+    }
+
+    private AssemblyDefinition CacheAssembly(string requestedFullName, AssemblyDefinition assembly)
+    {
+        _cache[requestedFullName] = assembly;
+        _cache[assembly.Name.FullName] = assembly;
+        return assembly;
+    }
+
+    private AssemblyDefinition ResolveWithoutDirectoryFallback(AssemblyNameReference name)
+    {
+        // Directory probing is handled by ResolveFromSearchDirectories so every output-folder read
+        // goes through CoverageAssemblyPathLock. The base resolver is only used for platform/TPA
+        // fallback paths that are not rewritten by the coverage collector.
+        var searchDirectories = GetSearchDirectories();
+        foreach (var directory in searchDirectories)
+        {
+            RemoveSearchDirectory(directory);
         }
 
-        private AssemblyDefinition ResolveWithoutDirectoryFallback(AssemblyNameReference name)
+        try
         {
-            // Directory probing is handled by ResolveFromSearchDirectories so every output-folder read
-            // goes through CoverageAssemblyPathLock. The base resolver is only used for platform/TPA
-            // fallback paths that are not rewritten by the coverage collector.
-            var searchDirectories = GetSearchDirectories();
+            return base.Resolve(name, CreateDependencyReaderParameters());
+        }
+        finally
+        {
             foreach (var directory in searchDirectories)
             {
-                RemoveSearchDirectory(directory);
+                AddSearchDirectory(directory);
             }
+        }
+    }
 
-            try
+    private ReaderParameters CreateDependencyReaderParameters()
+        => new()
+        {
+            InMemory = true,
+            AssemblyResolver = this
+        };
+
+    private void InvalidateTracerCache()
+    {
+        var tracerAssemblyName = TracerAssembly.GetName();
+        HashSet<AssemblyDefinition>? assembliesToDispose = null;
+        List<string>? cacheKeysToRemove = null;
+        foreach (var entry in _cache)
+        {
+            if (IsTracerAssembly(entry.Value.Name, tracerAssemblyName))
             {
-                return base.Resolve(name, CreateDependencyReaderParameters());
-            }
-            finally
-            {
-                foreach (var directory in searchDirectories)
-                {
-                    AddSearchDirectory(directory);
-                }
+                cacheKeysToRemove ??= [];
+                cacheKeysToRemove.Add(entry.Key);
+                assembliesToDispose ??= [];
+                assembliesToDispose.Add(entry.Value);
             }
         }
 
-        private ReaderParameters CreateDependencyReaderParameters()
-            => new()
-            {
-                InMemory = true,
-                AssemblyResolver = this
-            };
-
-        private void InvalidateTracerCache()
+        if (cacheKeysToRemove?.Count > 0)
         {
-            var tracerAssemblyName = TracerAssembly.GetName();
-            var cacheEntries = _cache.ToArray();
-            var assembliesToDispose = new HashSet<AssemblyDefinition>();
-
-            foreach (var entry in cacheEntries)
+            foreach (var entryKey in cacheKeysToRemove)
             {
-                if (IsTracerAssembly(entry.Value.Name, tracerAssemblyName))
-                {
-                    _cache.Remove(entry.Key);
-                    assembliesToDispose.Add(entry.Value);
-                }
+                _cache.Remove(entryKey);
             }
 
-            foreach (var assembly in assembliesToDispose)
+            foreach (var assembly in assembliesToDispose!)
             {
                 assembly.Dispose();
             }
         }
+    }
 
-        private bool IsTracerAssembly(AssemblyNameReference name, AssemblyName tracerAssemblyName)
-            => name.Name == tracerAssemblyName.Name && name.Version == tracerAssemblyName.Version;
+    private bool IsTracerAssembly(AssemblyNameReference name, AssemblyName tracerAssemblyName)
+        => name.Name == tracerAssemblyName.Name && name.Version == tracerAssemblyName.Version;
 
-        private string GetMscorlibBasePath(Version version)
-        {
-            string? GetSubFolderForVersion()
-                => version.Major switch
-                {
-                    1 when version.MajorRevision == 3300 => "v1.0.3705",
-                    1 => "v1.1.4322",
-                    2 => "v2.0.50727",
-                    4 => "v4.0.30319",
-                    _ => throw new NotSupportedException("Version not supported: " + version),
-                };
-
-            var rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Microsoft.NET");
-            string[] frameworkPaths =
-            [
-                Path.Combine(rootPath, "Framework"),
-                Path.Combine(rootPath, "Framework64")
-            ];
-
-            var folder = GetSubFolderForVersion();
-
-            if (folder != null)
+    private string GetMscorlibBasePath(Version version)
+    {
+        string? GetSubFolderForVersion()
+            => version.Major switch
             {
-                foreach (var path in frameworkPaths)
+                1 when version.MajorRevision == 3300 => "v1.0.3705",
+                1 => "v1.1.4322",
+                2 => "v2.0.50727",
+                4 => "v4.0.30319",
+                _ => throw new NotSupportedException("Version not supported: " + version),
+            };
+
+        var rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Microsoft.NET");
+        string[] frameworkPaths =
+        [
+            Path.Combine(rootPath, "Framework"),
+            Path.Combine(rootPath, "Framework64")
+        ];
+
+        var folder = GetSubFolderForVersion();
+
+        if (folder != null)
+        {
+            foreach (var path in frameworkPaths)
+            {
+                var basePath = Path.Combine(path, folder);
+                if (Directory.Exists(basePath))
                 {
-                    var basePath = Path.Combine(path, folder);
-                    if (Directory.Exists(basePath))
-                    {
-                        return basePath;
-                    }
+                    return basePath;
                 }
             }
-
-            throw new NotSupportedException("Version not supported: " + version);
         }
 
-        private void ThrowIfDisposed()
+        throw new NotSupportedException("Version not supported: " + version);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
         {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(CoverageAssemblyResolver));
-            }
+            throw new ObjectDisposedException(nameof(CoverageAssemblyResolver));
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -181,10 +181,9 @@ namespace Datadog.Trace.Coverage.Collector
                     {
                         if (File.Exists(Path.Combine(path, fileWithoutExtension + ".pdb")) || File.Exists(Path.Combine(path, fileWithoutExtension + ".PDB")))
                         {
+                            const int maxAttempts = 3;
                             List<Exception>? exceptions = null;
-                            var remain = 3;
-                        Retry:
-                            if (--remain > 0)
+                            for (var attempt = 1; attempt <= maxAttempts; attempt++)
                             {
                                 try
                                 {
@@ -198,17 +197,24 @@ namespace Datadog.Trace.Coverage.Collector
                                             processedDirectories.Add(Path.GetDirectoryName(file) ?? string.Empty);
                                         }
                                     }
+
+                                    exceptions = null;
+                                    break;
                                 }
                                 catch (PdbNotFoundException)
                                 {
                                     // If the PDB file was not found, we skip the assembly without throwing error.
                                     _logger?.Debug($"{nameof(PdbNotFoundException)} processing file: {file}");
+                                    exceptions = null;
+                                    break;
                                 }
                                 catch (BadImageFormatException)
                                 {
                                     // If the Assembly has not the correct format (eg. native dll / exe)
                                     // We skip processing the assembly.
                                     _logger?.Debug($"{nameof(BadImageFormatException)} processing file: {file}");
+                                    exceptions = null;
+                                    break;
                                 }
                                 catch (IOException ioException)
                                 {
@@ -217,12 +223,16 @@ namespace Datadog.Trace.Coverage.Collector
                                     // it is being used by another process`
                                     exceptions ??= new List<Exception>();
                                     exceptions.Add(ioException);
-                                    Thread.Sleep(1000);
-                                    goto Retry;
+                                    if (attempt < maxAttempts)
+                                    {
+                                        Thread.Sleep(1000);
+                                    }
                                 }
                                 catch (Exception ex)
                                 {
                                     _logger?.Error(ex);
+                                    exceptions = null;
+                                    break;
                                 }
                             }
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -160,6 +160,51 @@ public class CoverageResolverTests
     }
 
     /// <summary>
+    /// Verifies that target reads load the assembly into memory and release the path lock before processing continues.
+    /// </summary>
+    [Fact]
+    public void ReadTargetAssemblyDoesNotHoldPathLockAfterRead()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+        using var resolver = CreateResolver(directory.Path);
+
+        using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
+
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath, TimeSpan.FromMilliseconds(20));
+        assembly.Name.Name.Should().Be("CoverageRewriterAssembly");
+    }
+
+    /// <summary>
+    /// Verifies that target writes still exclude concurrent dependency reads of the same assembly path.
+    /// </summary>
+    [Fact]
+    public async Task WriteTargetAssemblyWaitsForDependencyReadLock()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+        using var resolver = CreateResolver(directory.Path);
+        using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
+        var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromSeconds(1));
+
+        try
+        {
+            var writeTask = Task.Run(() => AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null));
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(100));
+            writeTask.IsCompleted.Should().BeFalse();
+            readLock.Dispose();
+            var completedTask = await Task.WhenAny(writeTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            completedTask.Should().BeSameAs(writeTask);
+            await writeTask;
+        }
+        finally
+        {
+            readLock.Dispose();
+        }
+    }
+
+    /// <summary>
     /// Verifies that multiple dependency reads for the same path can proceed together.
     /// </summary>
     [Fact]
@@ -218,6 +263,7 @@ public class CoverageResolverTests
     {
         var targetPath = Path.Combine(directory, fileName);
         File.Copy("CoverageRewriterAssembly.dll", targetPath, overwrite: true);
+        File.Copy("CoverageRewriterAssembly.pdb", Path.ChangeExtension(targetPath, ".pdb"), overwrite: true);
         return targetPath;
     }
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -1,0 +1,283 @@
+// <copyright file="CoverageResolverTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Coverage.Collector;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Mono.Cecil;
+using Xunit;
+
+namespace Datadog.Trace.Tools.Runner.Tests;
+
+public class CoverageResolverTests
+{
+    /// <summary>
+    /// Verifies that sibling assembly resolution still finds assemblies in the target output directory.
+    /// </summary>
+    [Fact]
+    public void ResolveCopiedSiblingAssemblySucceeds()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var dependencyPath = CopyCoverageFixture(directory.Path);
+        using var resolver = CreateResolver(directory.Path);
+        var assemblyName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(dependencyPath).FullName);
+
+        var assembly = resolver.Resolve(assemblyName);
+
+        assembly.Name.Name.Should().Be("CoverageRewriterAssembly");
+    }
+
+    /// <summary>
+    /// Verifies that repeated resolutions reuse the same owned Cecil assembly instead of opening the DLL again.
+    /// </summary>
+    [Fact]
+    public void ResolveCopiedSiblingAssemblyUsesCache()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var dependencyPath = CopyCoverageFixture(directory.Path);
+        using var resolver = CreateResolver(directory.Path);
+        var assemblyName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(dependencyPath).FullName);
+
+        var first = resolver.Resolve(assemblyName);
+        var second = resolver.Resolve(assemblyName);
+
+        second.Should().BeSameAs(first);
+    }
+
+    /// <summary>
+    /// Verifies the Windows failure mode from issue 8592: resolved dependency handles are released.
+    /// </summary>
+    [SkippableFact]
+    public void DisposingResolverReleasesCopiedSiblingAssemblyOnWindows()
+    {
+        SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
+
+        using var directory = TemporaryDirectory.Create();
+        var dependencyPath = CopyCoverageFixture(directory.Path);
+        var resolver = CreateResolver(directory.Path);
+        var assemblyName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(dependencyPath).FullName);
+
+        _ = resolver.Resolve(assemblyName);
+        resolver.Dispose();
+
+        AssertCanOpenExclusively(dependencyPath);
+    }
+
+    /// <summary>
+    /// Verifies that changing the copied tracer location invalidates any earlier cached tracer assembly.
+    /// </summary>
+    [Fact]
+    public void SetTracerAssemblyLocationInvalidatesCachedTracerAssembly()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var firstTracerPath = CopyTracerAssembly(directory.Path, "first");
+        var secondTracerPath = CopyTracerAssembly(directory.Path, "second");
+        using var resolver = CreateResolver(directory.Path);
+        var tracerName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(firstTracerPath).FullName);
+
+        resolver.SetTracerAssemblyLocation(firstTracerPath);
+        var first = resolver.Resolve(tracerName);
+        resolver.SetTracerAssemblyLocation(secondTracerPath);
+        var second = resolver.Resolve(tracerName);
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    /// <summary>
+    /// Verifies that tracer cache invalidation releases the old tracer assembly file on Windows.
+    /// </summary>
+    [SkippableFact]
+    public void SetTracerAssemblyLocationReleasesOldTracerCopyOnWindows()
+    {
+        SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
+
+        using var directory = TemporaryDirectory.Create();
+        var firstTracerPath = CopyTracerAssembly(directory.Path, "first");
+        var secondTracerPath = CopyTracerAssembly(directory.Path, "second");
+        using var resolver = CreateResolver(directory.Path);
+        var tracerName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(firstTracerPath).FullName);
+
+        resolver.SetTracerAssemblyLocation(firstTracerPath);
+        _ = resolver.Resolve(tracerName);
+        resolver.SetTracerAssemblyLocation(secondTracerPath);
+
+        AssertCanOpenExclusively(firstTracerPath);
+    }
+
+    /// <summary>
+    /// Verifies that an active target rewrite lock blocks dependency reads for the same path.
+    /// </summary>
+    [Fact]
+    public void TargetWriteLockBlocksDependencyReadLockForSamePath()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath, TimeSpan.FromSeconds(1));
+
+        var exception = CaptureExceptionFromThread(() =>
+        {
+            using var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromMilliseconds(20));
+        });
+
+        exception.Should().BeOfType<IOException>();
+    }
+
+    /// <summary>
+    /// Verifies that resolver dependency reads wait behind an active rewrite for the same assembly path.
+    /// </summary>
+    [Fact]
+    public async Task ResolverWaitsForTargetWriteLockBeforeReadingDependency()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var dependencyPath = CopyCoverageFixture(directory.Path);
+        using var resolver = CreateResolver(directory.Path);
+        var assemblyName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(dependencyPath).FullName);
+        var writeLock = CoverageAssemblyPathLock.EnterWrite(dependencyPath, TimeSpan.FromSeconds(1));
+
+        try
+        {
+            var resolveTask = Task.Run(() => resolver.Resolve(assemblyName));
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(100));
+            resolveTask.IsCompleted.Should().BeFalse();
+            writeLock.Dispose();
+            var completedTask = await Task.WhenAny(resolveTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            completedTask.Should().BeSameAs(resolveTask);
+            var assembly = await resolveTask;
+            assembly.Name.Name.Should().Be("CoverageRewriterAssembly");
+        }
+        finally
+        {
+            writeLock.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that multiple dependency reads for the same path can proceed together.
+    /// </summary>
+    [Fact]
+    public void DependencyReadLocksAllowConcurrentReads()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+
+        using var firstReadLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromSeconds(1));
+        using var secondReadLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
+    /// Verifies that unrelated assembly paths do not serialize each other.
+    /// </summary>
+    [Fact]
+    public void DifferentPathLocksDoNotBlockEachOther()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var firstPath = CopyCoverageFixture(directory.Path, "first.dll");
+        var secondPath = CopyCoverageFixture(directory.Path, "second.dll");
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(firstPath, TimeSpan.FromSeconds(1));
+
+        using var readLock = CoverageAssemblyPathLock.EnterRead(secondPath, TimeSpan.FromMilliseconds(20));
+    }
+
+    /// <summary>
+    /// Verifies that Windows path casing aliases use the same lock registry entry.
+    /// </summary>
+    [SkippableFact]
+    public void WindowsPathCasingUsesSameLock()
+    {
+        SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
+
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath.ToUpperInvariant(), TimeSpan.FromSeconds(1));
+
+        var exception = CaptureExceptionFromThread(() =>
+        {
+            using var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath.ToLowerInvariant(), TimeSpan.FromMilliseconds(20));
+        });
+
+        exception.Should().BeOfType<IOException>();
+    }
+
+    private static CoverageAssemblyResolver CreateResolver(string directory)
+    {
+        var targetPath = Path.Combine(directory, "Target.dll");
+        var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath);
+        resolver.AddSearchDirectory(directory);
+        return resolver;
+    }
+
+    private static string CopyCoverageFixture(string directory, string fileName = "CoverageRewriterAssembly.dll")
+    {
+        var targetPath = Path.Combine(directory, fileName);
+        File.Copy("CoverageRewriterAssembly.dll", targetPath, overwrite: true);
+        return targetPath;
+    }
+
+    private static Exception CaptureExceptionFromThread(ThreadStart action)
+    {
+        Exception exception = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+        });
+
+        thread.Start();
+        thread.Join(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        return exception;
+    }
+
+    private static string CopyTracerAssembly(string directory, string subDirectory)
+    {
+        var tracerDirectory = Path.Combine(directory, subDirectory);
+        Directory.CreateDirectory(tracerDirectory);
+        var tracerPath = typeof(Datadog.Trace.Tracer).Assembly.Location;
+        var targetPath = Path.Combine(tracerDirectory, Path.GetFileName(tracerPath));
+        File.Copy(tracerPath, targetPath, overwrite: true);
+        return targetPath;
+    }
+
+    private static void AssertCanOpenExclusively(string path)
+    {
+        using var stream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private TemporaryDirectory(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TemporaryDirectory Create()
+        {
+            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+            Directory.CreateDirectory(path);
+            return new TemporaryDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -7,7 +7,6 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using Datadog.Trace.Coverage.Collector;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -18,6 +17,9 @@ namespace Datadog.Trace.Tools.Runner.Tests;
 
 public class CoverageResolverTests
 {
+    private static readonly TimeSpan LockAcquisitionTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ExpectedContentionTimeout = TimeSpan.FromMilliseconds(200);
+
     /// <summary>
     /// Verifies that sibling assembly resolution still finds assemblies in the target output directory.
     /// </summary>
@@ -55,10 +57,8 @@ public class CoverageResolverTests
     /// Verifies the Windows failure mode from issue 8592: resolved dependency handles are released.
     /// </summary>
     [SkippableFact]
-    public void DisposingResolverReleasesCopiedSiblingAssemblyOnWindows()
+    public void DisposingResolverReleasesCopiedSiblingAssembly()
     {
-        SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
-
         using var directory = TemporaryDirectory.Create();
         var dependencyPath = CopyCoverageFixture(directory.Path);
         var resolver = CreateResolver(directory.Path);
@@ -71,7 +71,7 @@ public class CoverageResolverTests
     }
 
     /// <summary>
-    /// Verifies that changing the copied tracer location invalidates any earlier cached tracer assembly.
+    /// Verifies that changing the copied tracer location invalidates and releases the previous cached tracer assembly.
     /// </summary>
     [Fact]
     public void SetTracerAssemblyLocationInvalidatesCachedTracerAssembly()
@@ -88,27 +88,29 @@ public class CoverageResolverTests
         var second = resolver.Resolve(tracerName);
 
         second.Should().NotBeSameAs(first);
+        if (EnvironmentTools.IsWindows())
+        {
+            AssertCanOpenExclusively(firstTracerPath);
+        }
     }
 
     /// <summary>
-    /// Verifies that tracer cache invalidation releases the old tracer assembly file on Windows.
+    /// Verifies that setting the same copied tracer location keeps the existing cached tracer assembly.
     /// </summary>
-    [SkippableFact]
-    public void SetTracerAssemblyLocationReleasesOldTracerCopyOnWindows()
+    [Fact]
+    public void SetTracerAssemblyLocationKeepsCachedTracerAssemblyForSamePath()
     {
-        SkipOn.AllExcept(SkipOn.PlatformValue.Windows);
-
         using var directory = TemporaryDirectory.Create();
-        var firstTracerPath = CopyTracerAssembly(directory.Path, "first");
-        var secondTracerPath = CopyTracerAssembly(directory.Path, "second");
+        var tracerPath = CopyTracerAssembly(directory.Path, "tracer");
         using var resolver = CreateResolver(directory.Path);
-        var tracerName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(firstTracerPath).FullName);
+        var tracerName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(tracerPath).FullName);
 
-        resolver.SetTracerAssemblyLocation(firstTracerPath);
-        _ = resolver.Resolve(tracerName);
-        resolver.SetTracerAssemblyLocation(secondTracerPath);
+        resolver.SetTracerAssemblyLocation(tracerPath);
+        var first = resolver.Resolve(tracerName);
+        resolver.SetTracerAssemblyLocation(tracerPath);
+        var second = resolver.Resolve(tracerName);
 
-        AssertCanOpenExclusively(firstTracerPath);
+        second.Should().BeSameAs(first);
     }
 
     /// <summary>
@@ -119,11 +121,11 @@ public class CoverageResolverTests
     {
         using var directory = TemporaryDirectory.Create();
         var assemblyPath = CopyCoverageFixture(directory.Path);
-        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath, TimeSpan.FromSeconds(1));
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath, LockAcquisitionTimeout);
 
         var exception = CaptureExceptionFromThread(() =>
         {
-            using var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromMilliseconds(20));
+            using var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, ExpectedContentionTimeout);
         });
 
         exception.Should().BeOfType<IOException>();
@@ -133,30 +135,17 @@ public class CoverageResolverTests
     /// Verifies that resolver dependency reads wait behind an active rewrite for the same assembly path.
     /// </summary>
     [Fact]
-    public async Task ResolverWaitsForTargetWriteLockBeforeReadingDependency()
+    public void ResolverCannotReadDependencyWhileTargetWriteLockIsHeld()
     {
         using var directory = TemporaryDirectory.Create();
         var dependencyPath = CopyCoverageFixture(directory.Path);
         using var resolver = CreateResolver(directory.Path);
         var assemblyName = AssemblyNameReference.Parse(AssemblyName.GetAssemblyName(dependencyPath).FullName);
-        var writeLock = CoverageAssemblyPathLock.EnterWrite(dependencyPath, TimeSpan.FromSeconds(1));
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(dependencyPath, LockAcquisitionTimeout);
 
-        try
-        {
-            var resolveTask = Task.Run(() => resolver.Resolve(assemblyName));
+        var exception = CaptureExceptionFromThread(() => resolver.Resolve(assemblyName));
 
-            Thread.Sleep(TimeSpan.FromMilliseconds(100));
-            resolveTask.IsCompleted.Should().BeFalse();
-            writeLock.Dispose();
-            var completedTask = await Task.WhenAny(resolveTask, Task.Delay(TimeSpan.FromSeconds(5)));
-            completedTask.Should().BeSameAs(resolveTask);
-            var assembly = await resolveTask;
-            assembly.Name.Name.Should().Be("CoverageRewriterAssembly");
-        }
-        finally
-        {
-            writeLock.Dispose();
-        }
+        exception.Should().BeOfType<IOException>();
     }
 
     /// <summary>
@@ -171,7 +160,7 @@ public class CoverageResolverTests
 
         using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
 
-        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath, TimeSpan.FromMilliseconds(20));
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath, LockAcquisitionTimeout);
         assembly.Name.Name.Should().Be("CoverageRewriterAssembly");
     }
 
@@ -179,29 +168,17 @@ public class CoverageResolverTests
     /// Verifies that target writes still exclude concurrent dependency reads of the same assembly path.
     /// </summary>
     [Fact]
-    public async Task WriteTargetAssemblyWaitsForDependencyReadLock()
+    public void WriteTargetAssemblyCannotWriteWhileDependencyReadLockIsHeld()
     {
         using var directory = TemporaryDirectory.Create();
         var assemblyPath = CopyCoverageFixture(directory.Path);
         using var resolver = CreateResolver(directory.Path);
         using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
-        var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromSeconds(1));
+        using var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, LockAcquisitionTimeout);
 
-        try
-        {
-            var writeTask = Task.Run(() => AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null));
+        var exception = CaptureExceptionFromThread(() => AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null));
 
-            Thread.Sleep(TimeSpan.FromMilliseconds(100));
-            writeTask.IsCompleted.Should().BeFalse();
-            readLock.Dispose();
-            var completedTask = await Task.WhenAny(writeTask, Task.Delay(TimeSpan.FromSeconds(5)));
-            completedTask.Should().BeSameAs(writeTask);
-            await writeTask;
-        }
-        finally
-        {
-            readLock.Dispose();
-        }
+        exception.Should().BeOfType<IOException>();
     }
 
     /// <summary>
@@ -213,8 +190,8 @@ public class CoverageResolverTests
         using var directory = TemporaryDirectory.Create();
         var assemblyPath = CopyCoverageFixture(directory.Path);
 
-        using var firstReadLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromSeconds(1));
-        using var secondReadLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, TimeSpan.FromSeconds(1));
+        using var firstReadLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, LockAcquisitionTimeout);
+        using var secondReadLock = CoverageAssemblyPathLock.EnterRead(assemblyPath, LockAcquisitionTimeout);
     }
 
     /// <summary>
@@ -226,9 +203,9 @@ public class CoverageResolverTests
         using var directory = TemporaryDirectory.Create();
         var firstPath = CopyCoverageFixture(directory.Path, "first.dll");
         var secondPath = CopyCoverageFixture(directory.Path, "second.dll");
-        using var writeLock = CoverageAssemblyPathLock.EnterWrite(firstPath, TimeSpan.FromSeconds(1));
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(firstPath, LockAcquisitionTimeout);
 
-        using var readLock = CoverageAssemblyPathLock.EnterRead(secondPath, TimeSpan.FromMilliseconds(20));
+        using var readLock = CoverageAssemblyPathLock.EnterRead(secondPath, LockAcquisitionTimeout);
     }
 
     /// <summary>
@@ -241,11 +218,11 @@ public class CoverageResolverTests
 
         using var directory = TemporaryDirectory.Create();
         var assemblyPath = CopyCoverageFixture(directory.Path);
-        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath.ToUpperInvariant(), TimeSpan.FromSeconds(1));
+        using var writeLock = CoverageAssemblyPathLock.EnterWrite(assemblyPath.ToUpperInvariant(), LockAcquisitionTimeout);
 
         var exception = CaptureExceptionFromThread(() =>
         {
-            using var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath.ToLowerInvariant(), TimeSpan.FromMilliseconds(20));
+            using var readLock = CoverageAssemblyPathLock.EnterRead(assemblyPath.ToLowerInvariant(), ExpectedContentionTimeout);
         });
 
         exception.Should().BeOfType<IOException>();
@@ -283,7 +260,7 @@ public class CoverageResolverTests
         });
 
         thread.Start();
-        thread.Join(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        thread.Join(LockAcquisitionTimeout).Should().BeTrue();
         return exception;
     }
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.Tools.Runner\Datadog.Trace.Tools.Runner.csproj" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

- Replace the coverage collector's nested custom resolver with an owned resolver that caches and disposes Cecil assemblies.
- Add per-assembly path read/write locking so dependency reads cannot race with target assembly writes.
- Read target and resolved dependency assemblies in memory so Cecil does not keep output-folder DLL handles open after the read phase.
- Prevent Cecil fallback probing from bypassing the locked resolver path for output-folder assemblies.
- Add focused resolver and locking tests for the issue #8592 failure mode.

## Reason for change

When the coverage collector processes test assemblies in parallel, one assembly can resolve a sibling DLL as a dependency while another worker tries to rewrite that same DLL. Cecil can keep those resolved dependency handles open inside the same `dotnet` process, so the rewrite worker repeatedly fails to open the DLL for read/write access.

Fixes #8592.

## Implementation details

- `AssemblyProcessor` reads the target assembly into memory under a short per-path read lock, then releases that lock before metadata processing and dependency resolution continue.
- `AssemblyProcessor` acquires the per-path write lock only while writing the rewritten target assembly back to disk.
- `CoverageAssemblyResolver` reads output-folder dependencies through a per-path read lock, uses `InMemory = true`, caches owned `AssemblyDefinition` instances, and disposes them with the resolver.
- The resolver prefers the target assembly directory, invalidates cached copied tracer assemblies when the copied tracer path changes, and removes search directories before using Cecil's platform fallback so output-folder reads cannot bypass the lock.
- `CoverageCollector` keeps bounded IOException retry handling and avoids logging stale IO failures after later success or skip paths.

## Test coverage

- `dotnet build tracer/src/Datadog.Trace.Coverage.collector/Datadog.Trace.Coverage.collector.csproj`
- `dotnet test tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj -f net10.0 --filter "FullyQualifiedName~CoverageResolverTests"`
- `DOTNET_ROOT=/usr/local/share/dotnet/x64 /usr/local/share/dotnet/x64/dotnet test tracer/test/Datadog.Trace.Tools.Runner.Tests/Datadog.Trace.Tools.Runner.Tests.csproj -f net8.0 --filter "FullyQualifiedName~CoverageResolverTests"`
- `git diff --check master...HEAD`

## Other details

The Windows-only exclusive-handle assertions are included in `CoverageResolverTests` and are skipped on non-Windows platforms.
