### PR TITLE
[Build] Skip musl tarball assets on arm64

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1199,9 +1199,13 @@ partial class Build
 
                 if (isTar)
                 {
-                    var includeMuslArtifacts = !IsAlpine;
+                    // On x64 we package the linux-musl-x64 target as well, to simplify onboarding
+                    // (see comment in PrepareMonitoringHomeLinuxForPackaging). The documented
+                    // intent is "we don't need this on arm64 (currently)" -- and on arm64 (notably
+                    // local macOS arm64 builds) the matching musl monitoring-home directory isn't
+                    // produced, so attempting to package it makes the hard-link step fail.
+                    var includeMuslArtifacts = !IsAlpine && !IsArm64;
 
-                    // On x64, for tar only, we package the linux-musl-x64 target as well, to simplify onboarding
                     PrepareMonitoringHomeLinuxForPackaging(assetsDirectory, arch, ext, muslArch, includeMuslArtifacts);
 
                     // technically we don't need these scripts, but we've been including them in the tar, so keep doing that


### PR DESCRIPTION
## Summary of changes

`PrepareMonitoringHomeLinuxForPackaging` already documents the intent as *"we don't need this on arm64 (currently)"*, but the surrounding tar branch unconditionally set `includeMuslArtifacts = !IsAlpine`. Add `!IsArm64` so the documented intent is also the actual behaviour.

```diff
- var includeMuslArtifacts = !IsAlpine;
+ var includeMuslArtifacts = !IsAlpine && !IsArm64;
```

## Reason for change

On any arm64 build where the matching `linux-musl-arm64` monitoring-home directory isn't produced, the hard-link step inside `PrepareMonitoringHomeLinuxForPackaging` fails — it tries to hard-link `assetsDirectory/arm64/Datadog.Trace.ClrProfiler.Native.so` into `assetsDirectory/linux-musl-arm64/`, but the destination directory doesn't exist because `CopyDirectoryRecursively(MonitoringHomeDirectory, …)` had nothing to copy.

The concrete trigger: running the system-tests local-build harness on macOS arm64 (Apple Silicon). That flow runs `BuildTracerHome BuildProfilerHome PackageTracerHome` in a Linux container, which only produces `linux-arm64`. With the old guard, packaging crashed; manually `mkdir -p`'ing the musl folder produced a degenerate tarball that contained the wrapper hard-links but no actual musl tracer files.

## Implementation details

- Reuse the existing `IsArm64` helper (`bool IsArm64 => RuntimeInformation.ProcessArchitecture == Architecture.Arm64;` at the top of the file).
- Non-Alpine x64 builds still hard-require the musl-x64 monitoring home — no silent payload drop in release packaging for the documented x64 musl path.
- The deb/rpm branch already passes `includeMuslArtifacts: false`, so it's unaffected.

## Test coverage

- Local: built on macOS arm64 via the system-tests `prepare-local-build.sh dotnet` flow, ran `TEST_LIBRARY=dotnet ./run.sh PARAMETRIC -k "test_start_span"` — passes (with this fix, no more `mkdir -p shared/bin/monitoring-home/linux-musl-arm64` workaround needed).
- No new automated coverage — this is an arch-specific guard in a build script. Existing Linux x64 CI exercises the unchanged x64 musl path.

## Other details

Found while doing a fresh-laptop verification across all nine dd-trace tracers. A separate PR (DataDog/system-tests #6987) drops a similar amd64 pin from the Ruby parametric Dockerfile, and another (DataDog/claude-marketplace #2149) fixes related issues in the local-build helper script that surfaces these gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)