### PR TITLE
feat: update DSM SNS to use Topic ARN

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
 {
@@ -48,7 +49,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
         // `detail` is a string, so we have to manually modify it using a StringBuilder.
         private static void InjectHeadersIntoDetail(Tracer tracer, IPutEventsRequestEntry entry, Scope? scope, PropagationContext context)
         {
-            var pathwayContext = SetDataStreamsCheckpoint(tracer, scope, entry.DetailType, entry.EventBusName);
             var detail = entry.Detail?.Trim() ?? "{}";
             if (!detail.EndsWith("}"))
             {
@@ -56,6 +56,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
                 Log.Debug("Unable to parse detail string. Not injecting trace context.");
                 return;
             }
+
+            var payloadSizeBytes = GetPayloadSizeBytes(detail);
+            var pathwayContext = SetDataStreamsCheckpoint(tracer, scope, entry.DetailType, entry.EventBusName, payloadSizeBytes);
 
             var detailBuilder = Util.StringBuilderCache.Acquire().Append(detail);
             detailBuilder.Remove(detail.Length - 1, 1); // Remove last bracket
@@ -106,7 +109,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
             return Util.StringBuilderCache.GetStringAndRelease(jsonBuilder);
         }
 
-        private static PathwayContext? SetDataStreamsCheckpoint(Tracer tracer, Scope? scope, string? detailType, string? eventBusName)
+        [TestingAndPrivateOnly]
+        internal static int GetPayloadSizeBytes(string detail)
+        {
+            return Encoding.UTF8.GetByteCount(detail);
+        }
+
+        private static PathwayContext? SetDataStreamsCheckpoint(Tracer tracer, Scope? scope, string? detailType, string? eventBusName, long payloadSizeBytes)
         {
             if (scope is null || StringUtil.IsNullOrEmpty(eventBusName))
             {
@@ -123,7 +132,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
                 new EventBridgeEdgeTagCacheKey(detailType ?? string.Empty, eventBusName!),
                 static k => ["direction:out", $"topic:{k.DetailType}", $"type:eventbridge:{k.EventBusName}"]);
 
-            scope.Span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Produce, edgeTags, payloadSizeBytes: 0, timeInQueueMs: 0);
+            scope.Span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Produce, edgeTags, payloadSizeBytes, timeInQueueMs: 0);
             return scope.Span.Context.PathwayContext;
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/ContextPropagation.cs
@@ -7,7 +7,9 @@
 
 using System;
 using System.Text;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
 
@@ -23,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
         private const int MaxSizeBytes = 256 * 1024; // 256 KB
 
         // Loops through all entries of the EventBridge event and tries to inject Datadog context into each.
-        public static void InjectContext<TPutEventsRequest>(Tracer tracer, TPutEventsRequest request, PropagationContext context)
+        public static void InjectContext<TPutEventsRequest>(Tracer tracer, TPutEventsRequest request, Scope? scope, PropagationContext context)
             where TPutEventsRequest : IPutEventsRequest, IDuckType
         {
             var entries = request.Entries.Value;
@@ -37,15 +39,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
                 var duckEntry = entry.DuckCast<IPutEventsRequestEntry>();
                 if (duckEntry != null)
                 {
-                    InjectHeadersIntoDetail(tracer, duckEntry, context);
+                    InjectHeadersIntoDetail(tracer, duckEntry, scope, context);
                 }
             }
         }
 
         // Tries to add Datadog trace context under the `_datadog` key at the top level of the `detail` field.
         // `detail` is a string, so we have to manually modify it using a StringBuilder.
-        private static void InjectHeadersIntoDetail(Tracer tracer, IPutEventsRequestEntry entry, PropagationContext context)
+        private static void InjectHeadersIntoDetail(Tracer tracer, IPutEventsRequestEntry entry, Scope? scope, PropagationContext context)
         {
+            var pathwayContext = SetDataStreamsCheckpoint(tracer, scope, entry.DetailType, entry.EventBusName);
             var detail = entry.Detail?.Trim() ?? "{}";
             if (!detail.EndsWith("}"))
             {
@@ -61,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
                 detailBuilder.Append(','); // Add comma if the original detail is not empty
             }
 
-            var traceContext = BuildContextJson(tracer, context, entry.EventBusName);
+            var traceContext = BuildContextJson(tracer, context, entry.EventBusName, pathwayContext);
             detailBuilder.Append($"\"{DatadogKey}\":{traceContext}").Append('}');
 
             // Check new detail size
@@ -77,13 +80,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
         }
 
         // Builds a JSON string containing Datadog trace context
-        private static string BuildContextJson(Tracer tracer, PropagationContext context, string? eventBusName)
+        private static string BuildContextJson(Tracer tracer, PropagationContext context, string? eventBusName, PathwayContext? pathwayContext)
         {
             // Inject trace context
             var jsonBuilder = Util.StringBuilderCache.Acquire();
             jsonBuilder.Append('{');
 
             tracer.TracerManager.SpanContextPropagator.Inject(context, jsonBuilder, new StringBuilderCarrierSetter());
+            if (pathwayContext is not null)
+            {
+                tracer.TracerManager.DataStreamsManager.InjectPathwayContextAsBase64String(
+                    pathwayContext,
+                    new CarrierWithDelegate<StringBuilder>(jsonBuilder, setter: static (carrier, key, value) => AppendJsonProperty(carrier, key, value)));
+            }
 
             // Inject start time and bus name
             var startTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -97,11 +106,37 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
             return Util.StringBuilderCache.GetStringAndRelease(jsonBuilder);
         }
 
+        private static PathwayContext? SetDataStreamsCheckpoint(Tracer tracer, Scope? scope, string? detailType, string? eventBusName)
+        {
+            if (scope is null || StringUtil.IsNullOrEmpty(eventBusName))
+            {
+                return null;
+            }
+
+            var dataStreamsManager = tracer.TracerManager.DataStreamsManager;
+            if (!dataStreamsManager.IsEnabled)
+            {
+                return null;
+            }
+
+            var edgeTags = dataStreamsManager.GetOrCreateEdgeTags(
+                new EventBridgeEdgeTagCacheKey(detailType ?? string.Empty, eventBusName!),
+                static k => ["direction:out", $"topic:{k.DetailType}", $"type:eventbridge:{k.EventBusName}"]);
+
+            scope.Span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Produce, edgeTags, payloadSizeBytes: 0, timeInQueueMs: 0);
+            return scope.Span.Context.PathwayContext;
+        }
+
+        private static void AppendJsonProperty(StringBuilder carrier, string key, string value)
+        {
+            carrier.AppendFormat("\"{0}\":\"{1}\",", key, value);
+        }
+
         private struct StringBuilderCarrierSetter : ICarrierSetter<StringBuilder>
         {
             public void Set(StringBuilder carrier, string key, string value)
             {
-                carrier.AppendFormat("\"{0}\":\"{1}\",", key, value);
+                AppendJsonProperty(carrier, key, value);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/EventBridgeEdgeTagCacheKey.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/EventBridgeEdgeTagCacheKey.cs
@@ -1,0 +1,14 @@
+// <copyright file="EventBridgeEdgeTagCacheKey.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge;
+
+/// <summary>
+/// Value-type cache key for EventBridge produce edge tags. Using a named struct avoids boxing and
+/// is compatible with all supported target frameworks.
+/// </summary>
+internal readonly record struct EventBridgeEdgeTagCacheKey(string DetailType, string EventBusName);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/IPutEventsRequestEntry.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/IPutEventsRequestEntry.cs
@@ -15,6 +15,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge
     {
         string? Detail { get; set; }
 
+        string? DetailType { get; }
+
         string? EventBusName { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsAsyncIntegration.cs
@@ -66,7 +66,7 @@ public sealed class PutEventsAsyncIntegration
         if (scope?.Span.Context is { } context)
         {
             var propagationContext = new PropagationContext(context, Baggage.Current);
-            ContextPropagation.InjectContext(tracer, request, propagationContext);
+            ContextPropagation.InjectContext(tracer, request, scope, propagationContext);
         }
 
         return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/EventBridge/PutEventsIntegration.cs
@@ -63,7 +63,7 @@ public sealed class PutEventsIntegration
         if (scope?.Span.Context is { } context)
         {
             var propagationContext = new PropagationContext(context, Baggage.Current);
-            ContextPropagation.InjectContext(tracer, request, propagationContext);
+            ContextPropagation.InjectContext(tracer, request, scope, propagationContext);
         }
 
         return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/AwsSnsHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/AwsSnsHandlerCommon.cs
@@ -27,20 +27,21 @@ internal sealed class AwsSnsHandlerCommon
         var tracer = Tracer.Instance;
         var scope = AwsSnsCommon.CreateScope(tracer, sendType.OperationName, SpanKinds.Producer, out var tags);
 
-        var topicName = AwsSnsCommon.GetTopicName(requestProxy.TopicArn);
-        if (tags is not null && requestProxy.TopicArn is not null)
+        var topicArn = requestProxy.TopicArn;
+        var topicName = AwsSnsCommon.GetTopicName(topicArn);
+        if (tags is not null && topicArn is not null)
         {
-            tags.TopicArn = requestProxy.TopicArn;
+            tags.TopicArn = topicArn;
             tags.TopicName = topicName;
         }
 
-        if (scope?.Span.Context is { } context && !StringUtil.IsNullOrEmpty(topicName))
+        if (scope?.Span.Context is { } context && !StringUtil.IsNullOrEmpty(topicArn))
         {
             var dataStreamsManager = tracer.TracerManager.DataStreamsManager;
             var edgeTags = dataStreamsManager is { IsEnabled: true }
                                ? dataStreamsManager.GetOrCreateEdgeTags(
-                                   new SnsEdgeTagCacheKey(topicName),
-                                   static k => ["direction:out", $"topic:{k.TopicName}", "type:sns"])
+                                   new SnsEdgeTagCacheKey(topicArn),
+                                   static k => ["direction:out", $"topic:{k.TopicArn}", "type:sns"])
                                : [];
 
             if (sendType == SendType.SingleMessage)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/SnsEdgeTagCacheKey.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/SnsEdgeTagCacheKey.cs
@@ -11,4 +11,4 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS;
 /// Value-type cache key for SNS produce edge tags. Using a named struct avoids boxing and
 /// is compatible with all supported target frameworks.
 /// </summary>
-internal readonly record struct SnsEdgeTagCacheKey(string TopicName);
+internal readonly record struct SnsEdgeTagCacheKey(string TopicArn);

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
@@ -286,6 +286,14 @@ public class ContextPropagationTests
     }
 
     [Fact]
+    public void GetPayloadSizeBytes_UsesUtf8Encoding()
+    {
+        const string detail = "{\"name\":\"Jørdan\",\"emoji\":\"🙂\"}";
+
+        ContextPropagation.GetPayloadSizeBytes(detail).Should().Be(Encoding.UTF8.GetByteCount(detail));
+    }
+
+    [Fact]
     public async Task InjectTracingContext_WithDsmEnabled_AddsPathwayContext()
     {
         var request = GeneratePutEventsRequest([
@@ -325,6 +333,36 @@ public class ContextPropagationTests
             encodedPathway.Should().NotBeNullOrEmpty();
             System.Convert.FromBase64String(encodedPathway!).Should().NotBeEmpty();
             scope.Span.GetTag("pathway.hash").Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            scope?.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task InjectTracingContext_WithDsmEnabled_AndInvalidDetail_DoesNotCreatePathwayContext()
+    {
+        var request = GeneratePutEventsRequest([
+            new PutEventsRequestEntry { Detail = "{invalid json", DetailType = DetailType, EventBusName = EventBusName }
+        ]);
+
+        var proxy = request.DuckCast<IPutEventsRequest>();
+        var settings = TracerSettings.Create(new() { { ConfigurationKeys.DataStreamsMonitoring.Enabled, true } });
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+        var scope = AwsEventBridgeCommon.CreateScope(tracer, "PutEvents", SpanKinds.Producer, out _);
+
+        try
+        {
+            ContextPropagation.InjectContext(tracer, proxy, scope, new PropagationContext(scope!.Span.Context, baggage: null));
+
+            var entries = (IList)proxy.Entries.Value!;
+            entries.Count.Should().Be(1);
+            var entry = (PutEventsRequestEntry)entries[0]!;
+
+            entry.Detail.Should().Be("{invalid json");
+            scope.Span.GetTag("pathway.hash").Should().BeNull();
         }
         finally
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/AWS/EventBridge/ContextPropagationTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Amazon.EventBridge.Model;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.EventBridge;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.TestHelpers.TestTracer;
@@ -23,6 +24,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.AWS.EventB
 public class ContextPropagationTests
 {
     private const string DatadogKey = "_datadog";
+    private const string DataStreamsContextKey = "dd-pathway-ctx-base64";
+    private const string DetailType = "test-detail-type";
     private const string StartTimeKey = "x-datadog-start-time";
     private const string ResourceNameKey = "x-datadog-resource-name";
     private const string EventBusName = "test-event-bus";
@@ -44,13 +47,13 @@ public class ContextPropagationTests
     public async Task InjectTracingContext_EmptyDetail_AddsTraceContext()
     {
         var request = GeneratePutEventsRequest([
-            new PutEventsRequestEntry { Detail = "{}", EventBusName = EventBusName }
+            new PutEventsRequestEntry { Detail = "{}", DetailType = DetailType, EventBusName = EventBusName }
         ]);
 
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -84,7 +87,7 @@ public class ContextPropagationTests
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -119,7 +122,7 @@ public class ContextPropagationTests
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -153,7 +156,7 @@ public class ContextPropagationTests
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -173,7 +176,7 @@ public class ContextPropagationTests
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(2);
@@ -210,7 +213,7 @@ public class ContextPropagationTests
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -245,7 +248,7 @@ public class ContextPropagationTests
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -266,7 +269,7 @@ public class ContextPropagationTests
         var proxy = request.DuckCast<IPutEventsRequest>();
 
         await using var tracer = TracerHelper.CreateWithFakeAgent();
-        ContextPropagation.InjectContext(tracer, proxy, new PropagationContext(_spanContext, baggage: null));
+        ContextPropagation.InjectContext(tracer, proxy, scope: null, new PropagationContext(_spanContext, baggage: null));
 
         var entries = (IList)proxy.Entries.Value!;
         entries.Count.Should().Be(1);
@@ -280,6 +283,53 @@ public class ContextPropagationTests
 
         var byteSize = Encoding.UTF8.GetByteCount(entry.Detail);
         byteSize.Should().BeLessThan(MaxSizeBytes);
+    }
+
+    [Fact]
+    public async Task InjectTracingContext_WithDsmEnabled_AddsPathwayContext()
+    {
+        var request = GeneratePutEventsRequest([
+            new PutEventsRequestEntry { Detail = "{}", DetailType = DetailType, EventBusName = EventBusName }
+        ]);
+
+        var proxy = request.DuckCast<IPutEventsRequest>();
+        var settings = TracerSettings.Create(new() { { ConfigurationKeys.DataStreamsMonitoring.Enabled, true } });
+
+        await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+        var scope = AwsEventBridgeCommon.CreateScope(tracer, "PutEvents", SpanKinds.Producer, out _);
+
+        try
+        {
+            ContextPropagation.InjectContext(tracer, proxy, scope, new PropagationContext(scope!.Span.Context, baggage: null));
+
+            var entries = (IList)proxy.Entries.Value!;
+            entries.Count.Should().Be(1);
+            var entry = (PutEventsRequestEntry)entries[0]!;
+
+            var detail = JsonConvert.DeserializeObject<Dictionary<string, object>>(entry.Detail);
+            detail.Should().NotBeNull();
+            var detailDictionary = detail!;
+            detailDictionary.Should().ContainKey(DatadogKey);
+
+            var extracted = detailDictionary.TryGetValue(DatadogKey, out var datadogObject);
+            extracted.Should().BeTrue();
+            datadogObject.Should().NotBeNull();
+
+            var jsonString = JsonConvert.SerializeObject(datadogObject);
+            var extractedTraceContext = JsonConvert.DeserializeObject<Dictionary<string, object>>(jsonString);
+            var extractedTraceContextDictionary = extractedTraceContext!;
+
+            extractedTraceContextDictionary.Should().ContainKey(DataStreamsContextKey);
+            extractedTraceContextDictionary[DataStreamsContextKey].Should().NotBeNull();
+            var encodedPathway = extractedTraceContextDictionary[DataStreamsContextKey].ToString();
+            encodedPathway.Should().NotBeNullOrEmpty();
+            System.Convert.FromBase64String(encodedPathway!).Should().NotBeEmpty();
+            scope.Span.GetTag("pathway.hash").Should().NotBeNullOrEmpty();
+        }
+        finally
+        {
+            scope?.Dispose();
+        }
     }
 
     private static PutEventsRequest GeneratePutEventsRequest(List<PutEventsRequestEntry> entries)

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -511,8 +511,8 @@ public class DataStreamsManagerTests
         var dsm = GetDataStreamManager(true, out _);
         var key = new SnsEdgeTagCacheKey("arn:topic1");
 
-        var first = dsm.GetOrCreateEdgeTags(key, static k => ["direction:out", $"topic:{k.TopicName}", "type:sns"]);
-        var second = dsm.GetOrCreateEdgeTags(key, static k => ["direction:out", $"topic:{k.TopicName}", "type:sns"]);
+        var first = dsm.GetOrCreateEdgeTags(key, static k => ["direction:out", $"topic:{k.TopicArn}", "type:sns"]);
+        var second = dsm.GetOrCreateEdgeTags(key, static k => ["direction:out", $"topic:{k.TopicArn}", "type:sns"]);
 
         second.Should().BeSameAs(first);
     }

--- a/tracer/test/snapshots/DataStreamsMonitoringAwsSnsTests.NetCore.SubmitsDsmMetrics.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringAwsSnsTests.NetCore.SubmitsDsmMetrics.verified.txt
@@ -11,10 +11,10 @@
         {
           EdgeTags: [
             direction:out,
-            topic:MyTopic,
+            topic:arn:aws:sns:us-east-1:000000000000:MyTopic,
             type:sns
           ],
-          Hash: 2371434532713766699,
+          Hash: 5224683988148621372,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,
@@ -29,10 +29,10 @@
         {
           EdgeTags: [
             direction:out,
-            topic:MyTopic,
+            topic:arn:aws:sns:us-east-1:000000000000:MyTopic,
             type:sns
           ],
-          Hash: 2371434532713766699,
+          Hash: 5224683988148621372,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,

--- a/tracer/test/snapshots/DataStreamsMonitoringAwsSnsTests.NetFramework.SubmitsDsmMetrics.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringAwsSnsTests.NetFramework.SubmitsDsmMetrics.verified.txt
@@ -11,10 +11,10 @@
         {
           EdgeTags: [
             direction:out,
-            topic:MyTopic,
+            topic:arn:aws:sns:us-east-1:000000000000:MyTopic,
             type:sns
           ],
-          Hash: 2371434532713766699,
+          Hash: 5224683988148621372,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,
@@ -29,10 +29,10 @@
         {
           EdgeTags: [
             direction:out,
-            topic:MyTopic,
+            topic:arn:aws:sns:us-east-1:000000000000:MyTopic,
             type:sns
           ],
-          Hash: 2371434532713766699,
+          Hash: 5224683988148621372,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,


### PR DESCRIPTION
## Summary of changes
Updated AWS SNS Data Streams Monitoring produce edge tags to use the full TopicArn instead of the derived topic name.
Kept the existing SNS span tags unchanged, so aws.topic.arn and aws.topic.name continue to be populated as before.
Updated the SNS DSM cache-key usage and snapshot expectations to match the ARN-based edge tag.

## Reason for change
SNS publish requests target a topic ARN, but the DSM edge tag was previously keyed on the shortened topic name.
Using the ARN makes the DSM destination identity line up with the actual SNS publish target and preserves the account and region context that is lost when only the topic name is used.

## Implementation details
In AwsSnsHandlerCommon, the publish path now reads topicArn once, still derives topicName for span tagging, and builds DSM edge tags from topicArn.
SnsEdgeTagCacheKey now keys SNS produce edge tags by ARN instead of topic name.
The focused SNS DSM cache test and SNS DSM verification snapshots were updated to expect topic:<topic-arn>.

## Test coverage
dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj -f net8.0 --filter FullyQualifiedName~DataStreamsManagerTests.GetOrCreateEdgeTags_Sns_ReturnsSameArrayReference_WhenCalledTwiceWithSameKey --no-restore
dotnet test tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj -f net8.0 --filter FullyQualifiedName~Datadog.Trace.ClrProfiler.IntegrationTests.AWS.DataStreamsMonitoringAwsSnsTests.SubmitsDsmMetrics --no-restore

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
