### PR TITLE
[Profiler] Stop unwinding when unsafe

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/HybridUnwinder.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/HybridUnwinder.cpp
@@ -104,14 +104,22 @@ bool HybridUnwinder::UnwindNativeFrames(UnwindCursor* cursor, Callstack& callsta
         }
 
         auto stepResult = unw_step(&cursor->cursor);
+        unw_cursor_snapshot_t snapshot;
+        unw_get_cursor_snapshot(&cursor->cursor, &snapshot);
+        bool unSafeStep = stepResult <= 0 || snapshot.step_method == UNW_STEP_FALLBACK_LR_NO_PROC_INFO;
+
         if (recorder)
         {
-            unw_cursor_snapshot_t snapshot;
-            unw_get_cursor_snapshot(&cursor->cursor, &snapshot);
             recorder->Record(EventType::LibunwindStep, stepResult, snapshot);
         }
-        if (stepResult <= 0)
+
+        if (unSafeStep)
         {
+            if (stepResult > 0)
+            {
+                stepResult = -UNW_STEP_FALLBACK_LR_NO_PROC_INFO;
+            }
+
             if (recorder)
             {
                 recorder->RecordFinish(static_cast<std::int32_t>(stepResult), FinishReason::FailedLibunwindStep);


### PR DESCRIPTION
## Summary of changes

Check that we can continue unwinding after each `unw_step` call.

## Reason for change

We had a crash in libunwind. The profiler interrupted the thread in `enframe` (from musl-libc). But the library does not have symbtab, dynamic table...
In that case, libunwind failed unwinding using dwarf and tried to get the function assembly code. Since it's a stripped binary, failed and fell back to LR (flipped a coin).

Since we added in libunwind insights on what actually failed, we can decide to stop or continue unwinding.

## Implementation details

Read the cursor snapshot `step_method` field: This field indicates if we fell back to LR because we did not find the function assembly code (https://github.com/DataDog/libunwind/blob/gleocadie/v1.8.3-custom-1/include/libunwind-common.h.in#L270 and https://github.com/DataDog/libunwind/blob/gleocadie/v1.8.3-custom-1/src/aarch64/Gstep.c#L805)

## Test coverage

We should have less crashes

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
