### PR TITLE
[DSM] Guard against future timestamps when extracting pathway context

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -325,6 +325,11 @@ internal sealed class DataStreamsManager
             var parentHash = previousContext?.Hash ?? default;
             var pathwayHash = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
 
+            // Clamp latencies to non-negative values. A future-dated upstream timestamp (clock skew or
+            // a buggy/malicious peer) would otherwise give a negative value
+            var pathwayLatencyNs = Math.Max(0, nowNs - pathwayStartNs);
+            var edgeLatencyNs = Math.Max(0, nowNs - (previousContext?.EdgeStart ?? edgeStartNs));
+
             var writer = Volatile.Read(ref _writer);
             writer?.Add(
                 new StatsPoint(
@@ -332,8 +337,8 @@ internal sealed class DataStreamsManager
                     hash: pathwayHash,
                     parentHash: parentHash,
                     timestampNs: nowNs,
-                    pathwayLatencyNs: nowNs - pathwayStartNs,
-                    edgeLatencyNs: nowNs - (previousContext?.EdgeStart ?? edgeStartNs),
+                    pathwayLatencyNs: pathwayLatencyNs,
+                    edgeLatencyNs: edgeLatencyNs,
                     payloadSizeBytes));
 
             var pathway = new PathwayContext(

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -327,7 +327,6 @@ internal sealed class DataStreamsManager
 
             // Prevent negative value latencies from a future-dated upstream timestamp
             // (clock skew or a buggy/malicious peer)
-            
             var pathwayLatencyNs = Math.Max(0, nowNs - pathwayStartNs);
             var edgeLatencyNs = Math.Max(0, nowNs - (previousContext?.EdgeStart ?? edgeStartNs));
 

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -325,7 +325,7 @@ internal sealed class DataStreamsManager
             var parentHash = previousContext?.Hash ?? default;
             var pathwayHash = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
 
-            // Prevent negative value latencies from a future-dated upstream timestamp 
+            // Prevent negative value latencies from a future-dated upstream timestamp
             // (clock skew or a buggy/malicious peer)
             
             var pathwayLatencyNs = Math.Max(0, nowNs - pathwayStartNs);

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -325,8 +325,9 @@ internal sealed class DataStreamsManager
             var parentHash = previousContext?.Hash ?? default;
             var pathwayHash = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
 
-            // Clamp latencies to non-negative values. A future-dated upstream timestamp (clock skew or
-            // a buggy/malicious peer) would otherwise give a negative value
+            // Prevent negative value latencies from a future-dated upstream timestamp 
+            // (clock skew or a buggy/malicious peer)
+            
             var pathwayLatencyNs = Math.Max(0, nowNs - pathwayStartNs);
             var edgeLatencyNs = Math.Max(0, nowNs - (previousContext?.EdgeStart ?? edgeStartNs));
 

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
@@ -22,6 +22,12 @@ internal static class PathwayContextEncoder
     internal const int MaxBase64EncodedSize = 36;
 
     /// <summary>
+    /// Tolerance (in nanoseconds) applied when validating that decoded pathway/edge timestamps
+    /// are not in the future. Allows for normal clock drift between hosts.
+    /// </summary>
+    internal const long MaxClockSkewNs = 60L * 1_000_000_000L;
+
+    /// <summary>
     /// Encodes a <see cref="PathwayContext"/> as a series of bytes
     /// NOTE: the encoding is lossy, in that we convert <see cref="PathwayContext.PathwayStart"/>
     /// and <see cref="PathwayContext.EdgeStart"/> from ns to ms
@@ -108,8 +114,8 @@ internal static class PathwayContextEncoder
             return null;
         }
 
-        var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
-        if (pathwayStartNs > nowNs || edgeStartNs > nowNs)
+        var maxAllowedNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds() + MaxClockSkewNs;
+        if (pathwayStartNs > maxAllowedNs || edgeStartNs > maxAllowedNs)
         {
             Log.Warning(
                 "Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: pathway or edge start is in the future",
@@ -161,8 +167,8 @@ internal static class PathwayContextEncoder
             return null;
         }
 
-        var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
-        if (pathwayStartNs > nowNs || edgeStartNs > nowNs)
+        var maxAllowedNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds() + MaxClockSkewNs;
+        if (pathwayStartNs > maxAllowedNs || edgeStartNs > maxAllowedNs)
         {
             Log.Warning("Error decoding Data Stream PathwayContext from bytes: pathway or edge start is in the future");
             return null;

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
@@ -108,6 +108,15 @@ internal static class PathwayContextEncoder
             return null;
         }
 
+        var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+        if (pathwayStartNs > nowNs || edgeStartNs > nowNs)
+        {
+            Log.Warning(
+                "Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: pathway or edge start is in the future",
+                Convert.ToBase64String(bytes));
+            return null;
+        }
+
         // Pathway context values are in ns
         return new PathwayContext(new PathwayHash(hash), pathwayStartNs, edgeStartNs);
     }
@@ -149,6 +158,13 @@ internal static class PathwayContextEncoder
                 "Overflow detected in Data Stream PathwayContext from bytes: invalid pathway {PathwayMs}ms or edge {EdgeMs}ms",
                 pathwayStartMs,
                 edgeStartMs);
+            return null;
+        }
+
+        var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+        if (pathwayStartNs > nowNs || edgeStartNs > nowNs)
+        {
+            Log.Warning("Error decoding Data Stream PathwayContext from bytes: pathway or edge start is in the future");
             return null;
         }
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
@@ -6,7 +6,9 @@
 using System;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.ExtensionMethods;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.DataStreamsMonitoring;
@@ -21,14 +23,30 @@ public class PathwayContextEncoderTests
         var nowNs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000;
         for (var i = 0; i < 1000; i++)
         {
-            EncodeTest(unchecked((ulong)GetLong()), Math.Abs(GetLong()) % nowNs, Math.Abs(GetLong()) % nowNs);
+            // Mask off the sign bit to guarantee non-negative — Math.Abs(long.MinValue) returns long.MinValue
+            // (overflow), which would feed a negative timestamp into EncodeTest and fail the overflow guard.
+            EncodeTest(unchecked((ulong)GetLong()), GetNonNegativeLongInThePast(nowNs), GetNonNegativeLongInThePast(nowNs));
         }
+
+        static long GetNonNegativeLongInThePast(long nowNs) => (GetLong() & long.MaxValue) % nowNs;
     }
 
     [Theory]
     [InlineData(0, 0, 0)]
     public void TestEdgeCases(ulong hash, long pathwayStartNs, long edgeStartNs)
         => EncodeTest(hash, pathwayStartNs, edgeStartNs);
+
+    [Theory]
+    [InlineData(ulong.MaxValue, long.MaxValue, long.MaxValue)]
+    public void DecoderFailure_OverflowTimestamps(ulong hash, long pathwayStartNs, long edgeStartNs)
+    {
+        var pathway = new PathwayContext(new PathwayHash(hash), pathwayStartNs, edgeStartNs);
+
+        var bytes = PathwayContextEncoder.Encode(pathway);
+        var decoded = PathwayContextEncoder.Decode(bytes);
+
+        decoded.Should().BeNull();
+    }
 
     [Theory]
     [InlineData(0)]
@@ -108,13 +126,32 @@ public class PathwayContextEncoderTests
     [Fact]
     public void DecoderFailure_FutureTimestamps()
     {
-        var futureNs = DateTimeOffset.UtcNow.AddMinutes(1).ToUnixTimeMilliseconds() * 1_000_000;
+        var futureNs = DateTimeOffset.UtcNow
+                                     .AddNanoseconds(PathwayContextEncoder.MaxClockSkewNs * 5)
+                                     .ToUnixTimeNanoseconds();
         var pathway = new PathwayContext(new PathwayHash(123), pathwayStartNs: futureNs, edgeStartNs: futureNs);
 
         var bytes = PathwayContextEncoder.Encode(pathway);
         var decoded = PathwayContextEncoder.Decode(bytes);
 
         decoded.Should().BeNull();
+    }
+
+    [Fact]
+    public void DecodeSucceeds_TimestampExactlyNow()
+    {
+        // The check uses strict >, so a timestamp equal to nowNs (within tolerance) must round-trip.
+        var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+        EncodeTest(hash: 123, pathwayStartNs: nowNs, edgeStartNs: nowNs);
+    }
+
+    [Fact]
+    public void DecodeSucceeds_TimestampWithinSkewTolerance()
+    {
+        var futureNs = DateTimeOffset.UtcNow
+                                     .AddNanoseconds(PathwayContextEncoder.MaxClockSkewNs / 2)
+                                     .ToUnixTimeNanoseconds();
+        EncodeTest(hash: 123, pathwayStartNs: futureNs, edgeStartNs: futureNs);
     }
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -131,6 +168,22 @@ public class PathwayContextEncoderTests
         var bytesWritten = PathwayContextEncoder.EncodeInto(pathway, buffer);
 
         buffer.Slice(0, bytesWritten).ToArray().Should().Equal(expected);
+    }
+
+    [Fact]
+    public void DecoderFailure_FutureTimestamps_Span()
+    {
+        var futureNs = DateTimeOffset.UtcNow
+                                     .AddNanoseconds(PathwayContextEncoder.MaxClockSkewNs * 5)
+                                     .ToUnixTimeNanoseconds();
+        var pathway = new PathwayContext(new PathwayHash(123), pathwayStartNs: futureNs, edgeStartNs: futureNs);
+
+        Span<byte> buffer = stackalloc byte[PathwayContextEncoder.MaxEncodedSize];
+        var bytesWritten = PathwayContextEncoder.EncodeInto(pathway, buffer);
+
+        var decoded = PathwayContextEncoder.Decode(buffer.Slice(0, bytesWritten));
+
+        decoded.Should().BeNull();
     }
 #endif
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
@@ -18,15 +18,15 @@ public class PathwayContextEncoderTests
     [Fact]
     public void TestRandomValues()
     {
+        var nowNs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000;
         for (var i = 0; i < 1000; i++)
         {
-            EncodeTest(unchecked((ulong)GetLong()), Math.Abs(GetLong()), Math.Abs(GetLong()));
+            EncodeTest(unchecked((ulong)GetLong()), Math.Abs(GetLong()) % nowNs, Math.Abs(GetLong()) % nowNs);
         }
     }
 
     [Theory]
     [InlineData(0, 0, 0)]
-    [InlineData(ulong.MaxValue, long.MaxValue, long.MaxValue)]
     public void TestEdgeCases(ulong hash, long pathwayStartNs, long edgeStartNs)
         => EncodeTest(hash, pathwayStartNs, edgeStartNs);
 
@@ -102,6 +102,18 @@ public class PathwayContextEncoderTests
         }
 
         var decoded = PathwayContextEncoder.Decode(bytes);
+        decoded.Should().BeNull();
+    }
+
+    [Fact]
+    public void DecoderFailure_FutureTimestamps()
+    {
+        var futureNs = DateTimeOffset.UtcNow.AddMinutes(1).ToUnixTimeMilliseconds() * 1_000_000;
+        var pathway = new PathwayContext(new PathwayHash(123), pathwayStartNs: futureNs, edgeStartNs: futureNs);
+
+        var bytes = PathwayContextEncoder.Encode(pathway);
+        var decoded = PathwayContextEncoder.Decode(bytes);
+
         decoded.Should().BeNull();
     }
 


### PR DESCRIPTION
## Summary of changes

Guards against future timestamps when extracting pathwayContext and calculating `pathwayLatencyNs`

## Reason for change

We decode the `dd-pathway-ctx` from inbound headers, and use the decoded `PathwayStart` to compute `pathwayLatencyNs`. This is then used to calculate an `originTimestamp` and is added to `_originBuckets`. We then only flush `_originBuckets` for which the start time is <= the current bucket window.

If a "future" timestamp ends up in `PathwayStart`, then we would end up with that future bucket never being flushed and accumulating. This PR guards against those future timestamps so we don't end up with unbounded growth.

## Implementation details

Add two guards:
- In `SetCheckpoint`, guard against generating negative `pathwayLatencyNs` or `edgeLatencyNs`
- In `PathwayContextEncoder.Decode`, reject data points with a "future" `PathwayStart` time
  - Using a tolerance here of 60s to make sure clock skew issues don't bite us. I _think_ that number seems reasonable, but open to suggestions.
  - I was initially concerned about daylight savings etc, but given we're using UTC for all of this, that shouldn't be an issue

## Test coverage

Added a bunch of additional unit tests around this.
