### PR TITLE
[Profiler] Try fixing crashes in etw events based profiler

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.cpp
@@ -23,9 +23,9 @@ EtwEventsHandler::EtwEventsHandler()
 {
 }
 
-EtwEventsHandler::EtwEventsHandler(IIpcLogger* logger, IEtwEventsReceiver* pClrEventsReceiver, FILE* pEventsFile)
+EtwEventsHandler::EtwEventsHandler(std::shared_ptr<IIpcLogger> logger, IEtwEventsReceiver* pClrEventsReceiver, FILE* pEventsFile)
     :
-    _logger {logger},
+    _logger {std::move(logger)},
     _showMessages {false},
     _pReceiver {pClrEventsReceiver},
     _pEventsFile {pEventsFile}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.h
@@ -20,7 +20,7 @@ class EtwEventsHandler : public INamedPipeHandler
 {
 public:
     EtwEventsHandler();
-    EtwEventsHandler(IIpcLogger* logger, IEtwEventsReceiver* pClrEventsReceiver, FILE* pEventsFile);
+    EtwEventsHandler(std::shared_ptr<IIpcLogger> logger, IEtwEventsReceiver* pClrEventsReceiver, FILE* pEventsFile);
     ~EtwEventsHandler();
     void Cleanup();
 
@@ -38,6 +38,6 @@ private:
     std::atomic<bool> _stopRequested = false;
     bool _showMessages;
     IEtwEventsReceiver* _pReceiver;
-    IIpcLogger* _logger;
+    std::shared_ptr<IIpcLogger> _logger;
     FILE* _pEventsFile;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcClient.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcClient.cpp
@@ -11,9 +11,9 @@ IpcClient::IpcClient()
     _hPipe = nullptr;
 }
 
-IpcClient::IpcClient(IIpcLogger* pLogger, HANDLE hPipe)
+IpcClient::IpcClient(std::shared_ptr<IIpcLogger> pLogger, HANDLE hPipe)
 {
-    _pLogger = pLogger;
+    _pLogger = std::move(pLogger);
     _hPipe = hPipe;
 }
 
@@ -35,9 +35,9 @@ bool IpcClient::Disconnect()
 }
 
 
-std::unique_ptr<IpcClient> IpcClient::Connect(IIpcLogger* pLogger, const std::string& portName, uint32_t timeoutMS)
+std::unique_ptr<IpcClient> IpcClient::Connect(std::shared_ptr<IIpcLogger> pLogger, const std::string& portName, uint32_t timeoutMS)
 {
-    HANDLE hPipe = GetEndPoint(pLogger, portName, timeoutMS);
+    HANDLE hPipe = GetEndPoint(pLogger.get(), portName, timeoutMS);
     if (hPipe == INVALID_HANDLE_VALUE)
     {
         if (pLogger != nullptr)
@@ -56,7 +56,7 @@ std::unique_ptr<IpcClient> IpcClient::Connect(IIpcLogger* pLogger, const std::st
         builder << "Pipe to  " << portName << " has been created";
         pLogger->Info(builder.str());
     }
-    return std::make_unique<IpcClient>(pLogger, hPipe);
+    return std::make_unique<IpcClient>(std::move(pLogger), hPipe);
  }
 
 uint32_t IpcClient::Send(PVOID pBuffer, uint32_t bufferSize)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcClient.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcClient.h
@@ -24,8 +24,8 @@ enum NamedPipesCode : uint32_t
 class IpcClient
 {
 public:
-    static std::unique_ptr<IpcClient> Connect(IIpcLogger* pLogger, const std::string& portName, uint32_t timeoutMS = NMPWAIT_USE_DEFAULT_WAIT);
-    IpcClient(IIpcLogger* pLogger, HANDLE hPipe);
+    static std::unique_ptr<IpcClient> Connect(std::shared_ptr<IIpcLogger> pLogger, const std::string& portName, uint32_t timeoutMS = NMPWAIT_USE_DEFAULT_WAIT);
+    IpcClient(std::shared_ptr<IIpcLogger> pLogger, HANDLE hPipe);
 
     uint32_t Send(PVOID pBuffer, uint32_t bufferSize);
     uint32_t Read(PVOID pBuffer, uint32_t bufferSize);
@@ -39,6 +39,6 @@ private:
 
 private:
     HANDLE _hPipe;
-    IIpcLogger* _pLogger;
+    std::shared_ptr<IIpcLogger> _pLogger;
 };
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.cpp
@@ -77,7 +77,7 @@ void IpcServer::WaitForNamedPipe(DWORD timeoutMS)
     ::WaitForSingleObject(_hInitializedEvent, timeoutMS);
 }
 
-IpcServer::IpcServer(IIpcLogger* pLogger,
+IpcServer::IpcServer(std::shared_ptr<IIpcLogger> pLogger,
                      const std::string& portName,
                      INamedPipeHandler* pHandler,
                      uint32_t inBufferSize,
@@ -91,7 +91,7 @@ IpcServer::IpcServer(IIpcLogger* pLogger,
     _maxInstances = maxInstances;
     _timeoutMS = timeoutMS;
     _pHandler = pHandler;
-    _pLogger = pLogger;
+    _pLogger = std::move(pLogger);
     _hNamedPipe = nullptr;
     _showMessages = false;
 
@@ -100,7 +100,7 @@ IpcServer::IpcServer(IIpcLogger* pLogger,
 }
 
 IpcServer* IpcServer::StartAsync(
-    IIpcLogger* pLogger,
+    std::shared_ptr<IIpcLogger> pLogger,
     const std::string& portName,
     INamedPipeHandler* pHandler,
     uint32_t inBufferSize,
@@ -116,7 +116,7 @@ IpcServer* IpcServer::StartAsync(
 
     // the lifetime of this instance is the lifetime of the application (i.e. it won't be deleted to avoid random crashes)
     auto server = new IpcServer(
-        pLogger, portName, pHandler, inBufferSize, outBufferSize, maxInstances, timeoutMS
+        std::move(pLogger), portName, pHandler, inBufferSize, outBufferSize, maxInstances, timeoutMS
         );
 
     // let a threadpool thread process the command because there is a blocking call to ConnectNamedPipe()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.h
@@ -16,19 +16,11 @@
 class IpcServer
 {
 public:
-    IpcServer();
-    IpcServer(IIpcLogger* pLogger,
-              const std::string& portName,
-              INamedPipeHandler* pHandler,
-              uint32_t inBufferSize,
-              uint32_t outBufferSize,
-              uint32_t maxInstances,
-              uint32_t timeoutMS);
     ~IpcServer();
 
     // TODO: remove this method and use Start instead in the sample application
     static IpcServer* StartAsync(
-        IIpcLogger* pLogger,
+        std::shared_ptr<IIpcLogger> pLogger,
         const std::string& portName,
         INamedPipeHandler* pHandler,
         uint32_t inBufferSize,
@@ -39,6 +31,15 @@ public:
     void Stop();
 
 private:
+    IpcServer();
+    IpcServer(std::shared_ptr<IIpcLogger> pLogger,
+              const std::string& portName,
+              INamedPipeHandler* pHandler,
+              uint32_t inBufferSize,
+              uint32_t outBufferSize,
+              uint32_t maxInstances,
+              uint32_t timeoutMS);
+
     static void CALLBACK StartCallback(PTP_CALLBACK_INSTANCE instance, PVOID context);
     void ShowLastError(const char* message, uint32_t lastError = ::GetLastError());
 
@@ -50,7 +51,7 @@ private:
     uint32_t _maxInstances;
     uint32_t _timeoutMS;
     INamedPipeHandler* _pHandler;
-    IIpcLogger* _pLogger;
+    std::shared_ptr<IIpcLogger> _pLogger;
     HANDLE _hNamedPipe;
 
     // will be set when the server is initialized

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
@@ -42,7 +42,7 @@ EtwEventsManager::EtwEventsManager(
         pGCSuspensionsListener,
         nullptr // no GC dump for .NET Framework (TODO: how to trigger it from ETW?)
         );
-    _logger = std::make_unique<ProfilerLogger>();
+    _logger = std::make_shared<ProfilerLogger>();
     _IpcClient = nullptr;
     _IpcServer = nullptr;
 }
@@ -363,9 +363,9 @@ bool EtwEventsManager::Start()
 
     Log::Info("Exposing ", pipeName);
 
-    _eventsHandler = std::make_unique<EtwEventsHandler>(_logger.get(), this, nullptr);
+    _eventsHandler = std::make_unique<EtwEventsHandler>(_logger, this, nullptr);
     _IpcServer = IpcServer::StartAsync(
-        _logger.get(),
+        _logger,
         pipeName,
         _eventsHandler.get(),
         (1 << 16) + sizeof(IpcHeader),  // in buffer size = 64K + header
@@ -382,7 +382,7 @@ bool EtwEventsManager::Start()
     pipeName = (_agentReplayEndpoint.empty()) ? NamedPipeAgent : _agentReplayEndpoint;
     Log::Info("Contacting ", pipeName, "...");
 
-    _IpcClient = IpcClient::Connect(_logger.get(), pipeName, TimeoutMS);
+    _IpcClient = IpcClient::Connect(_logger, pipeName, TimeoutMS);
     if (_IpcClient == nullptr)
     {
         Log::Error("Impossible to connect to the Datadog Agent named pipe...");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.h
@@ -109,7 +109,7 @@ private:
     std::unique_ptr<ClrEventsParser> _parser;
 
     // injected logger
-    std::unique_ptr<ProfilerLogger> _logger;
+    std::shared_ptr<ProfilerLogger> _logger;
 
     // responsible for receiving ETW events from the Windows Agent
     std::unique_ptr<EtwEventsHandler> _eventsHandler;

--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.cpp
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.cpp
@@ -209,10 +209,10 @@ int main(int argc, char* argv[])
     std::cout << "Exposing " << pipeName << "\n";
 
     EtwEventDumper eventDumper;
-    std::unique_ptr<ConsoleLogger> logger = std::make_unique<ConsoleLogger>();
-    auto handler = std::make_unique<EtwEventsHandler>(logger.get(), &eventDumper, pEventsFile);
+    auto logger = std::make_shared<ConsoleLogger>();
+    auto handler = std::make_unique<EtwEventsHandler>(logger, &eventDumper, pEventsFile);
     auto server = IpcServer::StartAsync(
-        logger.get(),
+        logger,
         pipeName,
         handler.get(),
         (1 << 16) + sizeof(IpcHeader),


### PR DESCRIPTION
## Summary of changes

This crash was detected by crashtracker:
```
0x7FFD1B5F14A6 IpcServer::StartCallback(_TP_CALLBACK_INSTANCE*, void*) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\ETW\IpcServer.cpp:195)
0x7FFD36C87243 TppSimplepExecuteCallback
0x7FFD36C8BB36 TppWorkerThread
0x7EB811E7 C:\Windows\System32\cyinjct.dll!<unknown>+11e7
0x7FFD35564DE0 BaseThreadInitThunk
0x7FFD36CFEDAB RtlUserThreadStart
```

## Reason for change

 In any case, the `pThis` which represents the `IpcServer` instance is leaked so it's not destroyed at any point. The only thing remaining, the `_pLogger` could be `nullptr` (shutdown, the smart pointer was destroyed) due to a race. This crash feels like an application start quickly followed by shutdown.

One thing we can do, use `std::shared_ptr` instead.

## Implementation details

Use `std::shared_ptr` to share the logger amongst components.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
