### PR TITLE
[Tracer] Tolerate clock skew when reparenting Activities to active Span

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -36,6 +36,12 @@ namespace Datadog.Trace.Activity.Handlers
         // long enough that an in-flight listener would have completed.
         private static readonly TimeSpan MissedStopGracePeriod = TimeSpan.FromMinutes(1);
 
+        // Activity.StartTimeUtc comes from DateTime.UtcNow while Span.StartTime comes from
+        // TraceClock (a Stopwatch-based clock calibrated against DateTime.UtcNow periodically).
+        // The two sources can drift apart, so when comparing parent/child ordering across them
+        // we allow a small tolerance to avoid spurious "parent appears newer than child" results.
+        private static readonly TimeSpan ParentReorderingClockSkewTolerance = TimeSpan.FromMilliseconds(50);
+
         private static int _sweepInProgress;
         private static Timer? _reconciliationTimer;
 
@@ -129,7 +135,7 @@ namespace Datadog.Trace.Activity.Handlers
                  && activitySpanId is not null
                  && activityTraceId is not null
                  && Tracer.Instance.ActiveScope?.Span is Span activeSpan
-                 && (activity.Parent is null || activity.Parent.StartTimeUtc <= activeSpan.StartTime.UtcDateTime))
+                 && (activity.Parent is null || activity.Parent.StartTimeUtc <= activeSpan.StartTime.UtcDateTime + ParentReorderingClockSkewTolerance))
                 {
                     // We ensure the activity follows the same TraceId as the span
                     // And marks the ParentId the current spanId


### PR DESCRIPTION
## Summary of changes

Add a 50 ms tolerance to the Activity → Span reparenting time check in `ActivityHandlerCommon`.

## Reason for change

`SimpleActivitiesAndSpansTest` flaked on master (build [202056](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/202056/logs/5419)) because the reparenting heuristic compares two different clock sources:

- `Activity.StartTimeUtc` — `DateTime.UtcNow` (system clock)
- `Span.StartTime` — `TraceClock.UtcNow` (Stopwatch-based, recalibrated against `DateTime.UtcNow` only every 5 min, with up to 16 ms calibration slack)

These can drift apart, so an `Activity` started a few µs before a `Span` can still end up with `Parent.StartTimeUtc > activeSpan.StartTime`, causing the `<=` guard to fail and reparenting to silently skip. In #5735 the same guard was relaxed from `<` to `<=` to handle low-resolution clocks on macOS — that fix doesn't cover the drift case where the parent time is strictly *greater* than the child.

The customer-visible impact of skipping reparenting is the same as the test symptom: an OTel child `Activity` created right after a DD `Span` keeps its original W3C parent instead of being linked to the DD span, breaking trace continuity.

## Implementation details

Added `ParentReorderingClockSkewTolerance = 50 ms` and changed the guard from
`activity.Parent.StartTimeUtc <= activeSpan.StartTime.UtcDateTime`
to
`activity.Parent.StartTimeUtc <= activeSpan.StartTime.UtcDateTime + ParentReorderingClockSkewTolerance`.

50 ms comfortably covers TraceClock's 16 ms calibration slack plus typical NTP step adjustments, while still being well under any realistic causal gap between unrelated spans in a single async chain.

## Test coverage

Existing `ActivityTests.SimpleActivitiesAndSpansTest` exercises this path; the change makes that test stable on Windows where the drift was observed.

## Other details