### PR TITLE
[Crashtracker] Do not redact frames in crashtracker

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -300,7 +300,7 @@ internal class CreatedumpCommand : Command
                     resolvedFrame->IsSuspicious = IsMethodSuspicious(frame.Method);
 
                     var assemblyName = frame.Method.Type.Module.AssemblyName;
-                    var methodName = ShouldRedactFrame(assemblyName) ? "REDACTED" : $"{frame.Method.Type}.{frame.Method.Name}";
+                    var methodName = $"{frame.Method.Type}.{frame.Method.Name}";
                     symbolName = $"{Path.GetFileName(assemblyName)}!{methodName}";
                 }
                 else

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -586,9 +586,10 @@ public class CreatedumpTests : ConsoleTestHelper
             {
                 // ClrMD preserves Roslyn's local function ordinal suffix (e.g. g__DoCrash|0)
                 // while .NET's StackTrace API strips it, so we normalize before comparing.
+                var regex = new Regex(@"\|\d+$");
                 var frame = frames.FirstOrDefault(f =>
                 {
-                    var functionName = Regex.Replace(f["function"].Value<string>(), @"\|\d+$", string.Empty);
+                    var functionName = regex.Replace(f["function"].Value<string>(), string.Empty);
                     return expectedFrame.Equals(functionName);
                 });
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -584,7 +584,13 @@ public class CreatedumpTests : ConsoleTestHelper
 
             foreach (var expectedFrame in expectedCallstack)
             {
-                var frame = frames.FirstOrDefault(f => expectedFrame.Equals(f["function"].Value<string>()));
+                // ClrMD preserves Roslyn's local function ordinal suffix (e.g. g__DoCrash|0)
+                // while .NET's StackTrace API strips it, so we normalize before comparing.
+                var frame = frames.FirstOrDefault(f =>
+                {
+                    var functionName = Regex.Replace(f["function"].Value<string>(), @"\|\d+$", string.Empty);
+                    return expectedFrame.Equals(functionName);
+                });
 
                 frame.Should().NotBeNull($"couldn't find expected frame {expectedFrame}");
             }

--- a/tracer/test/test-applications/integrations/Samples.Console/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Console/Program.cs
@@ -141,7 +141,7 @@ namespace Samples.Console_
                 var declaringType = method.DeclaringType.FullName;
                 var methodName = method.Name;
 
-                var symbol = method.Module.Assembly == typeof(Program).Assembly ? "REDACTED" : $"{declaringType}.{methodName}";
+                var symbol =$"{declaringType}.{methodName}";
 
                 // .NET and ClrMD reports generics with a different syntax
                 symbol = symbol.Replace("Progress`1", "Progress<System.__Canon>");


### PR DESCRIPTION
## Summary of changes

Do not redact managed frames in crash reports.

## Reason for change

There 2 aspects:
- Security review agreed that callstacks are not considered as PII and can be sent without any redaction mechanism
- Customers can use crash reports from the ErrorTracking UI and redacted frames will prevent them on acting on the crashes.

## Implementation details

- Remove method `ShouldRedactFrame` and the call to it.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
