### PR TITLE
[crashtracker] Remove Telemetry check

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -615,18 +615,6 @@ internal class CreatedumpCommand : Command
         return true;
     }
 
-    private static bool IsTelemetryEnabled()
-    {
-        var value = Environment.GetEnvironmentVariable(ConfigurationKeys.Telemetry.Enabled);
-
-        if (string.Equals(value, "false", StringComparison.OrdinalIgnoreCase) || value == "0")
-        {
-            return false;
-        }
-
-        return true;
-    }
-
     private static bool IsMethodSuspicious(ClrMethod method)
     {
         var assemblyName = Path.GetFileName(method.Type.Module.Name ?? string.Empty);
@@ -671,20 +659,13 @@ internal class CreatedumpCommand : Command
 
         try
         {
-            if (IsTelemetryEnabled())
+            if (ParseArguments(allArguments, out var pid, out var signal, out var signalCode, out var crashThread, out var nativeExceptionCode))
             {
-                if (ParseArguments(allArguments, out var pid, out var signal, out var signalCode, out var crashThread, out var nativeExceptionCode))
-                {
-                    GenerateCrashReport(pid, signal, signalCode, crashThread, nativeExceptionCode);
-                }
-                else
-                {
-                    AddError($"Unable to parse the command-line arguments: {string.Join(" ", allArguments)}");
-                }
+                GenerateCrashReport(pid, signal, signalCode, crashThread, nativeExceptionCode);
             }
             else
             {
-                DebugPrint("Telemetry is disabled, not generating crash report");
+                AddError($"Unable to parse the command-line arguments: {string.Join(" ", allArguments)}");
             }
         }
         catch (Exception ex)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -199,66 +199,6 @@ public class CreatedumpTests : ConsoleTestHelper
         File.Exists(reportFile.Path).Should().BeFalse();
     }
 
-    [SkippableTheory]
-    [InlineData(true, true)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task DisableTelemetry(bool telemetryEnabled, bool crashdumpEnabled)
-    {
-        SkipOn.Platform(SkipOn.PlatformValue.MacOs);
-        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Windows, SkipOn.ArchitectureValue.X86);
-
-        using var reportFile = new TemporaryFile();
-
-        (string, string)[] args = [LdPreloadConfig, CrashReportConfig(reportFile)];
-
-        if (crashdumpEnabled)
-        {
-            args = [.. args, .. CreatedumpConfig];
-        }
-
-        args = [.. args, ("DD_INSTRUMENTATION_TELEMETRY_ENABLED", telemetryEnabled ? "1" : "0")];
-
-        using var helper = await StartConsoleWithArgs("crash-datadog", enableProfiler: true, args);
-
-        await helper.Task;
-
-        using var assertionScope = new AssertionScope();
-        assertionScope.AddReportable("stdout", helper.StandardOutput);
-        assertionScope.AddReportable("stderr", helper.ErrorOutput);
-
-#if !NETFRAMEWORK
-        if (crashdumpEnabled)
-        {
-            AssertCreatedumpWasInvoked(helper.StandardOutput);
-        }
-        else
-        {
-            helper.StandardOutput.Should().NotContain(CreatedumpExpectedOutput);
-            helper.StandardOutput.Should().NotContain(CreatedumpInvokedOutput);
-        }
-#endif
-
-        if (telemetryEnabled)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                helper.StandardOutput.Should().Contain(CrashReportExpectedOutput);
-            }
-
-            File.Exists(reportFile.Path).Should().BeTrue();
-        }
-        else
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                helper.StandardOutput.Should().NotContain(CrashReportExpectedOutput);
-            }
-
-            File.Exists(reportFile.Path).Should().BeFalse();
-        }
-    }
-
     [SkippableFact]
     public async Task WriteCrashReport()
     {


### PR DESCRIPTION
## Summary of changes

Try sending crashreport even if telemetry is not present.

## Reason for change

As of today, crash reports are sent to telemetry endpoint AND errors intake. Even if telemetry is not enabled, we should try sending the crash report, it will go through errors intake path.

## Implementation details

Remove telemetry check

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
