### PR TITLE
[crashtracker] Libdatadog provides OS info

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
@@ -53,46 +53,6 @@ CrashReporting::~CrashReporting()
     }
 }
 
-ddog_crasht_OsInfo GetOsInfo()
-{
-    auto osType = libdatadog::to_char_slice(
-#ifdef _WINDOWS
-                "Windows"
-#elif MACOS
-                "macOS"
-#else
-                "Linux"
-#endif
-    );
-
-    auto architecture = libdatadog::to_char_slice(
-#ifdef _WINDOWS
-#ifdef BIT64
-                "x86_64"
-#else
-                "x86"
-#endif
-#elif AMD64
-                "x86_64"
-#elif X86
-                "x86"
-#elif ARM64
-                "arm64"
-#elif ARM
-                "arm"
-#endif
-    );
-
-    auto osInfo = ddog_crasht_OsInfo {
-        .architecture = architecture,
-        .bitness = {},
-        .os_type = osType,
-        .version = {}
-    };
-
-    return osInfo;
-}
-
 int32_t CrashReporting::Initialize()
 {
     bool succeeded = false;
@@ -106,7 +66,7 @@ int32_t CrashReporting::Initialize()
 
     CHECK_RESULT(ddog_crasht_CrashInfoBuilder_with_proc_info(&_builder, {_pid}));
 
-    CHECK_RESULT(ddog_crasht_CrashInfoBuilder_with_os_info(&_builder, GetOsInfo()));
+    CHECK_RESULT(ddog_crasht_CrashInfoBuilder_with_os_info_this_machine(&_builder));
 
 #ifdef _WINDOWS
     CHECK_RESULT(ddog_crasht_CrashInfoBuilder_with_kind(&_builder, DDOG_CRASHT_ERROR_KIND_UNHANDLED_EXCEPTION));

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -306,6 +306,13 @@ public class CreatedumpTests : ConsoleTestHelper
         }
 
         report["error"]!["message"].Value<string>().Should().Be("Process was terminated due to an unhandled exception of type 'System.BadImageFormatException'. Message: Expected.");
+
+        var osInfo = report["os_info"];
+        osInfo.Should().NotBeNull();
+        osInfo!["architecture"]!.Value<string>().Should().NotBe("unknown");
+        osInfo!["bitness"]!.Value<string>().Should().NotBe("unknown");
+        osInfo!["os_type"]!.Value<string>().Should().NotBe("unknown");
+        osInfo!["version"]!.Value<string>().Should().NotBe("unknown");
     }
 
 #if !NETFRAMEWORK


### PR DESCRIPTION
## Summary of changes

Let libdatadog set OS info in the report.

## Reason for change

Libdatadog uses a crate that can give more information (linux distribution, version....) which will be more precise.

## Implementation details

Use `ddog_crasht_CrashInfoBuilder_with_os_info_this_machine` API.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
