### PR TITLE
[DBM] Skip telemetry for DBM errors

### DIFF
--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -358,7 +358,8 @@ namespace Datadog.Trace.DatabaseMonitoring
                         var actualRemaining = Interlocked.Decrement(ref _remainingErrorLogs);
                         if (actualRemaining >= 0)
                         {
-                            Log.Error<string, int>(e, "Error setting context_info [{ContextValue}] for DB query, falling back to service only propagation mode. There won't be any link with APM traces. (will log this error {N} more time and then stop)", HexConverter.ToString(contextValue), actualRemaining);
+                            // We're making a SQL call, so this could fail for all sorts of reasons out of our control.
+                            Log.ErrorSkipTelemetry<string, int>(e, "Error setting context_info [{ContextValue}] for DB query, falling back to service only propagation mode. There won't be any link with APM traces. (will log this error {N} more time and then stop)", HexConverter.ToString(contextValue), actualRemaining);
                         }
                     }
 


### PR DESCRIPTION
## Summary of changes

Skips telemetry for errors when executing a command with DBM

## Reason for change

We're making a "real" SQL request, so it could fail for all sorts of reasons

## Implementation details

Suppress the errors - there's too much noise. 

## Test coverage

Meh

## Other details

Fixes [this error](https://app.datadoghq.com/error-tracking/issue/9b34e73e-55c6-11f1-a16a-da7ad0900002) - among others