### PR TITLE
[Build] Retry git clone in exploration tests setup

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Nuke.Common;
@@ -118,10 +119,24 @@ partial class Build
         var source = ExplorationTestCloneLatest ? testDescription.GitRepositoryUrl : $"-b {testDescription.GitRepositoryTag} {testDescription.GitRepositoryUrl}";
         var target = $"{ExplorationTestsDirectory}/{testDescription.Name}";
 
-        FileSystemTasks.EnsureCleanDirectory(target);
+        // Fail fast on stalled connections (default git timeout is ~10 min) so the retry loop can recover.
+        var cloneCommand = $"-c http.lowSpeedLimit=1000 -c http.lowSpeedTime=60 clone -q -c advice.detachedHead=false {depth} {submodules} {source} {target}";
 
-        var cloneCommand = $"clone -q -c advice.detachedHead=false {depth} {submodules} {source} {target}";
-        GitTasks.Git(cloneCommand);
+        const int maxAttempts = 3;
+        for (var attempt = 1; ; attempt++)
+        {
+            FileSystemTasks.EnsureCleanDirectory(target);
+            try
+            {
+                GitTasks.Git(cloneCommand);
+                break;
+            }
+            catch (Exception ex) when (attempt < maxAttempts)
+            {
+                Logger.Warning(ex, "git clone of {Repo} failed on attempt {Attempt}/{MaxAttempts}, retrying...", testDescription.Name, attempt, maxAttempts);
+                Thread.Sleep(TimeSpan.FromSeconds(5 * attempt));
+            }
+        }
 
         var projectPath = $"{ExplorationTestsDirectory}/{testDescription.Name}/{testDescription.PathToUnitTestProject}";
         if (!Directory.Exists(projectPath))


### PR DESCRIPTION
## Summary of changes

Adds retry logic and a fail-fast timeout around the `git clone` call in the exploration tests setup target.

## Reason for change

The `SetUpExplorationTests` target clones third-party repos from github.com over the network, which can hang or fail transiently. We hit this on [build 202170](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/202170/logs/12495) cloning `cake-build/cake`:

```
error: RPC failed; curl 56 Recv failure: Operation timed out
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
Process 'git' exited with code 128.
```

The clone hung ~10 minutes before the default git timeout kicked in, then failed the whole target with no retry.

## Implementation details

In `Build.ExplorationTests.cs::GitCloneAndBuild`:

- Added `-c http.lowSpeedLimit=1000 -c http.lowSpeedTime=60` to the clone command so git aborts after 60s of throughput below 1KB/s instead of waiting on the default ~10-minute timeout.
- Wrapped the clone in a 3-attempt loop with 5s / 10s linear backoff. The target directory is re-cleaned before each attempt so a partially-fetched clone doesn't poison the retry.
- Only the clone retries; the subsequent `DotNetBuild` is unchanged.

Worst-case clone time is now ~3 minutes instead of ~10 minutes, and a single transient network blip no longer fails the whole exploration tests run.

## Test coverage

No new tests — this is build infrastructure for exploration tests, exercised by the existing exploration test pipelines.

## Other details