### PR TITLE
[Profiler] Improve native unwinding performance on arm64

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -75,9 +75,9 @@ bool LibrariesInfoCache::StartImpl()
 
     // Wait for the thread to be fully started and the cache populated
     // before setting s_instance and registering with libunwind.
-    // BuildSymbolCache (ARM64) parses ELF symbol tables for every loaded library,
-    // which can be slow under sanitizers — use a longer timeout in that case.
-#if defined(ARM64) && defined(__SANITIZE_ADDRESS__)
+    // Cache population can be slow under sanitizers (ASAN/UBSAN add overhead to
+    // every allocation and memory access) — use a longer timeout in that case.
+#if defined(DD_SANITIZERS)
     constexpr auto startTimeout = 10s;
 #else
     constexpr auto startTimeout = 2s;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -16,6 +16,28 @@
 
 using namespace std::chrono_literals;
 
+namespace {
+struct ScopedMmap
+{
+    void* data;
+    size_t size;
+
+    ScopedMmap(int fd, size_t len) : data(MAP_FAILED), size(len)
+    {
+        data = mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0);
+        posix_fadvise(fd, 0, len, POSIX_FADV_DONTNEED);
+        close(fd);
+    }
+
+    ~ScopedMmap() { if (data != MAP_FAILED) munmap(data, size); }
+
+    ScopedMmap(const ScopedMmap&) = delete;
+    ScopedMmap& operator=(const ScopedMmap&) = delete;
+
+    explicit operator bool() const { return data != MAP_FAILED; }
+};
+} // anonymous namespace
+
 std::atomic<LibrariesInfoCache*> LibrariesInfoCache::s_instance{nullptr};
 
 extern "C" void (*volatile dd_notify_libraries_cache_update)() __attribute__((weak));
@@ -271,29 +293,21 @@ void LibrariesInfoCache::BuildSymbolCache(
         }
 
         auto fileSize = static_cast<size_t>(st.st_size);
-        void* mapped = mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE, fd, 0);
-        close(fd);
-
-        if (mapped == MAP_FAILED)
+        ScopedMmap mapping(fd, fileSize);
+        if (!mapping)
             continue;
 
-        auto* ehdr = static_cast<const ElfW(Ehdr)*>(mapped);
+        auto* ehdr = static_cast<const ElfW(Ehdr)*>(mapping.data);
         if (memcmp(ehdr->e_ident, ELFMAG, SELFMAG) != 0)
-        {
-            munmap(mapped, fileSize);
             continue;
-        }
 
         unw_word_t loadOffset = info->dlpi_addr;
 
-        auto base = static_cast<const uint8_t*>(mapped);
+        auto base = static_cast<const uint8_t*>(mapping.data);
 
         if (ehdr->e_shoff == 0 || ehdr->e_shnum == 0 ||
             ehdr->e_shoff + static_cast<size_t>(ehdr->e_shnum) * sizeof(ElfW(Shdr)) > fileSize)
-        {
-            munmap(mapped, fileSize);
             continue;
-        }
 
         auto* shdrs = reinterpret_cast<const ElfW(Shdr)*>(base + ehdr->e_shoff);
 
@@ -328,13 +342,20 @@ void LibrariesInfoCache::BuildSymbolCache(
             }
         }
 
-        munmap(mapped, fileSize);
-
         if (moduleSymbols.empty())
             continue;
 
         std::sort(moduleSymbols.begin(), moduleSymbols.end(),
-                  [](const FuncEntry& a, const FuncEntry& b) { return a.start_ip < b.start_ip; });
+                  [](const FuncEntry& a, const FuncEntry& b) {
+                      return a.start_ip < b.start_ip || (a.start_ip == b.start_ip && a.end_ip < b.end_ip);
+                  });
+
+        // Remove duplicates
+        auto last = std::unique(moduleSymbols.begin(), moduleSymbols.end(),
+                                [](const FuncEntry& a, const FuncEntry& b) {
+                                    return a.start_ip == b.start_ip && a.end_ip == b.end_ip;
+                                });
+        moduleSymbols.erase(last, moduleSymbols.end());
 
         auto symOffset = static_cast<uint32_t>(outSymbols.size());
         auto symCount = static_cast<uint32_t>(moduleSymbols.size());

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -6,6 +6,12 @@
 #include "Log.h"
 #include "OpSysTools.h"
 
+#include <algorithm>
+#include <elf.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 using namespace std::chrono_literals;
@@ -57,16 +63,25 @@ bool LibrariesInfoCache::StartImpl()
     // Now that the cache is populated, set the instance pointer
     s_instance.store(this, std::memory_order_release);
 
-    // Register the custom function with libunwind
+    // Register the custom iterate_phdr with libunwind.
     // Note: unw_set_iterate_phdr_function will call tdep_init() if needed,
     // which has once-initialization semantics, so this is thread-safe.
     unw_set_iterate_phdr_function(unw_local_addr_space, LibrariesInfoCache::DlIteratePhdr);
 
-    // CRITICAL: Force a memory barrier to ensure the write to iterate_phdr_function
-    // is visible to all CPU cores. libunwind's unw_set_iterate_phdr_function does
-    // a plain pointer write with no memory barriers, which can cause the signal
-    // handler on a different CPU core to see the old value (dl_iterate_phdr).
-    // This atomic fence with seq_cst ordering ensures all previous writes are visible.
+#ifdef ARM64
+    // On ARM64, unw_step's fallback path (get_frame_state) calls get_proc_name
+    // on every step when DWARF info is missing. The default get_static_proc_name
+    // does expensive /proc/maps parsing + ELF mmap + symbol scan each time.
+    // Replace it with our cached binary-search implementation.
+    unw_accessors_t* acc = unw_get_accessors(unw_local_addr_space);
+    _originalGetProcName = acc->get_proc_name;
+    acc->get_proc_name = LibrariesInfoCache::GetProcName;
+#endif
+
+    // CRITICAL: Force a memory barrier to ensure the writes to iterate_phdr_function
+    // (and get_proc_name on ARM64) are visible to all CPU cores. libunwind's setters
+    // do plain pointer writes with no memory barriers, which can cause the signal
+    // handler on a different CPU core to see old values.
     std::atomic_thread_fence(std::memory_order_seq_cst);
 
     Log::Info("LibrariesInfoCache: Registered custom iterate_phdr_function with libunwind.");
@@ -76,14 +91,30 @@ bool LibrariesInfoCache::StartImpl()
 
 bool LibrariesInfoCache::StopImpl()
 {
-    unw_set_iterate_phdr_function(unw_local_addr_space, dl_iterate_phdr);
+    // Clear s_instance first so signal handlers stop using our accessors
     s_instance.store(nullptr, std::memory_order_release);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+
+    unw_set_iterate_phdr_function(unw_local_addr_space, dl_iterate_phdr);
+
+#ifdef ARM64
+    if (_originalGetProcName != nullptr)
+    {
+        unw_accessors_t* acc = unw_get_accessors(unw_local_addr_space);
+        acc->get_proc_name = _originalGetProcName;
+        _originalGetProcName = nullptr;
+    }
+#endif
 
     _stopRequested = true;
     NotifyCacheUpdateImpl();
     Log::Debug("Notification to stop the worker has been sent.");
     _worker.join();
     _librariesInfo.clear();
+#ifdef ARM64
+    _moduleRegions.clear();
+    _symbols.clear();
+#endif
 
     return true;
 }
@@ -165,13 +196,214 @@ void LibrariesInfoCache::UpdateCache()
         },
         &data);
 
+#ifdef ARM64
+    static std::vector<ModuleRegion> newRegions;
+    static std::vector<FuncEntry> newSymbols;
+    newRegions.clear();
+    newSymbols.clear();
+    BuildSymbolCache(newCache, newRegions, newSymbols);
+#endif
+
     {
         std::unique_lock l{_cacheLock};
         _librariesInfo.swap(newCache);
+#ifdef ARM64
+        _moduleRegions.swap(newRegions);
+        _symbols.swap(newSymbols);
+#endif
     }
 
     newCache.clear();
+#ifdef ARM64
+    newRegions.clear();
+    newSymbols.clear();
+#endif
 }
+
+#ifdef ARM64
+void LibrariesInfoCache::BuildSymbolCache(
+    std::vector<DlPhdrInfoWrapper>& phdrCache,
+    std::vector<ModuleRegion>& outRegions,
+    std::vector<FuncEntry>& outSymbols)
+{
+    std::vector<FuncEntry> moduleSymbols;
+
+    for (auto& wrapper : phdrCache)
+    {
+        auto [info, size] = wrapper.Get();
+
+        const char* modulePath = info->dlpi_name;
+        if (modulePath == nullptr || modulePath[0] == '\0')
+        {
+            modulePath = "/proc/self/exe";
+        }
+
+        unw_word_t segLow = 0;
+        unw_word_t segHigh = 0;
+        bool foundExecSeg = false;
+        for (int i = 0; i < info->dlpi_phnum; ++i)
+        {
+            const auto& phdr = info->dlpi_phdr[i];
+            if (phdr.p_type == PT_LOAD && (phdr.p_flags & PF_X))
+            {
+                unw_word_t low = info->dlpi_addr + phdr.p_vaddr;
+                unw_word_t high = low + phdr.p_memsz;
+                if (!foundExecSeg || low < segLow)
+                    segLow = low;
+                if (!foundExecSeg || high > segHigh)
+                    segHigh = high;
+                foundExecSeg = true;
+            }
+        }
+
+        if (!foundExecSeg || segLow == segHigh)
+            continue;
+
+        int fd = open(modulePath, O_RDONLY | O_CLOEXEC);
+        if (fd < 0)
+            continue;
+
+        struct stat st;
+        if (fstat(fd, &st) < 0 || st.st_size < static_cast<off_t>(sizeof(ElfW(Ehdr))))
+        {
+            close(fd);
+            continue;
+        }
+
+        auto fileSize = static_cast<size_t>(st.st_size);
+        void* mapped = mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE, fd, 0);
+        close(fd);
+
+        if (mapped == MAP_FAILED)
+            continue;
+
+        auto* ehdr = static_cast<const ElfW(Ehdr)*>(mapped);
+        if (memcmp(ehdr->e_ident, ELFMAG, SELFMAG) != 0)
+        {
+            munmap(mapped, fileSize);
+            continue;
+        }
+
+        unw_word_t loadOffset = info->dlpi_addr;
+
+        auto base = static_cast<const uint8_t*>(mapped);
+
+        if (ehdr->e_shoff == 0 || ehdr->e_shnum == 0 ||
+            ehdr->e_shoff + static_cast<size_t>(ehdr->e_shnum) * sizeof(ElfW(Shdr)) > fileSize)
+        {
+            munmap(mapped, fileSize);
+            continue;
+        }
+
+        auto* shdrs = reinterpret_cast<const ElfW(Shdr)*>(base + ehdr->e_shoff);
+
+        moduleSymbols.clear();
+
+        for (int s = 0; s < ehdr->e_shnum; ++s)
+        {
+            if (shdrs[s].sh_type != SHT_SYMTAB && shdrs[s].sh_type != SHT_DYNSYM)
+                continue;
+
+            if (shdrs[s].sh_entsize == 0)
+                continue;
+
+            if (shdrs[s].sh_offset + shdrs[s].sh_size > fileSize)
+                continue;
+
+            auto symCount = shdrs[s].sh_size / shdrs[s].sh_entsize;
+            auto* syms = reinterpret_cast<const ElfW(Sym)*>(base + shdrs[s].sh_offset);
+
+            for (size_t j = 0; j < symCount; ++j)
+            {
+                if (ELF64_ST_TYPE(syms[j].st_info) != STT_FUNC)
+                    continue;
+                if (syms[j].st_shndx == SHN_UNDEF)
+                    continue;
+                if (syms[j].st_size == 0)
+                    continue;
+
+                unw_word_t startIp = syms[j].st_value + loadOffset;
+                unw_word_t endIp = startIp + syms[j].st_size;
+                moduleSymbols.push_back({startIp, endIp});
+            }
+        }
+
+        munmap(mapped, fileSize);
+
+        if (moduleSymbols.empty())
+            continue;
+
+        std::sort(moduleSymbols.begin(), moduleSymbols.end(),
+                  [](const FuncEntry& a, const FuncEntry& b) { return a.start_ip < b.start_ip; });
+
+        auto symOffset = static_cast<uint32_t>(outSymbols.size());
+        auto symCount = static_cast<uint32_t>(moduleSymbols.size());
+        outRegions.push_back({segLow, segHigh, symOffset, symCount});
+        outSymbols.insert(outSymbols.end(), moduleSymbols.begin(), moduleSymbols.end());
+    }
+
+    std::sort(outRegions.begin(), outRegions.end(),
+              [](const ModuleRegion& a, const ModuleRegion& b) { return a.addr_low < b.addr_low; });
+
+    Log::Debug("LibrariesInfoCache: Symbol cache built with ", outRegions.size(),
+               " modules and ", outSymbols.size(), " function entries.");
+}
+
+int LibrariesInfoCache::FindFunctionStart(unw_word_t ip, unw_word_t* func_start) const
+{
+    auto regionIt = std::upper_bound(
+        _moduleRegions.begin(), _moduleRegions.end(), ip,
+        [](unw_word_t addr, const ModuleRegion& region) { return addr < region.addr_low; });
+
+    if (regionIt == _moduleRegions.begin())
+        return -UNW_ENOINFO;
+
+    --regionIt;
+    if (ip >= regionIt->addr_high)
+        return -UNW_ENOINFO;
+
+    const FuncEntry* symBegin = _symbols.data() + regionIt->sym_offset;
+    const FuncEntry* symEnd = symBegin + regionIt->sym_count;
+
+    auto symIt = std::upper_bound(
+        symBegin, symEnd, ip,
+        [](unw_word_t addr, const FuncEntry& entry) { return addr < entry.start_ip; });
+
+    if (symIt == symBegin)
+        return -UNW_ENOINFO;
+
+    --symIt;
+    if (ip >= symIt->end_ip)
+        return -UNW_ENOINFO;
+
+    *func_start = symIt->start_ip;
+    return 0;
+}
+
+int LibrariesInfoCache::GetProcName(unw_addr_space_t as, unw_word_t ip,
+                                    char* buf, size_t buf_len,
+                                    unw_word_t* offp, void* arg)
+{
+    auto* instance = s_instance.load(std::memory_order_acquire);
+    if (instance == nullptr)
+        return -UNW_ENOINFO;
+    return instance->GetProcNameImpl(as, ip, buf, buf_len, offp, arg);
+}
+
+int LibrariesInfoCache::GetProcNameImpl(unw_addr_space_t /*as*/, unw_word_t ip,
+                                        char* buf, size_t /*buf_len*/,
+                                        unw_word_t* offp, void* /*arg*/)
+{
+    std::shared_lock lock(_cacheLock);
+    unw_word_t func_start;
+    if (FindFunctionStart(ip, &func_start) != 0)
+        return -UNW_ENOINFO;
+
+    *offp = ip - func_start;
+    buf[0] = '\0';
+    return 0;
+}
+#endif
 
 int LibrariesInfoCache::DlIteratePhdr(unw_iterate_phdr_callback_t callback, void* data)
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -74,11 +74,21 @@ bool LibrariesInfoCache::StartImpl()
     _worker = std::thread(&LibrariesInfoCache::Work, this, startEvent);
 
     // Wait for the thread to be fully started and the cache populated
-    // before setting s_instance and registering with libunwind. 2s timeout for CI.
-    if (!startEvent->Wait(2s))
+    // before setting s_instance and registering with libunwind.
+    // BuildSymbolCache (ARM64) parses ELF symbol tables for every loaded library,
+    // which can be slow under sanitizers — use a longer timeout in that case.
+#if defined(ARM64) && defined(__SANITIZE_ADDRESS__)
+    constexpr auto startTimeout = 10s;
+#else
+    constexpr auto startTimeout = 2s;
+#endif
+    if (!startEvent->Wait(startTimeout))
     {
         Log::Error("Failed to populate LibrariesInfoCache within timeout. "
                    "Not registering custom iterate_phdr_function with libunwind.");
+        _stopRequested = true;
+        _event.Set();
+        _worker.join();
         return false;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -74,9 +74,15 @@ private:
 
     void UpdateCache();
 #ifdef ARM64
+#ifdef DD_TEST
+public:
+#endif
     void BuildSymbolCache(std::vector<DlPhdrInfoWrapper>& phdrCache,
                           std::vector<ModuleRegion>& outRegions,
                           std::vector<FuncEntry>& outSymbols);
+#ifdef DD_TEST
+private:
+#endif
     int FindFunctionStart(unw_word_t ip, unw_word_t* func_start) const;
     int GetProcNameImpl(unw_addr_space_t as, unw_word_t ip,
                         char* buf, size_t buf_len,
@@ -91,8 +97,14 @@ private:
     std::vector<DlPhdrInfoWrapper> _librariesInfo;
 
 #ifdef ARM64
+#ifdef DD_TEST
+public:
+#endif
     std::vector<ModuleRegion> _moduleRegions;
     std::vector<FuncEntry> _symbols;
+#ifdef DD_TEST
+private:
+#endif
 
     using GetProcNameFn = int (*)(unw_addr_space_t, unw_word_t, char*, size_t, unw_word_t*, void*);
     GetProcNameFn _originalGetProcName = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -20,6 +20,22 @@
 #include <thread>
 #include <vector>
 
+#ifdef ARM64
+struct FuncEntry
+{
+    unw_word_t start_ip;
+    unw_word_t end_ip;
+};
+
+struct ModuleRegion
+{
+    unw_word_t addr_low;
+    unw_word_t addr_high;
+    uint32_t sym_offset;
+    uint32_t sym_count;
+};
+#endif
+
 class LibrariesInfoCache : public ServiceBase
 {
 public:
@@ -45,6 +61,11 @@ public:
 private:
 #endif
     static int DlIteratePhdr(unw_iterate_phdr_callback_t callback, void* data);
+#ifdef ARM64
+    static int GetProcName(unw_addr_space_t as, unw_word_t ip,
+                           char* buf, size_t buf_len,
+                           unw_word_t* offp, void* arg);
+#endif
     void NotifyCacheUpdateImpl();
 #ifdef DD_TEST
 private:
@@ -52,6 +73,15 @@ private:
     static void NotifyCacheUpdate();
 
     void UpdateCache();
+#ifdef ARM64
+    void BuildSymbolCache(std::vector<DlPhdrInfoWrapper>& phdrCache,
+                          std::vector<ModuleRegion>& outRegions,
+                          std::vector<FuncEntry>& outSymbols);
+    int FindFunctionStart(unw_word_t ip, unw_word_t* func_start) const;
+    int GetProcNameImpl(unw_addr_space_t as, unw_word_t ip,
+                        char* buf, size_t buf_len,
+                        unw_word_t* offp, void* arg);
+#endif
     int DlIteratePhdrImpl(unw_iterate_phdr_callback_t callback, void* data);
     void Work(std::shared_ptr<AutoResetEvent> startEvent);
 
@@ -59,6 +89,14 @@ private:
 
     std::shared_mutex _cacheLock;
     std::vector<DlPhdrInfoWrapper> _librariesInfo;
+
+#ifdef ARM64
+    std::vector<ModuleRegion> _moduleRegions;
+    std::vector<FuncEntry> _symbols;
+
+    using GetProcNameFn = int (*)(unw_addr_space_t, unw_word_t, char*, size_t, unw_word_t*, void*);
+    GetProcNameFn _originalGetProcName = nullptr;
+#endif
 
     std::thread _worker;
     std::atomic<bool> _stopRequested;

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -18,11 +18,11 @@ if (IS_ALPINE)
 endif()
 
 if (RUN_ASAN)
-    add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer)
+    add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer -DDD_SANITIZERS)
 endif()
 
 if (RUN_UBSAN)
-    add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all)
+    add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all -DDD_SANITIZERS)
 endif()
 
 if (RUN_TSAN)

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -15,10 +15,12 @@
 struct ServiceWrapper
 {
     ServiceWrapper(ServiceBase* service) : _service(service) {
-        _service->Start();
+        auto started = _service->Start();
+        std::cerr << "[DIAG] Start() returned " << started << std::endl;
     }
     ~ServiceWrapper() {
-        _service->Stop();
+        auto stopped = _service->Stop();
+        std::cerr << "[DIAG] Stop() returned " << stopped << std::endl;
     }
     ServiceBase* _service;
 };
@@ -29,13 +31,26 @@ struct ServiceWrapper
 TEST(LibrariesInfoCacheTests, MakeSureWeDoNotLeakMemory)
 {
     auto cache = LibrariesInfoCache(MemoryResourceManager::GetDefault());
-    ServiceWrapper serviceWrapper(&cache);
 
-    for(auto i = 0; i < 10; i++)
+    auto t0 = std::chrono::steady_clock::now();
+    auto started = cache.Start();
+    auto t1 = std::chrono::steady_clock::now();
+    auto startMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+    std::cerr << "[DIAG] Start() returned " << started << " after " << startMs << "ms" << std::endl;
+
+    for(auto i = 0; i < 2; i++)
     {
         cache.NotifyCacheUpdateImpl();
         std::this_thread::sleep_for(100ms);
     }
+
+    auto t2 = std::chrono::steady_clock::now();
+    std::cerr << "[DIAG] Calling Stop()..." << std::endl;
+    auto stopped = cache.Stop();
+    auto t3 = std::chrono::steady_clock::now();
+    auto stopMs = std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
+    std::cerr << "[DIAG] Stop() returned " << stopped << " after " << stopMs << "ms" << std::endl;
+    std::cerr << "[DIAG] IsStarted() = " << cache.IsStarted() << std::endl;
 }
 
 TEST(LibrariesInfoCacheTests, MakeSureWeUseTheCorrectAddressSpace)

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -15,8 +15,7 @@
 struct ServiceWrapper
 {
     ServiceWrapper(ServiceBase* service) : _service(service) {
-        auto started = _service->Start();
-        std::cerr << "[DIAG] Start() returned " << started << std::endl;
+        EXPECT_TRUE(_service->Start()) << "Failed to start " << _service->GetName();
     }
     ~ServiceWrapper() {
         auto stopped = _service->Stop();

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -18,8 +18,7 @@ struct ServiceWrapper
         EXPECT_TRUE(_service->Start()) << "Failed to start " << _service->GetName();
     }
     ~ServiceWrapper() {
-        auto stopped = _service->Stop();
-        std::cerr << "[DIAG] Stop() returned " << stopped << std::endl;
+        EXPECT_TRUE(_service->Stop()) << "Failed to stop " << _service->GetName();
     }
     ServiceBase* _service;
 };
@@ -31,25 +30,11 @@ TEST(LibrariesInfoCacheTests, MakeSureWeDoNotLeakMemory)
 {
     auto cache = LibrariesInfoCache(MemoryResourceManager::GetDefault());
 
-    auto t0 = std::chrono::steady_clock::now();
-    auto started = cache.Start();
-    auto t1 = std::chrono::steady_clock::now();
-    auto startMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
-    std::cerr << "[DIAG] Start() returned " << started << " after " << startMs << "ms" << std::endl;
-
-    for(auto i = 0; i < 2; i++)
+    for(auto i = 0; i < 5; i++)
     {
         cache.NotifyCacheUpdateImpl();
         std::this_thread::sleep_for(100ms);
     }
-
-    auto t2 = std::chrono::steady_clock::now();
-    std::cerr << "[DIAG] Calling Stop()..." << std::endl;
-    auto stopped = cache.Stop();
-    auto t3 = std::chrono::steady_clock::now();
-    auto stopMs = std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2).count();
-    std::cerr << "[DIAG] Stop() returned " << stopped << " after " << stopMs << "ms" << std::endl;
-    std::cerr << "[DIAG] IsStarted() = " << cache.IsStarted() << std::endl;
 }
 
 TEST(LibrariesInfoCacheTests, MakeSureWeUseTheCorrectAddressSpace)

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -6,6 +6,8 @@
 #include "MemoryResourceManager.h"
 #include "LibrariesInfoCache.h"
 
+#include <cstdlib>
+
 #ifndef ARM64
 #include "Backtrace2Unwinder.h"
 #endif
@@ -88,3 +90,123 @@ TEST(LibrariesInfoCacheTests, CheckBehaviorAgainstDlIteratePhdr)
         ASSERT_EQ(cache[i].size, cache2[i].size);
     }
 }
+
+#ifdef ARM64
+__attribute__((noinline)) void KnownTestFunction_ForGetProcNameTest()
+{
+    asm volatile("");
+}
+
+__attribute__((noinline)) int KnownTestFunction_Second(int x)
+{
+    asm volatile("");
+    return x + 1;
+}
+
+__attribute__((noinline)) int KnownTestFunction_Third(int x, int y)
+{
+    asm volatile("");
+    return x * y;
+}
+
+TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForKnownFunction)
+{
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    ServiceWrapper serviceWrapper(&libCache);
+
+    auto ip = reinterpret_cast<unw_word_t>(&KnownTestFunction_ForGetProcNameTest);
+
+    char buf[128] = {};
+    unw_word_t offp = 0;
+
+    auto* as = static_cast<unw_addr_space_t>(LibrariesInfoCache::GetLocalAddressSpace());
+    int rc = LibrariesInfoCache::GetProcName(as, ip, buf, sizeof(buf), &offp, nullptr);
+
+    ASSERT_EQ(rc, 0) << "GetProcName failed for a known function address";
+    ASSERT_EQ(offp, 0u);
+}
+
+TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForMultipleKnownFunctions)
+{
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    ServiceWrapper serviceWrapper(&libCache);
+
+    auto* as = static_cast<unw_addr_space_t>(LibrariesInfoCache::GetLocalAddressSpace());
+
+    // Test functions from this binary (noinline, guaranteed symbol table entries)
+    // plus qsort from libc: pure C on both glibc and musl, no IFUNC, no assembly,
+    // always has st_size > 0 — unlike strlen/memcpy which are IFUNC-dispatched on
+    // ARM64 glibc with st_size == 0 assembly implementations.
+    std::vector<unw_word_t> testIps = {
+        reinterpret_cast<unw_word_t>(&KnownTestFunction_ForGetProcNameTest),
+        reinterpret_cast<unw_word_t>(&KnownTestFunction_Second),
+        reinterpret_cast<unw_word_t>(&KnownTestFunction_Third),
+        reinterpret_cast<unw_word_t>(&qsort),
+    };
+
+    for (auto ip : testIps)
+    {
+        char buf[128] = {};
+        unw_word_t offp = 0;
+        int rc = LibrariesInfoCache::GetProcName(as, ip, buf, sizeof(buf), &offp, nullptr);
+
+        ASSERT_EQ(rc, 0) << "GetProcName failed for ip=0x" << std::hex << ip;
+        ASSERT_EQ(offp, 0u) << "Offset at entry should be 0 for ip=0x" << std::hex << ip;
+    }
+}
+
+TEST(LibrariesInfoCacheTests, GetProcNameReturnsOffsetForAddressInsideFunction)
+{
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    ServiceWrapper serviceWrapper(&libCache);
+
+    auto funcAddr = reinterpret_cast<unw_word_t>(&KnownTestFunction_Third);
+    auto ip = funcAddr + 4;
+
+    char buf[128] = {};
+    unw_word_t offp = 0;
+
+    auto* as = static_cast<unw_addr_space_t>(LibrariesInfoCache::GetLocalAddressSpace());
+    int rc = LibrariesInfoCache::GetProcName(as, ip, buf, sizeof(buf), &offp, nullptr);
+
+    ASSERT_EQ(rc, 0) << "GetProcName failed for address inside KnownTestFunction_Third";
+    ASSERT_EQ(offp, 4u) << "Offset should reflect distance from function start";
+}
+
+TEST(LibrariesInfoCacheTests, GetProcNameFailsForBogusAddress)
+{
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    ServiceWrapper serviceWrapper(&libCache);
+
+    unw_word_t ip = 0x1;
+
+    char buf[128] = {};
+    unw_word_t offp = 0;
+
+    auto* as = static_cast<unw_addr_space_t>(LibrariesInfoCache::GetLocalAddressSpace());
+    int rc = LibrariesInfoCache::GetProcName(as, ip, buf, sizeof(buf), &offp, nullptr);
+
+    ASSERT_NE(rc, 0) << "GetProcName should fail for an unmapped address";
+}
+
+TEST(LibrariesInfoCacheTests, GetProcNameReplacesAndRestoresOriginalAccessor)
+{
+    auto* as = static_cast<unw_addr_space_t>(LibrariesInfoCache::GetLocalAddressSpace());
+    unw_accessors_t* acc = unw_get_accessors(as);
+
+    auto originalGetProcName = acc->get_proc_name;
+
+    {
+        LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+        ServiceWrapper serviceWrapper(&libCache);
+
+        ASSERT_EQ(acc->get_proc_name, &LibrariesInfoCache::GetProcName)
+            << "get_proc_name should point to LibrariesInfoCache::GetProcName after Start";
+        ASSERT_NE(acc->get_proc_name, originalGetProcName)
+            << "get_proc_name should differ from the original after Start";
+    }
+
+    ASSERT_EQ(acc->get_proc_name, originalGetProcName)
+        << "get_proc_name should be restored to the original after Stop";
+}
+#endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -209,4 +209,42 @@ TEST(LibrariesInfoCacheTests, GetProcNameReplacesAndRestoresOriginalAccessor)
     ASSERT_EQ(acc->get_proc_name, originalGetProcName)
         << "get_proc_name should be restored to the original after Stop";
 }
+
+TEST(LibrariesInfoCacheTests, BuildSymbolCacheProducesNoDuplicates)
+{
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    ServiceWrapper serviceWrapper(&libCache);
+
+    std::vector<DlPhdrInfoWrapper> phdrCache;
+    dl_iterate_phdr(
+        [](struct dl_phdr_info* info, std::size_t size, void* data) {
+            auto* cache = static_cast<std::vector<DlPhdrInfoWrapper>*>(data);
+            cache->emplace_back(info, size);
+            return 0;
+        },
+        &phdrCache);
+
+    std::vector<ModuleRegion> regions;
+    std::vector<FuncEntry> symbols;
+    libCache.BuildSymbolCache(phdrCache, regions, symbols);
+
+    ASSERT_FALSE(symbols.empty()) << "Expected at least some symbols from the test binary";
+
+    for (size_t r = 0; r < regions.size(); ++r)
+    {
+        auto& region = regions[r];
+        for (uint32_t i = 1; i < region.sym_count; ++i)
+        {
+            auto idx = region.sym_offset + i;
+            auto prev = region.sym_offset + i - 1;
+            bool isDuplicate = symbols[idx].start_ip == symbols[prev].start_ip &&
+                               symbols[idx].end_ip == symbols[prev].end_ip;
+            EXPECT_FALSE(isDuplicate)
+                << "Duplicate symbol entry in region " << r
+                << " at index " << i
+                << ": start_ip=0x" << std::hex << symbols[idx].start_ip
+                << " end_ip=0x" << symbols[idx].end_ip;
+        }
+    }
+}
 #endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -216,10 +216,11 @@ TEST(LibrariesInfoCacheTests, BuildSymbolCacheProducesNoDuplicates)
     ServiceWrapper serviceWrapper(&libCache);
 
     std::vector<DlPhdrInfoWrapper> phdrCache;
+    
     dl_iterate_phdr(
         [](struct dl_phdr_info* info, std::size_t size, void* data) {
             auto* cache = static_cast<std::vector<DlPhdrInfoWrapper>*>(data);
-            cache->emplace_back(info, size);
+            cache->emplace_back(info, size, MemoryResourceManager::GetDefault());
             return 0;
         },
         &phdrCache);

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -6,6 +6,7 @@
 #include "MemoryResourceManager.h"
 #include "LibrariesInfoCache.h"
 
+#include <chrono>
 #include <cstdlib>
 
 #ifndef ARM64
@@ -15,10 +16,20 @@
 struct ServiceWrapper
 {
     ServiceWrapper(ServiceBase* service) : _service(service) {
-        EXPECT_TRUE(_service->Start()) << "Failed to start " << _service->GetName();
+        auto start = std::chrono::steady_clock::now();
+        bool ok = _service->Start();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        EXPECT_TRUE(ok) << "Failed to start " << _service->GetName()
+                        << " after " << elapsed.count() << "ms";
     }
     ~ServiceWrapper() {
-        EXPECT_TRUE(_service->Stop()) << "Failed to stop " << _service->GetName();
+        auto start = std::chrono::steady_clock::now();
+        bool ok = _service->Stop();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        EXPECT_TRUE(ok) << "Failed to stop " << _service->GetName()
+                        << " after " << elapsed.count() << "ms";
     }
     ServiceBase* _service;
 };


### PR DESCRIPTION
## Summary of changes

Improve unwinding performance on arm64.

## Reason for change

After releasing, we conducted performance tests and saw that unwinding was causing a +50% CPU overhead.
<img width="1548" height="750" alt="image" src="https://github.com/user-attachments/assets/b527b1c2-d2ba-42a2-84ef-5f6e771ea199" />

In parallel, we got a report confirming our measurements https://github.com/DataDog/dd-trace-dotnet/issues/8694.
With the improvement brought by this PR, we drastically reduce it
<img width="1534" height="250" alt="image" src="https://github.com/user-attachments/assets/80a04522-bd78-48d3-ae8c-4cbb05ed6ee8" />

## Implementation details

As the flamegraph exposed, the libunwind `get_proc_name` function was causing troubles. For each instruction pointer, it would parse the `/proc/<id>/maps` file.

In this PR, we use the same approach as `dl_iterate_phdr`: we listen to `dlopen`/`dlcose`, build a cache of `proc names` and replace libunwind `get_proc_name` by ours.


## Test coverage

Current tests should still work.
Additional tests on parsing `symtab` and `dynsym`. 
## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
