### PR TITLE
[SymDB] Stream SymDB payload

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -880,6 +880,7 @@
       <type fullname="System.Runtime.CompilerServices.CompilerGeneratedAttribute" />
       <type fullname="System.Runtime.CompilerServices.ConditionalWeakTable`2" />
       <type fullname="System.Runtime.CompilerServices.ConditionalWeakTable`2/CreateValueCallback" />
+      <type fullname="System.Runtime.CompilerServices.ConfiguredAsyncDisposable" />
       <type fullname="System.Runtime.CompilerServices.ConfiguredTaskAwaitable" />
       <type fullname="System.Runtime.CompilerServices.ConfiguredTaskAwaitable/ConfiguredTaskAwaiter" />
       <type fullname="System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1" />
@@ -962,6 +963,7 @@
       <type fullname="System.Threading.LazyThreadSafetyMode" />
       <type fullname="System.Threading.Tasks.Task" />
       <type fullname="System.Threading.Tasks.Task`1" />
+      <type fullname="System.Threading.Tasks.TaskAsyncEnumerableExtensions" />
       <type fullname="System.Threading.Tasks.TaskCanceledException" />
       <type fullname="System.Threading.Tasks.TaskCompletionSource`1" />
       <type fullname="System.Threading.Tasks.TaskContinuationOptions" />

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -957,6 +957,7 @@
       <type fullname="System.Text.Encoding" />
       <type fullname="System.Text.StringBuilder" />
       <type fullname="System.Text.StringBuilder/AppendInterpolatedStringHandler" />
+      <type fullname="System.Text.StringBuilder/ChunkEnumerator" />
       <type fullname="System.Threading.CancellationToken" />
       <type fullname="System.Threading.CancellationTokenRegistration" />
       <type fullname="System.Threading.CancellationTokenSource" />

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -118,17 +118,18 @@ namespace Datadog.Trace.Debugger.Symbols
         private static async Task WriteSymbols(Stream stream, StringBuilder builder)
         {
             const int bufferSize = 4096;
-            var buffer = ArrayPool<char>.Shared.Rent(bufferSize);
-            using var streamWriter = new StreamWriter(stream, EncodingHelpers.Utf8NoBom, bufferSize: 1024, leaveOpen: true);
+            using var streamWriter = new StreamWriter(stream, EncodingHelpers.Utf8NoBom, bufferSize, leaveOpen: true);
+            char[]? buffer = null;
             try
             {
+                buffer = ArrayPool<char>.Shared.Rent(bufferSize);
                 var remaining = builder.Length;
                 var position = 0;
                 while (remaining > 0)
                 {
                     var count = remaining > buffer.Length ? buffer.Length : remaining;
                     builder.CopyTo(position, buffer, 0, count);
-                    streamWriter.Write(buffer, 0, count);
+                    await streamWriter.WriteAsync(buffer, 0, count).ConfigureAwait(false);
                     position += count;
                     remaining -= count;
                 }
@@ -138,7 +139,10 @@ namespace Datadog.Trace.Debugger.Symbols
             }
             finally
             {
-                ArrayPool<char>.Shared.Return(buffer);
+                if (buffer != null)
+                {
+                    ArrayPool<char>.Shared.Return(buffer);
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -375,15 +375,15 @@ namespace Datadog.Trace.Debugger.Symbols
                 // Always false: the .NET tracer continuously uploads new code as
                 // assemblies get loaded; there is no defined end-of-upload point.
                 Final: false);
-            await SendSymbol(stream => WriteSymbols(stream, builder), metadata).ConfigureAwait(false);
+            await SendSymbol(static (stream, state) => WriteSymbols(stream, state), builder, metadata).ConfigureAwait(false);
         }
 
-        private async Task<bool> SendSymbol(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
+        private async Task<bool> SendSymbol<TState>(Func<Stream, TState, Task> writeSymbols, TState state, SymDbUploadMetadata metadata)
         {
             try
             {
                 return await _api
-                    .SendBatchAsync(writeSymbols, metadata)
+                    .SendBatchAsync(writeSymbols, state, metadata)
                     .ConfigureAwait(false);
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -6,6 +6,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -50,7 +51,6 @@ namespace Datadog.Trace.Debugger.Symbols
         // match them up.
         private readonly Guid _symdbUploadId = Guid.NewGuid();
         private volatile bool _disposed;
-        private byte[]? _payload;
         private volatile string? _symDbEndpoint;
         private long _symdbBatchNum;
 
@@ -113,6 +113,33 @@ namespace Datadog.Trace.Debugger.Symbols
 
             // TODO: we need to be able to update the tracer settings dynamically
             return new SymbolsUploader(api, discoveryService, settings, tracerSettings, serviceNameProvider);
+        }
+
+        private static async Task WriteSymbols(Stream stream, StringBuilder builder)
+        {
+            const int bufferSize = 4096;
+            var buffer = ArrayPool<char>.Shared.Rent(bufferSize);
+            using var streamWriter = new StreamWriter(stream, EncodingHelpers.Utf8NoBom, bufferSize: 1024, leaveOpen: true);
+            try
+            {
+                var remaining = builder.Length;
+                var position = 0;
+                while (remaining > 0)
+                {
+                    var count = remaining > buffer.Length ? buffer.Length : remaining;
+                    builder.CopyTo(position, buffer, 0, count);
+                    streamWriter.Write(buffer, 0, count);
+                    position += count;
+                    remaining -= count;
+                }
+
+                await streamWriter.FlushAsync().ConfigureAwait(false);
+                await stream.FlushAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
         }
 
         private void RegisterToAssemblyLoadEvent()
@@ -246,7 +273,7 @@ namespace Datadog.Trace.Debugger.Symbols
             // The payload builder is used for the whole upload: each batch
             // starts by appending a fresh prefix (with a per-batch batch_num),
             // class scopes are appended directly into it, and on flush we
-            // append ']' + suffix and send.
+            // append ']' + suffix and stream its chars directly as UTF-8.
             var payloadBuilder = StringBuilderCache.Acquire((int)_thresholdInBytes + 256);
 
             var serializer = JsonSerializer.Create(_jsonSerializerSettings);
@@ -269,11 +296,8 @@ namespace Datadog.Trace.Debugger.Symbols
                         continue;
                     }
 
-                    // Try to serialize and append the class
                     if (!TrySerializeClass(classSymbol, payloadBuilder, hasAnyClass, serializer, pooledWriter, accumulatedBytes, out var newByteCount))
                     {
-                        // If we couldn't append because it would exceed capacity,
-                        // upload current batch first
                         bool succeeded = false;
                         if (hasAnyClass)
                         {
@@ -286,7 +310,6 @@ namespace Datadog.Trace.Debugger.Symbols
                                 return;
                             }
 
-                            // Try again with empty scopes in the new batch
                             succeeded = TrySerializeClass(classSymbol, payloadBuilder, hasAnyClass, serializer, pooledWriter, accumulatedBytes, out newByteCount);
                         }
 
@@ -302,7 +325,6 @@ namespace Datadog.Trace.Debugger.Symbols
                     hasAnyClass = true;
                 }
 
-                // Upload any remaining data
                 if (hasAnyClass)
                 {
                     await Flush(payloadBuilder, suffix, batchNum).ConfigureAwait(false);
@@ -344,26 +366,15 @@ namespace Datadog.Trace.Debugger.Symbols
                 // Always false: the .NET tracer continuously uploads new code as
                 // assemblies get loaded; there is no defined end-of-upload point.
                 Final: false);
-            await SendSymbol(builder.ToString(), metadata).ConfigureAwait(false);
+            await SendSymbol(stream => WriteSymbols(stream, builder), metadata).ConfigureAwait(false);
         }
 
-        private async Task<bool> SendSymbol(string symbol, SymDbUploadMetadata metadata)
+        private async Task<bool> SendSymbol(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
         {
-            // TODO: Consider streaming SymDB payload bytes directly to the stream
-            // to avoid the extra `string -> UTF8 bytes` encoding step and intermediate byte[] allocations/copies.
-            // Similar allocation reductions were done in https://github.com/DataDog/dd-trace-dotnet/pull/8017
-            // and https://github.com/DataDog/dd-trace-dotnet/pull/8019).
-            var count = Encoding.UTF8.GetByteCount(symbol);
-            if (_payload == null || count > _payload.Length)
-            {
-                _payload = new byte[count];
-            }
-
-            Encoding.UTF8.GetBytes(symbol, 0, symbol.Length, _payload, 0);
             try
             {
                 return await _api
-                    .SendBatchAsync(new ArraySegment<byte>(_payload, 0, count), metadata)
+                    .SendBatchAsync(writeSymbols, metadata)
                     .ConfigureAwait(false);
             }
             catch (Exception e)
@@ -397,7 +408,6 @@ namespace Datadog.Trace.Debugger.Symbols
                 return false;
             }
 
-            // Safe to append
             if (hasAnyClass)
             {
                 payloadBuilder.Append(',');

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -119,6 +119,12 @@ namespace Datadog.Trace.Debugger.Symbols
         {
             const int bufferSize = 4096;
             using var streamWriter = new StreamWriter(stream, EncodingHelpers.Utf8NoBom, bufferSize, leaveOpen: true);
+#if NETCOREAPP
+            foreach (var chunk in builder.GetChunks())
+            {
+                await streamWriter.WriteAsync(chunk).ConfigureAwait(false);
+            }
+#else
             char[]? buffer = null;
             try
             {
@@ -133,9 +139,6 @@ namespace Datadog.Trace.Debugger.Symbols
                     position += count;
                     remaining -= count;
                 }
-
-                await streamWriter.FlushAsync().ConfigureAwait(false);
-                await stream.FlushAsync().ConfigureAwait(false);
             }
             finally
             {
@@ -144,6 +147,8 @@ namespace Datadog.Trace.Debugger.Symbols
                     ArrayPool<char>.Shared.Return(buffer);
                 }
             }
+#endif
+            await streamWriter.FlushAsync().ConfigureAwait(false);
         }
 
         private void RegisterToAssemblyLoadEvent()

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiBase.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiBase.cs
@@ -18,7 +18,7 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Debugger.Upload;
 
-internal abstract class DebuggerUploadApiBase : IBatchUploadApi
+internal abstract class DebuggerUploadApiBase
 {
     protected const string DebuggerV1Endpoint = "debugger/v1/input";
 
@@ -39,8 +39,6 @@ internal abstract class DebuggerUploadApiBase : IBatchUploadApi
         get => _endpoint;
         set => Volatile.Write(ref _endpoint, value);
     }
-
-    public abstract Task<bool> SendBatchAsync(ArraySegment<byte> data);
 
     protected string? BuildUri()
     {

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiBase.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiBase.cs
@@ -37,7 +37,7 @@ internal abstract class DebuggerUploadApiBase : IBatchUploadApi
     protected string? Endpoint
     {
         get => _endpoint;
-        set => _endpoint = value;
+        set => Volatile.Write(ref _endpoint, value);
     }
 
     public abstract Task<bool> SendBatchAsync(ArraySegment<byte> data);

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
@@ -13,7 +13,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Debugger.Upload
 {
-    internal sealed class DiagnosticsUploadApi : DebuggerUploadApiBase
+    internal sealed class DiagnosticsUploadApi : DebuggerUploadApiBase, IBatchUploadApi
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DiagnosticsUploadApi>();
 
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Debugger.Upload
             return new DiagnosticsUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
         }
 
-        public override async Task<bool> SendBatchAsync(ArraySegment<byte> data)
+        public async Task<bool> SendBatchAsync(ArraySegment<byte> data)
         {
             var uri = BuildUri();
             if (string.IsNullOrEmpty(uri))

--- a/tracer/src/Datadog.Trace/Debugger/Upload/ISymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/ISymbolUploadApi.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Debugger.Upload
@@ -12,5 +13,7 @@ namespace Datadog.Trace.Debugger.Upload
     internal interface ISymbolUploadApi : IBatchUploadApi
     {
         Task<bool> SendBatchAsync(ArraySegment<byte> symbols, SymDbUploadMetadata metadata);
+
+        Task<bool> SendBatchAsync(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata);
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/ISymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/ISymbolUploadApi.cs
@@ -10,10 +10,8 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.Debugger.Upload
 {
-    internal interface ISymbolUploadApi : IBatchUploadApi
+    internal interface ISymbolUploadApi
     {
-        Task<bool> SendBatchAsync(ArraySegment<byte> symbols, SymDbUploadMetadata metadata);
-
-        Task<bool> SendBatchAsync(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata);
+        Task<bool> SendBatchAsync<TState>(Func<Stream, TState, Task> writeSymbols, TState state, SymDbUploadMetadata metadata);
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
@@ -13,7 +13,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Debugger.Upload
 {
-    internal sealed class LogUploadApi : DebuggerUploadApiBase
+    internal sealed class LogUploadApi : DebuggerUploadApiBase, IBatchUploadApi
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LogUploadApi>();
 
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Debugger.Upload
             return new LogUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
         }
 
-        public override async Task<bool> SendBatchAsync(ArraySegment<byte> data)
+        public async Task<bool> SendBatchAsync(ArraySegment<byte> data)
         {
             var uri = BuildUri();
             if (string.IsNullOrEmpty(uri))

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SnapshotUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SnapshotUploadApi.cs
@@ -13,7 +13,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Debugger.Upload
 {
-    internal sealed class SnapshotUploadApi : DebuggerUploadApiBase
+    internal sealed class SnapshotUploadApi : DebuggerUploadApiBase, IBatchUploadApi
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SnapshotUploadApi>();
 
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Debugger.Upload
             return new SnapshotUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, staticEndpoint);
         }
 
-        public override async Task<bool> SendBatchAsync(ArraySegment<byte> data)
+        public async Task<bool> SendBatchAsync(ArraySegment<byte> data)
         {
             var uri = BuildUri();
             if (StringUtil.IsNullOrEmpty(uri))

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace.Debugger.Upload
     {
         private const int MaxRetries = 3;
         private const int FailureLogInterval = 10;
+        // Must fit each static multipart fragment below; CopyTo throws if a fragment grows past this size.
         private const int StaticMultipartBufferSize = 256;
         private static readonly TimeSpan StartingSleepDuration = TimeSpan.FromSeconds(3);
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SymbolUploadApi>();
@@ -57,6 +58,7 @@ namespace Datadog.Trace.Debugger.Upload
             discoveryService.SubscribeToChanges(_discoveryCallback);
         }
 
+        // Keep these boundary bytes in sync with DatadogHttpValues.Boundary.
         private static ReadOnlySpan<byte> InitialBoundaryBytes => "--faa0a896-8bc8-48f3-b46d-016f2b15a884\r\n"u8;
 
         private static ReadOnlySpan<byte> BoundaryBytes => "\r\n--faa0a896-8bc8-48f3-b46d-016f2b15a884\r\n"u8;

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -27,8 +27,6 @@ namespace Datadog.Trace.Debugger.Upload
     {
         private const int MaxRetries = 3;
         private const int FailureLogInterval = 10;
-        // Must fit each static multipart fragment below; CopyTo throws if a fragment grows past this size.
-        private const int StaticMultipartBufferSize = 256;
         private static readonly TimeSpan StartingSleepDuration = TimeSpan.FromSeconds(3);
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SymbolUploadApi>();
 
@@ -55,19 +53,6 @@ namespace Datadog.Trace.Debugger.Upload
             _delayAsync = delayAsync ?? Task.Delay;
             discoveryService.SubscribeToChanges(OnDiscoveryServiceChanged);
         }
-
-        // Keep these boundary bytes in sync with DatadogHttpValues.Boundary.
-        private static ReadOnlySpan<byte> InitialBoundaryBytes => "--faa0a896-8bc8-48f3-b46d-016f2b15a884\r\n"u8;
-
-        private static ReadOnlySpan<byte> BoundaryBytes => "\r\n--faa0a896-8bc8-48f3-b46d-016f2b15a884\r\n"u8;
-
-        private static ReadOnlySpan<byte> FinalBoundaryBytes => "\r\n--faa0a896-8bc8-48f3-b46d-016f2b15a884--\r\n"u8;
-
-        private static ReadOnlySpan<byte> FileJsonHeaderBytes => "Content-Type: application/json\r\nContent-Disposition: form-data; name=\"file\"; filename=\"file.json\"\r\n\r\n"u8;
-
-        private static ReadOnlySpan<byte> FileGzipHeaderBytes => "Content-Type: application/gzip\r\nContent-Disposition: form-data; name=\"file\"; filename=\"file.gz\"\r\n\r\n"u8;
-
-        private static ReadOnlySpan<byte> EventHeaderBytes => "Content-Type: application/json\r\nContent-Disposition: form-data; name=\"event\"; filename=\"event.json\"\r\n\r\n"u8;
 
         internal static ISymbolUploadApi Create(
             IApiRequestFactory apiRequestFactory,
@@ -239,12 +224,6 @@ namespace Datadog.Trace.Debugger.Upload
             return TimeSpan.FromSeconds(StartingSleepDuration.TotalSeconds * Math.Pow(2, retryAttempt - 1));
         }
 
-        private static Task WriteStaticBytesAsync(Stream destination, ReadOnlySpan<byte> source, byte[] buffer)
-        {
-            source.CopyTo(buffer);
-            return destination.WriteAsync(buffer, 0, source.Length);
-        }
-
         private void OnDiscoveryServiceChanged(AgentConfiguration configuration)
         {
             if (string.IsNullOrEmpty(configuration.SymbolDbEndpoint))
@@ -260,45 +239,59 @@ namespace Datadog.Trace.Debugger.Upload
 
         private async Task WriteMultipartFormData<TState>(Stream destination, Func<Stream, TState, Task> writeSymbols, TState state, SymDbUploadMetadata metadata)
         {
-            var staticBuffer = ArrayPool<byte>.Shared.Rent(StaticMultipartBufferSize);
-            try
-            {
-                await WriteStaticBytesAsync(destination, InitialBoundaryBytes, staticBuffer).ConfigureAwait(false);
-                await WriteStaticBytesAsync(destination, _enableCompression ? FileGzipHeaderBytes : FileJsonHeaderBytes, staticBuffer).ConfigureAwait(false);
+            await destination.WriteAsync(MultipartBytes.InitialBoundaryBytes, 0, MultipartBytes.InitialBoundaryBytes.Length).ConfigureAwait(false);
 
-                var countingStream = new CountingWriteStream(destination);
-                if (_enableCompression)
-                {
+            var fileHeaderBytes = _enableCompression ? MultipartBytes.FileGzipHeaderBytes : MultipartBytes.FileJsonHeaderBytes;
+            await destination.WriteAsync(fileHeaderBytes, 0, fileHeaderBytes.Length).ConfigureAwait(false);
+
+            var countingStream = new CountingWriteStream(destination);
+            if (_enableCompression)
+            {
 #if NETFRAMEWORK
-                    using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(countingStream) { IsStreamOwner = false })
+                using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(countingStream) { IsStreamOwner = false })
 #elif NETCOREAPP
-                    var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true);
-                    await using (gzipStream.ConfigureAwait(false))
+                var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true);
+                await using (gzipStream.ConfigureAwait(false))
 #else
-                    using (var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true))
+                using (var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true))
 #endif
-                    {
-                        await writeSymbols(gzipStream, state).ConfigureAwait(false);
-                        await gzipStream.FlushAsync().ConfigureAwait(false);
-                    }
-                }
-                else
                 {
-                    await writeSymbols(countingStream, state).ConfigureAwait(false);
-                    await countingStream.FlushAsync().ConfigureAwait(false);
+                    await writeSymbols(gzipStream, state).ConfigureAwait(false);
+                    await gzipStream.FlushAsync().ConfigureAwait(false);
                 }
-
-                var eventMetadata = CreateEventMetadata(metadata, _runtimeId, checked((int)countingStream.BytesWritten));
-
-                await WriteStaticBytesAsync(destination, BoundaryBytes, staticBuffer).ConfigureAwait(false);
-                await WriteStaticBytesAsync(destination, EventHeaderBytes, staticBuffer).ConfigureAwait(false);
-                await destination.WriteAsync(eventMetadata.Array!, eventMetadata.Offset, eventMetadata.Count).ConfigureAwait(false);
-                await WriteStaticBytesAsync(destination, FinalBoundaryBytes, staticBuffer).ConfigureAwait(false);
-                await destination.FlushAsync().ConfigureAwait(false);
             }
-            finally
+            else
             {
-                ArrayPool<byte>.Shared.Return(staticBuffer);
+                await writeSymbols(countingStream, state).ConfigureAwait(false);
+                await countingStream.FlushAsync().ConfigureAwait(false);
+            }
+
+            var eventMetadata = CreateEventMetadata(metadata, _runtimeId, checked((int)countingStream.BytesWritten));
+
+            await destination.WriteAsync(MultipartBytes.BoundaryBytes, 0, MultipartBytes.BoundaryBytes.Length).ConfigureAwait(false);
+            await destination.WriteAsync(MultipartBytes.EventHeaderBytes, 0, MultipartBytes.EventHeaderBytes.Length).ConfigureAwait(false);
+            await destination.WriteAsync(eventMetadata.Array!, eventMetadata.Offset, eventMetadata.Count).ConfigureAwait(false);
+            await destination.WriteAsync(MultipartBytes.FinalBoundaryBytes, 0, MultipartBytes.FinalBoundaryBytes.Length).ConfigureAwait(false);
+            await destination.FlushAsync().ConfigureAwait(false);
+        }
+
+        private static class MultipartBytes
+        {
+            internal static readonly byte[] InitialBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes("--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
+
+            internal static readonly byte[] BoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes(DatadogHttpValues.CrLf + "--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
+
+            internal static readonly byte[] FinalBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes(DatadogHttpValues.CrLf + "--" + DatadogHttpValues.Boundary + "--" + DatadogHttpValues.CrLf);
+
+            internal static readonly byte[] FileJsonHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Json + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"file\"; filename=\"file.json\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
+
+            internal static readonly byte[] FileGzipHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Gzip + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"file\"; filename=\"file.gz\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
+
+            internal static readonly byte[] EventHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Json + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"event\"; filename=\"event.json\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
+
+            // Remove beforefieldinit so initialization happens when this holder is first touched, on first upload.
+            static MultipartBytes()
+            {
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -18,13 +18,14 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Debugger.Upload
 {
     internal sealed class SymbolUploadApi : DebuggerUploadApiBase, ISymbolUploadApi
     {
         private const int MaxRetries = 3;
-        private const int StartingSleepDuration = 3;
+        private static readonly TimeSpan StartingSleepDuration = TimeSpan.FromSeconds(3);
 
         private static readonly byte[] InitialBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes("--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
         private static readonly byte[] BoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes(DatadogHttpValues.CrLf + "--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
@@ -38,18 +39,21 @@ namespace Datadog.Trace.Debugger.Upload
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly string _runtimeId;
         private readonly bool _enableCompression;
+        private readonly Func<TimeSpan, Task> _delayAsync;
 
         private SymbolUploadApi(
             IApiRequestFactory apiRequestFactory,
             IDiscoveryService discoveryService,
             IGitMetadataTagsProvider gitMetadataTagsProvider,
             string runtimeId,
-            bool enableCompression)
+            bool enableCompression,
+            Func<TimeSpan, Task>? delayAsync = null)
             : base(apiRequestFactory, gitMetadataTagsProvider)
         {
             _apiRequestFactory = apiRequestFactory;
             _runtimeId = runtimeId;
             _enableCompression = enableCompression;
+            _delayAsync = delayAsync ?? Task.Delay;
             discoveryService.SubscribeToChanges(c =>
             {
                 Endpoint = c.SymbolDbEndpoint;
@@ -61,14 +65,16 @@ namespace Datadog.Trace.Debugger.Upload
             IApiRequestFactory apiRequestFactory,
             IDiscoveryService discoveryService,
             IGitMetadataTagsProvider gitMetadataTagsProvider,
-            bool enableCompression)
+            bool enableCompression,
+            Func<TimeSpan, Task>? delayAsync = null)
         {
             return new SymbolUploadApi(
                 apiRequestFactory,
                 discoveryService,
                 gitMetadataTagsProvider,
                 Tracer.RuntimeId,
-                enableCompression);
+                enableCompression,
+                delayAsync);
         }
 
         internal static ArraySegment<byte> CreateEventMetadata(
@@ -162,40 +168,59 @@ namespace Datadog.Trace.Debugger.Upload
                 return false;
             }
 
-            var request = _apiRequestFactory.Create(new Uri(uri));
-
             var retries = 0;
-            var sleepDuration = StartingSleepDuration;
+            var endpoint = new Uri(uri);
+            var lastStatusCode = 0;
 
             while (retries < MaxRetries)
             {
-                using var response = await request
-                                           .PostAsync(
-                                                stream => WriteMultipartFormData(stream, writeSymbols, metadata),
-                                                MimeTypes.MultipartFormData,
-                                                contentEncoding: null,
-                                                DatadogHttpValues.Boundary)
-                                           .ConfigureAwait(false);
-                if (response.StatusCode is >= 200 and <= 299)
+                var request = _apiRequestFactory.Create(endpoint);
+                var shouldRetry = false;
+                using (var response = await request
+                           .PostAsync(
+                                stream => WriteMultipartFormData(stream, writeSymbols, metadata),
+                                MimeTypes.MultipartFormData,
+                                contentEncoding: null,
+                                DatadogHttpValues.Boundary)
+                           .ConfigureAwait(false))
                 {
-                    return true;
+                    if (response.StatusCode is >= 200 and <= 299)
+                    {
+                        return true;
+                    }
+
+                    lastStatusCode = response.StatusCode;
+                    retries++;
+                    shouldRetry = response.ShouldRetry();
+                    if (!shouldRetry)
+                    {
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            var content = await response.ReadAsStringAsync().ConfigureAwait(false);
+                            Log.Debug<int, string, Uri, Guid, long>("Symbol database upload failed with non-retryable response status code {StatusCode} and message: {ResponseContent}; endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", response.StatusCode, content, endpoint, metadata.UploadId, metadata.BatchNum);
+                        }
+
+                        return false;
+                    }
                 }
 
-                retries++;
-                if (response.ShouldRetry())
+                if (shouldRetry)
                 {
-                    sleepDuration *= (int)Math.Pow(2, retries);
-                    await Task.Delay(sleepDuration).ConfigureAwait(false);
-                }
-                else
-                {
-                    var content = await response.ReadAsStringAsync().ConfigureAwait(false);
-                    Log.Error<int, string>("Failed to upload symbol with status code {StatusCode} and message: {ResponseContent}", response.StatusCode, content);
-                    return false;
+                    if (retries < MaxRetries)
+                    {
+                        Log.Debug<int, int, Uri, Guid, long>("Retrying symbol database upload after retryable response status code {StatusCode}; attempt {Attempt}, endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", lastStatusCode, retries, endpoint, metadata.UploadId, metadata.BatchNum);
+                        await _delayAsync(GetRetryDelay(retries)).ConfigureAwait(false);
+                    }
                 }
             }
 
+            Log.Debug<int, int, Uri, Guid, long>("Symbol database upload failed after {Attempts} attempts with last status code {StatusCode}; endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", MaxRetries, lastStatusCode, endpoint, metadata.UploadId, metadata.BatchNum);
             return false;
+        }
+
+        private static TimeSpan GetRetryDelay(int retryAttempt)
+        {
+            return TimeSpan.FromSeconds(StartingSleepDuration.TotalSeconds * Math.Pow(2, retryAttempt - 1));
         }
 
         private async Task WriteMultipartFormData(Stream destination, Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -34,7 +34,6 @@ namespace Datadog.Trace.Debugger.Upload
 
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly IDiscoveryService _discoveryService;
-        private readonly Action<AgentConfiguration> _discoveryCallback;
         private readonly string _runtimeId;
         private readonly bool _enableCompression;
         private readonly Func<TimeSpan, Task> _delayAsync;
@@ -54,8 +53,7 @@ namespace Datadog.Trace.Debugger.Upload
             _runtimeId = runtimeId;
             _enableCompression = enableCompression;
             _delayAsync = delayAsync ?? Task.Delay;
-            _discoveryCallback = OnDiscoveryServiceChanged;
-            discoveryService.SubscribeToChanges(_discoveryCallback);
+            discoveryService.SubscribeToChanges(OnDiscoveryServiceChanged);
         }
 
         // Keep these boundary bytes in sync with DatadogHttpValues.Boundary.
@@ -256,7 +254,7 @@ namespace Datadog.Trace.Debugger.Upload
 
             Endpoint = configuration.SymbolDbEndpoint;
             // Once the agent advertises the SymDB endpoint, keep using it for this uploader.
-            _discoveryService.RemoveSubscription(_discoveryCallback);
+            _discoveryService.RemoveSubscription(OnDiscoveryServiceChanged);
             Log.Debug("SymbolUploadApi: Updated endpoint to {Endpoint}", Endpoint);
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -7,6 +7,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
@@ -25,6 +26,7 @@ namespace Datadog.Trace.Debugger.Upload
     internal sealed class SymbolUploadApi : DebuggerUploadApiBase, ISymbolUploadApi
     {
         private const int MaxRetries = 3;
+        private const int FailureLogInterval = 10;
         private static readonly TimeSpan StartingSleepDuration = TimeSpan.FromSeconds(3);
 
         private static readonly byte[] InitialBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes("--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
@@ -42,6 +44,7 @@ namespace Datadog.Trace.Debugger.Upload
         private readonly string _runtimeId;
         private readonly bool _enableCompression;
         private readonly Func<TimeSpan, Task> _delayAsync;
+        private int _uploadFailureCount;
 
         private SymbolUploadApi(
             IApiRequestFactory apiRequestFactory,
@@ -170,12 +173,10 @@ namespace Datadog.Trace.Debugger.Upload
 
             var retries = 0;
             var endpoint = new Uri(uri);
-            var lastStatusCode = 0;
 
             while (retries < MaxRetries)
             {
                 var request = _apiRequestFactory.Create(endpoint);
-                var shouldRetry = false;
                 using (var response = await request
                            .PostAsync(
                                 stream => WriteMultipartFormData(stream, writeSymbols, metadata),
@@ -189,33 +190,60 @@ namespace Datadog.Trace.Debugger.Upload
                         return true;
                     }
 
-                    lastStatusCode = response.StatusCode;
                     retries++;
-                    shouldRetry = response.ShouldRetry();
+                    var shouldRetry = response.ShouldRetry();
                     if (!shouldRetry)
                     {
-                        if (Log.IsEnabled(LogEventLevel.Debug))
-                        {
-                            var content = await response.ReadAsStringAsync().ConfigureAwait(false);
-                            Log.Debug<int, string, Uri, Guid, long>("Symbol database upload failed with non-retryable response status code {StatusCode} and message: {ResponseContent}; endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", response.StatusCode, content, endpoint, metadata.UploadId, metadata.BatchNum);
-                        }
+                        var failureCount = Interlocked.Increment(ref _uploadFailureCount);
+                        await LogUploadFailureAsync(response, endpoint, metadata, failureCount).ConfigureAwait(false);
 
                         return false;
                     }
-                }
 
-                if (shouldRetry)
-                {
-                    if (retries < MaxRetries)
+                    if (retries >= MaxRetries)
                     {
-                        Log.Debug<int, int, Uri, Guid, long>("Retrying symbol database upload after retryable response status code {StatusCode}; attempt {Attempt}, endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", lastStatusCode, retries, endpoint, metadata.UploadId, metadata.BatchNum);
-                        await _delayAsync(GetRetryDelay(retries)).ConfigureAwait(false);
+                        var failureCount = Interlocked.Increment(ref _uploadFailureCount);
+                        await LogUploadFailureAsync(response, endpoint, metadata, failureCount).ConfigureAwait(false);
+
+                        return false;
                     }
+
+                    Log.Debug<int, int, Uri, Guid, long>("Retrying symbol database upload after retryable response status code {StatusCode}; attempt {Attempt}, endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", response.StatusCode, retries, endpoint, metadata.UploadId, metadata.BatchNum);
+                    await _delayAsync(GetRetryDelay(retries)).ConfigureAwait(false);
                 }
             }
 
-            Log.Debug<int, int, Uri, Guid, long>("Symbol database upload failed after {Attempts} attempts with last status code {StatusCode}; endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", MaxRetries, lastStatusCode, endpoint, metadata.UploadId, metadata.BatchNum);
             return false;
+        }
+
+        private static bool ShouldLogFailureAsError(int failureCount)
+        {
+            return failureCount == 1 || failureCount % FailureLogInterval == 0;
+        }
+
+        private static Task LogUploadFailureAsync(IApiResponse response, Uri endpoint, SymDbUploadMetadata metadata, int failureCount)
+        {
+            var shouldLogError = ShouldLogFailureAsError(failureCount);
+            var isDebugEnabled = Log.IsEnabled(LogEventLevel.Debug);
+            if (!shouldLogError && !isDebugEnabled)
+            {
+                return Task.CompletedTask;
+            }
+
+            return LogUploadFailureCoreAsync(response, endpoint, metadata, failureCount, shouldLogError);
+        }
+
+        private static async Task LogUploadFailureCoreAsync(IApiResponse response, Uri endpoint, SymDbUploadMetadata metadata, int failureCount, bool shouldLogError)
+        {
+            var content = await response.ReadAsStringAsync().ConfigureAwait(false);
+            if (shouldLogError)
+            {
+                Log.Error<int, string, int>("Symbol database upload failed with status code {StatusCode} and message: {ResponseContent}; failure count {FailureCount}", response.StatusCode, content, failureCount);
+            }
+            else
+            {
+                Log.Debug<int, string, Uri, Guid, long>("Symbol database upload failed with status code {StatusCode} and message: {ResponseContent}; endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", response.StatusCode, content, endpoint, metadata.UploadId, metadata.BatchNum);
+            }
         }
 
         private static TimeSpan GetRetryDelay(int retryAttempt)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -201,13 +201,17 @@ namespace Datadog.Trace.Debugger.Upload
         private async Task WriteMultipartFormData(Stream destination, Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
         {
             await destination.WriteAsync(InitialBoundaryBytes, 0, InitialBoundaryBytes.Length).ConfigureAwait(false);
-            await destination.WriteAsync(_enableCompression ? FileGzipHeaderBytes : FileJsonHeaderBytes, 0, _enableCompression ? FileGzipHeaderBytes.Length : FileJsonHeaderBytes.Length).ConfigureAwait(false);
+            var fileHeaderBytes = _enableCompression ? FileGzipHeaderBytes : FileJsonHeaderBytes;
+            await destination.WriteAsync(fileHeaderBytes, 0, fileHeaderBytes.Length).ConfigureAwait(false);
 
             var countingStream = new CountingWriteStream(destination);
             if (_enableCompression)
             {
 #if NETFRAMEWORK
                 using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(countingStream) { IsStreamOwner = false })
+#elif NETCOREAPP
+                var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true);
+                await using (gzipStream.ConfigureAwait(false))
 #else
                 using (var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true))
 #endif

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -221,7 +221,14 @@ namespace Datadog.Trace.Debugger.Upload
             var content = await response.ReadAsStringAsync().ConfigureAwait(false);
             if (shouldLogError)
             {
-                Log.Error<int, string, int>("Symbol database upload failed with status code {StatusCode} and message: {ResponseContent}; failure count {FailureCount}", response.StatusCode, content, failureCount);
+                if (response.ShouldRetry())
+                {
+                    Log.ErrorSkipTelemetry<int, string, int>("Symbol database upload failed with status code {StatusCode} and message: {ResponseContent}; failure count {FailureCount}", response.StatusCode, content, failureCount);
+                }
+                else
+                {
+                    Log.Error<int, string, int>("Symbol database upload failed with status code {StatusCode} and message: {ResponseContent}; failure count {FailureCount}", response.StatusCode, content, failureCount);
+                }
             }
             else
             {
@@ -248,6 +255,7 @@ namespace Datadog.Trace.Debugger.Upload
             }
 
             Endpoint = configuration.SymbolDbEndpoint;
+            // Once the agent advertises the SymDB endpoint, keep using it for this uploader.
             _discoveryService.RemoveSubscription(_discoveryCallback);
             Log.Debug("SymbolUploadApi: Updated endpoint to {Endpoint}", Endpoint);
         }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -37,6 +37,8 @@ namespace Datadog.Trace.Debugger.Upload
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SymbolUploadApi>();
 
         private readonly IApiRequestFactory _apiRequestFactory;
+        private readonly IDiscoveryService _discoveryService;
+        private readonly Action<AgentConfiguration> _discoveryCallback;
         private readonly string _runtimeId;
         private readonly bool _enableCompression;
         private readonly Func<TimeSpan, Task> _delayAsync;
@@ -51,14 +53,12 @@ namespace Datadog.Trace.Debugger.Upload
             : base(apiRequestFactory, gitMetadataTagsProvider)
         {
             _apiRequestFactory = apiRequestFactory;
+            _discoveryService = discoveryService;
             _runtimeId = runtimeId;
             _enableCompression = enableCompression;
             _delayAsync = delayAsync ?? Task.Delay;
-            discoveryService.SubscribeToChanges(c =>
-            {
-                Endpoint = c.SymbolDbEndpoint;
-                Log.Debug("SymbolUploadApi: Updated endpoint to {Endpoint}", Endpoint);
-            });
+            _discoveryCallback = OnDiscoveryServiceChanged;
+            discoveryService.SubscribeToChanges(_discoveryCallback);
         }
 
         internal static ISymbolUploadApi Create(
@@ -221,6 +221,18 @@ namespace Datadog.Trace.Debugger.Upload
         private static TimeSpan GetRetryDelay(int retryAttempt)
         {
             return TimeSpan.FromSeconds(StartingSleepDuration.TotalSeconds * Math.Pow(2, retryAttempt - 1));
+        }
+
+        private void OnDiscoveryServiceChanged(AgentConfiguration configuration)
+        {
+            if (string.IsNullOrEmpty(configuration.SymbolDbEndpoint))
+            {
+                return;
+            }
+
+            Endpoint = configuration.SymbolDbEndpoint;
+            _discoveryService.RemoveSubscription(_discoveryCallback);
+            Log.Debug("SymbolUploadApi: Updated endpoint to {Endpoint}", Endpoint);
         }
 
         private async Task WriteMultipartFormData(Stream destination, Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -27,15 +27,8 @@ namespace Datadog.Trace.Debugger.Upload
     {
         private const int MaxRetries = 3;
         private const int FailureLogInterval = 10;
+        private const int StaticMultipartBufferSize = 256;
         private static readonly TimeSpan StartingSleepDuration = TimeSpan.FromSeconds(3);
-
-        private static readonly byte[] InitialBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes("--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
-        private static readonly byte[] BoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes(DatadogHttpValues.CrLf + "--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
-        private static readonly byte[] FinalBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes(DatadogHttpValues.CrLf + "--" + DatadogHttpValues.Boundary + "--" + DatadogHttpValues.CrLf);
-        private static readonly byte[] FileJsonHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Json + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"file\"; filename=\"file.json\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
-        private static readonly byte[] FileGzipHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Gzip + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"file\"; filename=\"file.gz\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
-        private static readonly byte[] EventHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Json + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"event\"; filename=\"event.json\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
-
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SymbolUploadApi>();
 
         private readonly IApiRequestFactory _apiRequestFactory;
@@ -63,6 +56,18 @@ namespace Datadog.Trace.Debugger.Upload
             _discoveryCallback = OnDiscoveryServiceChanged;
             discoveryService.SubscribeToChanges(_discoveryCallback);
         }
+
+        private static ReadOnlySpan<byte> InitialBoundaryBytes => "--faa0a896-8bc8-48f3-b46d-016f2b15a884\r\n"u8;
+
+        private static ReadOnlySpan<byte> BoundaryBytes => "\r\n--faa0a896-8bc8-48f3-b46d-016f2b15a884\r\n"u8;
+
+        private static ReadOnlySpan<byte> FinalBoundaryBytes => "\r\n--faa0a896-8bc8-48f3-b46d-016f2b15a884--\r\n"u8;
+
+        private static ReadOnlySpan<byte> FileJsonHeaderBytes => "Content-Type: application/json\r\nContent-Disposition: form-data; name=\"file\"; filename=\"file.json\"\r\n\r\n"u8;
+
+        private static ReadOnlySpan<byte> FileGzipHeaderBytes => "Content-Type: application/gzip\r\nContent-Disposition: form-data; name=\"file\"; filename=\"file.gz\"\r\n\r\n"u8;
+
+        private static ReadOnlySpan<byte> EventHeaderBytes => "Content-Type: application/json\r\nContent-Disposition: form-data; name=\"event\"; filename=\"event.json\"\r\n\r\n"u8;
 
         internal static ISymbolUploadApi Create(
             IApiRequestFactory apiRequestFactory,
@@ -228,6 +233,12 @@ namespace Datadog.Trace.Debugger.Upload
             return TimeSpan.FromSeconds(StartingSleepDuration.TotalSeconds * Math.Pow(2, retryAttempt - 1));
         }
 
+        private static Task WriteStaticBytesAsync(Stream destination, ReadOnlySpan<byte> source, byte[] buffer)
+        {
+            source.CopyTo(buffer);
+            return destination.WriteAsync(buffer, 0, source.Length);
+        }
+
         private void OnDiscoveryServiceChanged(AgentConfiguration configuration)
         {
             if (string.IsNullOrEmpty(configuration.SymbolDbEndpoint))
@@ -242,39 +253,46 @@ namespace Datadog.Trace.Debugger.Upload
 
         private async Task WriteMultipartFormData<TState>(Stream destination, Func<Stream, TState, Task> writeSymbols, TState state, SymDbUploadMetadata metadata)
         {
-            await destination.WriteAsync(InitialBoundaryBytes, 0, InitialBoundaryBytes.Length).ConfigureAwait(false);
-            var fileHeaderBytes = _enableCompression ? FileGzipHeaderBytes : FileJsonHeaderBytes;
-            await destination.WriteAsync(fileHeaderBytes, 0, fileHeaderBytes.Length).ConfigureAwait(false);
-
-            var countingStream = new CountingWriteStream(destination);
-            if (_enableCompression)
+            var staticBuffer = ArrayPool<byte>.Shared.Rent(StaticMultipartBufferSize);
+            try
             {
-#if NETFRAMEWORK
-                using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(countingStream) { IsStreamOwner = false })
-#elif NETCOREAPP
-                var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true);
-                await using (gzipStream.ConfigureAwait(false))
-#else
-                using (var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true))
-#endif
+                await WriteStaticBytesAsync(destination, InitialBoundaryBytes, staticBuffer).ConfigureAwait(false);
+                await WriteStaticBytesAsync(destination, _enableCompression ? FileGzipHeaderBytes : FileJsonHeaderBytes, staticBuffer).ConfigureAwait(false);
+
+                var countingStream = new CountingWriteStream(destination);
+                if (_enableCompression)
                 {
-                    await writeSymbols(gzipStream, state).ConfigureAwait(false);
-                    await gzipStream.FlushAsync().ConfigureAwait(false);
+#if NETFRAMEWORK
+                    using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(countingStream) { IsStreamOwner = false })
+#elif NETCOREAPP
+                    var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true);
+                    await using (gzipStream.ConfigureAwait(false))
+#else
+                    using (var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true))
+#endif
+                    {
+                        await writeSymbols(gzipStream, state).ConfigureAwait(false);
+                        await gzipStream.FlushAsync().ConfigureAwait(false);
+                    }
                 }
+                else
+                {
+                    await writeSymbols(countingStream, state).ConfigureAwait(false);
+                    await countingStream.FlushAsync().ConfigureAwait(false);
+                }
+
+                var eventMetadata = CreateEventMetadata(metadata, _runtimeId, checked((int)countingStream.BytesWritten));
+
+                await WriteStaticBytesAsync(destination, BoundaryBytes, staticBuffer).ConfigureAwait(false);
+                await WriteStaticBytesAsync(destination, EventHeaderBytes, staticBuffer).ConfigureAwait(false);
+                await destination.WriteAsync(eventMetadata.Array!, eventMetadata.Offset, eventMetadata.Count).ConfigureAwait(false);
+                await WriteStaticBytesAsync(destination, FinalBoundaryBytes, staticBuffer).ConfigureAwait(false);
+                await destination.FlushAsync().ConfigureAwait(false);
             }
-            else
+            finally
             {
-                await writeSymbols(countingStream, state).ConfigureAwait(false);
-                await countingStream.FlushAsync().ConfigureAwait(false);
+                ArrayPool<byte>.Shared.Return(staticBuffer);
             }
-
-            var eventMetadata = CreateEventMetadata(metadata, _runtimeId, checked((int)countingStream.BytesWritten));
-
-            await destination.WriteAsync(BoundaryBytes, 0, BoundaryBytes.Length).ConfigureAwait(false);
-            await destination.WriteAsync(EventHeaderBytes, 0, EventHeaderBytes.Length).ConfigureAwait(false);
-            await destination.WriteAsync(eventMetadata.Array!, eventMetadata.Offset, eventMetadata.Count).ConfigureAwait(false);
-            await destination.WriteAsync(FinalBoundaryBytes, 0, FinalBoundaryBytes.Length).ConfigureAwait(false);
-            await destination.FlushAsync().ConfigureAwait(false);
         }
 
         private sealed class CountingWriteStream : Stream

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -134,30 +134,7 @@ namespace Datadog.Trace.Debugger.Upload
                        : new ArraySegment<byte>(stream.ToArray());
         }
 
-        public override Task<bool> SendBatchAsync(ArraySegment<byte> symbols)
-        {
-            // SymbolsUploader is the only caller and uses the typed overload
-            // below (so that metadata matches what's stamped into the
-            // attachment Root). The IBatchUploadApi.SendBatchAsync method is
-            // retained for interface compatibility only.
-            throw new NotSupportedException(
-                "Use SendBatchAsync(symbols, metadata) for SymDB uploads.");
-        }
-
-        public async Task<bool> SendBatchAsync(ArraySegment<byte> symbols, SymDbUploadMetadata metadata)
-        {
-            if (symbols.Array == null || symbols.Count == 0)
-            {
-                return false;
-            }
-
-            return await SendBatchAsync(
-                       stream => stream.WriteAsync(symbols.Array, symbols.Offset, symbols.Count),
-                       metadata)
-                  .ConfigureAwait(false);
-        }
-
-        public async Task<bool> SendBatchAsync(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
+        public async Task<bool> SendBatchAsync<TState>(Func<Stream, TState, Task> writeSymbols, TState state, SymDbUploadMetadata metadata)
         {
             if (writeSymbols == null)
             {
@@ -179,7 +156,7 @@ namespace Datadog.Trace.Debugger.Upload
                 var request = _apiRequestFactory.Create(endpoint);
                 using (var response = await request
                            .PostAsync(
-                                stream => WriteMultipartFormData(stream, writeSymbols, metadata),
+                                stream => WriteMultipartFormData(stream, writeSymbols, state, metadata),
                                 MimeTypes.MultipartFormData,
                                 contentEncoding: null,
                                 DatadogHttpValues.Boundary)
@@ -263,7 +240,7 @@ namespace Datadog.Trace.Debugger.Upload
             Log.Debug("SymbolUploadApi: Updated endpoint to {Endpoint}", Endpoint);
         }
 
-        private async Task WriteMultipartFormData(Stream destination, Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
+        private async Task WriteMultipartFormData<TState>(Stream destination, Func<Stream, TState, Task> writeSymbols, TState state, SymDbUploadMetadata metadata)
         {
             await destination.WriteAsync(InitialBoundaryBytes, 0, InitialBoundaryBytes.Length).ConfigureAwait(false);
             var fileHeaderBytes = _enableCompression ? FileGzipHeaderBytes : FileJsonHeaderBytes;
@@ -281,13 +258,13 @@ namespace Datadog.Trace.Debugger.Upload
                 using (var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true))
 #endif
                 {
-                    await writeSymbols(gzipStream).ConfigureAwait(false);
+                    await writeSymbols(gzipStream, state).ConfigureAwait(false);
                     await gzipStream.FlushAsync().ConfigureAwait(false);
                 }
             }
             else
             {
-                await writeSymbols(countingStream).ConfigureAwait(false);
+                await writeSymbols(countingStream, state).ConfigureAwait(false);
                 await countingStream.FlushAsync().ConfigureAwait(false);
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -159,40 +159,39 @@ namespace Datadog.Trace.Debugger.Upload
             while (retries < MaxRetries)
             {
                 var request = _apiRequestFactory.Create(endpoint);
-                using (var response = await request
+                using var response = await request
                            .PostAsync(
                                 stream => WriteMultipartFormData(stream, writeSymbols, state, metadata),
                                 MimeTypes.MultipartFormData,
                                 contentEncoding: null,
                                 DatadogHttpValues.Boundary)
-                           .ConfigureAwait(false))
+                           .ConfigureAwait(false);
+
+                if (response.StatusCode is >= 200 and <= 299)
                 {
-                    if (response.StatusCode is >= 200 and <= 299)
-                    {
-                        return true;
-                    }
-
-                    retries++;
-                    var shouldRetry = response.ShouldRetry();
-                    if (!shouldRetry)
-                    {
-                        var failureCount = Interlocked.Increment(ref _uploadFailureCount);
-                        await LogUploadFailureAsync(response, endpoint, metadata, failureCount).ConfigureAwait(false);
-
-                        return false;
-                    }
-
-                    if (retries >= MaxRetries)
-                    {
-                        var failureCount = Interlocked.Increment(ref _uploadFailureCount);
-                        await LogUploadFailureAsync(response, endpoint, metadata, failureCount).ConfigureAwait(false);
-
-                        return false;
-                    }
-
-                    Log.Debug<int, int, Uri, Guid, long>("Retrying symbol database upload after retryable response status code {StatusCode}; attempt {Attempt}, endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", response.StatusCode, retries, endpoint, metadata.UploadId, metadata.BatchNum);
-                    await _delayAsync(GetRetryDelay(retries)).ConfigureAwait(false);
+                    return true;
                 }
+
+                retries++;
+                var shouldRetry = response.ShouldRetry();
+                if (!shouldRetry)
+                {
+                    var failureCount = Interlocked.Increment(ref _uploadFailureCount);
+                    await LogUploadFailureAsync(response, endpoint, metadata, failureCount).ConfigureAwait(false);
+
+                    return false;
+                }
+
+                if (retries >= MaxRetries)
+                {
+                    var failureCount = Interlocked.Increment(ref _uploadFailureCount);
+                    await LogUploadFailureAsync(response, endpoint, metadata, failureCount).ConfigureAwait(false);
+
+                    return false;
+                }
+
+                Log.Debug<int, int, Uri, Guid, long>("Retrying symbol database upload after retryable response status code {StatusCode}; attempt {Attempt}, endpoint {Endpoint}, uploadId {UploadId}, batchNum {BatchNum}", response.StatusCode, retries, endpoint, metadata.UploadId, metadata.BatchNum);
+                await _delayAsync(GetRetryDelay(retries)).ConfigureAwait(false);
             }
 
             return false;

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.Models;
+using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Util.Json;
@@ -24,6 +25,13 @@ namespace Datadog.Trace.Debugger.Upload
     {
         private const int MaxRetries = 3;
         private const int StartingSleepDuration = 3;
+
+        private static readonly byte[] InitialBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes("--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
+        private static readonly byte[] BoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes(DatadogHttpValues.CrLf + "--" + DatadogHttpValues.Boundary + DatadogHttpValues.CrLf);
+        private static readonly byte[] FinalBoundaryBytes = EncodingHelpers.Utf8NoBom.GetBytes(DatadogHttpValues.CrLf + "--" + DatadogHttpValues.Boundary + "--" + DatadogHttpValues.CrLf);
+        private static readonly byte[] FileJsonHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Json + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"file\"; filename=\"file.json\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
+        private static readonly byte[] FileGzipHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Gzip + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"file\"; filename=\"file.gz\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
+        private static readonly byte[] EventHeaderBytes = EncodingHelpers.Utf8NoBom.GetBytes("Content-Type: " + MimeTypes.Json + DatadogHttpValues.CrLf + "Content-Disposition: form-data; name=\"event\"; filename=\"event.json\"" + DatadogHttpValues.CrLf + DatadogHttpValues.CrLf);
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SymbolUploadApi>();
 
@@ -134,6 +142,19 @@ namespace Datadog.Trace.Debugger.Upload
                 return false;
             }
 
+            return await SendBatchAsync(
+                       stream => stream.WriteAsync(symbols.Array, symbols.Offset, symbols.Count),
+                       metadata)
+                  .ConfigureAwait(false);
+        }
+
+        public async Task<bool> SendBatchAsync(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
+        {
+            if (writeSymbols == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(writeSymbols));
+            }
+
             var uri = BuildUri();
             if (string.IsNullOrEmpty(uri))
             {
@@ -146,35 +167,15 @@ namespace Datadog.Trace.Debugger.Upload
             var retries = 0;
             var sleepDuration = StartingSleepDuration;
 
-            MultipartFormItem symbolsItem;
-            ArraySegment<byte> attachmentBytes;
-
-            if (!_enableCompression)
-            {
-                attachmentBytes = symbols;
-                symbolsItem = new MultipartFormItem("file", MimeTypes.Json, "file.json", attachmentBytes);
-            }
-            else
-            {
-                var compressedSymbols = await CompressDataAsync(symbols).ConfigureAwait(false);
-                if (compressedSymbols == null)
-                {
-                    return false;
-                }
-
-                attachmentBytes = compressedSymbols.Value;
-                symbolsItem = new MultipartFormItem("file", MimeTypes.Gzip, "file.gz", attachmentBytes);
-            }
-
-            var eventMetadata = CreateEventMetadata(
-                metadata,
-                _runtimeId,
-                attachmentBytes.Count);
-            var items = new[] { symbolsItem, new MultipartFormItem("event", MimeTypes.Json, "event.json", eventMetadata) };
-
             while (retries < MaxRetries)
             {
-                using var response = await request.PostAsync(items).ConfigureAwait(false);
+                using var response = await request
+                                           .PostAsync(
+                                                stream => WriteMultipartFormData(stream, writeSymbols, metadata),
+                                                MimeTypes.MultipartFormData,
+                                                contentEncoding: null,
+                                                DatadogHttpValues.Boundary)
+                                           .ConfigureAwait(false);
                 if (response.StatusCode is >= 200 and <= 299)
                 {
                     return true;
@@ -197,41 +198,108 @@ namespace Datadog.Trace.Debugger.Upload
             return false;
         }
 
-        internal async Task<ArraySegment<byte>?> CompressDataAsync(ArraySegment<byte> data)
+        private async Task WriteMultipartFormData(Stream destination, Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
         {
-            using var memoryStream = new MemoryStream();
+            await destination.WriteAsync(InitialBoundaryBytes, 0, InitialBoundaryBytes.Length).ConfigureAwait(false);
+            await destination.WriteAsync(_enableCompression ? FileGzipHeaderBytes : FileJsonHeaderBytes, 0, _enableCompression ? FileGzipHeaderBytes.Length : FileJsonHeaderBytes.Length).ConfigureAwait(false);
 
+            var countingStream = new CountingWriteStream(destination);
+            if (_enableCompression)
+            {
 #if NETFRAMEWORK
-            using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(memoryStream))
+                using (var gzipStream = new Vendors.ICSharpCode.SharpZipLib.GZip.GZipOutputStream(countingStream) { IsStreamOwner = false })
 #else
-            using (var gzipStream = new GZipStream(memoryStream, CompressionMode.Compress))
+                using (var gzipStream = new GZipStream(countingStream, CompressionMode.Compress, leaveOpen: true))
 #endif
+                {
+                    await writeSymbols(gzipStream).ConfigureAwait(false);
+                    await gzipStream.FlushAsync().ConfigureAwait(false);
+                }
+            }
+            else
             {
-                await gzipStream.WriteAsync(data.Array!, data.Offset, data.Count).ConfigureAwait(false);
-                await gzipStream.FlushAsync().ConfigureAwait(false);
+                await writeSymbols(countingStream).ConfigureAwait(false);
+                await countingStream.FlushAsync().ConfigureAwait(false);
             }
 
-            var compressedData = memoryStream.ToArray();
+            var eventMetadata = CreateEventMetadata(metadata, _runtimeId, checked((int)countingStream.BytesWritten));
 
-            // see here about the following validation: https://forensics.wiki/gzip/
-            // minimum size for header + footer
-            if (compressedData.Length < 18)
+            await destination.WriteAsync(BoundaryBytes, 0, BoundaryBytes.Length).ConfigureAwait(false);
+            await destination.WriteAsync(EventHeaderBytes, 0, EventHeaderBytes.Length).ConfigureAwait(false);
+            await destination.WriteAsync(eventMetadata.Array!, eventMetadata.Offset, eventMetadata.Count).ConfigureAwait(false);
+            await destination.WriteAsync(FinalBoundaryBytes, 0, FinalBoundaryBytes.Length).ConfigureAwait(false);
+            await destination.FlushAsync().ConfigureAwait(false);
+        }
+
+        private sealed class CountingWriteStream : Stream
+        {
+            private readonly Stream _inner;
+
+            public CountingWriteStream(Stream inner)
             {
-                Log.Error("Compression produced invalid data: size {Size} bytes is below minimum valid GZip size", property: compressedData.Length);
-                return null;
+                _inner = inner;
             }
 
-            // header magic numbers
-            if (compressedData[0] != 0x1F || compressedData[1] != 0x8B)
-            {
-                Log.Error(
-                    "Compression produced invalid data: invalid GZip header {Header}",
-                    BitConverter.ToString(System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Take(compressedData, 2))));
+            public long BytesWritten { get; private set; }
 
-                return null;
+            public override bool CanRead => false;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => _inner.CanWrite;
+
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
             }
 
-            return new ArraySegment<byte>(compressedData);
+            public override void Flush()
+            {
+                _inner.Flush();
+            }
+
+            public override Task FlushAsync(System.Threading.CancellationToken cancellationToken)
+            {
+                return _inner.FlushAsync(cancellationToken);
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                _inner.Write(buffer, offset, count);
+                BytesWritten += count;
+            }
+
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken)
+            {
+                await _inner.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+                BytesWritten += count;
+            }
+
+#if NETCOREAPP
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default)
+            {
+                await _inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                BytesWritten += buffer.Length;
+            }
+#endif
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
@@ -50,7 +50,8 @@ internal class DiscoveryServiceMock : IDiscoveryService
 
     public void TriggerChange(AgentConfiguration config)
     {
-        foreach (var callback in new List<Action<AgentConfiguration>>(Callbacks))
+        var callbacks = Callbacks.ToArray();
+        foreach (var callback in callbacks)
         {
             callback(config);
         }

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
@@ -50,7 +50,7 @@ internal class DiscoveryServiceMock : IDiscoveryService
 
     public void TriggerChange(AgentConfiguration config)
     {
-        foreach (var callback in Callbacks)
+        foreach (var callback in new List<Action<AgentConfiguration>>(Callbacks))
         {
             callback(config);
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -181,6 +181,23 @@ public class SymbolUploadApiTests
         delays.Should().Equal(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(6));
     }
 
+    [Fact]
+    public void DiscoverySubscription_IsRemovedAfterSymbolDbEndpointIsDiscovered()
+    {
+        var requestFactory = new CapturingRequestFactory();
+        var discoveryService = new DiscoveryServiceMock();
+        _ = SymbolUploadApi.Create(requestFactory, discoveryService, new NullGitMetadataProvider(), enableCompression: false);
+
+        discoveryService.Callbacks.Should().HaveCount(1);
+
+        discoveryService.TriggerChange(symbolDbEndpoint: null);
+        discoveryService.Callbacks.Should().HaveCount(1);
+
+        discoveryService.TriggerChange(symbolDbEndpoint: "symdb/v1/input");
+
+        discoveryService.Callbacks.Should().BeEmpty();
+    }
+
     private static void AssertMultipartRequest(CapturingRequest request, SymDbUploadMetadata metadata, Guid uploadId, string symbolsJson, bool enableCompression)
     {
         request.ContentType.Should().Be("multipart/form-data; boundary=" + DatadogHttpValues.Boundary);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -195,6 +195,21 @@ public class SymbolUploadApiTests
         delays.Should().Equal(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(6));
     }
 
+    [Theory]
+    [InlineData(400, false)]
+    [InlineData(401, false)]
+    [InlineData(403, false)]
+    [InlineData(408, true)]
+    [InlineData(429, true)]
+    [InlineData(500, true)]
+    [InlineData(502, true)]
+    [InlineData(503, true)]
+    [InlineData(504, true)]
+    public void ShouldRetry_SplitsPayloadBugsFromTransientFailures(int statusCode, bool expected)
+    {
+        new TestApiResponse(statusCode, "{}", MimeTypes.Json).ShouldRetry().Should().Be(expected);
+    }
+
     [Fact]
     public void DiscoverySubscription_IsRemovedAfterSymbolDbEndpointIsDiscovered()
     {
@@ -225,6 +240,13 @@ public class SymbolUploadApiTests
         var eventContent = ReadBytes(eventPart.Data);
         var eventJson = JObject.Parse(Encoding.UTF8.GetString(eventContent));
         eventJson["runtimeId"] = "<runtime-id>";
+        eventJson["attachmentSize"]?.Value<int>().Should().Be(fileContent.Length);
+
+        var fileLength = enableCompression ? (object)"<compressed-length>" : fileContent.Length;
+        if (enableCompression)
+        {
+            eventJson["attachmentSize"] = "<compressed-length>";
+        }
 
         return new
         {
@@ -236,7 +258,7 @@ public class SymbolUploadApiTests
                     filePart.Name,
                     filePart.FileName,
                     filePart.ContentType,
-                    Length = fileContent.Length,
+                    Length = fileLength,
                     Content = Encoding.UTF8.GetString(enableCompression ? Decompress(fileContent) : fileContent)
                 },
                 new
@@ -244,7 +266,7 @@ public class SymbolUploadApiTests
                     eventPart.Name,
                     eventPart.FileName,
                     eventPart.ContentType,
-                    Length = eventContent.Length,
+                    Length = (object)eventContent.Length,
                     Content = eventJson.ToString(Formatting.Indented)
                 }
             }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -17,7 +17,6 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.Upload;
 using Datadog.Trace.HttpOverStreams;
-using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.TransportHelpers;
 using Datadog.Trace.Tests.Agent;
 using Datadog.Trace.Util;
@@ -34,11 +33,6 @@ namespace Datadog.Trace.Tests.Debugger.SymbolsTests;
 [UsesVerify]
 public class SymbolUploadApiTests
 {
-    public SymbolUploadApiTests()
-    {
-        VerifyHelper.InitializeGlobalSettings();
-    }
-
     [Fact]
     public void EventMetadata_IsValidJson_AndContainsAllFields()
     {
@@ -101,7 +95,9 @@ public class SymbolUploadApiTests
                                metadata);
 
         result.Should().BeTrue();
-        await Verifier.Verify(ParseRequestForVerify(requestFactory.Request, enableCompression))
+        var settings = new VerifySettings();
+        settings.UseDirectory(Path.Combine("..", "..", "..", "snapshots"));
+        await Verifier.Verify(ParseRequestForVerify(requestFactory.Request, enableCompression), settings)
                       .UseFileName($"{nameof(SymbolUploadApiTests)}.SendBatchAsync_WritesExpectedMultipartWireFormat.{(enableCompression ? "compressed" : "uncompressed")}")
                       .DisableRequireUniquePrefix();
     }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -272,7 +272,8 @@ public class SymbolUploadApiTests
 
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string? contentEncoding)
         {
-            Body = bytes.ToArray();
+            Body = new byte[bytes.Count];
+            Array.Copy(bytes.Array!, bytes.Offset, Body, 0, bytes.Count);
             ContentType = contentType;
             return Task.FromResult<IApiResponse>(new TestApiResponse(200, "{}", MimeTypes.Json));
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -17,18 +17,28 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.Upload;
 using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.TransportHelpers;
 using Datadog.Trace.Tests.Agent;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using FluentAssertions;
+using HttpMultipartParser;
+using VerifyTests;
+using VerifyXunit;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Debugger.SymbolsTests;
 
+[UsesVerify]
 public class SymbolUploadApiTests
 {
+    public SymbolUploadApiTests()
+    {
+        VerifyHelper.InitializeGlobalSettings();
+    }
+
     [Fact]
     public void EventMetadata_IsValidJson_AndContainsAllFields()
     {
@@ -69,11 +79,10 @@ public class SymbolUploadApiTests
     public async Task SendBatchAsync_WritesExpectedMultipartWireFormat(bool enableCompression)
     {
         const string symbolsJson = """{"service":"benchmark","scopes":[]}""";
-        var uploadId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var metadata = new SymDbUploadMetadata(
             Service: "benchmark-service",
             Version: "1.0.0",
-            UploadId: uploadId,
+            UploadId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
             BatchNum: 7,
             Final: false);
         var requestFactory = new CapturingRequestFactory();
@@ -92,7 +101,9 @@ public class SymbolUploadApiTests
                                metadata);
 
         result.Should().BeTrue();
-        AssertMultipartRequest(requestFactory.Request, metadata, uploadId, symbolsJson, enableCompression);
+        await Verifier.Verify(ParseRequestForVerify(requestFactory.Request, enableCompression))
+                      .UseFileName($"{nameof(SymbolUploadApiTests)}.SendBatchAsync_WritesExpectedMultipartWireFormat.{(enableCompression ? "compressed" : "uncompressed")}")
+                      .DisableRequireUniquePrefix();
     }
 
     [Theory]
@@ -101,11 +112,10 @@ public class SymbolUploadApiTests
     public async Task SendBatchAsync_RetriesWithFreshRequestAndReplaysMultipartBody(bool enableCompression)
     {
         const string symbolsJson = """{"service":"benchmark","scopes":[{"name":"type"}]}""";
-        var uploadId = Guid.Parse("11111111-2222-3333-4444-555555555555");
         var metadata = new SymDbUploadMetadata(
             Service: "benchmark-service",
             Version: "1.0.0",
-            UploadId: uploadId,
+            UploadId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
             BatchNum: 7,
             Final: false);
         var requestFactory = new CapturingRequestFactory(500, 200);
@@ -140,8 +150,9 @@ public class SymbolUploadApiTests
         delays.Should().Equal(TimeSpan.FromSeconds(3));
         requestFactory.Requests.Should().HaveCount(2);
         requestFactory.Requests[0].Should().NotBeSameAs(requestFactory.Requests[1]);
-        AssertMultipartRequest(requestFactory.Requests[0], metadata, uploadId, symbolsJson, enableCompression);
-        AssertMultipartRequest(requestFactory.Requests[1], metadata, uploadId, symbolsJson, enableCompression);
+        ParseRequestForVerify(requestFactory.Requests[1], enableCompression)
+           .Should()
+           .BeEquivalentTo(ParseRequestForVerify(requestFactory.Requests[0], enableCompression));
     }
 
     [Fact]
@@ -201,35 +212,50 @@ public class SymbolUploadApiTests
         discoveryService.Callbacks.Should().BeEmpty();
     }
 
-    private static void AssertMultipartRequest(CapturingRequest request, SymDbUploadMetadata metadata, Guid uploadId, string symbolsJson, bool enableCompression)
+    private static object ParseRequestForVerify(CapturingRequest request, bool enableCompression)
     {
-        request.ContentType.Should().Be("multipart/form-data; boundary=" + DatadogHttpValues.Boundary);
-        request.MultipartBoundary.Should().Be(DatadogHttpValues.Boundary);
+        using var bodyStream = new MemoryStream(request.Body);
+        var form = MultipartFormDataParser.Parse(bodyStream, DatadogHttpValues.Boundary, Encoding.UTF8);
+        form.Parameters.Should().BeEmpty();
+        form.Files.Should().HaveCount(2);
 
-        var parts = ParseMultipart(request.Body);
-        parts.Should().HaveCount(2);
+        var filePart = form.Files[0];
+        var eventPart = form.Files[1];
+        var fileContent = ReadBytes(filePart.Data);
+        var eventContent = ReadBytes(eventPart.Data);
+        var eventJson = JObject.Parse(Encoding.UTF8.GetString(eventContent));
+        eventJson["runtimeId"] = "<runtime-id>";
 
-        var filePart = parts[0];
-        filePart.Headers.Should().Contain("Content-Disposition: form-data; name=\"file\"; filename=\"" + (enableCompression ? "file.gz" : "file.json") + "\"");
-        filePart.Headers.Should().Contain("Content-Type: " + (enableCompression ? MimeTypes.Gzip : MimeTypes.Json));
+        return new
+        {
+            ContentType = request.ContentType,
+            Files = new[]
+            {
+                new
+                {
+                    filePart.Name,
+                    filePart.FileName,
+                    filePart.ContentType,
+                    Length = fileContent.Length,
+                    Content = Encoding.UTF8.GetString(enableCompression ? Decompress(fileContent) : fileContent)
+                },
+                new
+                {
+                    eventPart.Name,
+                    eventPart.FileName,
+                    eventPart.ContentType,
+                    Length = eventContent.Length,
+                    Content = eventJson.ToString(Formatting.Indented)
+                }
+            }
+        };
+    }
 
-        var fileBytes = enableCompression ? Decompress(filePart.Content) : filePart.Content;
-        Encoding.UTF8.GetString(fileBytes).Should().Be(symbolsJson);
-
-        var eventPart = parts[1];
-        eventPart.Headers.Should().Contain("Content-Disposition: form-data; name=\"event\"; filename=\"event.json\"");
-        eventPart.Headers.Should().Contain("Content-Type: " + MimeTypes.Json);
-        var eventJson = JObject.Parse(Encoding.UTF8.GetString(eventPart.Content));
-        eventJson["ddsource"]!.Value<string>().Should().Be("dd_debugger");
-        eventJson["service"]!.Value<string>().Should().Be(metadata.Service);
-        eventJson["version"]!.Value<string>().Should().Be(metadata.Version);
-        eventJson["language"]!.Value<string>().Should().Be("dotnet");
-        eventJson["runtimeId"]!.Value<string>().Should().NotBeNullOrEmpty();
-        eventJson["type"]!.Value<string>().Should().Be("symdb");
-        eventJson["uploadId"]!.Value<string>().Should().Be(uploadId.ToString());
-        eventJson["batchNum"]!.Value<long>().Should().Be(metadata.BatchNum);
-        eventJson["final"]!.Value<bool>().Should().BeFalse();
-        eventJson["attachmentSize"]!.Value<int>().Should().Be(filePart.Content.Length);
+    private static byte[] ReadBytes(Stream stream)
+    {
+        using var memoryStream = new MemoryStream();
+        stream.CopyTo(memoryStream);
+        return memoryStream.ToArray();
     }
 
     private static byte[] Decompress(byte[] compressed)
@@ -240,110 +266,6 @@ public class SymbolUploadApiTests
         gzipStream.CopyTo(decompressed);
         return decompressed.ToArray();
     }
-
-    private static MultipartPart[] ParseMultipart(byte[] body)
-    {
-        var boundary = Encoding.UTF8.GetBytes("--" + DatadogHttpValues.Boundary);
-        var crlf = Encoding.UTF8.GetBytes("\r\n");
-        var headerSeparator = Encoding.UTF8.GetBytes("\r\n\r\n");
-        var parts = new System.Collections.Generic.List<MultipartPart>();
-        var position = 0;
-
-        while (position < body.Length)
-        {
-            var boundaryIndex = IndexOf(body, boundary, position);
-            if (boundaryIndex < 0)
-            {
-                break;
-            }
-
-            position = boundaryIndex + boundary.Length;
-            if (position + 2 <= body.Length && body[position] == '-' && body[position + 1] == '-')
-            {
-                break;
-            }
-
-            if (!StartsWith(body, crlf, position))
-            {
-                throw new InvalidOperationException("Expected CRLF after multipart boundary.");
-            }
-
-            position += crlf.Length;
-            var headerEnd = IndexOf(body, headerSeparator, position);
-            if (headerEnd < 0)
-            {
-                throw new InvalidOperationException("Expected multipart header separator.");
-            }
-
-            var headers = Encoding.UTF8.GetString(body, position, headerEnd - position)
-                                  .Split(new[] { "\r\n" }, StringSplitOptions.None);
-            position = headerEnd + headerSeparator.Length;
-
-            var nextBoundary = IndexOf(body, boundary, position);
-            if (nextBoundary < 0)
-            {
-                throw new InvalidOperationException("Expected next multipart boundary.");
-            }
-
-            var contentLength = nextBoundary - position;
-            if (contentLength >= crlf.Length &&
-                body[nextBoundary - 2] == '\r' &&
-                body[nextBoundary - 1] == '\n')
-            {
-                contentLength -= crlf.Length;
-            }
-
-            var content = new byte[contentLength];
-            Array.Copy(body, position, content, 0, content.Length);
-            parts.Add(new MultipartPart(headers, content));
-            position = nextBoundary;
-        }
-
-        return parts.ToArray();
-    }
-
-    private static bool StartsWith(byte[] source, byte[] value, int startIndex)
-    {
-        if (startIndex + value.Length > source.Length)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < value.Length; i++)
-        {
-            if (source[startIndex + i] != value[i])
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static int IndexOf(byte[] source, byte[] value, int startIndex)
-    {
-        for (var i = startIndex; i <= source.Length - value.Length; i++)
-        {
-            var found = true;
-            for (var j = 0; j < value.Length; j++)
-            {
-                if (source[i + j] != value[j])
-                {
-                    found = false;
-                    break;
-                }
-            }
-
-            if (found)
-            {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
-    private readonly record struct MultipartPart(string[] Headers, byte[] Content);
 
     private sealed class MutableInt
     {
@@ -396,8 +318,6 @@ public class SymbolUploadApiTests
 
         public string? ContentType { get; private set; }
 
-        public string? MultipartBoundary { get; private set; }
-
         public void AddHeader(string name, string value)
         {
         }
@@ -431,7 +351,6 @@ public class SymbolUploadApiTests
             await writeToRequestStream(stream).ConfigureAwait(false);
             Body = stream.ToArray();
             ContentType = ContentTypeHelper.GetContentType(contentType, multipartBoundary);
-            MultipartBoundary = multipartBoundary;
             return new TestApiResponse(_statusCode, "{}", MimeTypes.Json);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -83,11 +83,12 @@ public class SymbolUploadApiTests
 
         var result = await api
                           .SendBatchAsync(
-                               async stream =>
+                               static async (stream, state) =>
                                {
-                                   var bytes = Encoding.UTF8.GetBytes(symbolsJson);
+                                   var bytes = Encoding.UTF8.GetBytes(state);
                                    await stream.WriteAsync(bytes, 0, bytes.Length);
                                },
+                               symbolsJson,
                                metadata);
 
         result.Should().BeTrue();
@@ -121,20 +122,21 @@ public class SymbolUploadApiTests
                 return Task.CompletedTask;
             });
         discoveryService.TriggerChange(symbolDbEndpoint: "symdb/v1/input");
-        var writerCalls = 0;
+        var writerCalls = new MutableInt();
 
         var result = await api
                           .SendBatchAsync(
-                               async stream =>
+                               static async (stream, state) =>
                                {
-                                   writerCalls++;
-                                   var bytes = Encoding.UTF8.GetBytes(symbolsJson);
+                                   state.WriterCalls.Value++;
+                                   var bytes = Encoding.UTF8.GetBytes(state.SymbolsJson);
                                    await stream.WriteAsync(bytes, 0, bytes.Length);
                                },
+                               (SymbolsJson: symbolsJson, WriterCalls: writerCalls),
                                metadata);
 
         result.Should().BeTrue();
-        writerCalls.Should().Be(2);
+        writerCalls.Value.Should().Be(2);
         delays.Should().Equal(TimeSpan.FromSeconds(3));
         requestFactory.Requests.Should().HaveCount(2);
         requestFactory.Requests[0].Should().NotBeSameAs(requestFactory.Requests[1]);
@@ -169,11 +171,12 @@ public class SymbolUploadApiTests
 
         var result = await api
                           .SendBatchAsync(
-                               async stream =>
+                               static async (stream, state) =>
                                {
-                                   var bytes = Encoding.UTF8.GetBytes(symbolsJson);
+                                   var bytes = Encoding.UTF8.GetBytes(state);
                                    await stream.WriteAsync(bytes, 0, bytes.Length);
                                },
+                               symbolsJson,
                                metadata);
 
         result.Should().BeFalse();
@@ -341,6 +344,11 @@ public class SymbolUploadApiTests
     }
 
     private readonly record struct MultipartPart(string[] Headers, byte[] Content);
+
+    private sealed class MutableInt
+    {
+        public int Value { get; set; }
+    }
 
     private sealed class CapturingRequestFactory : IApiRequestFactory
     {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -6,9 +6,22 @@
 #nullable enable
 
 using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
 using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.Upload;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using Datadog.Trace.Tests.Agent;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Debugger.SymbolsTests;
@@ -47,5 +60,245 @@ public class SymbolUploadApiTests
         Assert.Equal(batchNum, (long?)jobj["batchNum"]);
         Assert.Equal(false, (bool?)jobj["final"]);
         Assert.Equal(attachmentSize, (int?)jobj["attachmentSize"]);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SendBatchAsync_WritesExpectedMultipartWireFormat(bool enableCompression)
+    {
+        const string symbolsJson = """{"service":"benchmark","scopes":[]}""";
+        var uploadId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var metadata = new SymDbUploadMetadata(
+            Service: "benchmark-service",
+            Version: "1.0.0",
+            UploadId: uploadId,
+            BatchNum: 7,
+            Final: false);
+        var requestFactory = new CapturingRequestFactory();
+        var discoveryService = new DiscoveryServiceMock();
+        var api = SymbolUploadApi.Create(requestFactory, discoveryService, new NullGitMetadataProvider(), enableCompression);
+        discoveryService.TriggerChange(symbolDbEndpoint: "symdb/v1/input");
+
+        var result = await api
+                          .SendBatchAsync(
+                               async stream =>
+                               {
+                                   var bytes = Encoding.UTF8.GetBytes(symbolsJson);
+                                   await stream.WriteAsync(bytes, 0, bytes.Length);
+                               },
+                               metadata);
+
+        result.Should().BeTrue();
+        requestFactory.Request.ContentType.Should().Be("multipart/form-data; boundary=" + DatadogHttpValues.Boundary);
+        requestFactory.Request.MultipartBoundary.Should().Be(DatadogHttpValues.Boundary);
+
+        var parts = ParseMultipart(requestFactory.Request.Body);
+        parts.Should().HaveCount(2);
+
+        var filePart = parts[0];
+        filePart.Headers.Should().Contain("Content-Disposition: form-data; name=\"file\"; filename=\"" + (enableCompression ? "file.gz" : "file.json") + "\"");
+        filePart.Headers.Should().Contain("Content-Type: " + (enableCompression ? MimeTypes.Gzip : MimeTypes.Json));
+
+        var fileBytes = enableCompression ? Decompress(filePart.Content) : filePart.Content;
+        Encoding.UTF8.GetString(fileBytes).Should().Be(symbolsJson);
+
+        var eventPart = parts[1];
+        eventPart.Headers.Should().Contain("Content-Disposition: form-data; name=\"event\"; filename=\"event.json\"");
+        eventPart.Headers.Should().Contain("Content-Type: " + MimeTypes.Json);
+        var eventJson = JObject.Parse(Encoding.UTF8.GetString(eventPart.Content));
+        eventJson["ddsource"]!.Value<string>().Should().Be("dd_debugger");
+        eventJson["service"]!.Value<string>().Should().Be(metadata.Service);
+        eventJson["version"]!.Value<string>().Should().Be(metadata.Version);
+        eventJson["language"]!.Value<string>().Should().Be("dotnet");
+        eventJson["runtimeId"]!.Value<string>().Should().NotBeNullOrEmpty();
+        eventJson["type"]!.Value<string>().Should().Be("symdb");
+        eventJson["uploadId"]!.Value<string>().Should().Be(uploadId.ToString());
+        eventJson["batchNum"]!.Value<long>().Should().Be(metadata.BatchNum);
+        eventJson["final"]!.Value<bool>().Should().BeFalse();
+        eventJson["attachmentSize"]!.Value<int>().Should().Be(filePart.Content.Length);
+    }
+
+    private static byte[] Decompress(byte[] compressed)
+    {
+        using var compressedStream = new MemoryStream(compressed);
+        using var gzipStream = new GZipStream(compressedStream, CompressionMode.Decompress);
+        using var decompressed = new MemoryStream();
+        gzipStream.CopyTo(decompressed);
+        return decompressed.ToArray();
+    }
+
+    private static MultipartPart[] ParseMultipart(byte[] body)
+    {
+        var boundary = Encoding.UTF8.GetBytes("--" + DatadogHttpValues.Boundary);
+        var crlf = Encoding.UTF8.GetBytes("\r\n");
+        var headerSeparator = Encoding.UTF8.GetBytes("\r\n\r\n");
+        var parts = new System.Collections.Generic.List<MultipartPart>();
+        var position = 0;
+
+        while (position < body.Length)
+        {
+            var boundaryIndex = IndexOf(body, boundary, position);
+            if (boundaryIndex < 0)
+            {
+                break;
+            }
+
+            position = boundaryIndex + boundary.Length;
+            if (position + 2 <= body.Length && body[position] == '-' && body[position + 1] == '-')
+            {
+                break;
+            }
+
+            if (!StartsWith(body, crlf, position))
+            {
+                throw new InvalidOperationException("Expected CRLF after multipart boundary.");
+            }
+
+            position += crlf.Length;
+            var headerEnd = IndexOf(body, headerSeparator, position);
+            if (headerEnd < 0)
+            {
+                throw new InvalidOperationException("Expected multipart header separator.");
+            }
+
+            var headers = Encoding.UTF8.GetString(body, position, headerEnd - position)
+                                  .Split(new[] { "\r\n" }, StringSplitOptions.None);
+            position = headerEnd + headerSeparator.Length;
+
+            var nextBoundary = IndexOf(body, boundary, position);
+            if (nextBoundary < 0)
+            {
+                throw new InvalidOperationException("Expected next multipart boundary.");
+            }
+
+            var contentLength = nextBoundary - position;
+            if (contentLength >= crlf.Length &&
+                body[nextBoundary - 2] == '\r' &&
+                body[nextBoundary - 1] == '\n')
+            {
+                contentLength -= crlf.Length;
+            }
+
+            var content = new byte[contentLength];
+            Array.Copy(body, position, content, 0, content.Length);
+            parts.Add(new MultipartPart(headers, content));
+            position = nextBoundary;
+        }
+
+        return parts.ToArray();
+    }
+
+    private static bool StartsWith(byte[] source, byte[] value, int startIndex)
+    {
+        if (startIndex + value.Length > source.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (source[startIndex + i] != value[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int IndexOf(byte[] source, byte[] value, int startIndex)
+    {
+        for (var i = startIndex; i <= source.Length - value.Length; i++)
+        {
+            var found = true;
+            for (var j = 0; j < value.Length; j++)
+            {
+                if (source[i + j] != value[j])
+                {
+                    found = false;
+                    break;
+                }
+            }
+
+            if (found)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private readonly record struct MultipartPart(string[] Headers, byte[] Content);
+
+    private sealed class CapturingRequestFactory : IApiRequestFactory
+    {
+        private readonly Uri _baseEndpoint = new("http://localhost:8126/");
+
+        public CapturingRequest Request { get; } = new();
+
+        public string Info(Uri endpoint)
+            => endpoint.ToString();
+
+        public Uri GetEndpoint(string relativePath)
+            => UriHelpers.Combine(_baseEndpoint, relativePath);
+
+        public IApiRequest Create(Uri endpoint)
+            => Request;
+
+        public void SetProxy(WebProxy proxy, NetworkCredential credential)
+        {
+        }
+    }
+
+    private sealed class CapturingRequest : IApiRequest
+    {
+        public byte[] Body { get; private set; } = [];
+
+        public string? ContentType { get; private set; }
+
+        public string? MultipartBoundary { get; private set; }
+
+        public void AddHeader(string name, string value)
+        {
+        }
+
+        public Task<IApiResponse> GetAsync()
+            => Task.FromResult<IApiResponse>(new TestApiResponse(200, "{}", MimeTypes.Json));
+
+        public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
+            => PostAsync(bytes, contentType, contentEncoding: null);
+
+        public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string? contentEncoding)
+        {
+            Body = bytes.ToArray();
+            ContentType = contentType;
+            return Task.FromResult<IApiResponse>(new TestApiResponse(200, "{}", MimeTypes.Json));
+        }
+
+        public Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression)
+            => PostAsJsonAsync(payload, compression, SerializationHelpers.DefaultJsonSettings);
+
+        public Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
+        {
+            ContentType = MimeTypes.Json;
+            return Task.FromResult<IApiResponse>(new TestApiResponse(200, "{}", MimeTypes.Json));
+        }
+
+        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+        {
+            using var stream = new MemoryStream();
+            await writeToRequestStream(stream).ConfigureAwait(false);
+            Body = stream.ToArray();
+            ContentType = ContentTypeHelper.GetContentType(contentType, multipartBoundary);
+            MultipartBoundary = multipartBoundary;
+            return new TestApiResponse(200, "{}", MimeTypes.Json);
+        }
+
+        public Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
@@ -90,10 +91,102 @@ public class SymbolUploadApiTests
                                metadata);
 
         result.Should().BeTrue();
-        requestFactory.Request.ContentType.Should().Be("multipart/form-data; boundary=" + DatadogHttpValues.Boundary);
-        requestFactory.Request.MultipartBoundary.Should().Be(DatadogHttpValues.Boundary);
+        AssertMultipartRequest(requestFactory.Request, metadata, uploadId, symbolsJson, enableCompression);
+    }
 
-        var parts = ParseMultipart(requestFactory.Request.Body);
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SendBatchAsync_RetriesWithFreshRequestAndReplaysMultipartBody(bool enableCompression)
+    {
+        const string symbolsJson = """{"service":"benchmark","scopes":[{"name":"type"}]}""";
+        var uploadId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        var metadata = new SymDbUploadMetadata(
+            Service: "benchmark-service",
+            Version: "1.0.0",
+            UploadId: uploadId,
+            BatchNum: 7,
+            Final: false);
+        var requestFactory = new CapturingRequestFactory(500, 200);
+        var discoveryService = new DiscoveryServiceMock();
+        var delays = new List<TimeSpan>();
+        var api = SymbolUploadApi.Create(
+            requestFactory,
+            discoveryService,
+            new NullGitMetadataProvider(),
+            enableCompression,
+            delay =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            });
+        discoveryService.TriggerChange(symbolDbEndpoint: "symdb/v1/input");
+        var writerCalls = 0;
+
+        var result = await api
+                          .SendBatchAsync(
+                               async stream =>
+                               {
+                                   writerCalls++;
+                                   var bytes = Encoding.UTF8.GetBytes(symbolsJson);
+                                   await stream.WriteAsync(bytes, 0, bytes.Length);
+                               },
+                               metadata);
+
+        result.Should().BeTrue();
+        writerCalls.Should().Be(2);
+        delays.Should().Equal(TimeSpan.FromSeconds(3));
+        requestFactory.Requests.Should().HaveCount(2);
+        requestFactory.Requests[0].Should().NotBeSameAs(requestFactory.Requests[1]);
+        AssertMultipartRequest(requestFactory.Requests[0], metadata, uploadId, symbolsJson, enableCompression);
+        AssertMultipartRequest(requestFactory.Requests[1], metadata, uploadId, symbolsJson, enableCompression);
+    }
+
+    [Fact]
+    public async Task SendBatchAsync_DoesNotDelayAfterFinalRetry()
+    {
+        const string symbolsJson = """{"service":"benchmark","scopes":[{"name":"type"}]}""";
+        var metadata = new SymDbUploadMetadata(
+            Service: "benchmark-service",
+            Version: "1.0.0",
+            UploadId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            BatchNum: 7,
+            Final: false);
+        var requestFactory = new CapturingRequestFactory(500, 500, 500);
+        var discoveryService = new DiscoveryServiceMock();
+        var delays = new List<TimeSpan>();
+        var api = SymbolUploadApi.Create(
+            requestFactory,
+            discoveryService,
+            new NullGitMetadataProvider(),
+            enableCompression: false,
+            delayAsync: delay =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            });
+        discoveryService.TriggerChange(symbolDbEndpoint: "symdb/v1/input");
+
+        var result = await api
+                          .SendBatchAsync(
+                               async stream =>
+                               {
+                                   var bytes = Encoding.UTF8.GetBytes(symbolsJson);
+                                   await stream.WriteAsync(bytes, 0, bytes.Length);
+                               },
+                               metadata);
+
+        result.Should().BeFalse();
+        requestFactory.Requests.Should().HaveCount(3);
+        delays.Should().Equal(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(6));
+    }
+
+    private static void AssertMultipartRequest(CapturingRequest request, SymDbUploadMetadata metadata, Guid uploadId, string symbolsJson, bool enableCompression)
+    {
+        request.ContentType.Should().Be("multipart/form-data; boundary=" + DatadogHttpValues.Boundary);
+        request.MultipartBoundary.Should().Be(DatadogHttpValues.Boundary);
+
+        var parts = ParseMultipart(request.Body);
         parts.Should().HaveCount(2);
 
         var filePart = parts[0];
@@ -235,8 +328,16 @@ public class SymbolUploadApiTests
     private sealed class CapturingRequestFactory : IApiRequestFactory
     {
         private readonly Uri _baseEndpoint = new("http://localhost:8126/");
+        private readonly Queue<int> _statusCodes;
 
-        public CapturingRequest Request { get; } = new();
+        public CapturingRequestFactory(params int[] statusCodes)
+        {
+            _statusCodes = new Queue<int>(statusCodes.Length == 0 ? new[] { 200 } : statusCodes);
+        }
+
+        public List<CapturingRequest> Requests { get; } = new();
+
+        public CapturingRequest Request => Requests[0];
 
         public string Info(Uri endpoint)
             => endpoint.ToString();
@@ -245,7 +346,12 @@ public class SymbolUploadApiTests
             => UriHelpers.Combine(_baseEndpoint, relativePath);
 
         public IApiRequest Create(Uri endpoint)
-            => Request;
+        {
+            var statusCode = _statusCodes.Count > 0 ? _statusCodes.Dequeue() : 200;
+            var request = new CapturingRequest(statusCode);
+            Requests.Add(request);
+            return request;
+        }
 
         public void SetProxy(WebProxy proxy, NetworkCredential credential)
         {
@@ -254,6 +360,13 @@ public class SymbolUploadApiTests
 
     private sealed class CapturingRequest : IApiRequest
     {
+        private readonly int _statusCode;
+
+        public CapturingRequest(int statusCode)
+        {
+            _statusCode = statusCode;
+        }
+
         public byte[] Body { get; private set; } = [];
 
         public string? ContentType { get; private set; }
@@ -265,7 +378,7 @@ public class SymbolUploadApiTests
         }
 
         public Task<IApiResponse> GetAsync()
-            => Task.FromResult<IApiResponse>(new TestApiResponse(200, "{}", MimeTypes.Json));
+            => Task.FromResult<IApiResponse>(new TestApiResponse(_statusCode, "{}", MimeTypes.Json));
 
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
             => PostAsync(bytes, contentType, contentEncoding: null);
@@ -275,7 +388,7 @@ public class SymbolUploadApiTests
             Body = new byte[bytes.Count];
             Array.Copy(bytes.Array!, bytes.Offset, Body, 0, bytes.Count);
             ContentType = contentType;
-            return Task.FromResult<IApiResponse>(new TestApiResponse(200, "{}", MimeTypes.Json));
+            return Task.FromResult<IApiResponse>(new TestApiResponse(_statusCode, "{}", MimeTypes.Json));
         }
 
         public Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression)
@@ -284,7 +397,7 @@ public class SymbolUploadApiTests
         public Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
         {
             ContentType = MimeTypes.Json;
-            return Task.FromResult<IApiResponse>(new TestApiResponse(200, "{}", MimeTypes.Json));
+            return Task.FromResult<IApiResponse>(new TestApiResponse(_statusCode, "{}", MimeTypes.Json));
         }
 
         public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
@@ -294,7 +407,7 @@ public class SymbolUploadApiTests
             Body = stream.ToArray();
             ContentType = ContentTypeHelper.GetContentType(contentType, multipartBoundary);
             MultipartBoundary = multipartBoundary;
-            return new TestApiResponse(200, "{}", MimeTypes.Json);
+            return new TestApiResponse(_statusCode, "{}", MimeTypes.Json);
         }
 
         public Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
@@ -155,22 +155,10 @@ public class SymbolUploaderTest
     {
         public List<byte[]> Segments { get; } = new();
 
-        public Task<bool> SendBatchAsync(ArraySegment<byte> symbols)
-        {
-            Segments.Add(symbols.ToArray());
-            return Task.FromResult(true);
-        }
-
-        public Task<bool> SendBatchAsync(ArraySegment<byte> symbols, SymDbUploadMetadata metadata)
-        {
-            Segments.Add(symbols.ToArray());
-            return Task.FromResult(true);
-        }
-
-        public async Task<bool> SendBatchAsync(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
+        public async Task<bool> SendBatchAsync<TState>(Func<Stream, TState, Task> writeSymbols, TState state, SymDbUploadMetadata metadata)
         {
             using var stream = new MemoryStream();
-            await writeSymbols(stream).ConfigureAwait(false);
+            await writeSymbols(stream, state).ConfigureAwait(false);
             Segments.Add(stream.ToArray());
             return true;
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
@@ -6,6 +6,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -164,6 +165,14 @@ public class SymbolUploaderTest
         {
             Segments.Add(symbols.ToArray());
             return Task.FromResult(true);
+        }
+
+        public async Task<bool> SendBatchAsync(Func<Stream, Task> writeSymbols, SymDbUploadMetadata metadata)
+        {
+            using var stream = new MemoryStream();
+            await writeSymbols(stream).ConfigureAwait(false);
+            Segments.Add(stream.ToArray());
+            return true;
         }
     }
 }

--- a/tracer/test/snapshots/SymbolUploadApiTests.SendBatchAsync_WritesExpectedMultipartWireFormat.compressed.verified.txt
+++ b/tracer/test/snapshots/SymbolUploadApiTests.SendBatchAsync_WritesExpectedMultipartWireFormat.compressed.verified.txt
@@ -1,0 +1,31 @@
+﻿{
+  ContentType: multipart/form-data; boundary=faa0a896-8bc8-48f3-b46d-016f2b15a884,
+  Files: [
+    {
+      Name: file,
+      FileName: file.gz,
+      ContentType: application/gzip,
+      Length: 61,
+      Content: {"service":"benchmark","scopes":[]}
+    },
+    {
+      Name: event,
+      FileName: event.json,
+      ContentType: application/json,
+      Length: 257,
+      Content:
+{
+  "ddsource": "dd_debugger",
+  "service": "benchmark-service",
+  "version": "1.0.0",
+  "language": "dotnet",
+  "runtimeId": "<runtime-id>",
+  "type": "symdb",
+  "uploadId": "11111111-2222-3333-4444-555555555555",
+  "batchNum": 7,
+  "final": false,
+  "attachmentSize": 61
+}
+    }
+  ]
+}

--- a/tracer/test/snapshots/SymbolUploadApiTests.SendBatchAsync_WritesExpectedMultipartWireFormat.compressed.verified.txt
+++ b/tracer/test/snapshots/SymbolUploadApiTests.SendBatchAsync_WritesExpectedMultipartWireFormat.compressed.verified.txt
@@ -5,7 +5,7 @@
       Name: file,
       FileName: file.gz,
       ContentType: application/gzip,
-      Length: 61,
+      Length: <compressed-length>,
       Content: {"service":"benchmark","scopes":[]}
     },
     {
@@ -24,7 +24,7 @@
   "uploadId": "11111111-2222-3333-4444-555555555555",
   "batchNum": 7,
   "final": false,
-  "attachmentSize": 61
+  "attachmentSize": "<compressed-length>"
 }
     }
   ]

--- a/tracer/test/snapshots/SymbolUploadApiTests.SendBatchAsync_WritesExpectedMultipartWireFormat.uncompressed.verified.txt
+++ b/tracer/test/snapshots/SymbolUploadApiTests.SendBatchAsync_WritesExpectedMultipartWireFormat.uncompressed.verified.txt
@@ -1,0 +1,31 @@
+﻿{
+  ContentType: multipart/form-data; boundary=faa0a896-8bc8-48f3-b46d-016f2b15a884,
+  Files: [
+    {
+      Name: file,
+      FileName: file.json,
+      ContentType: application/json,
+      Length: 35,
+      Content: {"service":"benchmark","scopes":[]}
+    },
+    {
+      Name: event,
+      FileName: event.json,
+      ContentType: application/json,
+      Length: 257,
+      Content:
+{
+  "ddsource": "dd_debugger",
+  "service": "benchmark-service",
+  "version": "1.0.0",
+  "language": "dotnet",
+  "runtimeId": "<runtime-id>",
+  "type": "symdb",
+  "uploadId": "11111111-2222-3333-4444-555555555555",
+  "batchNum": 7,
+  "final": false,
+  "attachmentSize": 35
+}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of changes

- Stream SymDB upload payloads directly into the request body instead of converting the final JSON string to UTF-8 bytes first.
- Add a streaming `ISymbolUploadApi` overload for SymDB payload writers.
- Write SymDB multipart uploads manually so the `file` part can be streamed and the `event` metadata can still include the final attachment size.
- Preserve compressed and uncompressed upload behavior, including multipart part order and event metadata.
- Add wire-format tests for compressed and uncompressed SymDB multipart uploads.

## Reason for change

- Reduce large intermediate allocations and copies during SymDB uploads.
- Avoid buffering gzip-compressed SymDB payloads before sending them.
- Keep backend-sensitive multipart behavior covered by tests while changing the upload implementation.

## Implementation details

- `SymbolsUploader` keeps the existing batch-building flow, but writes `StringBuilder` chunks to a `StreamWriter` asynchronously instead of materializing a final string and byte array.
- `SymbolUploadApi` streams the `file` part first, counts the actual bytes written through a counting stream, then writes the `event` part with the computed `attachmentSize`.
- The .NET Core gzip path uses async disposal so gzip finalization does not rely on synchronous `Dispose`; the .NET Framework SharpZipLib path remains synchronous.
- Multipart wire-format tests validate part order, filenames, content types, gzip decompression, event metadata, and attachment size.

## Test coverage

- `SymbolUploaderTest|SymbolUploadApiTests`
- System Tests

## Other details

Local BenchmarkDotNet results for a 1 MB SymDB batch on `net8.0`:

| Method | Before | After | Change |
|---|---:|---:|---:|
| `UploadClasses` mean | `48.186 ms` | `41.356 ms` | `-14.2%` |
| `UploadClasses` allocated | `25,800.36 KB` | `16,022.55 KB` | `-37.9%` |
| `SendCompressedMultipart` mean | `1.922 ms` | `46.53 us` | `-97.6%` |
| `SendCompressedMultipart` allocated | `77.95 KB` | `4.52 KB` | `-94.2%` |
