### PR TITLE
Increase integration_tests_linux Test job timeout to 90 minutes

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2265,7 +2265,7 @@ stages:
       jobs: [Test, DockerTest, Serverless]
 
   - job: Test
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_matrix']]
 


### PR DESCRIPTION
## Summary of changes

Bumps the `timeoutInMinutes` for the `Test` job in `integration_tests_linux` from 60 to 90.

## Reason for change

Some linux integration tests jobs were being killed from time to time by the 60-minute agent wall-clock limit. The job takes ~64 minutes legitimately: ~10 minutes of Early Flake Detection tests (which spawn child test processes and run each test multiple times by design) and ~3 minutes of `RuntimeMetricsTests` (each test runs a sample app with a 30-second sleep). No unexpected retries involved — the slowness is by design.

Example of failing job: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=202258&view=logs&s=81ae2f89-c25e-5081-04b4-ddbf80377ce9&j=98203481-d655-5e50-8507-a7118df54a6e