### PR TITLE
[DBM] Add dynamic_service propagation mode

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -79,10 +79,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
             try
             {
                 var dbmPropagationMode = tracer.Settings.DbmPropagationMode;
-                // DynamicService is service-level propagation with base-hash injection; normalize to Service for the propagators
-                var effectivePropagationMode = dbmPropagationMode == DbmPropagationLevel.DynamicService
-                    ? DbmPropagationLevel.Service
-                    : dbmPropagationMode;
                 if (dbmPropagationMode != DbmPropagationLevel.Disabled)
                 {
                     var alreadyInjected = commandText.StartsWith(DatabaseMonitoringPropagator.DbmPrefix) ||
@@ -95,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                         // There's not a lot we can do about it (we don't want to start parsing commandText), so just
                         // report it for now
                         if (!Volatile.Read(ref _dbCommandCachingLogged)
-                            && effectivePropagationMode != DbmPropagationLevel.Service)
+                            && dbmPropagationMode != DbmPropagationLevel.Service)
                         {
                             _dbCommandCachingLogged = true;
                             var spanContext = scope.Span.Context;
@@ -116,9 +112,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
                         // PropagateDataViaComment (service) - this injects various trace information as a comment in the query
                         // PropagateDataViaContext (full)    - this makes a special set context_info for Microsoft SQL Server (nothing else supported)
-                        var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(effectivePropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span, tracer.Settings.InjectContextIntoStoredProceduresEnabled, baseHash);
+                        var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span, tracer.Settings.InjectContextIntoStoredProceduresEnabled, baseHash);
                         // try context injection only after comment injection, so that if it fails, we still have service level propagation
-                        var traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(effectivePropagationMode, integrationId, command, scope.Span);
+                        var traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(dbmPropagationMode, integrationId, command, scope.Span);
 
                         if (traceParentInjectedInComment || traceParentInjectedInContext)
                         {
@@ -270,8 +266,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
             public static Scope? CreateDbCommandScope(Tracer tracer, IDbCommand command)
             {
                 var commandType = command.GetType();
-                var isDynamicService = tracer.Settings.DbmPropagationMode == DbmPropagationLevel.DynamicService;
-                var baseHash = tracer.Settings.PropagateProcessTags && (tracer.Settings.DbmInjectSqlBasehash || isDynamicService)
+                var baseHash = tracer.Settings.PropagateProcessTags && tracer.Settings.DbmInjectSqlBasehash
                                    ? tracer.TracerManager.ServiceRemappingHash?.Base64Value
                                    : null; // null if disabled
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -78,7 +78,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
             try
             {
-                if (tracer.Settings.DbmPropagationMode != DbmPropagationLevel.Disabled)
+                var dbmPropagationMode = tracer.Settings.DbmPropagationMode;
+                // DynamicService is service-level propagation with base-hash injection; normalize to Service for the propagators
+                var effectivePropagationMode = dbmPropagationMode == DbmPropagationLevel.DynamicService
+                    ? DbmPropagationLevel.Service
+                    : dbmPropagationMode;
+                if (dbmPropagationMode != DbmPropagationLevel.Disabled)
                 {
                     var alreadyInjected = commandText.StartsWith(DatabaseMonitoringPropagator.DbmPrefix) ||
                                           // if we appended the comment, we need to look for a potential DBM comment in the whole string.
@@ -90,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                         // There's not a lot we can do about it (we don't want to start parsing commandText), so just
                         // report it for now
                         if (!Volatile.Read(ref _dbCommandCachingLogged)
-                            && tracer.Settings.DbmPropagationMode != DbmPropagationLevel.Service)
+                            && effectivePropagationMode != DbmPropagationLevel.Service)
                         {
                             _dbCommandCachingLogged = true;
                             var spanContext = scope.Span.Context;
@@ -111,9 +116,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
                         // PropagateDataViaComment (service) - this injects various trace information as a comment in the query
                         // PropagateDataViaContext (full)    - this makes a special set context_info for Microsoft SQL Server (nothing else supported)
-                        var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(tracer.Settings.DbmPropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span, tracer.Settings.InjectContextIntoStoredProceduresEnabled, baseHash);
+                        var traceParentInjectedInComment = DatabaseMonitoringPropagator.PropagateDataViaComment(effectivePropagationMode, integrationId, command, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span, tracer.Settings.InjectContextIntoStoredProceduresEnabled, baseHash);
                         // try context injection only after comment injection, so that if it fails, we still have service level propagation
-                        var traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(tracer.Settings.DbmPropagationMode, integrationId, command, scope.Span);
+                        var traceParentInjectedInContext = DatabaseMonitoringPropagator.PropagateDataViaContext(effectivePropagationMode, integrationId, command, scope.Span);
 
                         if (traceParentInjectedInComment || traceParentInjectedInContext)
                         {
@@ -265,7 +270,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
             public static Scope? CreateDbCommandScope(Tracer tracer, IDbCommand command)
             {
                 var commandType = command.GetType();
-                var baseHash = tracer.Settings.PropagateProcessTags && tracer.Settings.DbmInjectSqlBasehash
+                var isDynamicService = tracer.Settings.DbmPropagationMode == DbmPropagationLevel.DynamicService;
+                var baseHash = tracer.Settings.PropagateProcessTags && (tracer.Settings.DbmInjectSqlBasehash || isDynamicService)
                                    ? tracer.TracerManager.ServiceRemappingHash?.Base64Value
                                    : null; // null if disabled
 

--- a/tracer/src/Datadog.Trace/Configuration/DbmPropagationLevel.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DbmPropagationLevel.cs
@@ -16,9 +16,6 @@ namespace Datadog.Trace.Configuration
         /// <summary>Only service tags should be injected</summary>
         Service,
 
-        /// <summary>Service tags injected and base hash injected; equivalent to Service with DD_DBM_INJECT_SQL_BASEHASH=true</summary>
-        DynamicService,
-
         /// <summary>Both service details and span traceparent should be injected</summary>
         Full
     }

--- a/tracer/src/Datadog.Trace/Configuration/DbmPropagationLevel.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DbmPropagationLevel.cs
@@ -16,6 +16,9 @@ namespace Datadog.Trace.Configuration
         /// <summary>Only service tags should be injected</summary>
         Service,
 
+        /// <summary>Service tags injected and base hash injected; equivalent to Service with DD_DBM_INJECT_SQL_BASEHASH=true</summary>
+        DynamicService,
+
         /// <summary>Both service details and span traceparent should be injected</summary>
         Full
     }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -638,16 +638,24 @@ namespace Datadog.Trace.Configuration
                                                   ? TrimSplitString(urlSubstringSkips.ToUpperInvariant(), commaSeparator)
                                                   : [];
 
-            DbmPropagationMode = config
-                                .WithKeys(ConfigurationKeys.DbmPropagationMode)
-                                .GetAs(
-                                     defaultValue: new(DbmPropagationLevel.Disabled, nameof(DbmPropagationLevel.Disabled)),
-                                     converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
-                                     validator: null);
+            var dbmPropagationMode = config
+                                    .WithKeys(ConfigurationKeys.DbmPropagationMode)
+                                    .GetAs(
+                                         defaultValue: new(new(DbmPropagationLevel.Disabled), nameof(DbmPropagationLevel.Disabled)),
+                                         converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationResult>.Failure(),
+                                         validator: null);
+            DbmPropagationMode = dbmPropagationMode.EffectiveLevel;
 
             DbmInjectSqlBasehash = config
                 .WithKeys(ConfigurationKeys.DbmInjectSqlBasehash)
                 .AsBool(false);
+
+            if (dbmPropagationMode.ForceInjectBaseHash && !DbmInjectSqlBasehash)
+            {
+                // dynamic_service overrides the DbmInjectSqlBaseHash setting
+                DbmInjectSqlBasehash = true;
+                telemetry.Record(ConfigurationKeys.DbmInjectSqlBasehash, true, ConfigurationOrigins.Calculated);
+            }
 
             RemoteConfigurationEnabled = config.WithKeys(ConfigurationKeys.Rcm.RemoteConfigurationEnabled).AsBool(true);
 
@@ -1449,24 +1457,24 @@ namespace Datadog.Trace.Configuration
             return string.Empty;
         }
 
-        private static DbmPropagationLevel? ToDbmPropagationInput(string inputValue)
+        private static DbmPropagationResult? ToDbmPropagationInput(string inputValue)
         {
             inputValue = inputValue.Trim(); // we know inputValue isn't null (and have tests for it)
             if (inputValue.Equals("disabled", StringComparison.OrdinalIgnoreCase))
             {
-                return DbmPropagationLevel.Disabled;
+                return new(DbmPropagationLevel.Disabled);
             }
             else if (inputValue.Equals("service", StringComparison.OrdinalIgnoreCase))
             {
-                return DbmPropagationLevel.Service;
+                return new(DbmPropagationLevel.Service);
             }
             else if (inputValue.Equals("dynamic_service", StringComparison.OrdinalIgnoreCase))
             {
-                return DbmPropagationLevel.DynamicService;
+                return new(DbmPropagationLevel.Service, forceInjectBaseHash: true);
             }
             else if (inputValue.Equals("full", StringComparison.OrdinalIgnoreCase))
             {
-                return DbmPropagationLevel.Full;
+                return new(DbmPropagationLevel.Full);
             }
             else
             {
@@ -1479,6 +1487,12 @@ namespace Datadog.Trace.Configuration
         {
             Log.Warning("Unsupported OTLP protocol '{Protocol}'. Supported values are 'grpc', 'http/protobuf' and 'http/json'. Using default: http/protobuf", inputValue);
             return ParsingResult<OtlpProtocol>.Failure();
+        }
+
+        private readonly struct DbmPropagationResult(DbmPropagationLevel level, bool forceInjectBaseHash = false)
+        {
+            public readonly DbmPropagationLevel EffectiveLevel = level;
+            public readonly bool ForceInjectBaseHash = forceInjectBaseHash;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -1460,13 +1460,17 @@ namespace Datadog.Trace.Configuration
             {
                 return DbmPropagationLevel.Service;
             }
+            else if (inputValue.Equals("dynamic_service", StringComparison.OrdinalIgnoreCase))
+            {
+                return DbmPropagationLevel.DynamicService;
+            }
             else if (inputValue.Equals("full", StringComparison.OrdinalIgnoreCase))
             {
                 return DbmPropagationLevel.Full;
             }
             else
             {
-                Log.Warning("Wrong setting '{PropagationInput}' for DD_DBM_PROPAGATION_MODE supported values include: disabled, service or full", inputValue);
+                Log.Warning("Wrong setting '{PropagationInput}' for DD_DBM_PROPAGATION_MODE supported values include: disabled, service, dynamic_service or full", inputValue);
                 return null;
             }
         }

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -567,7 +567,8 @@ supportedConfigurations:
     const_name: DbmPropagationMode
     documentation: |-
       Configuration key for setting DBM propagation mode
-      Default value is disabled, expected values are either: disabled, service or full
+      Default value is disabled, expected values are either: disabled, service, dynamic_service or full
+      dynamic_service is equivalent to service with DD_DBM_INJECT_SQL_BASEHASH=true
       <seealso cref="Datadog.Trace.Configuration.TracerSettings.DbmPropagationMode"/>
   DD_DBM_INJECT_SQL_BASEHASH:
   - implementation: A

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -80,7 +80,8 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for setting DBM propagation mode
-    /// Default value is disabled, expected values are either: disabled, service or full
+    /// Default value is disabled, expected values are either: disabled, service, dynamic_service or full
+    /// dynamic_service is equivalent to service with DD_DBM_INJECT_SQL_BASEHASH=true
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.TracerSettings.DbmPropagationMode"/>
     public const string DbmPropagationMode = "DD_DBM_PROPAGATION_MODE";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -80,7 +80,8 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for setting DBM propagation mode
-    /// Default value is disabled, expected values are either: disabled, service or full
+    /// Default value is disabled, expected values are either: disabled, service, dynamic_service or full
+    /// dynamic_service is equivalent to service with DD_DBM_INJECT_SQL_BASEHASH=true
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.TracerSettings.DbmPropagationMode"/>
     public const string DbmPropagationMode = "DD_DBM_PROPAGATION_MODE";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -80,7 +80,8 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for setting DBM propagation mode
-    /// Default value is disabled, expected values are either: disabled, service or full
+    /// Default value is disabled, expected values are either: disabled, service, dynamic_service or full
+    /// dynamic_service is equivalent to service with DD_DBM_INJECT_SQL_BASEHASH=true
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.TracerSettings.DbmPropagationMode"/>
     public const string DbmPropagationMode = "DD_DBM_PROPAGATION_MODE";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -80,7 +80,8 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for setting DBM propagation mode
-    /// Default value is disabled, expected values are either: disabled, service or full
+    /// Default value is disabled, expected values are either: disabled, service, dynamic_service or full
+    /// dynamic_service is equivalent to service with DD_DBM_INJECT_SQL_BASEHASH=true
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.TracerSettings.DbmPropagationMode"/>
     public const string DbmPropagationMode = "DD_DBM_PROPAGATION_MODE";

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         public static IEnumerable<object[]> GetEnabledDbmData()
             => from command in (IEnumerable<object[]>)GetDbmCommands()
-               from dbm in new[] { "service", "full" }
+               from dbm in new[] { "service", "dynamic_service", "full" }
                from enabled in new[] { false, true }
                select new[] { command[0], dbm, enabled };
 
@@ -181,6 +181,30 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 scope.Span.GetTag(Tags.BaseHash).Should().BeNull();
                 command.CommandText.Should().NotContain("ddsh=");
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDbmCommands))]
+        public async Task CreateDbCommandScope_DynamicService_EnablesBaseHashWithoutExplicitFlag(Type commandType)
+        {
+            var command = (IDbCommand)Activator.CreateInstance(commandType)!;
+            command.CommandText = DbmCommandText;
+
+            // dynamic_service should inject base-hash even without DD_DBM_INJECT_SQL_BASEHASH=true
+            var tracerSettings = TracerSettings.Create(new Dictionary<string, object>
+            {
+                { ConfigurationKeys.PropagateProcessTags, "true" },
+                { ConfigurationKeys.DbmInjectSqlBasehash, "false" },
+                { ConfigurationKeys.DbmPropagationMode, "dynamic_service" }
+            });
+            var serviceRemappingHash = new ServiceRemappingHash("process:tag,service:service");
+            await using var tracer = TracerHelper.Create(tracerSettings, serviceRemappingHash: serviceRemappingHash);
+
+            using var scope = CreateDbCommandScope(tracer, command);
+
+            scope.Should().NotBeNull();
+            scope.Span.GetTag(Tags.BaseHash).Should().Be(serviceRemappingHash.Base64Value);
+            command.CommandText.Should().Contain($"ddsh='{serviceRemappingHash.Base64Value}'");
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -693,31 +693,32 @@ namespace Datadog.Trace.Tests.Configuration
         // See TracerSettingsServerlessTests for tests which rely on environment variables
 
         [Theory]
-        [InlineData("", DbmPropagationLevel.Disabled)]              // empty string defaults to disabled
-        [InlineData(null, DbmPropagationLevel.Disabled)]            // null defaults to disabled
-        [InlineData("      ", DbmPropagationLevel.Disabled)]        // whitespace defaults to disabled
-        [InlineData("invalid", DbmPropagationLevel.Disabled)]       // invalid input
-        [InlineData("full", DbmPropagationLevel.Full)]                              // exact match
-        [InlineData("service", DbmPropagationLevel.Service)]                      // exact match
-        [InlineData("dynamic_service", DbmPropagationLevel.DynamicService)]       // exact match
-        [InlineData("disabled", DbmPropagationLevel.Disabled)]                    // exact match
-        [InlineData("Disabled", DbmPropagationLevel.Disabled)]                    // case insenstive
-        [InlineData("SERVICE", DbmPropagationLevel.Service)]                      // case insensitive
-        [InlineData("FuLl", DbmPropagationLevel.Full)]                            // case insensitive
-        [InlineData("DYNAMIC_SERVICE", DbmPropagationLevel.DynamicService)]       // case insensitive
-        [InlineData("Dynamic_Service", DbmPropagationLevel.DynamicService)]       // case insensitive
-        [InlineData(" service", DbmPropagationLevel.Service)]                     // trim whitespace
-        [InlineData("service ", DbmPropagationLevel.Service)]                     // trim whitespace
-        [InlineData("full   ", DbmPropagationLevel.Full)]                         // trim whitespace
-        [InlineData("     disabled", DbmPropagationLevel.Disabled)]               // trim whitespace
-        [InlineData(" dynamic_service ", DbmPropagationLevel.DynamicService)]     // trim whitespace
-        [InlineData("s e r v i c e", DbmPropagationLevel.Disabled)]               // invalid input
-        public void DbmPropagationMode(string value, object expected)
+        [InlineData("", DbmPropagationLevel.Disabled, false)]              // empty string defaults to disabled
+        [InlineData(null, DbmPropagationLevel.Disabled, false)]            // null defaults to disabled
+        [InlineData("      ", DbmPropagationLevel.Disabled, false)]        // whitespace defaults to disabled
+        [InlineData("invalid", DbmPropagationLevel.Disabled, false)]       // invalid input
+        [InlineData("full", DbmPropagationLevel.Full, false)]                              // exact match
+        [InlineData("service", DbmPropagationLevel.Service, false)]                      // exact match
+        [InlineData("dynamic_service", DbmPropagationLevel.Service, true)]       // exact match
+        [InlineData("disabled", DbmPropagationLevel.Disabled, false)]                    // exact match
+        [InlineData("Disabled", DbmPropagationLevel.Disabled, false)]                    // case insenstive
+        [InlineData("SERVICE", DbmPropagationLevel.Service, false)]                      // case insensitive
+        [InlineData("FuLl", DbmPropagationLevel.Full, false)]                            // case insensitive
+        [InlineData("DYNAMIC_SERVICE", DbmPropagationLevel.Service, true)]       // case insensitive
+        [InlineData("Dynamic_Service", DbmPropagationLevel.Service, true)]       // case insensitive
+        [InlineData(" service", DbmPropagationLevel.Service, false)]                     // trim whitespace
+        [InlineData("service ", DbmPropagationLevel.Service, false)]                     // trim whitespace
+        [InlineData("full   ", DbmPropagationLevel.Full, false)]                         // trim whitespace
+        [InlineData("     disabled", DbmPropagationLevel.Disabled, false)]               // trim whitespace
+        [InlineData(" dynamic_service ", DbmPropagationLevel.Service, true)]     // trim whitespace
+        [InlineData("s e r v i c e", DbmPropagationLevel.Disabled, false)]               // invalid input
+        public void DbmPropagationMode(string value, object expected, bool injectBaseHash)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DbmPropagationMode, value));
             var settings = new TracerSettings(source);
 
             settings.DbmPropagationMode.Should().Be((DbmPropagationLevel)expected);
+            settings.DbmInjectSqlBasehash.Should().Be(injectBaseHash);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -697,17 +697,21 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData(null, DbmPropagationLevel.Disabled)]            // null defaults to disabled
         [InlineData("      ", DbmPropagationLevel.Disabled)]        // whitespace defaults to disabled
         [InlineData("invalid", DbmPropagationLevel.Disabled)]       // invalid input
-        [InlineData("full", DbmPropagationLevel.Full)]              // exact match
-        [InlineData("service", DbmPropagationLevel.Service)]        // exact match
-        [InlineData("disabled", DbmPropagationLevel.Disabled)]      // exact match
-        [InlineData("Disabled", DbmPropagationLevel.Disabled)]      // case insenstive
-        [InlineData("SERVICE", DbmPropagationLevel.Service)]        // case insensitive
-        [InlineData("FuLl", DbmPropagationLevel.Full)]              // case insensitive
-        [InlineData(" service", DbmPropagationLevel.Service)]       // trim whitespace
-        [InlineData("service ", DbmPropagationLevel.Service)]       // trim whitespace
-        [InlineData("full   ", DbmPropagationLevel.Full)]           // trim whitespace
-        [InlineData("     disabled", DbmPropagationLevel.Disabled)] // trim whitespace
-        [InlineData("s e r v i c e", DbmPropagationLevel.Disabled)] // invalid input
+        [InlineData("full", DbmPropagationLevel.Full)]                              // exact match
+        [InlineData("service", DbmPropagationLevel.Service)]                      // exact match
+        [InlineData("dynamic_service", DbmPropagationLevel.DynamicService)]       // exact match
+        [InlineData("disabled", DbmPropagationLevel.Disabled)]                    // exact match
+        [InlineData("Disabled", DbmPropagationLevel.Disabled)]                    // case insenstive
+        [InlineData("SERVICE", DbmPropagationLevel.Service)]                      // case insensitive
+        [InlineData("FuLl", DbmPropagationLevel.Full)]                            // case insensitive
+        [InlineData("DYNAMIC_SERVICE", DbmPropagationLevel.DynamicService)]       // case insensitive
+        [InlineData("Dynamic_Service", DbmPropagationLevel.DynamicService)]       // case insensitive
+        [InlineData(" service", DbmPropagationLevel.Service)]                     // trim whitespace
+        [InlineData("service ", DbmPropagationLevel.Service)]                     // trim whitespace
+        [InlineData("full   ", DbmPropagationLevel.Full)]                         // trim whitespace
+        [InlineData("     disabled", DbmPropagationLevel.Disabled)]               // trim whitespace
+        [InlineData(" dynamic_service ", DbmPropagationLevel.DynamicService)]     // trim whitespace
+        [InlineData("s e r v i c e", DbmPropagationLevel.Disabled)]               // invalid input
         public void DbmPropagationMode(string value, object expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DbmPropagationMode, value));


### PR DESCRIPTION
## Summary of changes

Adds a new value for `DD_DBM_PROPAGATION_MODE`: `dynamic_service`.

It's a shorthand for `DD_DBM_PROPAGATION_MODE=service` + `DD_DBM_INJECT_SQL_BASEHASH=true`. Instead of requiring two separate env vars to get service-level metadata with base-hash injection, users can now set one.

The base hash (`ddsh`) lets the DBM backend remap services based on process tags without needing a full traceparent. It's useful for customers who want dynamic service attribution but don't want the query plan overhead that comes with `full` mode.

On the long term, this will replace the default mode that's today `service`

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
