### PR TITLE
Truncate CI Visibility meta tag values

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
@@ -14,7 +14,8 @@ namespace Datadog.Trace.Ci.Agent.MessagePack;
 
 internal sealed class CIEventMessagePackFormatter : EventMessagePackFormatter<CIVisibilityProtocolPayload>
 {
-    private readonly byte[] _runtimeIdValueBytes = StringEncoding.UTF8.GetBytes(Tracer.RuntimeId);
+    private readonly byte[] _runtimeIdValueBytes =
+        StringEncoding.UTF8.GetBytes(CIVisibilityMetadataStringTruncator.Truncate(Tracer.RuntimeId));
     private readonly byte[]? _environmentValueBytes;
     private readonly byte[]? _testSessionNameValueBytes;
     private readonly ArraySegment<byte> _envelopBytes;
@@ -24,13 +25,18 @@ internal sealed class CIEventMessagePackFormatter : EventMessagePackFormatter<CI
         // we don't subscribe, because we assume this _can't_ change in CI Visibility
         if (!string.IsNullOrEmpty(tracerSettings.Manager.InitialMutableSettings.Environment))
         {
-            _environmentValueBytes = StringEncoding.UTF8.GetBytes(tracerSettings.Manager.InitialMutableSettings.Environment);
+            _environmentValueBytes =
+                StringEncoding.UTF8.GetBytes(
+                    CIVisibilityMetadataStringTruncator.Truncate(
+                        tracerSettings.Manager.InitialMutableSettings.Environment));
         }
 
         var testOptimization = TestOptimization.Instance;
         if (!string.IsNullOrWhiteSpace(testOptimization.Settings.TestSessionName))
         {
-            _testSessionNameValueBytes = StringEncoding.UTF8.GetBytes(testOptimization.Settings.TestSessionName);
+            _testSessionNameValueBytes =
+                StringEncoding.UTF8.GetBytes(
+                    CIVisibilityMetadataStringTruncator.Truncate(testOptimization.Settings.TestSessionName));
         }
 
         _envelopBytes = GetEnvelopeArraySegment();

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIVisibilityMetadataStringTruncator.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIVisibilityMetadataStringTruncator.cs
@@ -1,0 +1,16 @@
+// <copyright file="CIVisibilityMetadataStringTruncator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Ci.Agent.MessagePack;
+
+internal static class CIVisibilityMetadataStringTruncator
+{
+    public const int MaxMetaStringLength = 5_000;
+
+    public static string Truncate(string value)
+        => value.Length <= MaxMetaStringLength ? value : value.Substring(0, MaxMetaStringLength);
+}

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -249,7 +249,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
         {
             count++;
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, EnvironmentNameBytes);
-            offset += MessagePackBinary.WriteString(ref bytes, offset, env);
+            offset += MessagePackBinary.WriteString(ref bytes, offset, CIVisibilityMetadataStringTruncator.Truncate(env));
         }
 
         // add "language=dotnet" tag to all spans, except those that
@@ -270,7 +270,7 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
             {
                 count++;
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, VersionNameBytes);
-                offset += MessagePackBinary.WriteString(ref bytes, offset, version);
+                offset += MessagePackBinary.WriteString(ref bytes, offset, CIVisibilityMetadataStringTruncator.Truncate(version));
             }
         }
 
@@ -294,6 +294,8 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
             }
         }
 
+        value = CIVisibilityMetadataStringTruncator.Truncate(value);
+
         offset += MessagePackBinary.WriteString(ref bytes, offset, key);
         offset += MessagePackBinary.WriteString(ref bytes, offset, value);
     }
@@ -309,6 +311,8 @@ internal sealed class SpanMessagePackFormatter : IMessagePackFormatter<Span>
                 tagProcessors[i]?.ProcessMeta(ref key, ref value);
             }
         }
+
+        value = CIVisibilityMetadataStringTruncator.Truncate(value);
 
         MessagePackBinary.EnsureCapacity(ref bytes, offset, keyBytes.Length + StringEncoding.UTF8.GetMaxByteCount(value.Length) + 5);
         offset += MessagePackBinary.WriteRaw(ref bytes, offset, keyBytes);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -36,6 +37,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
     public class CiVisibilityProtocolWriterTests
     {
+        private const int MaxMetaStringLength = CIVisibilityMetadataStringTruncator.MaxMetaStringLength;
+
         [Fact]
         public async Task AgentlessTestEventTest()
         {
@@ -98,6 +101,74 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             await agentlessWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             Assert.True(finalPayload.SequenceEqual(expectedBytes));
+        }
+
+        [Fact]
+        public void TestEventMetaStringValuesAreTruncated()
+        {
+            var longValue = new string('a', MaxMetaStringLength + 1);
+            var exactValue = new string('b', MaxMetaStringLength);
+            var tags = new TestSpanTags
+            {
+                SessionId = 123,
+                ModuleId = 456,
+                SuiteId = 789,
+                Parameters = longValue
+            };
+            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow, tags)
+            {
+                Type = SpanTypes.Test
+            };
+            span.SetTag("custom.tag", longValue);
+            span.SetTag("exact.tag", exactValue);
+            span.SetTag(Datadog.Trace.Tags.ErrorMsg, longValue);
+            span.SetMetric("custom.metric", 42);
+
+            var payloadObject = SerializeTestCyclePayload(new TestEvent(span));
+            var content = (JObject)payloadObject["events"]![0]!["content"]!;
+            var meta = (JObject)content["meta"]!;
+            var metrics = (JObject)content["metrics"]!;
+
+            meta["custom.tag"]!.Value<string>().Should().Be(longValue.Substring(0, MaxMetaStringLength));
+            meta["custom.tag"]!.Value<string>().Should().HaveLength(MaxMetaStringLength);
+            meta[TestTags.Parameters]!.Value<string>().Should().Be(longValue.Substring(0, MaxMetaStringLength));
+            meta[Datadog.Trace.Tags.ErrorMsg]!.Value<string>().Should().Be(longValue.Substring(0, MaxMetaStringLength));
+            meta["exact.tag"]!.Value<string>().Should().Be(exactValue);
+            metrics["custom.metric"]!.Value<double>().Should().Be(42);
+            meta.ContainsKey("test_session_id").Should().BeFalse();
+            meta.ContainsKey("test_module_id").Should().BeFalse();
+            meta.ContainsKey("test_suite_id").Should().BeFalse();
+            content["test_session_id"]!.Value<ulong>().Should().Be(123);
+            content["test_module_id"]!.Value<ulong>().Should().Be(456);
+            content["test_suite_id"]!.Value<ulong>().Should().Be(789);
+        }
+
+        [Fact]
+        public void PayloadMetadataStringValuesAreTruncated()
+        {
+            var longValue = new string('e', MaxMetaStringLength + 1);
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new NameValueCollection
+            {
+                { ConfigurationKeys.Environment, longValue }
+            }));
+            var settings = new TestOptimizationSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
+            var formatter = new CIEventMessagePackFormatter(tracerSettings);
+            var payload = new Ci.Agent.Payloads.CITestCyclePayload(settings, CIFormatterResolver.Instance);
+            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow, new TestSpanTags())
+            {
+                Type = SpanTypes.Test
+            };
+            payload.TryProcessEvent(new TestEvent(span));
+
+            var bytes = new byte[8 * 1024];
+            var length = formatter.Serialize(ref bytes, 0, payload, CIFormatterResolver.Instance);
+            Array.Resize(ref bytes, length);
+            var payloadObject = JObject.Parse(MessagePackSerializer.ToJson(bytes));
+            var metadata = (JObject)payloadObject["metadata"]!;
+            var globalMetadata = (JObject)metadata["*"]!;
+
+            globalMetadata["env"]!.Value<string>().Should().Be(longValue.Substring(0, MaxMetaStringLength));
+            globalMetadata["env"]!.Value<string>().Should().HaveLength(MaxMetaStringLength);
         }
 
         [Fact]
@@ -361,6 +432,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 
                 bufferSize *= 2;
             }
+        }
+
+        private static JObject SerializeTestCyclePayload(IEvent @event)
+        {
+            var settings = new TestOptimizationSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
+            var formatter = CIFormatterResolver.Instance;
+            var payload = new Ci.Agent.Payloads.CITestCyclePayload(settings, formatter);
+            payload.TryProcessEvent(@event);
+            return JObject.Parse(MessagePackSerializer.ToJson(payload.ToArray()));
         }
 
         internal class TestMessageHandler : HttpMessageHandler


### PR DESCRIPTION
## Summary of changes

Truncate CI Visibility metadata/tag string values to 5000 characters in both CI event and span messagepack formatters.

## Reason for change

The backend maximum allowed size for a tag value is 5000 characters. Client-side truncation keeps oversized metadata values within that limit before payload submission.

## Implementation details

Adds a shared metadata string truncator for CI Visibility messagepack formatting and applies it to metadata dictionary values while preserving non-string values.

## Test coverage

- `git diff --check`

The .NET test command was not run locally because this checkout requires .NET SDK `10.0.100`, while the local machine currently has `8.0.400`.

## Other details

No issue reference was provided.