### PR TITLE
[Native] Make GetTypeInfo Iterative to Prevent Native Stack Exhaustion

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -215,8 +215,24 @@ ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id)
     return {module_id, shared::WSTRING(module_path), GetAssemblyInfo(info, assembly_id), module_flags};
 }
 
-TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token_)
+namespace
 {
+// PR #4415 capped mdtTypeSpec / ELEMENT_TYPE_GENERICINST cycles only. Uncapped recursion on
+// type_extends, parent_type_token, and GetSigTypeTokName can still exhaust the ~256 KB x86 thread
+// stack (each GetTypeInfo frame allocates ~2 KB for type_name). See APMS-19659.
+constexpr int kMaxTypeInfoDepth = 50;
+
+shared::WSTRING GetSigTypeTokNameImpl(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport,
+                                      std::set<mdToken>& processed, int depth);
+
+TypeInfo GetTypeInfoImpl(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token_,
+                         std::set<mdToken>& processed, int depth)
+{
+    if (depth >= kMaxTypeInfoDepth)
+    {
+        return {};
+    }
+
     mdToken parent_token = mdTokenNil;
     std::shared_ptr<TypeInfo> parentTypeInfo = nullptr;
     mdToken parent_type_token = mdTokenNil;
@@ -234,7 +250,6 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdTo
 
     auto token = token_;
     auto typeSpec = mdTypeSpecNil;
-    std::set<mdToken> processed;
 
     while (token != mdTokenNil)
     {
@@ -248,12 +263,14 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdTo
                 metadata_import->GetNestedClassProps(token, &parent_type_token);
                 if (parent_type_token != mdTokenNil)
                 {
-                    parentTypeInfo = std::make_shared<TypeInfo>(GetTypeInfo(metadata_import, parent_type_token));
+                    parentTypeInfo = std::make_shared<TypeInfo>(
+                        GetTypeInfoImpl(metadata_import, parent_type_token, processed, depth + 1));
                 }
 
                 if (type_extends != mdTokenNil)
                 {
-                    extendsInfo = std::make_shared<TypeInfo>(GetTypeInfo(metadata_import, type_extends));
+                    extendsInfo =
+                        std::make_shared<TypeInfo>(GetTypeInfoImpl(metadata_import, type_extends, processed, depth + 1));
                     type_valueType =
                         extendsInfo->name == WStr("System.ValueType") || extendsInfo->name == WStr("System.Enum");
                 }
@@ -279,7 +296,7 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdTo
 
                 if (signature[0] & ELEMENT_TYPE_GENERICINST)
                 {
-                    if (std::find(processed.begin(), processed.end(), token) != processed.end())
+                    if (processed.find(token) != processed.end())
                     {
                         return {}; // Break circular reference
                     }
@@ -322,6 +339,167 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdTo
                 type_isSealed, parentTypeInfo,   parent_token};
     }
     return {};
+}
+
+shared::WSTRING GetSigTypeTokNameImpl(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport,
+                                      std::set<mdToken>& processed, int depth)
+{
+    if (depth >= kMaxTypeInfoDepth)
+    {
+        return shared::EmptyWStr;
+    }
+
+    shared::WSTRING tokenName = shared::EmptyWStr;
+    bool ref_flag = false;
+    if (*pbCur == ELEMENT_TYPE_BYREF)
+    {
+        pbCur++;
+        ref_flag = true;
+    }
+
+    bool pointer_flag = false;
+    if (*pbCur == ELEMENT_TYPE_PTR)
+    {
+        pbCur++;
+        pointer_flag = true;
+    }
+
+    switch (*pbCur)
+    {
+        case ELEMENT_TYPE_BOOLEAN:
+            tokenName = SystemBoolean;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_CHAR:
+            tokenName = SystemChar;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I1:
+            tokenName = SystemSByte;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U1:
+            tokenName = SystemByte;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U2:
+            tokenName = SystemUInt16;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I2:
+            tokenName = SystemInt16;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I4:
+            tokenName = SystemInt32;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U4:
+            tokenName = SystemUInt32;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I8:
+            tokenName = SystemInt64;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U8:
+            tokenName = SystemUInt64;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_R4:
+            tokenName = SystemSingle;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_R8:
+            tokenName = SystemDouble;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I:
+            tokenName = SystemIntPtr;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U:
+            tokenName = SystemUIntPtr;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_STRING:
+            tokenName = SystemString;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_OBJECT:
+            tokenName = SystemObject;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_CLASS:
+        case ELEMENT_TYPE_VALUETYPE:
+        {
+            pbCur++;
+            mdToken token;
+            pbCur += CorSigUncompressToken(pbCur, &token);
+            tokenName = GetTypeInfoImpl(pImport, token, processed, depth + 1).name;
+            break;
+        }
+        case ELEMENT_TYPE_SZARRAY:
+        {
+            pbCur++;
+            tokenName = GetSigTypeTokNameImpl(pbCur, pImport, processed, depth + 1) + WStr("[]");
+            break;
+        }
+        case ELEMENT_TYPE_GENERICINST:
+        {
+            pbCur++;
+            tokenName = GetSigTypeTokNameImpl(pbCur, pImport, processed, depth + 1);
+            tokenName += WStr("[");
+            ULONG num = 0;
+            pbCur += CorSigUncompressData(pbCur, &num);
+            for (ULONG i = 0; i < num; i++)
+            {
+                tokenName += GetSigTypeTokNameImpl(pbCur, pImport, processed, depth + 1);
+                if (i != num - 1)
+                {
+                    tokenName += WStr(",");
+                }
+            }
+            tokenName += WStr("]");
+            break;
+        }
+        case ELEMENT_TYPE_MVAR:
+        {
+            pbCur++;
+            ULONG num = 0;
+            pbCur += CorSigUncompressData(pbCur, &num);
+            tokenName = WStr("!!") + shared::ToWSTRING(std::to_string(num));
+            break;
+        }
+        case ELEMENT_TYPE_VAR:
+        {
+            pbCur++;
+            ULONG num = 0;
+            pbCur += CorSigUncompressData(pbCur, &num);
+            tokenName = WStr("!") + shared::ToWSTRING(std::to_string(num));
+            break;
+        }
+        default:
+            break;
+    }
+
+    if (ref_flag)
+    {
+        tokenName += WStr("&");
+    }
+    if (pointer_flag)
+    {
+        tokenName += WStr("*");
+    }
+    return tokenName;
+}
+
+} // namespace
+
+TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token_)
+{
+    std::set<mdToken> processed;
+    return GetTypeInfoImpl(metadata_import, token_, processed, 0);
 }
 
 // Searches for an AssemblyRef whose name and version match exactly.
@@ -528,149 +706,8 @@ mdToken TypeSignature::GetTypeTok(const ComPtr<IMetaDataEmit2>& pEmit, mdAssembl
 
 shared::WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport)
 {
-    shared::WSTRING tokenName = shared::EmptyWStr;
-    bool ref_flag = false;
-    if (*pbCur == ELEMENT_TYPE_BYREF)
-    {
-        pbCur++;
-        ref_flag = true;
-    }
-
-    bool pointer_flag = false;
-    if (*pbCur == ELEMENT_TYPE_PTR)
-    {
-        pbCur++;
-        pointer_flag = true;
-    }
-
-    switch (*pbCur)
-    {
-        case ELEMENT_TYPE_BOOLEAN:
-            tokenName = SystemBoolean;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_CHAR:
-            tokenName = SystemChar;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I1:
-            tokenName = SystemSByte;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U1:
-            tokenName = SystemByte;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U2:
-            tokenName = SystemUInt16;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I2:
-            tokenName = SystemInt16;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I4:
-            tokenName = SystemInt32;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U4:
-            tokenName = SystemUInt32;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I8:
-            tokenName = SystemInt64;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U8:
-            tokenName = SystemUInt64;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_R4:
-            tokenName = SystemSingle;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_R8:
-            tokenName = SystemDouble;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I:
-            tokenName = SystemIntPtr;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U:
-            tokenName = SystemUIntPtr;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_STRING:
-            tokenName = SystemString;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_OBJECT:
-            tokenName = SystemObject;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_CLASS:
-        case ELEMENT_TYPE_VALUETYPE:
-        {
-            pbCur++;
-            mdToken token;
-            pbCur += CorSigUncompressToken(pbCur, &token);
-            tokenName = GetTypeInfo(pImport, token).name;
-            break;
-        }
-        case ELEMENT_TYPE_SZARRAY:
-        {
-            pbCur++;
-            tokenName = GetSigTypeTokName(pbCur, pImport) + WStr("[]");
-            break;
-        }
-        case ELEMENT_TYPE_GENERICINST:
-        {
-            pbCur++;
-            tokenName = GetSigTypeTokName(pbCur, pImport);
-            tokenName += WStr("[");
-            ULONG num = 0;
-            pbCur += CorSigUncompressData(pbCur, &num);
-            for (ULONG i = 0; i < num; i++)
-            {
-                tokenName += GetSigTypeTokName(pbCur, pImport);
-                if (i != num - 1)
-                {
-                    tokenName += WStr(",");
-                }
-            }
-            tokenName += WStr("]");
-            break;
-        }
-        case ELEMENT_TYPE_MVAR:
-        {
-            pbCur++;
-            ULONG num = 0;
-            pbCur += CorSigUncompressData(pbCur, &num);
-            tokenName = WStr("!!") + shared::ToWSTRING(std::to_string(num));
-            break;
-        }
-        case ELEMENT_TYPE_VAR:
-        {
-            pbCur++;
-            ULONG num = 0;
-            pbCur += CorSigUncompressData(pbCur, &num);
-            tokenName = WStr("!") + shared::ToWSTRING(std::to_string(num));
-            break;
-        }
-        default:
-            break;
-    }
-
-    if (ref_flag)
-    {
-        tokenName += WStr("&");
-    }
-    if (pointer_flag)
-    {
-        tokenName += WStr("*");
-    }
-    return tokenName;
+    std::set<mdToken> processed;
+    return GetSigTypeTokNameImpl(pbCur, pImport, processed, 0);
 }
 
 shared::WSTRING TypeSignature::GetTypeTokName(ComPtr<IMetaDataImport2>& pImport) const

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -8,8 +8,10 @@
 #include "environment_variables_util.h"
 #include "logger.h"
 #include "macros.h"
+#include <deque>
 #include <set>
 #include <stack>
+#include <unordered_map>
 
 #include "../../../shared/src/native-src/pal.h"
 
@@ -217,39 +219,37 @@ ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id)
 
 namespace
 {
-// PR #4415 capped mdtTypeSpec / ELEMENT_TYPE_GENERICINST cycles only. Uncapped recursion on
-// type_extends, parent_type_token, and GetSigTypeTokName can still exhaust the ~256 KB x86 thread
-// stack (each GetTypeInfo frame allocates ~2 KB for type_name). See APMS-19659.
-constexpr int kMaxTypeInfoDepth = 50;
-
-shared::WSTRING GetSigTypeTokNameImpl(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport,
-                                      std::set<mdToken>& processed, int depth);
-
-TypeInfo GetTypeInfoImpl(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token_,
-                         std::set<mdToken>& processed, int depth)
+// Resolves a metadata token to its leaf type properties without recursively building
+// extend_from / parent_type chains. TypeSpec generic-inst unwrapping tracks visited
+// TypeSpecs on the current unwrap path only; inheritance is handled in GetTypeInfo.
+struct TypeInfoLeaf
 {
-    if (depth >= kMaxTypeInfoDepth)
-    {
-        return {};
-    }
-
-    mdToken parent_token = mdTokenNil;
-    std::shared_ptr<TypeInfo> parentTypeInfo = nullptr;
-    mdToken parent_type_token = mdTokenNil;
-    WCHAR type_name[kNameMaxSize]{};
-    DWORD type_name_len = 0;
-    DWORD type_flags;
-    std::shared_ptr<TypeInfo> extendsInfo = nullptr;
+    bool valid = false;
+    bool is_method_token = false;
+    mdToken id = mdTokenNil;
+    shared::WSTRING name;
+    mdTypeSpec type_spec = mdTypeSpecNil;
+    ULONG32 token_type = 0;
+    mdToken scope_token = mdTokenNil;
     mdToken type_extends = mdTokenNil;
-    bool type_valueType = false;
+    mdToken parent_type_token = mdTokenNil;
     bool type_isGeneric = false;
     bool type_isAbstract = false;
     bool type_isSealed = false;
+};
 
+TypeInfoLeaf ResolveTypeInfoLeaf(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token_)
+{
+    TypeInfoLeaf leaf;
+    mdToken parent_token = mdTokenNil;
+    WCHAR type_name[kNameMaxSize]{};
+    DWORD type_name_len = 0;
+    DWORD type_flags = 0;
     HRESULT hr = E_FAIL;
 
     auto token = token_;
     auto typeSpec = mdTypeSpecNil;
+    std::set<mdToken> typespecs_on_path;
 
     while (token != mdTokenNil)
     {
@@ -258,29 +258,17 @@ TypeInfo GetTypeInfoImpl(const ComPtr<IMetaDataImport2>& metadata_import, const 
         {
             case mdtTypeDef:
                 hr = metadata_import->GetTypeDefProps(token, type_name, kNameMaxSize, &type_name_len, &type_flags,
-                                                      &type_extends);
+                                                      &leaf.type_extends);
 
-                metadata_import->GetNestedClassProps(token, &parent_type_token);
-                if (parent_type_token != mdTokenNil)
-                {
-                    parentTypeInfo = std::make_shared<TypeInfo>(
-                        GetTypeInfoImpl(metadata_import, parent_type_token, processed, depth + 1));
-                }
+                metadata_import->GetNestedClassProps(token, &leaf.parent_type_token);
 
-                if (type_extends != mdTokenNil)
-                {
-                    extendsInfo =
-                        std::make_shared<TypeInfo>(GetTypeInfoImpl(metadata_import, type_extends, processed, depth + 1));
-                    type_valueType =
-                        extendsInfo->name == WStr("System.ValueType") || extendsInfo->name == WStr("System.Enum");
-                }
-
-                type_isAbstract = IsTdAbstract(type_flags);
-                type_isSealed = IsTdSealed(type_flags);
+                leaf.type_isAbstract = IsTdAbstract(type_flags);
+                leaf.type_isSealed = IsTdSealed(type_flags);
 
                 break;
             case mdtTypeRef:
                 hr = metadata_import->GetTypeRefProps(token, &parent_token, type_name, kNameMaxSize, &type_name_len);
+                leaf.scope_token = parent_token;
                 break;
             case mdtTypeSpec:
             {
@@ -296,11 +284,11 @@ TypeInfo GetTypeInfoImpl(const ComPtr<IMetaDataImport2>& metadata_import, const 
 
                 if (signature[0] & ELEMENT_TYPE_GENERICINST)
                 {
-                    if (processed.find(token) != processed.end())
+                    if (typespecs_on_path.find(token) != typespecs_on_path.end())
                     {
                         return {}; // Break circular reference
                     }
-                    processed.insert(token);
+                    typespecs_on_path.insert(token);
 
                     mdToken type_token;
                     CorSigUncompressToken(&signature[2], &type_token);
@@ -314,11 +302,9 @@ TypeInfo GetTypeInfoImpl(const ComPtr<IMetaDataImport2>& metadata_import, const 
                 metadata_import->GetModuleRefProps(token, type_name, kNameMaxSize, &type_name_len);
                 break;
             case mdtMemberRef:
-                return GetFunctionInfo(metadata_import, token).type;
-                break;
             case mdtMethodDef:
-                return GetFunctionInfo(metadata_import, token).type;
-                break;
+                leaf.is_method_token = true;
+                return leaf;
         }
 
         if (FAILED(hr) || type_name_len == 0)
@@ -326,180 +312,141 @@ TypeInfo GetTypeInfoImpl(const ComPtr<IMetaDataImport2>& metadata_import, const 
             return {};
         }
 
-        const auto type_name_string = shared::WSTRING(type_name);
-        const auto generic_token_index = type_name_string.rfind(WStr("`"));
+        leaf.valid = true;
+        leaf.id = token;
+        leaf.name = shared::WSTRING(type_name);
+        leaf.type_spec = typeSpec;
+        leaf.token_type = typeSpec != mdTypeSpecNil ? mdtTypeSpec : token_type;
+
+        const auto generic_token_index = leaf.name.rfind(WStr("`"));
         if (generic_token_index != std::string::npos)
         {
-            const auto idxFromRight = type_name_string.length() - generic_token_index - 1;
-            type_isGeneric = idxFromRight == 1 || idxFromRight == 2;
+            const auto idxFromRight = leaf.name.length() - generic_token_index - 1;
+            leaf.type_isGeneric = idxFromRight == 1 || idxFromRight == 2;
         }
 
-        return {token,         type_name_string, typeSpec,       typeSpec != mdTypeSpecNil ? mdtTypeSpec : token_type,
-                extendsInfo,   type_valueType,   type_isGeneric, type_isAbstract,
-                type_isSealed, parentTypeInfo,   parent_token};
+        return leaf;
     }
+
     return {};
 }
 
-shared::WSTRING GetSigTypeTokNameImpl(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport,
-                                      std::set<mdToken>& processed, int depth)
+bool IsValueTypeBaseName(const shared::WSTRING& name)
 {
-    if (depth >= kMaxTypeInfoDepth)
-    {
-        return shared::EmptyWStr;
-    }
-
-    shared::WSTRING tokenName = shared::EmptyWStr;
-    bool ref_flag = false;
-    if (*pbCur == ELEMENT_TYPE_BYREF)
-    {
-        pbCur++;
-        ref_flag = true;
-    }
-
-    bool pointer_flag = false;
-    if (*pbCur == ELEMENT_TYPE_PTR)
-    {
-        pbCur++;
-        pointer_flag = true;
-    }
-
-    switch (*pbCur)
-    {
-        case ELEMENT_TYPE_BOOLEAN:
-            tokenName = SystemBoolean;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_CHAR:
-            tokenName = SystemChar;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I1:
-            tokenName = SystemSByte;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U1:
-            tokenName = SystemByte;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U2:
-            tokenName = SystemUInt16;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I2:
-            tokenName = SystemInt16;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I4:
-            tokenName = SystemInt32;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U4:
-            tokenName = SystemUInt32;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I8:
-            tokenName = SystemInt64;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U8:
-            tokenName = SystemUInt64;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_R4:
-            tokenName = SystemSingle;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_R8:
-            tokenName = SystemDouble;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_I:
-            tokenName = SystemIntPtr;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_U:
-            tokenName = SystemUIntPtr;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_STRING:
-            tokenName = SystemString;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_OBJECT:
-            tokenName = SystemObject;
-            pbCur++;
-            break;
-        case ELEMENT_TYPE_CLASS:
-        case ELEMENT_TYPE_VALUETYPE:
-        {
-            pbCur++;
-            mdToken token;
-            pbCur += CorSigUncompressToken(pbCur, &token);
-            tokenName = GetTypeInfoImpl(pImport, token, processed, depth + 1).name;
-            break;
-        }
-        case ELEMENT_TYPE_SZARRAY:
-        {
-            pbCur++;
-            tokenName = GetSigTypeTokNameImpl(pbCur, pImport, processed, depth + 1) + WStr("[]");
-            break;
-        }
-        case ELEMENT_TYPE_GENERICINST:
-        {
-            pbCur++;
-            tokenName = GetSigTypeTokNameImpl(pbCur, pImport, processed, depth + 1);
-            tokenName += WStr("[");
-            ULONG num = 0;
-            pbCur += CorSigUncompressData(pbCur, &num);
-            for (ULONG i = 0; i < num; i++)
-            {
-                tokenName += GetSigTypeTokNameImpl(pbCur, pImport, processed, depth + 1);
-                if (i != num - 1)
-                {
-                    tokenName += WStr(",");
-                }
-            }
-            tokenName += WStr("]");
-            break;
-        }
-        case ELEMENT_TYPE_MVAR:
-        {
-            pbCur++;
-            ULONG num = 0;
-            pbCur += CorSigUncompressData(pbCur, &num);
-            tokenName = WStr("!!") + shared::ToWSTRING(std::to_string(num));
-            break;
-        }
-        case ELEMENT_TYPE_VAR:
-        {
-            pbCur++;
-            ULONG num = 0;
-            pbCur += CorSigUncompressData(pbCur, &num);
-            tokenName = WStr("!") + shared::ToWSTRING(std::to_string(num));
-            break;
-        }
-        default:
-            break;
-    }
-
-    if (ref_flag)
-    {
-        tokenName += WStr("&");
-    }
-    if (pointer_flag)
-    {
-        tokenName += WStr("*");
-    }
-    return tokenName;
+    return name == WStr("System.ValueType") || name == WStr("System.Enum");
 }
 
 } // namespace
 
+// Builds the TypeInfo for a token, including its full extend_from / parent_type chains.
+// The inheritance and nesting graph is walked iteratively (breadth-first) rather than
+// recursively so that deep type hierarchies cannot exhaust the native thread stack. Each
+// reachable token's metadata is read exactly once, then the nodes are linked together.
 TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token_)
 {
-    std::set<mdToken> processed;
-    return GetTypeInfoImpl(metadata_import, token_, processed, 0);
+    const auto root_leaf = ResolveTypeInfoLeaf(metadata_import, token_);
+    if (root_leaf.is_method_token)
+    {
+        return GetFunctionInfo(metadata_import, token_).type;
+    }
+
+    if (!root_leaf.valid)
+    {
+        return {};
+    }
+
+    // Phase 1: breadth-first traversal of the inheritance + nesting graph, reading each
+    // reachable token's leaf metadata once.
+    std::unordered_map<mdToken, TypeInfoLeaf> leaves;
+    std::deque<mdToken> pending;
+
+    const auto enqueue = [&](const mdToken token) {
+        if (token != mdTokenNil && leaves.count(token) == 0)
+        {
+            pending.push_back(token);
+        }
+    };
+
+    leaves[token_] = root_leaf;
+    enqueue(root_leaf.type_extends);
+    enqueue(root_leaf.parent_type_token);
+
+    while (!pending.empty())
+    {
+        const auto current = pending.front();
+        pending.pop_front();
+        if (leaves.count(current) > 0)
+        {
+            continue;
+        }
+
+        const auto leaf = ResolveTypeInfoLeaf(metadata_import, current);
+        leaves[current] = leaf;
+        if (leaf.valid)
+        {
+            enqueue(leaf.type_extends);
+            enqueue(leaf.parent_type_token);
+        }
+    }
+
+    // Phase 2: construct a TypeInfo node per token. valueType depends on the base type's
+    // name, which is already resolved in the leaves map.
+    std::unordered_map<mdToken, std::shared_ptr<TypeInfo>> cache;
+    for (const auto& entry : leaves)
+    {
+        const auto& leaf = entry.second;
+        if (!leaf.valid)
+        {
+            cache[entry.first] = std::make_shared<TypeInfo>();
+            continue;
+        }
+
+        bool type_valueType = false;
+        if (leaf.type_extends != mdTokenNil)
+        {
+            const auto base_it = leaves.find(leaf.type_extends);
+            if (base_it != leaves.end() && base_it->second.valid)
+            {
+                type_valueType = IsValueTypeBaseName(base_it->second.name);
+            }
+        }
+
+        cache[entry.first] = std::make_shared<TypeInfo>(
+            leaf.id, leaf.name, leaf.type_spec, leaf.token_type, nullptr, type_valueType, leaf.type_isGeneric,
+            leaf.type_isAbstract, leaf.type_isSealed, nullptr, leaf.scope_token);
+    }
+
+    // Phase 3: link extend_from / parent_type to the materialized nodes.
+    for (const auto& entry : leaves)
+    {
+        const auto& leaf = entry.second;
+        if (!leaf.valid)
+        {
+            continue;
+        }
+
+        auto& info = cache[entry.first];
+
+        if (leaf.type_extends != mdTokenNil)
+        {
+            const auto extends_it = cache.find(leaf.type_extends);
+            if (extends_it != cache.end())
+            {
+                info->extend_from = extends_it->second;
+            }
+        }
+
+        if (leaf.parent_type_token != mdTokenNil)
+        {
+            const auto parent_it = cache.find(leaf.parent_type_token);
+            if (parent_it != cache.end())
+            {
+                info->parent_type = parent_it->second;
+            }
+        }
+    }
+
+    return *cache[token_];
 }
 
 // Searches for an AssemblyRef whose name and version match exactly.
@@ -706,8 +653,149 @@ mdToken TypeSignature::GetTypeTok(const ComPtr<IMetaDataEmit2>& pEmit, mdAssembl
 
 shared::WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport)
 {
-    std::set<mdToken> processed;
-    return GetSigTypeTokNameImpl(pbCur, pImport, processed, 0);
+    shared::WSTRING tokenName = shared::EmptyWStr;
+    bool ref_flag = false;
+    if (*pbCur == ELEMENT_TYPE_BYREF)
+    {
+        pbCur++;
+        ref_flag = true;
+    }
+
+    bool pointer_flag = false;
+    if (*pbCur == ELEMENT_TYPE_PTR)
+    {
+        pbCur++;
+        pointer_flag = true;
+    }
+
+    switch (*pbCur)
+    {
+        case ELEMENT_TYPE_BOOLEAN:
+            tokenName = SystemBoolean;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_CHAR:
+            tokenName = SystemChar;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I1:
+            tokenName = SystemSByte;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U1:
+            tokenName = SystemByte;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U2:
+            tokenName = SystemUInt16;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I2:
+            tokenName = SystemInt16;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I4:
+            tokenName = SystemInt32;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U4:
+            tokenName = SystemUInt32;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I8:
+            tokenName = SystemInt64;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U8:
+            tokenName = SystemUInt64;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_R4:
+            tokenName = SystemSingle;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_R8:
+            tokenName = SystemDouble;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_I:
+            tokenName = SystemIntPtr;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_U:
+            tokenName = SystemUIntPtr;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_STRING:
+            tokenName = SystemString;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_OBJECT:
+            tokenName = SystemObject;
+            pbCur++;
+            break;
+        case ELEMENT_TYPE_CLASS:
+        case ELEMENT_TYPE_VALUETYPE:
+        {
+            pbCur++;
+            mdToken token;
+            pbCur += CorSigUncompressToken(pbCur, &token);
+            tokenName = GetTypeInfo(pImport, token).name;
+            break;
+        }
+        case ELEMENT_TYPE_SZARRAY:
+        {
+            pbCur++;
+            tokenName = GetSigTypeTokName(pbCur, pImport) + WStr("[]");
+            break;
+        }
+        case ELEMENT_TYPE_GENERICINST:
+        {
+            pbCur++;
+            tokenName = GetSigTypeTokName(pbCur, pImport);
+            tokenName += WStr("[");
+            ULONG num = 0;
+            pbCur += CorSigUncompressData(pbCur, &num);
+            for (ULONG i = 0; i < num; i++)
+            {
+                tokenName += GetSigTypeTokName(pbCur, pImport);
+                if (i != num - 1)
+                {
+                    tokenName += WStr(",");
+                }
+            }
+            tokenName += WStr("]");
+            break;
+        }
+        case ELEMENT_TYPE_MVAR:
+        {
+            pbCur++;
+            ULONG num = 0;
+            pbCur += CorSigUncompressData(pbCur, &num);
+            tokenName = WStr("!!") + shared::ToWSTRING(std::to_string(num));
+            break;
+        }
+        case ELEMENT_TYPE_VAR:
+        {
+            pbCur++;
+            ULONG num = 0;
+            pbCur += CorSigUncompressData(pbCur, &num);
+            tokenName = WStr("!") + shared::ToWSTRING(std::to_string(num));
+            break;
+        }
+        default:
+            break;
+    }
+
+    if (ref_flag)
+    {
+        tokenName += WStr("&");
+    }
+    if (pointer_flag)
+    {
+        tokenName += WStr("*");
+    }
+    return tokenName;
 }
 
 shared::WSTRING TypeSignature::GetTypeTokName(ComPtr<IMetaDataImport2>& pImport) const


### PR DESCRIPTION
## Summary

Fixes a native stack exhaustion in `Datadog.Tracer.Native.dll` on **32-bit IIS worker processes**.

PR #4415 added a recursion depth cap for `mdtTypeSpec` / `ELEMENT_TYPE_GENERICINST` cycles in `GetTypeInfo`, but the other recursive paths were still uncapped:

- **`type_extends`**, which walks the inheritance chain
- **`parent_type_token`**, which walks the nested class hierarchy

During ReJIT, `rejit_preprocessor` enumerates every `TypeDef` in an assembly and calls `GetTypeInfo` for Derived/Interface integrations. Customer assemblies with deeply chained non-generic inheritance (or deep nesting) can recurse far enough to use up the ~256 KB default thread stack on x86 (each `GetTypeInfo` frame takes about 2 KB for `type_name`), which faults the process.

Instead of capping the depth, which would silently stop resolving legitimately deep hierarchies that used to work, this PR converts the recursion into an iterative, queue-based traversal. That removes the stack pressure without putting any limit on how deep we go.

Here's what changed:

- Added `ResolveTypeInfoLeaf`, which reads a single token's immediate metadata (name, flags, direct `type_extends`, direct `parent_type_token`) without recursing into base or enclosing types. When it unwraps a TypeSpec generic instantiation it only tracks the TypeSpecs seen on the current unwrap path, so sibling branches can't cause false cycle detection.
- `GetTypeInfo` now runs in three phases. First it does a breadth-first walk over a `std::deque` work queue, reading each reachable token's leaf exactly once and adding any newly found base or enclosing tokens to the queue. Then it builds one `TypeInfo` node per token (`valueType` comes from the base leaf's name, which is already resolved). Finally it links each node's `extend_from` and `parent_type` to the nodes it built.
- Since each token is resolved at most once, malformed cyclic metadata can no longer loop forever. Before this, it would have overflowed the stack.
- `GetSigTypeTokName` is left exactly as it is on `master`. Its recursion is bounded by how deeply a signature is nested rather than by type chains, it now calls the iterative `GetTypeInfo`, and its TypeSpec cycle was already handled by #4415.

## Testing

### What we built locally (removed before push)

| File / area | Purpose | Why removed |
|-------------|---------|-------------|
| `Samples.DeepTypeHierarchy/DeepNonGenericChains.cs` | 100-level non-generic inheritance chain plus 50-level nested classes to trigger `GetTypeInfo` recursion | Would add ~150 new types and a new test assembly to the repo |
| `Samples.DeepTypeHierarchy/Samples.DeepTypeHierarchy.csproj` | Builds the above as metadata input for native tests | Same, scope beyond the fix |
| `clr_helper_deep_hierarchy_test.cpp` | Native gtest that loads that DLL, enumerates all `TypeDef`s and calls `GetTypeInfo` (mirrors `rejit_preprocessor`) | Depends on the test assembly above |
| `Datadog.Tracer.Native.Tests.vcxproj` changes | Project ref to `Samples.DeepTypeHierarchy` and `StackReserveSize=262144` on x86 Release to match the IIS w3wp stack | Only needed for the automated regression |
| `regression/DeepNestedHierarchy/DeepNonGenericChains.cs` | Managed smoke-test sample for the IIS/profiler path | Blocked on full monitoring-home setup, and the native metadata test was enough to validate the root cause |

We first added the deep types to `Samples.ExampleLibrary`, which **broke 3 existing native tests** (`EnumeratesTypeDefs`, `GetsTypeInfoFromTypeDefs`, `GetsTypeInfoFromMethods`) because their expected type lists no longer matched. Moving the types to a dedicated assembly fixed that, but it still added a lot of test infrastructure, so we dropped it for this PR.

**How we verified the fix:** with that native gtest in place and the test executable forced to a 256 KB stack using `editbin /STACK:262144` (the default test-host stack is around 1 MB and hides the problem), the deep-hierarchy test crashed with a stack overflow before the change and passed after it. The existing native suite (89 tests, x86 Release) also passes with the change.

**Follow-up (optional):** land the `Samples.DeepTypeHierarchy` sample, the native gtest, and the x86 `StackReserveSize=262144` in a separate PR so CI catches this automatically, the same way PR #4415 added TypeSpec coverage.

## Local validation (Windows)

- **VS 2022 Preview**, required for native builds (`VsDevCmd.bat`)
- **Windows SDK 10.0.19041**, installed via winget (unblocked `CompileNativeLoaderWindows`)
- **IIS**, `W3SVC` running. We didn't use it for the final validation because the native metadata test hits the same code path more directly.
- **Debugging Tools**, `cdb.exe` available under `C:\Program Files (x86)\Windows Kits\10\Debuggers\` after the SDK install. Customer dumps aren't in the workspace, so nothing was symbolicated in this PR.