### PR TITLE
Split CI Visibility tests into a dedicated integration test job

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1721,7 +1721,7 @@ stages:
         SampleName: $(IntegrationTestSampleName)
 
     - script: tracer\build.cmd RunIntegrationTests RunWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
-      displayName: Run integration tests (Tracer)
+      displayName: Run integration tests (Tracer/CiVisibility)
       condition: ne(variables['area'], 'ASM')
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2310,7 +2310,7 @@ stages:
           -e SampleName=$(IntegrationTestSampleName) \
           -e Area=$(area) \
           IntegrationTests
-      displayName: docker-compose run IntegrationTests (Tracer)
+      displayName: docker-compose run IntegrationTests (Tracer/CiVisibility)
       condition: ne(variables['area'], 'ASM')
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1922,9 +1922,9 @@ partial class Build
 
         // CiVisibility tests carry both Area=Tracer (assembly-level) and Area=CiVisibility (class-level).
         // Exclude them from the Tracer job so they only run in the dedicated CiVisibility job.
-        if (Area == "Tracer")
+        if (Area == TracerArea)
         {
-            areaFilter += "&(Area!=CiVisibility)";
+            areaFilter += $"&(Area!={CiVisibilityArea})";
         }
 
         return string.IsNullOrWhiteSpace(filter) ? areaFilter : filter + $"&{areaFilter}";

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1918,12 +1918,16 @@ partial class Build
             return filter;
         }
 
-        if (string.IsNullOrWhiteSpace(filter))
+        var areaFilter = $"(Area={Area})";
+
+        // CiVisibility tests carry both Area=Tracer (assembly-level) and Area=CiVisibility (class-level).
+        // Exclude them from the Tracer job so they only run in the dedicated CiVisibility job.
+        if (Area == "Tracer")
         {
-            return $"(Area={Area})";
+            areaFilter += "&(Area!=CiVisibility)";
         }
 
-        return filter + $"&(Area={Area})";
+        return string.IsNullOrWhiteSpace(filter) ? areaFilter : filter + $"&{areaFilter}";
     }
 
     Target CompileAzureFunctionsSamplesWindows => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1921,8 +1921,10 @@ partial class Build
         var areaFilter = $"(Area={Area})";
 
         // CiVisibility tests carry both Area=Tracer (assembly-level) and Area=CiVisibility (class-level).
-        // Exclude them from the Tracer job so they only run in the dedicated CiVisibility job.
-        if (Area == TracerArea)
+        // On Linux they run in a dedicated CiVisibility job, so exclude them from the Tracer job there.
+        // On Windows there is no dedicated CiVisibility job (almost all CiVisibility tests are Linux-only),
+        // so the Windows Tracer job keeps running them (e.g. IpcSampleTest).
+        if (Area == TracerArea && !IsWin)
         {
             areaFilter += $"&(Area!={CiVisibilityArea})";
         }

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -18,6 +18,7 @@ partial class Build : NukeBuild
 {
     private const string TracerArea = "Tracer";
     private const string AsmArea = "ASM";
+    private const string CiVisibilityArea = "CiVisibility";
     private const string TracingDotnet = "@DataDog/tracing-dotnet";
     private const string ASMDotnet = "@DataDog/asm-dotnet";
     private const string DebuggerDotnet = "@DataDog/debugger-dotnet";
@@ -213,7 +214,7 @@ partial class Build : NukeBuild
             {
                 var targetFrameworks = GetTestingFrameworks(PlatformFamily.Windows);
                 var targetPlatforms = new[] { "x86", "x64" };
-                var areas = new[] { TracerArea, AsmArea };
+                var areas = new[] { TracerArea, AsmArea, CiVisibilityArea };
                 var matrix = new Dictionary<string, object>();
 
                 foreach (var framework in targetFrameworks)
@@ -374,7 +375,7 @@ partial class Build : NukeBuild
                         }
                         else
                         {
-                            var areas = new[] { TracerArea, AsmArea };
+                            var areas = new[] { TracerArea, AsmArea, CiVisibilityArea };
                             foreach (var area in areas)
                             {
                                 if (ShouldBeIncluded(area))

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -214,7 +214,10 @@ partial class Build : NukeBuild
             {
                 var targetFrameworks = GetTestingFrameworks(PlatformFamily.Windows);
                 var targetPlatforms = new[] { "x86", "x64" };
-                var areas = new[] { TracerArea, AsmArea, CiVisibilityArea };
+                // CiVisibility is not split out on Windows: almost all CiVisibility tests are Linux-only,
+                // so a dedicated Windows job would spin up per framework/platform just to run the single
+                // IpcSampleTest. Keep those tests in the Windows Tracer job instead (see AddAreaFilter).
+                var areas = new[] { TracerArea, AsmArea };
                 var matrix = new Dictionary<string, object>();
 
                 foreach (var framework in targetFrameworks)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/ApmAgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/ApmAgentWriterTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
+    [Trait("Area", "CiVisibility")]
     public class ApmAgentWriterTests
     {
         private readonly ApmAgentWriter _ciAgentWriter;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessEventBufferTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessEventBufferTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
+    [Trait("Area", "CiVisibility")]
     public class CIAgentlessEventBufferTests
     {
         [Theory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
@@ -34,6 +34,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
+    [Trait("Area", "CiVisibility")]
     public class CiVisibilityProtocolWriterTests
     {
         [Fact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
@@ -22,6 +22,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     [CollectionDefinition(nameof(CIEnvironmentVariableTests), DisableParallelization = true)]
     [Collection(nameof(CIEnvironmentVariableTests))]
+    [Trait("Area", "CiVisibility")]
     public class CIEnvironmentVariableTests
     {
         private IDictionary _originalEnvVars;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CiVisibility")]
     public class CIVisibilityTests
     {
         private static readonly ITestOptimizationTracerManagement TracerManagement = new TestOptimizationTracerManagement(TestOptimizationSettings.FromDefaultSources());

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersFallbackTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersFallbackTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CiVisibility")]
     public class CodeOwnersFallbackTests
     {
         private const string CommitSha = "3245605c3d1edc67226d725799ee969c71f7632b";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CiVisibility")]
     public class CodeOwnersTests
     {
         private readonly CodeOwners _githubCodeOwners;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CiVisibility")]
     public class GitParserTests
     {
         public static IEnumerable<object[]> GetData()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Ipc/IpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Ipc/IpcTests.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Ipc;
 
+[Trait("Area", "CiVisibility")]
 public class IpcTests : TestingFrameworkEvpTest
 {
     public IpcTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     [UsesVerify]
+    [Trait("Area", "CiVisibility")]
     public class MsTestV2EvpTests : TestingFrameworkEvpTest
     {
         private const string TestSuiteName = "Samples.MSTestTests.TestSuite";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class MsTestV2RetriesTests : TestingFrameworkRetriesTests
 {
     public MsTestV2RetriesTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -20,8 +20,10 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CiVisibility")]
     public class MsTestV2Tests(ITestOutputHelper output) : MsTestV2TestsBase("MSTestTests", output, pre224TestCount: 20, post224TestCount: 22);
 
+    [Trait("Area", "CiVisibility")]
     public class MsTestV2Tests2(ITestOutputHelper output) : MsTestV2TestsBase("MSTestTests2", output, pre224TestCount: 19, post224TestCount: 21);
 
     [Collection("MsTestV2Tests")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     [UsesVerify]
+    [Trait("Area", "CiVisibility")]
     public class NUnitEvpTests : TestingFrameworkEvpTest
     {
         private const int ExpectedTestCount = 33;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class NUnitRetriesTests : TestingFrameworkRetriesTests
 {
     public NUnitRetriesTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     [UsesVerify]
+    [Trait("Area", "CiVisibility")]
     public class NUnitTests : TestingFrameworkTest
     {
         private const int ExpectedSpanCount = 33;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitEvpTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class PipesXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output)
 {
     [SkippableTheory(Skip = "These are currently very flaky - revisit once we move to aspnetcore-based mock agent")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitTests.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class PipesXUnitTests(ITestOutputHelper output) : XUnitTests(output)
 {
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/SeleniumTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/SeleniumTests.cs
@@ -28,6 +28,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [UsesVerify]
+[Trait("Area", "CiVisibility")]
 public class SeleniumTests : TestingFrameworkEvpTest
 {
     private readonly GacFixture _gacFixture;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitEvpTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class TcpXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output)
 {
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class TcpXUnitTests(ITestOutputHelper output) : XUnitTests(output)
 {
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitEvpTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class UdsXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output)
 {
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class UdsXUnitTests(ITestOutputHelper output) : XUnitTests(output)
 {
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 #if NET8_0_OR_GREATER
 [UsesVerify]
+[Trait("Area", "CiVisibility")]
 public class XUnitEvpTestsV3 : TestingFrameworkEvpTest
 {
     private const string TestBundleName = "Samples.XUnitTestsV3";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
@@ -22,6 +22,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     [UsesVerify]
+    [Trait("Area", "CiVisibility")]
     public class XUnitImpactedTests : TestingFrameworkImpactedTests
     {
         private const string IsModifiedTag = "test.is_modified";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class XUnitRetriesTests : TestingFrameworkRetriesTests
 {
     public XUnitRetriesTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTestsV3.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 [Collection(nameof(TransportTestsCollection))]
+[Trait("Area", "CiVisibility")]
 public class XUnitRetriesTestsV3 : TestingFrameworkRetriesTests
 {
     public XUnitRetriesTestsV3(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.Tests/Ci/Coverage/FileBitmapTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/Coverage/FileBitmapTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="FileBitmapTests.cs" company="Datadog">
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// Unless otherwise specified all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
@@ -8,7 +8,7 @@ using Datadog.Trace.Ci.Coverage.Util;
 using FluentAssertions;
 using Xunit;
 
-namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Coverage;
+namespace Datadog.Trace.Tests.Ci.Coverage;
 
 public class FileBitmapTests
 {

--- a/tracer/test/Datadog.Trace.Tests/Ci/Coverage/FileBitmapTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/Coverage/FileBitmapTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="FileBitmapTests.cs" company="Datadog">
-// Unless otherwise specified all files in this repository are licensed under the Apache 2 License.
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 


### PR DESCRIPTION
## Summary of changes

Introduces a `CiVisibility` test area that splits CI Visibility integration tests out of the `Tracer` job into their own dedicated matrix entries (e.g. `debian_net10.0_CiVisibility`).

- Adds `[Trait("Area", "CiVisibility")]` at class level to all CI Visibility test classes in `CI/`
- Adds `CiVisibilityArea` to the Linux and Windows integration test matrix generators
- Updates `AddAreaFilter` so the `Tracer` job excludes `Area=CiVisibility` tests, and the new `CiVisibility` job selects only them
- Moves `FileBitmapTests` to `Datadog.Trace.Tests` (it is a unit test, not an integration test)

## Reason for change

CI Visibility tests (EarlyFlakeDetection, AttemptToFix, QuarantinedTests, etc.) account for ~28 minutes of the `Test debian_net10.0_Tracer` job, which was causing it to consistently exceed the 60-minute agent wall-clock limit. Evidence from [build 202459](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=202459&view=results) after this split:

| Job | Duration |
|-----|----------|
| Test debian_net10.0_Tracer | 31.7 min |
| Test debian_net10.0_CiVisibility | 28.3 min |

Splitting them out gives each area a correctly-scoped job, better failure signal, and brings the Tracer job back well within the 60-minute limit.

## Other details

CI Visibility tests currently run on every PR regardless of which files changed, unlike ASM tests which are gated on code ownership. This will be addressed in a follow-up PR.