### PR TITLE
fix(profiler): potential double free

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -28,7 +28,7 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     IManagedThreadList* pManagedThreadsList,
     CpuSampleProvider* pProvider,
     MetricsRegistry& metricsRegistry,
-    IUnwinder* pUnwinder,
+    std::unique_ptr<IUnwinder> unwinder,
     UnwindingRecorderFactory* pUnwindingRecorderFactory) noexcept
     :
     _pSignalManager{pSignalManager}, // put it as parameter for better testing
@@ -36,7 +36,7 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     _pProvider{pProvider},
     _samplingInterval{pConfiguration->GetCpuProfilingInterval()},
     _nbThreadsInSignalHandler{0},
-    _pUnwinder{pUnwinder},
+    _pUnwinder{std::move(unwinder)},
     _pUnwindingRecorderFactory{pUnwindingRecorderFactory}
 {
     Log::Info("Cpu profiling interval: ", _samplingInterval.count(), "ms");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -34,7 +34,7 @@ public:
         IManagedThreadList* pManagedThreadsList,
         CpuSampleProvider* pProvider,
         MetricsRegistry& metricsRegistry,
-        IUnwinder* pUnwinder,
+        std::unique_ptr<IUnwinder> unwinder,
         UnwindingRecorderFactory* pUnwindingRecorderFactory) noexcept;
 
     ~TimerCreateCpuProfiler();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -635,9 +635,9 @@ void CorProfilerCallback::InitializeServices()
     if (_pConfiguration->IsCpuProfilingEnabled() && _pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
     {
 #ifdef ARM64
-        _pUnwinder = std::make_unique<HybridUnwinder>(_managedCodeCache.get());
+        auto unwinder = std::make_unique<HybridUnwinder>(_managedCodeCache.get());
 #else
-        _pUnwinder = std::make_unique<Backtrace2Unwinder>();
+        auto unwinder = std::make_unique<Backtrace2Unwinder>();
 #endif
         // Other alternative in case of crash-at-shutdown, do not register it as a service
         // we will have to start it by hand (already stopped by hand)
@@ -647,7 +647,7 @@ void CorProfilerCallback::InitializeServices()
             _pManagedThreadList,
             _pCpuSampleProvider,
             _metricsRegistry,
-            _pUnwinder.get(),
+            std::move(unwinder),
             _pUnwindingRecorderFactory.get());
     }
 #endif

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -271,7 +271,6 @@ private :
 #ifdef LINUX
     SystemCallsShield* _systemCallsShield = nullptr;
     std::unique_ptr<TimerCreateCpuProfiler> _pCpuProfiler = nullptr;
-    std::unique_ptr<IUnwinder> _pUnwinder = nullptr;
     CpuSampleProvider* _pCpuSampleProvider = nullptr;
     std::unique_ptr<RingBuffer> _pCpuProfilerRb = nullptr;
     std::unique_ptr<UnwindingRecorderFactory> _pUnwindingRecorderFactory = nullptr;


### PR DESCRIPTION
## Summary of changes
Remove `std::unique_ptr<IUnwinder> _pUnwinder` field from `CorProfilerCallback`
## Reason for change
The same pointer is stored in two distinct `std::unique_ptr` once in `CorProfilerCallback` and once in `TimerCreateCpuProfiler`. If both instances are destructed, the `IUnwinder` may get freed twice, which may lead to security  bugs.

## Implementation details

## Test coverage
I did not test or compile this change
## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
