### PR TITLE
fix(profiler): fix Ninja generator compatibility in profiler CMake build

### DIFF
--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -2,6 +2,13 @@ SET(LIBUNWIND_VERSION "v1.8.3-custom-1")
 
 SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind-build)
 
+include(ProcessorCount)
+ProcessorCount(_LIBUNWIND_NPROC)
+if(NOT _LIBUNWIND_NPROC OR _LIBUNWIND_NPROC EQUAL 0)
+    set(_LIBUNWIND_NPROC 4)
+endif()
+find_program(_MAKE_PROGRAM NAMES make gmake REQUIRED)
+
 ExternalProject_Add(libunwind
     GIT_REPOSITORY https://github.com/DataDog/libunwind.git
     GIT_TAG gleocadie/v1.8.3-custom-1
@@ -9,7 +16,7 @@ ExternalProject_Add(libunwind
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -O3\ -g CFLAGS=-fPIC\ -O3\ -g --disable-minidebuginfo --disable-zlibdebuginfo --disable-tests && make -j$(nproc)
+    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -O3\ -g CFLAGS=-fPIC\ -O3\ -g --disable-minidebuginfo --disable-zlibdebuginfo --disable-tests && ${_MAKE_PROGRAM} -j${_LIBUNWIND_NPROC}
     BUILD_ALWAYS false
     BUILD_BYPRODUCTS ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind-${CMAKE_SYSTEM_PROCESSOR}.a
                      ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind.a

--- a/build/cmake/FindRe2.cmake
+++ b/build/cmake/FindRe2.cmake
@@ -2,17 +2,19 @@ include(ExternalProject)
 
 SET(RE2_VERSION "2018-10-01")
 
+find_program(_RE2_MAKE_PROGRAM NAMES make gmake REQUIRED)
+
 set (DOWNLOAD_COMMAND ${CMAKE_COMMAND} -DPROJECT_NAME=re2 -DPROJECT_REPOSITORY=https://github.com/google/re2.git -DPROJECT_BRANCH=${RE2_VERSION} -P ${CMAKE_SOURCE_DIR}/build/cmake/git-clone-quiet-once.cmake)
 
 if (ISMACOS)
     SET (OSXRE2BUILDCOMMAND
             echo "Building Re2 Arm64" &&
             rm -f -r ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj &&
-            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ arm64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ arm64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j obj/libre2.a &&
+            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ arm64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ arm64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 ${_RE2_MAKE_PROGRAM} -j obj/libre2.a &&
             mv ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.arm64.a &&
             echo "Building Re2 X86_64" &&
             rm -f -r ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj &&
-            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ x86_64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ x86_64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j obj/libre2.a &&
+            ${CMAKE_COMMAND} -E env MAKEFLAGS=-s LDFLAGS=-arch\ x86_64 ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ x86_64-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 ${_RE2_MAKE_PROGRAM} -j obj/libre2.a &&
             mv ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.x86_64.a &&
             echo "Creating Re2 universal binary" &&
             lipo ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.arm64.a ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/libre2.x86_64.a -create -output ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
@@ -38,7 +40,7 @@ elseif(ISLINUX)
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_IN_SOURCE TRUE
-        BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 ${_RE2_MAKE_PROGRAM} -j
         BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
     )
 endif()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -179,11 +179,11 @@ add_library(${PROFILER_SHARED_LIB_NAME} SHARED
 
 set_target_properties(${PROFILER_SHARED_LIB_NAME} PROPERTIES PREFIX "")
 set_target_properties(${PROFILER_SHARED_LIB_NAME} PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
+set_target_properties(${PROFILER_SHARED_LIB_NAME} PROPERTIES BUILD_RPATH "$ORIGIN")
 target_link_options(${PROFILER_SHARED_LIB_NAME} PRIVATE
                     "LINKER:--version-script=${dd_profiling_linker_script}")
 
 # Define linker libraries
 target_link_libraries(${PROFILER_SHARED_LIB_NAME}
     -Wl,--whole-archive $<TARGET_FILE:${PROFILER_STATIC_LIB_NAME}> -Wl,--no-whole-archive
-    -Wl,-rpath,'$ORIGIN'
     ${PROFILER_STATIC_LIB_NAME})


### PR DESCRIPTION
## Summary

- **`$(nproc)` / `$(MAKE)` in ExternalProject BUILD_COMMAND** (`FindLibunwind.cmake`, `FindRe2.cmake`): these shell substitutions are written verbatim into `build.ninja`, where Ninja rejects `$(` as a bad `\$`-escape (`ninja: error: build.ninja:NNN: bad $-escape`). Fix: use CMake's `ProcessorCount` module instead of `$(nproc)`, and `find_program(make)` instead of `$(MAKE)`.

- **`$ORIGIN` rpath** (`Datadog.Profiler.Native.Linux/CMakeLists.txt`): the original `-Wl,-rpath,'$ORIGIN'` flag works correctly with the Makefile generator (shell single-quotes protect the `$`), but silently produces an empty rpath with Ninja (`$ORIGIN` is expanded as an undefined Ninja variable). Simply replacing with `$$ORIGIN` would fix Ninja but break Makefile (CMake writes `$$ORIGIN` verbatim into `link.txt`; the shell passes it literally to the linker). The correct fix is the `BUILD_RPATH` target property, which CMake escapes appropriately per generator (`\$ORIGIN` in Makefile `link.txt`, `\$$ORIGIN` in `build.ninja`).

## Test plan

- [ ] `cmake -G Ninja` succeeds with no `\$`-escape errors in `build.ninja`
- [ ] `ninja Datadog.Profiler.Native Datadog.Linux.ApiWrapper.x64` builds successfully (tested in Debian Bullseye container with clang-18)
- [ ] Makefile generator `link.txt` contains `"\$ORIGIN"` (verified via `cmake -G "Unix Makefiles"`)
- [ ] Ninja `build.ninja` contains `"\$$ORIGIN"` (verified) — Ninja expands this to `$ORIGIN` for the linker

🤖 Generated with [Claude Code](https://claude.ai/claude-code)