### PR TITLE
[Profiler] Fix coding issue

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -64,6 +64,6 @@ private:
     std::shared_ptr<CounterMetric> _totalSampling;
     std::shared_ptr<DiscardMetrics> _discardMetrics;
     std::atomic<std::uint64_t> _nbThreadsInSignalHandler;
-    std::unique_ptr<IUnwinder> _pUnwinder;
+    IUnwinder* _pUnwinder;
     UnwindingRecorderFactory* _pUnwindingRecorderFactory;
 };


### PR DESCRIPTION
## Summary of changes

Fix potential issue in `TimerCreateCpuProfiler`. 

## Reason for change

Do not store raw pointer in a `std::unique_ptr`.

## Implementation details

- Use raw pointer instead of `std::unique_ptr` when storing a point in `TimerCreateCpuProfiler`.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

Thanks to [korniltsev-grafanista](https://github.com/korniltsev-grafanista) for pointing this out

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
