### PR TITLE
[Test] Mark DatadogSink batching tests as flaky

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -74,6 +74,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         }
 
         [Fact]
+        [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
         public void SinkSendsMessageAsJsonBatch()
         {
             using var mutex = new ManualResetEventSlim();
@@ -117,6 +118,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         }
 
         [Fact]
+        [Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]
         public void SinkSendsMultipleBatches()
         {
             using var mutex = new ManualResetEventSlim();


### PR DESCRIPTION
## Summary of changes

Add the `[Flaky]` attribute to `DatadogSinkTests.SinkSendsMessageAsJsonBatch` and `DatadogSinkTests.SinkSendsMultipleBatches`.

## Reason for change

Both tests intermittently fail in CI on a `mutex.Wait(10s)` timeout. The `BatchingSink` flush loop runs on the thread pool (`Task.Run`), so on an overloaded CI agent the flush is starved and logs aren't delivered within the 10s window — observed alongside neighbouring sub-second tests taking 8–12s on the same run. The two sibling tests (`SinkSendsMessagesToLogsApi`, `SinkRejectsGiantMessages`) share the same dependency and are already marked flaky for this reason.

Example: https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/202583/logs/8588

## Implementation details

Apply the same `[Flaky("Identified as flaky in error tracking. Marked as flaky until solved.")]` attribute used by the sibling tests. No production code changes.

## Test coverage

## Other details
