### PR TITLE
[Dynamic Instrumentation] Rate limit condition evaluation error snapshots

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -378,6 +378,7 @@ namespace Datadog.Trace.Debugger.Expressions
             {
                 // Condition evaluation errors bypass the per-probe sampler and global limiter.
                 // A hard one-per-5-min cap guarantees at least one diagnostic snapshot per window without flooding.
+                if (probeInfo.HasCondition && !ShouldSampleEvaluationErrorSnapshot())
                 {
                     shouldStopCapture = true;
                 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -376,9 +376,8 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (evaluationResult.HasError)
             {
-                // Errors skip the per-probe sampler and global limiter: a hard one-per-5-min cap
-                // guarantees at least one diagnostic snapshot per window without flooding.
-                if (probeInfo.HasCondition && !ShouldSampleEvaluationErrorSnapshot())
+                // Condition evaluation errors bypass the per-probe sampler and global limiter.
+                // A hard one-per-5-min cap guarantees at least one diagnostic snapshot per window without flooding.
                 {
                     shouldStopCapture = true;
                 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -33,7 +33,6 @@ namespace Datadog.Trace.Debugger.Expressions
 
         private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
         private volatile ProbeProcessorState _state;
-        private long _lastEvaluationErrorSnapshotTimestamp = -EvaluationErrorSnapshotRateLimitTicks;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProbeProcessor"/> class, that correlated to probe id
@@ -378,7 +377,7 @@ namespace Datadog.Trace.Debugger.Expressions
             {
                 // Condition evaluation errors bypass the per-probe sampler and global limiter.
                 // A hard one-per-5-min cap guarantees at least one diagnostic snapshot per window without flooding.
-                if (probeInfo.HasCondition && !ShouldSampleEvaluationErrorSnapshot())
+                if (probeInfo.HasCondition && !state.ShouldSampleEvaluationErrorSnapshot())
                 {
                     shouldStopCapture = true;
                 }
@@ -403,18 +402,6 @@ namespace Datadog.Trace.Debugger.Expressions
             EvaluateCaptureExpressionsIfNeeded(state, snapshotCreator, cacheEntry, ref evaluator, ref evaluationResult, ref captureExpressionsEvaluated);
 
             return evaluationResult;
-        }
-
-        internal bool ShouldSampleEvaluationErrorSnapshot()
-        {
-            var timestamp = Stopwatch.GetTimestamp();
-            var lastTimestamp = Volatile.Read(ref _lastEvaluationErrorSnapshotTimestamp);
-            if (timestamp - lastTimestamp < EvaluationErrorSnapshotRateLimitTicks)
-            {
-                return false;
-            }
-
-            return Interlocked.CompareExchange(ref _lastEvaluationErrorSnapshotTimestamp, timestamp, lastTimestamp) == lastTimestamp;
         }
 
         private void SetSpanDecoration(ProbeProcessorState state, in ProbeInfo probeInfo, DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)
@@ -727,6 +714,7 @@ namespace Datadog.Trace.Debugger.Expressions
         internal sealed class ProbeProcessorState
         {
             private ProbeExpressionEvaluator? _evaluator;
+            private long _lastEvaluationErrorSnapshotTimestamp = -EvaluationErrorSnapshotRateLimitTicks;
 
             private ProbeProcessorState(
                 ProbeInfo probeInfo,
@@ -858,6 +846,18 @@ namespace Datadog.Trace.Debugger.Expressions
                 var newEvaluator = new ProbeExpressionEvaluator(Templates, Condition, Metric, SpanDecorations, CaptureExpressions);
                 var previousEvaluator = Interlocked.CompareExchange(ref _evaluator, newEvaluator, null);
                 return previousEvaluator ?? newEvaluator;
+            }
+
+            internal bool ShouldSampleEvaluationErrorSnapshot()
+            {
+                var timestamp = Stopwatch.GetTimestamp();
+                var lastTimestamp = Volatile.Read(ref _lastEvaluationErrorSnapshotTimestamp);
+                if (timestamp - lastTimestamp < EvaluationErrorSnapshotRateLimitTicks)
+                {
+                    return false;
+                }
+
+                return Interlocked.CompareExchange(ref _lastEvaluationErrorSnapshotTimestamp, timestamp, lastTimestamp) == lastTimestamp;
             }
 
             internal void LogEvaluationState(MethodScopeMembers methodScopeMembers)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -26,10 +26,14 @@ namespace Datadog.Trace.Debugger.Expressions
     internal sealed class ProbeProcessor : IProbeProcessor
     {
         private const string DynamicPrefix = "_dd.di.";
+        internal const int EvaluationErrorSnapshotRateLimitSeconds = 5 * 60;
+
+        private static readonly long EvaluationErrorSnapshotRateLimitTicks = Stopwatch.Frequency * EvaluationErrorSnapshotRateLimitSeconds;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProbeProcessor));
 
         private readonly IDebuggerGlobalRateLimiter _globalRateLimiter;
         private volatile ProbeProcessorState _state;
+        private long _lastEvaluationErrorSnapshotTimestamp = -EvaluationErrorSnapshotRateLimitTicks;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProbeProcessor"/> class, that correlated to probe id
@@ -372,9 +376,9 @@ namespace Datadog.Trace.Debugger.Expressions
 
             if (evaluationResult.HasError)
             {
-                // Probes with conditions defer sampling until after the condition is evaluated,
-                // so evaluation errors must honor that same sampler before emitting a snapshot.
-                if (probeInfo.HasCondition && !SamplePayload(in probeInfo, sampler))
+                // Errors skip the per-probe sampler and global limiter: a hard one-per-5-min cap
+                // guarantees at least one diagnostic snapshot per window without flooding.
+                if (probeInfo.HasCondition && !ShouldSampleEvaluationErrorSnapshot())
                 {
                     shouldStopCapture = true;
                 }
@@ -399,6 +403,18 @@ namespace Datadog.Trace.Debugger.Expressions
             EvaluateCaptureExpressionsIfNeeded(state, snapshotCreator, cacheEntry, ref evaluator, ref evaluationResult, ref captureExpressionsEvaluated);
 
             return evaluationResult;
+        }
+
+        internal bool ShouldSampleEvaluationErrorSnapshot()
+        {
+            var timestamp = Stopwatch.GetTimestamp();
+            var lastTimestamp = Volatile.Read(ref _lastEvaluationErrorSnapshotTimestamp);
+            if (timestamp - lastTimestamp < EvaluationErrorSnapshotRateLimitTicks)
+            {
+                return false;
+            }
+
+            return Interlocked.CompareExchange(ref _lastEvaluationErrorSnapshotTimestamp, timestamp, lastTimestamp) == lastTimestamp;
         }
 
         private void SetSpanDecoration(ProbeProcessorState state, in ProbeInfo probeInfo, DebuggerSnapshotCreator snapshotCreator, ref bool shouldStopCapture, ExpressionEvaluationResult evaluationResult)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -28,7 +28,7 @@ public class ProbeProcessorTests
     private const string FalseConditionJson = @"{ ""eq"": [1, 0] }";
 
     [Fact]
-    public void ConditionEvaluationErrorsAreDroppedWhenSamplerRejects()
+    public void ConditionEvaluationErrorsBypassSampler()
     {
         var processor = CreateConditionalProbeProcessor();
         var sampler = new TestAdaptiveSampler(false);
@@ -39,12 +39,12 @@ public class ProbeProcessorTests
         Assert.Equal(0, sampler.SampleCalls);
 
         Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
-        Assert.False(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
-        Assert.Equal(1, sampler.SampleCalls);
+        Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+        Assert.Equal(0, sampler.SampleCalls);
     }
 
     [Fact]
-    public void ConditionEvaluationErrorsAreCapturedWhenSamplerKeeps()
+    public void ConditionEvaluationErrorsAreCapturedWithoutSampler()
     {
         var processor = CreateConditionalProbeProcessor();
         var sampler = new TestAdaptiveSampler(true);
@@ -56,11 +56,11 @@ public class ProbeProcessorTests
 
         Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
         Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
-        Assert.Equal(1, sampler.SampleCalls);
+        Assert.Equal(0, sampler.SampleCalls);
     }
 
     [Fact]
-    public void ConditionEvaluationExceptionsAreDroppedWhenSamplerRejects()
+    public void ConditionEvaluationExceptionsBypassSampler()
     {
         var processor = CreateConditionalProbeProcessor();
         var sampler = new TestAdaptiveSampler(false);
@@ -72,8 +72,63 @@ public class ProbeProcessorTests
 
         Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
         ClearMethodScopeMembers(snapshotCreator);
-        Assert.False(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
-        Assert.Equal(1, sampler.SampleCalls);
+        Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+        Assert.Equal(0, sampler.SampleCalls);
+    }
+
+    [Fact]
+    public void ConditionEvaluationErrorsAreRateLimitedWithoutSampler()
+    {
+        var processor = CreateConditionalProbeProcessor();
+        var sampler = new TestAdaptiveSampler(true, true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+
+        var firstSnapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        Assert.True(ProcessEntryStart(processor, firstSnapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, firstSnapshotCreator, in probeData, method));
+
+        var secondSnapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        Assert.True(ProcessEntryStart(processor, secondSnapshotCreator, in probeData, method));
+        Assert.False(ProcessEntryEnd(processor, secondSnapshotCreator, in probeData, method));
+
+        Assert.Equal(0, sampler.SampleCalls);
+    }
+
+    [Fact]
+    public void ConditionEvaluationErrorSamplerRejectionDoesNotBlockFirstSnapshot()
+    {
+        var processor = CreateConditionalProbeProcessor();
+        var sampler = new TestAdaptiveSampler(false);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+
+        var firstSnapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        Assert.True(ProcessEntryStart(processor, firstSnapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, firstSnapshotCreator, in probeData, method));
+
+        Assert.Equal(0, sampler.SampleCalls);
+    }
+
+    [Fact]
+    public void ConditionEvaluationErrorRateLimitSurvivesProbeUpdate()
+    {
+        var processor = CreateConditionalProbeProcessor();
+        var sampler = new TestAdaptiveSampler(true, true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+
+        var firstSnapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        Assert.True(ProcessEntryStart(processor, firstSnapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, firstSnapshotCreator, in probeData, method));
+
+        processor.UpdateProbeProcessor(CreateConditionalLogProbe("probe-id", InvalidConditionJson, captureSnapshot: false));
+
+        var secondSnapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        Assert.True(ProcessEntryStart(processor, secondSnapshotCreator, in probeData, method));
+        Assert.False(ProcessEntryEnd(processor, secondSnapshotCreator, in probeData, method));
+
+        Assert.Equal(0, sampler.SampleCalls);
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -111,6 +111,24 @@ public class ProbeProcessorTests
     }
 
     [Fact]
+    public void ConditionEvaluationErrorSnapshotBypassesGlobalLimiter()
+    {
+        var globalRateLimiter = new GlobalRateLimiterMock(false);
+        var sampler = new TestAdaptiveSampler(false);
+        var probe = CreateConditionalLogProbe("snapshot-probe", InvalidConditionJson, captureSnapshot: true);
+        var processor = new ProbeProcessor(probe, globalRateLimiter);
+        var probeData = new ProbeData(probe.Id, sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
+        Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+
+        Assert.Equal(0, globalRateLimiter.ShouldSampleCallCount);
+        Assert.Equal(0, sampler.SampleCalls);
+    }
+
+    [Fact]
     public void ConditionEvaluationErrorRateLimitSurvivesProbeUpdate()
     {
         var processor = CreateConditionalProbeProcessor();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -27,6 +27,13 @@ public class ProbeProcessorTests
 
     private const string FalseConditionJson = @"{ ""eq"": [1, 0] }";
 
+    private const string UpdatedInvalidConditionJson = @"{
+    ""gt"": [
+      {""ref"": ""updatedUndefined""},
+      2
+    ]
+}";
+
     [Fact]
     public void ConditionEvaluationErrorsBypassSampler()
     {
@@ -129,7 +136,7 @@ public class ProbeProcessorTests
     }
 
     [Fact]
-    public void ConditionEvaluationErrorRateLimitSurvivesProbeUpdate()
+    public void ConditionEvaluationErrorRateLimitResetsOnProbeUpdate()
     {
         var processor = CreateConditionalProbeProcessor();
         var sampler = new TestAdaptiveSampler(true, true);
@@ -140,11 +147,11 @@ public class ProbeProcessorTests
         Assert.True(ProcessEntryStart(processor, firstSnapshotCreator, in probeData, method));
         Assert.True(ProcessEntryEnd(processor, firstSnapshotCreator, in probeData, method));
 
-        processor.UpdateProbeProcessor(CreateConditionalLogProbe("probe-id", InvalidConditionJson, captureSnapshot: false));
+        processor.UpdateProbeProcessor(CreateConditionalLogProbe("probe-id", UpdatedInvalidConditionJson, captureSnapshot: false));
 
         var secondSnapshotCreator = CreateSnapshotCreator(processor, in probeData);
         Assert.True(ProcessEntryStart(processor, secondSnapshotCreator, in probeData, method));
-        Assert.False(ProcessEntryEnd(processor, secondSnapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, secondSnapshotCreator, in probeData, method));
 
         Assert.Equal(0, sampler.SampleCalls);
     }


### PR DESCRIPTION
## Summary of changes

- Adds a dedicated 5-minute rate limit for condition evaluation-error snapshots in Dynamic Instrumentation.
- Treats condition evaluation errors as diagnostic snapshots that bypass the normal probe/global snapshot sampler.

## Reason for change

- System-tests now require eval-error snapshots to be emitted at most once per probe per 5 minutes.
- This matches the Python tracer behavior, where condition errors use a dedicated condition-error limiter.
- A broken condition should surface as a bounded diagnostic signal without being hidden by the normal snapshot sampler.

## Implementation details

- Uses `Stopwatch.GetTimestamp()` with an atomic `Interlocked.CompareExchange` gate.
- Avoids timers, dictionaries, and per-hit allocations in the eval-error path.
- The normal sampler still applies to successful conditional probe captures; only condition eval-error snapshots use the dedicated diagnostic limiter.

## Test coverage

- `ProbeProcessorTests`