### PR TITLE
[CI] Point serverless-tools trigger at `main` to fix monitoring-home path

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
   SUPPORTED_CONFIG_PATH: "tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml"
   OCI_PACKAGE_MAX_SIZE_BYTES: 43000000
   LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 43000000
-  SLS_CI_BRANCH: v1.3.0
+  SLS_CI_BRANCH: main
   WINDOWS_BUILD_IMAGE_BASE: "registry.ddbuild.io/ci/dd-trace-dotnet/dd-trace-dotnet-docker-build"
 
 build-windows-ci-image:


### PR DESCRIPTION
@
## Summary of changes

Change `SLS_CI_BRANCH` in `.gitlab-ci.yml` from the `v1.3.0` tag to `main` for the `benchmark-serverless-trigger` downstream pipeline.

## Reason for change

The serverless benchmark trigger pins `serverless-tools` to tag `v1.3.0`, whose `.gitlab/setup.sh` copies the tracer home from the old `./shared/bin/monitoring-home` location. That output was relocated to `./artifacts/monitoring-home` (#8681), so the downstream job fails with `cp: cannot stat ./shared/bin/monitoring-home: No such file or directory` even though the tracer build succeeds.

`serverless-tools` already fixed this on `main` (commit `110e5dd`, "Fix path used by .NET artifacts"), but no tag containing the fix has been released yet — `v1.3.0` is still the latest tag.

## Implementation details

`SLS_CI_BRANCH: v1.3.0` → `SLS_CI_BRANCH: main`.

⚠️ **Temporary:** this tracks `serverless-tools` tip rather than a pinned release. Once `serverless-tools` cuts a new tag (e.g. `v1.3.1`) that includes the fix, this should be pointed back at that tag.

## Test coverage

## Other details
