### PR TITLE
[Profiler] profiler iteration loop for agents/devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,6 +356,9 @@ shared/src/Datadog.Trace.ClrProfiler.Native/cmake-build-debug/
 !shared/src/Datadog.Trace.ClrProfiler.Native/lib/**
 cmake-build-debug/*
 
+#profiler build files
+profiler/_build/
+
 # global build folder
 obj/*
 obj_arm64/*
@@ -402,3 +405,6 @@ tools/dumps/
 
 # test optimization temp/run folder
 .dd/
+
+# Output of tracer/profiler-run.sh
+.profiler-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,11 +109,11 @@ Only rebuild more targets if you edited their source: `BuildNativeLoader` for `s
 **Run a scenario** with the freshly-built profiler attached:
 
 ```bash
-./tracer/profiler-run.sh              # default: PiComputation
-./tracer/profiler-run.sh 5 --timeout 30   # scenario 5 = FibonacciComputation, run for 30s
+./profiler/run-scenario.sh              # default: PiComputation
+./profiler/run-scenario.sh 5 --timeout 30   # scenario 5 = FibonacciComputation, run for 30s
 ```
 
-`tracer/profiler-run.sh` wraps the docker run + env soup needed to load the native loader, profiler, tracer and `LD_PRELOAD` API wrapper from the locally-built monitoring home. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files are written under `.profiler-out/` (gitignored).
+`profiler/run-scenario.sh` wraps the docker run + env soup needed to load the native loader, profiler, tracer and `LD_PRELOAD` API wrapper from the locally-built monitoring home. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files are written under `.profiler-out/` (gitignored).
 
 - **`tracer/README.md`** — Complete development setup guide (VS requirements, Docker, Dev Containers, platform-specific build commands, and Nuke targets)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,16 +84,17 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 - Unit tests: `./tracer/build.sh BuildAndRunManagedUnitTests`
 - Integration tests: `./tracer/build.sh BuildAndRunIntegrationTests`
 
-**Linux native components** (profiler `.so`, native loader, native tracer, API wrapper) must be built inside the Alpine builder image — direct `cmake` does not work. From macOS this needs Docker (Colima, Docker Desktop, …):
+### Linux profiler iteration (host: macOS or Linux)
+
+> Applies only to the **Linux** profiler / native loader / native tracer / API wrapper. For Windows-host profiler development (Windows native code, Visual Studio debugging) see `profiler/README.md`.
+
+The native Linux components must be built inside the Alpine builder image — direct `cmake` does not work. From macOS this needs Docker (Colima, Docker Desktop, …).
 
 ```bash
 # Build everything needed to run the profiler end-to-end:
 ./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
-```
 
-**Iterate on the profiler — run a scenario with a freshly-built profiler attached:**
-
-```bash
+# Run a scenario with the freshly-built profiler attached:
 ./tracer/profiler-run.sh              # default: PiComputation
 ./tracer/profiler-run.sh 5 --timeout 30   # scenario 5 = FibonacciComputation, run for 30s
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,16 +90,30 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 
 The native Linux components must be built inside the Alpine builder image — direct `cmake` does not work. From macOS this needs Docker (Colima, Docker Desktop, …).
 
-```bash
-# Build everything needed to run the profiler end-to-end:
-./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
+**Initial / cold build** (once per fresh clone, or after pulling a large change):
 
-# Run a scenario with the freshly-built profiler attached:
+```bash
+./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
+```
+
+All five targets are required to run a scenario end-to-end: tracer home (managed tracer + native tracer), native loader (CorProfiler entry point), API wrapper (`LD_PRELOAD`), profiler home (`Datadog.Profiler.Native.so`), and samples (the `Samples.Computer01` demo app).
+
+**Iterative rebuild** after editing native profiler code (the common case):
+
+```bash
+./tracer/build_in_docker.sh BuildProfilerHome
+```
+
+Only rebuild more targets if you edited their source: `BuildNativeLoader` for `shared/src/Datadog.Trace.ClrProfiler.Native/`, `BuildTracerHome` for the managed tracer or `tracer/src/Datadog.Tracer.Native/`, `BuildNativeWrapper` for `profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/`, `BuildProfilerSamples` for `profiler/src/Demos/Samples.Computer01/`.
+
+**Run a scenario** with the freshly-built profiler attached:
+
+```bash
 ./tracer/profiler-run.sh              # default: PiComputation
 ./tracer/profiler-run.sh 5 --timeout 30   # scenario 5 = FibonacciComputation, run for 30s
 ```
 
-`tracer/profiler-run.sh` is a thin wrapper around the docker run + env soup needed to load the native loader, profiler, tracer and `LD_PRELOAD` API wrapper from the locally-built monitoring home. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files are written under `.profiler-out/` (gitignored). After a code change, rebuild only what you touched (e.g. `BuildProfilerHome` for native profiler changes) and rerun.
+`tracer/profiler-run.sh` wraps the docker run + env soup needed to load the native loader, profiler, tracer and `LD_PRELOAD` API wrapper from the locally-built monitoring home. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files are written under `.profiler-out/` (gitignored).
 
 - **`tracer/README.md`** — Complete development setup guide (VS requirements, Docker, Dev Containers, platform-specific build commands, and Nuke targets)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,26 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 
 ## Build & Development
 
-**Quick start:**
+**Quick start (managed-only, all platforms, no Docker):**
 - Build: `./tracer/build.sh` (Linux/macOS) or `.\tracer\build.cmd` (Windows)
 - Unit tests: `./tracer/build.sh BuildAndRunManagedUnitTests`
-- Integration tests: `BuildAndRunIntegrationTests`
+- Integration tests: `./tracer/build.sh BuildAndRunIntegrationTests`
+
+**Linux native components** (profiler `.so`, native loader, native tracer, API wrapper) must be built inside the Alpine builder image — direct `cmake` does not work. From macOS this needs Docker (Colima, Docker Desktop, …):
+
+```bash
+# Build everything needed to run the profiler end-to-end:
+./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
+```
+
+**Iterate on the profiler — run a scenario with a freshly-built profiler attached:**
+
+```bash
+./tracer/profiler-run.sh              # default: PiComputation
+./tracer/profiler-run.sh 5 --timeout 30   # scenario 5 = FibonacciComputation, run for 30s
+```
+
+`tracer/profiler-run.sh` is a thin wrapper around the docker run + env soup needed to load the native loader, profiler, tracer and `LD_PRELOAD` API wrapper from the locally-built monitoring home. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files are written under `.profiler-out/` (gitignored). After a code change, rebuild only what you touched (e.g. `BuildProfilerHome` for native profiler changes) and rerun.
 
 - **`tracer/README.md`** — Complete development setup guide (VS requirements, Docker, Dev Containers, platform-specific build commands, and Nuke targets)
 

--- a/profiler/run-scenario.sh
+++ b/profiler/run-scenario.sh
@@ -6,10 +6,10 @@
 #   ./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
 #
 # Usage:
-#   ./tracer/profiler-run.sh                       # default scenario: PiComputation (4)
-#   ./tracer/profiler-run.sh 5                     # scenario 5 = FibonacciComputation
-#   ./tracer/profiler-run.sh 5 --timeout 30        # extra args forwarded to the sample
-#   DD_PROFILING_CPU_ENABLED=1 ./tracer/profiler-run.sh 5
+#   ./profiler/run-scenario.sh                       # default scenario: PiComputation (4)
+#   ./profiler/run-scenario.sh 5                     # scenario 5 = FibonacciComputation
+#   ./profiler/run-scenario.sh 5 --timeout 30        # extra args forwarded to the sample
+#   DD_PROFILING_CPU_ENABLED=1 ./profiler/run-scenario.sh 5
 #
 # Scenario IDs are the values of the `Scenario` enum in
 # profiler/src/Demos/Samples.Computer01/Program.cs.

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -16,8 +16,9 @@ $IMAGE_NAME="dd-trace-dotnet/alpine-base"
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"
 
-# Use -t only when stdout is a terminal so this script works in CI / no-TTY agent harnesses.
-$ttyFlags = if ([Console]::IsOutputRedirected) { @('-i') } else { @('-i','-t') }
+# Use -t only when stdin is a terminal so this script works in CI / no-TTY agent harnesses.
+# Mirrors the bash sibling's `[[ -t 0 ]]` check (stdin / fd 0).
+$ttyFlags = if ([Console]::IsInputRedirected) { @('-i') } else { @('-i','-t') }
 
 &docker run @ttyFlags --rm `
     --mount "type=bind,source=$ROOT_DIR,target=/project" `

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -16,7 +16,10 @@ $IMAGE_NAME="dd-trace-dotnet/alpine-base"
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"
 
-&docker run -it --rm `
+# Use -t only when stdout is a terminal so this script works in CI / no-TTY agent harnesses.
+$ttyFlags = if ([Console]::IsOutputRedirected) { @('-i') } else { @('-i','-t') }
+
+&docker run @ttyFlags --rm `
     --mount "type=bind,source=$ROOT_DIR,target=/project" `
     --env NugetPackageDirectory=/project/packages `
     --env artifacts=/project/tracer/bin/artifacts `

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -12,7 +12,11 @@ docker build \
    --file "$BUILD_DIR/docker/alpine.dockerfile" \
    "$BUILD_DIR"
 
-docker run -it --rm \
+# Use -t only when stdin is a terminal so this script works in CI / no-TTY agent harnesses.
+TTY_FLAGS=(-i)
+[[ -t 0 ]] && TTY_FLAGS+=(-t)
+
+docker run "${TTY_FLAGS[@]}" --rm \
     --mount type=bind,source="$ROOT_DIR",target=/project \
     --env NugetPackageDirectory=/project/packages \
     --env artifacts=/project/tracer/bin/artifacts \

--- a/tracer/profiler-run.sh
+++ b/tracer/profiler-run.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Run a Samples.Computer01 scenario with the freshly-built profiler attached.
+#
+# Prerequisites — build artifacts must already exist. From the repo root:
+#   ./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
+#
+# Usage:
+#   ./tracer/profiler-run.sh                       # default scenario: PiComputation (4)
+#   ./tracer/profiler-run.sh 5                     # scenario 5 = FibonacciComputation
+#   ./tracer/profiler-run.sh 5 --timeout 30        # extra args forwarded to the sample
+#   DD_PROFILING_CPU_ENABLED=1 ./tracer/profiler-run.sh 5
+#
+# Scenario IDs are the values of the `Scenario` enum in
+# profiler/src/Demos/Samples.Computer01/Program.cs.
+#
+# Output (gitignored under .profiler-out/):
+#   .profiler-out/logs/    — DD-DotNet-Profiler-Native-*.log etc.
+#   .profiler-out/pprof/   — .pprof captures (set via DD_INTERNAL_PROFILING_OUTPUT_DIR)
+#
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR="$(dirname -- "$SCRIPT_DIR")"
+IMAGE_NAME="dd-trace-dotnet/alpine-base"
+
+# --- arg parsing --------------------------------------------------------------
+# First positional arg is the scenario number; anything starting with '-' is
+# treated as a sample-level flag and we fall back to the default scenario.
+SCENARIO=4   # 4 = PiComputation
+if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+    SCENARIO="$1"
+    shift
+fi
+EXTRA_ARGS=("$@")
+
+# --- arch detection -----------------------------------------------------------
+case "$(uname -m)" in
+    arm64|aarch64) RID="linux-musl-arm64"; BUILD_ARCH="ARM64" ;;
+    x86_64|amd64)  RID="linux-musl-x64";   BUILD_ARCH="x64"   ;;
+    *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# --- locate sample dll --------------------------------------------------------
+SAMPLE_REL=""
+for CFG in Release Debug; do
+    candidate="profiler/_build/bin/${CFG}-${BUILD_ARCH}/profiler/src/Demos/Samples.Computer01/net10.0/Samples.Computer01.dll"
+    if [[ -f "${ROOT_DIR}/${candidate}" ]]; then
+        SAMPLE_REL="$candidate"
+        break
+    fi
+done
+if [[ -z "$SAMPLE_REL" ]]; then
+    echo "ERROR: Samples.Computer01.dll not found under profiler/_build/bin/{Release,Debug}-${BUILD_ARCH}/." >&2
+    echo "Build first: ./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples" >&2
+    exit 1
+fi
+
+# --- sanity-check the monitoring-home layer ----------------------------------
+MH_REL="shared/bin/monitoring-home/${RID}"
+required=(Datadog.Trace.ClrProfiler.Native.so Datadog.Profiler.Native.so Datadog.Tracer.Native.so Datadog.Linux.ApiWrapper.x64.so loader.conf)
+for f in "${required[@]}"; do
+    [[ -f "${ROOT_DIR}/${MH_REL}/${f}" ]] || { echo "ERROR: missing ${MH_REL}/${f} — rebuild the missing target." >&2; exit 1; }
+done
+
+# --- output directories (gitignored) -----------------------------------------
+OUT_REL=".profiler-out"
+mkdir -p "${ROOT_DIR}/${OUT_REL}/logs" "${ROOT_DIR}/${OUT_REL}/pprof"
+
+# --- image -------------------------------------------------------------------
+if ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+    echo "Building $IMAGE_NAME (one-off)..."
+    docker build \
+        --build-arg DOTNETSDK_VERSION=10.0.100 \
+        --tag "$IMAGE_NAME" \
+        --file "${ROOT_DIR}/tracer/build/_build/docker/alpine.dockerfile" \
+        "${ROOT_DIR}/tracer/build/_build" >&2
+fi
+
+# --- TTY handling ------------------------------------------------------------
+TTY_FLAGS=(-i)
+[[ -t 0 ]] && TTY_FLAGS+=(-t)
+
+echo "→ scenario=${SCENARIO}  rid=${RID}  sample=${SAMPLE_REL}"
+echo "→ logs:    ${OUT_REL}/logs/"
+echo "→ pprofs:  ${OUT_REL}/pprof/"
+echo
+
+docker run --rm "${TTY_FLAGS[@]}" \
+    --mount type=bind,source="${ROOT_DIR}",target=/project \
+    --workdir /project \
+    --env CORECLR_ENABLE_PROFILING=1 \
+    --env "CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}" \
+    --env "CORECLR_PROFILER_PATH=/project/${MH_REL}/Datadog.Trace.ClrProfiler.Native.so" \
+    --env "DD_DOTNET_TRACER_HOME=/project/shared/bin/monitoring-home" \
+    --env "DD_NATIVELOADER_CONFIGFILE=/project/${MH_REL}/loader.conf" \
+    --env "LD_PRELOAD=/project/${MH_REL}/Datadog.Linux.ApiWrapper.x64.so" \
+    --env DD_PROFILING_ENABLED=1 \
+    --env DD_PROFILING_MANAGED_ACTIVATION_ENABLED=0 \
+    --env DD_TRACE_ENABLED=0 \
+    --env DD_TRACE_DEBUG="${DD_TRACE_DEBUG:-0}" \
+    --env "DD_TRACE_LOG_DIRECTORY=/project/${OUT_REL}/logs" \
+    --env "DD_INTERNAL_PROFILING_OUTPUT_DIR=/project/${OUT_REL}/pprof" \
+    ${DD_PROFILING_CPU_ENABLED:+--env DD_PROFILING_CPU_ENABLED="${DD_PROFILING_CPU_ENABLED}"} \
+    ${DD_PROFILING_WALLTIME_ENABLED:+--env DD_PROFILING_WALLTIME_ENABLED="${DD_PROFILING_WALLTIME_ENABLED}"} \
+    ${DD_PROFILING_UPLOAD_PERIOD:+--env DD_PROFILING_UPLOAD_PERIOD="${DD_PROFILING_UPLOAD_PERIOD}"} \
+    "$IMAGE_NAME" \
+    dotnet "/project/${SAMPLE_REL}" --scenario "$SCENARIO" "${EXTRA_ARGS[@]}"
+rc=$?
+
+# --- post-run sanity check --------------------------------------------------
+loader_log="${ROOT_DIR}/${OUT_REL}/logs/dotnet-native-loader-dotnet-1.log"
+if [[ -f "$loader_log" ]] && grep -q "Error loading dynamic library.*Datadog.Profiler.Native.so" "$loader_log"; then
+    echo >&2
+    echo "WARNING: the native profiler library failed to load — no .pprof will be produced." >&2
+    grep "Error loading dynamic library.*Datadog.Profiler.Native.so" "$loader_log" | tail -1 >&2
+    echo "Hint: rebuild the profiler home (./tracer/build_in_docker.sh BuildProfilerHome)." >&2
+fi
+exit $rc

--- a/tracer/profiler-run.sh
+++ b/tracer/profiler-run.sh
@@ -35,8 +35,9 @@ fi
 EXTRA_ARGS=("$@")
 
 # --- arch detection -----------------------------------------------------------
+ARCH_ENV=()
 case "$(uname -m)" in
-    arm64|aarch64) RID="linux-musl-arm64"; BUILD_ARCH="ARM64" ;;
+    arm64|aarch64) RID="linux-musl-arm64"; BUILD_ARCH="ARM64"; ARCH_ENV=(--env DD_INTERNAL_PROFILING_ENABLED_ARM64=1) ;;
     x86_64|amd64)  RID="linux-musl-x64";   BUILD_ARCH="x64"   ;;
     *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
 esac
@@ -96,6 +97,7 @@ docker run --rm "${TTY_FLAGS[@]}" \
     --env "DD_NATIVELOADER_CONFIGFILE=/project/${MH_REL}/loader.conf" \
     --env "LD_PRELOAD=/project/${MH_REL}/Datadog.Linux.ApiWrapper.x64.so" \
     --env DD_PROFILING_ENABLED=1 \
+    "${ARCH_ENV[@]}" \
     --env DD_PROFILING_MANAGED_ACTIVATION_ENABLED=0 \
     --env DD_TRACE_ENABLED=0 \
     --env DD_TRACE_DEBUG="${DD_TRACE_DEBUG:-0}" \


### PR DESCRIPTION
## Summary of changes

- New `tracer/profiler-run.sh` helper that runs a Samples.Computer01 scenario with the locally-built profiler attached.
- `tracer/build_in_docker.{sh,ps1}` now skip `-t` when stdin is not a TTY.
- `AGENTS.md` Build & Development section trimmed to a two-command iteration loop.
- `.gitignore` entry for `.profiler-out/`.

## Reason for change

Follow-up to #8573, which proposed the same iteration loop as documentation only — ~70 lines containing two large `docker run` invocations with ~10 env vars each. Hard to read, easy to drift, easy to mistype. Moving the setup into a script lets the docs say "run this" instead.

The TTY fix is needed because the stock `build_in_docker.sh` fails in non-TTY harnesses (CI, agent harnesses) with `cannot attach stdin to a TTY-enabled container because stdin is not a terminal`.

## Implementation details

`tracer/profiler-run.sh`:
- Detects arch from `uname -m` → `linux-musl-arm64` or `linux-musl-x64`.
- On arm64 sets `DD_INTERNAL_PROFILING_ENABLED_ARM64=1` (profiler is opt-in on arm64).
- Picks the matching `profiler/_build/bin/{Release,Debug}-{ARM64,x64}/.../Samples.Computer01.dll` (Release first, Debug fallback).
- Wires `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH`, `DD_DOTNET_TRACER_HOME`, `DD_NATIVELOADER_CONFIGFILE`, `LD_PRELOAD`, `DD_PROFILING_ENABLED` from the local monitoring home.
- Builds `dd-trace-dotnet/alpine-base` on first use.
- Writes logs to `.profiler-out/logs/` and pprofs to `.profiler-out/pprof/`.
- Post-run check greps the native-loader log and warns if `Datadog.Profiler.Native.so` failed to load.

`build_in_docker.{sh,ps1}`: `-i` always, `-t` only when `[[ -t 0 ]]` / `![Console]::IsOutputRedirected`.

Usage:
```bash
./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
./tracer/profiler-run.sh 5 --timeout 30   # 5 = FibonacciComputation
```

## Test coverage

Manual, on macOS + Colima + arm64:
- `./tracer/profiler-run.sh` (default scenario), `./tracer/profiler-run.sh 4 --timeout 5`, `./tracer/profiler-run.sh --timeout 3` (flag-only).
- Missing-build error path and the profiler-failed-to-load warning.
- `bash -c '</dev/null ./tracer/build_in_docker.sh --help'` and `bash -c '</dev/null ./tracer/profiler-run.sh 4 --timeout 3'` both succeed (no-TTY).

## Other details

No changes to product code, build pipelines, or CI.