### PR TITLE
[Dynamic Instrumentation] Omit capture data for condition evaluation errors

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ExpressionEvaluationResult.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ExpressionEvaluationResult.cs
@@ -27,6 +27,8 @@ internal ref struct ExpressionEvaluationResult
 
     internal List<EvaluationError>? Errors { get; set; }
 
+    internal bool HasConditionError { get; set; }
+
     internal readonly bool HasError => Errors is { Count: > 0 };
 
     internal readonly bool HasCaptureExpressions => CaptureExpressionCount > 0;

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
@@ -273,12 +273,14 @@ internal sealed class ProbeExpressionEvaluator
             if (compiledExpression.Errors != null)
             {
                 (result.Errors ??= new List<EvaluationError>()).AddRange(compiledExpression.Errors);
+                result.HasConditionError = true;
             }
         }
         catch (Exception e)
         {
             HandleException(ref result, compiledExpression, e);
             result.Condition = true;
+            result.HasConditionError = true;
         }
     }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -333,7 +333,6 @@ namespace Datadog.Trace.Debugger.Expressions
 
                 evaluationResult.Errors ??= new List<EvaluationError>();
                 evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {probeInfo.ProbeId}. Error: {e.Message}" });
-                evaluationResult.HasConditionError = probeInfo.HasCondition;
             }
 
             if (state.ShouldCaptureExpressions && evaluationResult.IsNull())

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -333,6 +333,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
                 evaluationResult.Errors ??= new List<EvaluationError>();
                 evaluationResult.Errors.Add(new EvaluationError { Message = $"Failed to evaluate expression for probe ID: {probeInfo.ProbeId}. Error: {e.Message}" });
+                evaluationResult.HasConditionError = probeInfo.HasCondition;
             }
 
             if (state.ShouldCaptureExpressions && evaluationResult.IsNull())
@@ -382,7 +383,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     shouldStopCapture = true;
                 }
 
-                if (!shouldStopCapture)
+                if (!shouldStopCapture && !evaluationResult.HasConditionError)
                 {
                     EvaluateCaptureExpressionsIfNeeded(state, snapshotCreator, cacheEntry, ref evaluator, ref evaluationResult, ref captureExpressionsEvaluated);
                 }

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -45,6 +45,7 @@ namespace Datadog.Trace.Debugger.Snapshots
         private List<EvaluationError>? _errors;
         private string? _snapshotId;
         private ObjectPool<MethodScopeMembers, MethodScopeMembersParameters> _scopeMembersPool;
+        private bool _omitCaptureData;
 
         // Track opened JSON containers explicitly to avoid using JsonWriter.Path (allocations + heuristic parsing).
         // This class is on the hot path, so these flags should stay extremely cheap.
@@ -67,6 +68,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             _captureBehaviour = CaptureBehaviour.Capture;
             _errors = null;
             _message = null;
+            _omitCaptureData = false;
             ProbeHasCondition = hasCondition;
             Tags = tags;
             _limitInfo = limitInfo;
@@ -231,7 +233,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void AddScopeMember<T>(string name, Type type, T value, ScopeMemberKind memberKind)
         {
-            if (MethodScopeMembers == null)
+            if (_omitCaptureData || MethodScopeMembers == null)
             {
                 return;
             }
@@ -290,6 +292,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void StartCaptures()
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             JsonWriter.WritePropertyName("captures");
             JsonWriter.WriteStartObject();
             _capturesOpen = true;
@@ -297,6 +304,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void StartEntry()
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             if (!_isFullSnapshot && !_capturesOpen)
             {
                 StartCaptures();
@@ -314,6 +326,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void StartLines(int lineNumber)
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             // For non-full snapshots we still want "captures", but it might not have been started yet.
             if (!_isFullSnapshot && !_capturesOpen)
             {
@@ -349,6 +366,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void StartReturn()
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             // StartCaptures is done during Initialize() for full snapshots. For non-full snapshots, we need it here,
             // but only once.
             if (!_isFullSnapshot && !_capturesOpen)
@@ -431,37 +453,7 @@ namespace Datadog.Trace.Debugger.Snapshots
         internal virtual DebuggerSnapshotCreator EndSnapshot()
         {
             // If any capture containers are still open for any reason, close them first (do not over-close).
-            CloseLocalsOrArgsIfOpen();
-
-            if (_entryOpen)
-            {
-                JsonWriter.WriteEndObject();
-                _entryOpen = false;
-            }
-
-            if (_returnOpen)
-            {
-                JsonWriter.WriteEndObject();
-                _returnOpen = false;
-            }
-
-            if (_lineNumberOpen)
-            {
-                JsonWriter.WriteEndObject();
-                _lineNumberOpen = false;
-            }
-
-            if (_linesOpen)
-            {
-                JsonWriter.WriteEndObject();
-                _linesOpen = false;
-            }
-
-            if (_capturesOpen)
-            {
-                JsonWriter.WriteEndObject();
-                _capturesOpen = false;
-            }
+            CloseCaptureDataContainers();
 
             JsonWriter.WritePropertyName("id");
             JsonWriter.WriteValue(SnapshotId);
@@ -493,6 +485,41 @@ namespace Datadog.Trace.Debugger.Snapshots
             }
         }
 
+        private void CloseCaptureDataContainers()
+        {
+            CloseLocalsOrArgsIfOpen();
+
+            if (_entryOpen)
+            {
+                JsonWriter.WriteEndObject();
+                _entryOpen = false;
+            }
+
+            if (_returnOpen)
+            {
+                JsonWriter.WriteEndObject();
+                _returnOpen = false;
+            }
+
+            if (_lineNumberOpen)
+            {
+                JsonWriter.WriteEndObject();
+                _lineNumberOpen = false;
+            }
+
+            if (_linesOpen)
+            {
+                JsonWriter.WriteEndObject();
+                _linesOpen = false;
+            }
+
+            if (_capturesOpen)
+            {
+                JsonWriter.WriteEndObject();
+                _capturesOpen = false;
+            }
+        }
+
         internal void CaptureInstance<TInstance>(TInstance instance, Type type)
         {
             if (instance == null)
@@ -505,6 +532,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         public void CaptureStaticFields<T>(ref CaptureInfo<T> info)
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             if (info.IsAsyncCapture())
             {
                 DebuggerSnapshotSerializer.SerializeStaticFields(info.AsyncCaptureInfo.KickoffInvocationTargetType, JsonWriter, _limitInfo);
@@ -517,6 +549,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void CaptureArgument<TArg>(TArg value, string name, Type? type = null)
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             StartLocalsOrArgsIfNeeded("arguments");
             // in case TArg is object and we have the concrete type, use it
             DebuggerSnapshotSerializer.Serialize(value, type ?? typeof(TArg), name, JsonWriter, _limitInfo);
@@ -524,6 +561,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void CaptureLocal<TLocal>(TLocal value, string name, Type? type = null)
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             StartLocalsOrArgsIfNeeded("locals");
             // in case TLocal is object and we have the concrete type, use it
             DebuggerSnapshotSerializer.Serialize(value, type ?? typeof(TLocal), name, JsonWriter, _limitInfo);
@@ -531,6 +573,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void CaptureCaptureExpressions(ref ExpressionEvaluationResult evaluationResult)
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             var captureExpressions = evaluationResult.CaptureExpressions;
             var captureExpressionCount = evaluationResult.CaptureExpressionCount;
             if (captureExpressions == null || captureExpressionCount == 0)
@@ -552,6 +599,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void CaptureException(Exception ex)
         {
+            if (_omitCaptureData)
+            {
+                return;
+            }
+
             JsonWriter.WritePropertyName("throwable");
             JsonWriter.WriteStartObject();
             JsonWriter.WritePropertyName("message");
@@ -654,6 +706,10 @@ namespace Datadog.Trace.Debugger.Snapshots
         {
             _errors = evaluationResult.Errors;
             _message = _errors?.FirstOrDefault(error => !string.IsNullOrEmpty(error.Message)).Message ?? evaluationResult.Template;
+            if (evaluationResult.HasConditionError)
+            {
+                _omitCaptureData = true;
+            }
         }
 
         private void CaptureAsyncMethodArguments(System.Reflection.FieldInfo[] asyncHoistedArguments, object moveNextInvocationTarget)
@@ -911,6 +967,11 @@ namespace Datadog.Trace.Debugger.Snapshots
             if (_errors == null || _errors.Count == 0)
             {
                 return this;
+            }
+
+            if (_omitCaptureData)
+            {
+                CloseCaptureDataContainers();
             }
 
             JsonWriter.WritePropertyName("evaluationErrors");

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.FullSnapshotWithConditionError.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.FullSnapshotWithConditionError.verified.txt
@@ -1,0 +1,42 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {},
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "this.undefined",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.ExpressionTests.FullSnapshotWithConditionError"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.FullSnapshotWithConditionError",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InvalidCondition.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InvalidCondition.verified.txt
@@ -5,31 +5,7 @@
     "ddsource": "dd_debugger",
     "debugger": {
       "snapshot": {
-        "captures": {
-          "return": {
-            "arguments": {
-              "intArg": {
-                "type": "Int32",
-                "value": "1"
-              },
-              "this": {
-                "type": "InvalidCondition"
-              }
-            },
-            "locals": {
-              "@return": {
-                "type": "String",
-                "value": "Argument: 1"
-              }
-            },
-            "staticFields": {
-              "Json": {
-                "type": "String",
-                "value": "{\r\n    \"gt\": [\r\n       \"undefined\",\r\n      2\r\n    ]\r\n}"
-              }
-            }
-          }
-        },
+        "captures": {},
         "duration": "ScrubbedValue",
         "evaluationErrors": [
           {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UndefinedValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UndefinedValue.verified.txt
@@ -5,31 +5,7 @@
     "ddsource": "dd_debugger",
     "debugger": {
       "snapshot": {
-        "captures": {
-          "return": {
-            "arguments": {
-              "intArg": {
-                "type": "Int32",
-                "value": "1"
-              },
-              "this": {
-                "type": "UndefinedValue"
-              }
-            },
-            "locals": {
-              "@return": {
-                "type": "String",
-                "value": "Argument: 1"
-              }
-            },
-            "staticFields": {
-              "Json": {
-                "type": "String",
-                "value": "{\r\n    \"gt\": [\r\n      {\"ref\": \"undefined\"},\r\n      2\r\n    ]\r\n}"
-              }
-            }
-          }
-        },
+        "captures": {},
         "duration": "ScrubbedValue",
         "evaluationErrors": [
           {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -493,6 +493,47 @@ public class ProbesTests : TestHelper
         await RunCaptureExpressionProbeTest(testDescription);
     }
 
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    public async Task ConditionErrorFullSnapshotOmitsCaptureData()
+    {
+        var testDescription = DebuggerTestHelper.SpecificTestDescription(typeof(FullSnapshotWithConditionError));
+        var probes = GetProbeConfiguration(testDescription.TestType, unlisted: true, new DeterministicGuidGenerator());
+        var snapshotProbes = probes.Select(p => p.Probe).ToArray();
+
+        using var agent = EnvironmentHelper.GetMockAgent();
+        SetDebuggerEnvironment(agent);
+        using var logEntryWatcher = CreateLogEntryWatcher(nameof(ConditionErrorFullSnapshotOmitsCaptureData));
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        try
+        {
+            SetProbeConfiguration(agent, snapshotProbes);
+            await logEntryWatcher.WaitForLogEntry(AddedProbesInstrumentedLogEntry);
+
+            await sample.RunCodeSample();
+
+            var snapshots = await agent.WaitForSnapshots(snapshotProbes.Length);
+            Assert.Equal(snapshotProbes.Length, snapshots?.Length);
+
+            var snapshot = JToken.Parse(snapshots[0]);
+            var evaluationErrors = snapshot.SelectToken("debugger.snapshot.evaluationErrors") as JArray;
+            evaluationErrors.Should().NotBeNull();
+            evaluationErrors.Should().ContainSingle();
+            evaluationErrors![0]["expr"]?.Value<string>().Should().Be("this.undefined");
+            evaluationErrors[0]["message"]?.Value<string>().Should().NotBeNullOrEmpty();
+            snapshot.SelectToken("debugger.snapshot.captures.entry").Should().BeNull();
+            snapshot.SelectToken("debugger.snapshot.captures.return").Should().BeNull();
+            snapshot.SelectToken("debugger.snapshot.captures.lines").Should().BeNull();
+
+            await ApproveSnapshots(snapshots, testDescription, isMultiPhase: false, phaseNumber: 1);
+        }
+        finally
+        {
+            await sample.StopSample();
+        }
+    }
+
     [SkippableTheory]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Debugger;
+using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.Snapshots;
@@ -167,6 +168,95 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ConditionEvaluationErrors_OmitMethodCaptureData()
+        {
+            var captureLimitInfo = CreateCaptureLimitInfo();
+            var snapshotCreator = new DebuggerSnapshotCreator(
+                isFullSnapshot: true,
+                Datadog.Trace.Debugger.Expressions.ProbeLocation.Method,
+                hasCondition: true,
+                tags: [],
+                limitInfo: captureLimitInfo,
+                processTagsProvider: static () => null,
+                serviceNameProvider: static () => "test-service");
+
+            var method = typeof(DebuggerSnapshotCreatorTests).GetMethod(nameof(DummyMethod), BindingFlags.NonPublic | BindingFlags.Static)!;
+            var entryStartCapture = new CaptureInfo<Type>(
+                methodMetadataIndex: 0,
+                methodState: MethodState.EntryStart,
+                method: method,
+                type: typeof(DebuggerSnapshotCreatorTests),
+                invocationTargetType: typeof(DebuggerSnapshotCreatorTests),
+                localsCount: 1,
+                argumentsCount: 1);
+
+            snapshotCreator.DefineSnapshotBehavior(ref entryStartCapture, EvaluateAt.Entry, hasCondition: true);
+            snapshotCreator.AddScopeMember("arg", typeof(string), "argument-value", ScopeMemberKind.Argument);
+            snapshotCreator.AddScopeMember("local", typeof(string), "local-value", ScopeMemberKind.Local);
+
+            var entryEndCapture = new CaptureInfo<object>(
+                methodMetadataIndex: 0,
+                methodState: MethodState.EntryEnd,
+                value: new object(),
+                method: method,
+                type: typeof(object),
+                invocationTargetType: typeof(object),
+                memberKind: ScopeMemberKind.This,
+                hasLocalOrArgument: true);
+
+            Assert.Equal(CaptureBehaviour.Evaluate, snapshotCreator.DefineSnapshotBehavior(ref entryEndCapture, EvaluateAt.Entry, hasCondition: true));
+
+            var evaluationResult = CreateConditionEvaluationErrorResult();
+            snapshotCreator.SetEvaluationResult(ref evaluationResult);
+
+            Assert.True(snapshotCreator.ProcessDelayedSnapshot(ref entryEndCapture, hasCondition: true));
+            snapshotCreator.CaptureEntryMethodEndMarker(entryEndCapture.Value, entryEndCapture.Type);
+
+            var snapshot = JObject.Parse(snapshotCreator.FinalizeMethodSnapshot("probe-id", 1, ref entryEndCapture));
+
+            Assert.Equal("condition failed", snapshot.SelectToken("debugger.snapshot.evaluationErrors[0].message")?.Value<string>());
+            Assert.False(CapturesContainData(snapshot.SelectToken("debugger.snapshot.captures")));
+            Assert.NotNull(snapshot.SelectToken("debugger.snapshot.stack"));
+        }
+
+        [Fact]
+        public void ConditionEvaluationErrors_OmitLineCaptureData()
+        {
+            var captureLimitInfo = CreateCaptureLimitInfo();
+            var snapshotCreator = new DebuggerSnapshotCreator(
+                isFullSnapshot: true,
+                Datadog.Trace.Debugger.Expressions.ProbeLocation.Line,
+                hasCondition: true,
+                tags: [],
+                limitInfo: captureLimitInfo,
+                processTagsProvider: static () => null,
+                serviceNameProvider: static () => "test-service");
+
+            var method = typeof(DebuggerSnapshotCreatorTests).GetMethod(nameof(DummyMethod), BindingFlags.NonPublic | BindingFlags.Static)!;
+            var beginLineCapture = CreateLineCaptureInfo(MethodState.BeginLine, method);
+
+            snapshotCreator.DefineSnapshotBehavior(ref beginLineCapture, EvaluateAt.Entry, hasCondition: true);
+            snapshotCreator.AddScopeMember("arg", typeof(string), "argument-value", ScopeMemberKind.Argument);
+            snapshotCreator.AddScopeMember("local", typeof(string), "local-value", ScopeMemberKind.Local);
+
+            var endLineCapture = CreateLineCaptureInfo(MethodState.EndLine, method);
+
+            Assert.Equal(CaptureBehaviour.Evaluate, snapshotCreator.DefineSnapshotBehavior(ref endLineCapture, EvaluateAt.Entry, hasCondition: true));
+
+            var evaluationResult = CreateConditionEvaluationErrorResult();
+            snapshotCreator.SetEvaluationResult(ref evaluationResult);
+
+            Assert.True(snapshotCreator.ProcessDelayedSnapshot(ref endLineCapture, hasCondition: true));
+            snapshotCreator.CaptureEndLine(ref endLineCapture);
+
+            var snapshot = JObject.Parse(snapshotCreator.FinalizeLineSnapshot("probe-id", 1, ref endLineCapture));
+
+            Assert.Equal("condition failed", snapshot.SelectToken("debugger.snapshot.evaluationErrors[0].message")?.Value<string>());
+            Assert.False(CapturesContainData(snapshot.SelectToken("debugger.snapshot.captures")));
+            Assert.NotNull(snapshot.SelectToken("debugger.snapshot.stack"));
+        }
+
+        [Fact]
         public void CaptureExpressions_AreWrittenWithoutArgumentsOrLocals()
         {
             var captureLimitInfo = new CaptureLimitInfo(
@@ -309,6 +399,86 @@ namespace Datadog.Trace.Tests.Debugger
 
         private static void DummyMethod()
         {
+        }
+
+        private static CaptureLimitInfo CreateCaptureLimitInfo()
+        {
+            return new CaptureLimitInfo(
+                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+                MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+        }
+
+        private static ExpressionEvaluationResult CreateConditionEvaluationErrorResult()
+        {
+            return new ExpressionEvaluationResult
+            {
+                Template = "template message",
+                HasConditionError = true,
+                Errors = [new EvaluationError { Expression = "definitelyDoesNotExist", Message = "condition failed" }]
+            };
+        }
+
+        private static CaptureInfo<object> CreateLineCaptureInfo(MethodState methodState, MethodInfo method)
+        {
+            return new CaptureInfo<object>(
+                methodMetadataIndex: 0,
+                methodState: methodState,
+                value: new object(),
+                method: method,
+                type: typeof(object),
+                invocationTargetType: typeof(object),
+                memberKind: ScopeMemberKind.This,
+                localsCount: 1,
+                argumentsCount: 1,
+                lineCaptureInfo: new LineCaptureInfo(42, "test-file.cs"));
+        }
+
+        private static bool CapturesContainData(JToken captures)
+        {
+            if (captures is not JObject capturesObject)
+            {
+                return false;
+            }
+
+            foreach (var property in capturesObject.Properties())
+            {
+                if (property.Name == "lines" && property.Value is JObject lines)
+                {
+                    foreach (var lineProperty in lines.Properties())
+                    {
+                        if (CapturePointContainsData(lineProperty.Value))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                else if (CapturePointContainsData(property.Value))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool CapturePointContainsData(JToken capturePoint)
+        {
+            if (capturePoint is not JObject capturePointObject)
+            {
+                return false;
+            }
+
+            return HasContent(capturePointObject["arguments"])
+                || HasContent(capturePointObject["locals"])
+                || HasContent(capturePointObject["staticFields"])
+                || HasContent(capturePointObject["throwable"]);
+        }
+
+        private static bool HasContent(JToken token)
+        {
+            return token != null && token.HasValues;
         }
 
         private class InfiniteRecursion

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Instrumentation.Collections;
 using Datadog.Trace.Debugger.RateLimiting;
 using Datadog.Trace.Debugger.Snapshots;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Debugger;
@@ -64,6 +65,25 @@ public class ProbeProcessorTests
         Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
         Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
         Assert.Equal(0, sampler.SampleCalls);
+    }
+	
+	[Fact]
+    public void ConditionEvaluationErrorsFinalizeWithoutCaptureData()
+    {
+        var processor = new ProbeProcessor(CreateConditionalLogProbe("probe-id", InvalidConditionJson, captureSnapshot: true));
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
+
+        Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+
+        var snapshot = JObject.Parse(FinalizeMethodSnapshot(snapshotCreator, "probe-id", method));
+
+        Assert.NotEmpty(snapshot.SelectToken("debugger.snapshot.evaluationErrors")!);
+        Assert.False(CapturesContainData(snapshot.SelectToken("debugger.snapshot.captures")));
+        Assert.NotNull(snapshot.SelectToken("debugger.snapshot.stack"));
     }
 
     [Fact]
@@ -588,6 +608,66 @@ public class ProbeProcessorTests
         typeof(DebuggerSnapshotCreator)
            .GetProperty(nameof(DebuggerSnapshotCreator.MethodScopeMembers), BindingFlags.Instance | BindingFlags.NonPublic)!
            .SetValue(snapshotCreator, null);
+    }
+
+    private static string FinalizeMethodSnapshot(DebuggerSnapshotCreator snapshotCreator, string probeId, MethodInfo method)
+    {
+        var captureInfo = new CaptureInfo<SampleTarget>(
+            methodMetadataIndex: 0,
+            methodState: MethodState.EntryEnd,
+            value: new SampleTarget(),
+            method: method,
+            type: typeof(SampleTarget),
+            invocationTargetType: typeof(SampleTarget),
+            memberKind: ScopeMemberKind.This);
+
+        return snapshotCreator.FinalizeMethodSnapshot(probeId, 0, ref captureInfo);
+    }
+
+    private static bool CapturesContainData(JToken captures)
+    {
+        if (captures is not JObject capturesObject)
+        {
+            return false;
+        }
+
+        foreach (var property in capturesObject.Properties())
+        {
+            if (property.Name == "lines" && property.Value is JObject lines)
+            {
+                foreach (var lineProperty in lines.Properties())
+                {
+                    if (CapturePointContainsData(lineProperty.Value))
+                    {
+                        return true;
+                    }
+                }
+            }
+            else if (CapturePointContainsData(property.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool CapturePointContainsData(JToken capturePoint)
+    {
+        if (capturePoint is not JObject capturePointObject)
+        {
+            return false;
+        }
+
+        return HasContent(capturePointObject["arguments"])
+            || HasContent(capturePointObject["locals"])
+            || HasContent(capturePointObject["staticFields"])
+            || HasContent(capturePointObject["throwable"]);
+    }
+
+    private static bool HasContent(JToken token)
+    {
+        return token != null && token.HasValues;
     }
 
     private sealed class SampleTarget

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -66,8 +66,8 @@ public class ProbeProcessorTests
         Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
         Assert.Equal(0, sampler.SampleCalls);
     }
-	
-	[Fact]
+
+    [Fact]
     public void ConditionEvaluationErrorsFinalizeWithoutCaptureData()
     {
         var processor = new ProbeProcessor(CreateConditionalLogProbe("probe-id", InvalidConditionJson, captureSnapshot: true));

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/FullSnapshotWithConditionError.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/FullSnapshotWithConditionError.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+using Samples.Probes.TestRuns.Shared;
+
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    public class FullSnapshotWithConditionError : IRun
+    {
+        private const string Json = @"{
+    ""gt"": [
+      {""ref"": ""undefined""},
+      2
+    ]
+}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method(3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData(
+            conditionJson: Json,
+            captureSnapshot: true,
+            evaluateAt: Const.Exit,
+            unlisted: true,
+            returnTypeName: "System.String",
+            parametersTypeName: new[] { "System.Int32" })]
+        public string Method(int intArg)
+        {
+            var local = intArg + 1;
+            return $"Argument: {intArg}, Local: {local}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Omit capture data from debugger snapshots emitted for condition evaluation errors.
- Track condition evaluation failures separately from other expression errors.
- Skip capture expression evaluation after a condition error.
- Preserve snapshot metadata, stack frames, and `evaluationErrors` in error-only snapshots.
- Add unit coverage for method, line, and `ProbeProcessor` condition-error snapshots.

## Reason for change

- Runtime condition evaluation errors should produce error-only snapshots without collecting capture data.
- This aligns .NET debugger behavior with the expected system-test behavior.
- Non-condition expression errors still need to be distinguishable so existing capture behavior is not broadly changed.

## Implementation details

- Added `HasConditionError` to `ExpressionEvaluationResult` and set it from condition evaluation failure paths.
- `ProbeProcessor` avoids evaluating capture expressions when a condition error has already occurred.
- `DebuggerSnapshotCreator` suppresses capture sections when handling condition errors, while still closing JSON containers correctly and writing stack/error metadata.
- The snapshot creator keeps capture omission scoped to condition errors rather than every evaluation error.

## Test coverage
- `DebuggerSnapshotCreateTests|ProbeProcessorTests`
