### PR TITLE
[Test] Handle dotnet/runtime#127957 BadImageFormatException fingerprint

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -85,6 +85,17 @@ public static class ErrorHelpers
             return true;
         }
 
+        // Linux/SIGABRT — BadImageFormatException with the "metadata is corrupt" message thrown
+        // during runtime startup (we've seen it from HostBuilder.Build()/ConfigurationBuilder.Build()).
+        // This is the most direct surfacing of the corrupted-metadata race and is unreachable
+        // through normal product or user code.
+        if (exitCode == 134
+            && standardError.Contains("System.BadImageFormatException")
+            && standardError.Contains("The metadata is corrupt"))
+        {
+            return true;
+        }
+
         return false;
     }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -86,12 +86,15 @@ public static class ErrorHelpers
         }
 
         // Linux/SIGABRT — BadImageFormatException with the "metadata is corrupt" message thrown
-        // during runtime startup (we've seen it from HostBuilder.Build()/ConfigurationBuilder.Build()).
-        // This is the most direct surfacing of the corrupted-metadata race and is unreachable
-        // through normal product or user code.
+        // while building host configuration at startup (ConfigurationBuilder.Build()). We deliberately
+        // anchor on that frame rather than matching the message anywhere: the retry only exists to
+        // paper over this one known-benign startup manifestation of the race. A "metadata is corrupt"
+        // crash on any other stack could be a genuine tracer-induced corruption and must fail loudly
+        // so it gets investigated (and a new fingerprint added deliberately).
         if (exitCode == 134
             && standardError.Contains("System.BadImageFormatException")
-            && standardError.Contains("The metadata is corrupt"))
+            && standardError.Contains("The metadata is corrupt")
+            && standardError.Contains("Microsoft.Extensions.Configuration.ConfigurationBuilder.Build"))
         {
             return true;
         }


### PR DESCRIPTION
## Summary of changes

Add a fourth `dotnet/runtime#127957` fingerprint to `ErrorHelpers.IsRuntime127957Race`:
Linux/SIGABRT (exit 134) + `System.BadImageFormatException` + "The metadata is corrupt".

## Reason for change

Follow-up to #8665. We hit a new manifestation of the same metadata-race in CI on
arm64/net9.0 — the test failed with "Unable to determine port application is listening on"
because the sample aborted at startup:

```
[webserver][stderr] Unhandled exception. System.BadImageFormatException: The metadata is corrupt.
   at ...PhysicalFilesWatcher.GetOrAddFilePathChangeToken(String)
   ...
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Samples.Security.AspNetCore5.Program.Main(String[])
```

Failing build log:
https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/202607/logs/6762

## Implementation details

The existing three fingerprints (#8665) surface the race as downstream `TypeLoadException` /
`MissingMethodException` / Windows FailFast symptoms. This one is the metadata reader throwing
the corruption directly. Crash-dump analysis confirms the fingerprint:
- `BadImageFormatException`, HRESULT `0x8007000b` (`COR_E_BADIMAGEFORMAT`)
- Throw originates inside the JIT/metadata reader while compiling `GetOrAddFilePathChangeToken`
  during the first `HostBuilder.Build()` — earliest startup, peak instrumentation window.
- Datadog native profiler/tracer threads are attached and active in the process.
- Transient (passes on retry), on a nightly arm64 build — the exact profile of the issue.

Like the others, "The metadata is corrupt" is unreachable through normal product/user code, so
the gate stays narrow. The retry/metrics harness and `AspNetCoreTestFixture.TryStartApp`
`port == null` path are unchanged — only the detection is extended.

## Test coverage

Existing suite. Retry/fail only fires on the narrow fingerprint.

## Other details

Revisit when dotnet/runtime#127957 is fixed upstream.
