### PR TITLE
[Config] Add scope field infrastructure to configuration registry (2/3)

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigKeyAliasesSwitcherGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigKeyAliasesSwitcherGenerator.cs
@@ -105,9 +105,9 @@ public class ConfigKeyAliasesSwitcherGenerator : IIncrementalGenerator
         var aliases = new Dictionary<string, string[]>();
         foreach (var kvp in parsedData.Configurations)
         {
-            if (kvp.Value.Aliases is { Length: > 0 })
+            if (kvp.Value.Aliases.Count > 0)
             {
-                aliases[kvp.Key] = kvp.Value.Aliases;
+                aliases[kvp.Key] = kvp.Value.Aliases.AsArray()!;
             }
         }
 

--- a/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
@@ -123,7 +123,7 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
             // Scope is required, non-empty, and must contain only recognized tokens.
             if (entry.Scope.Count == 0)
             {
-                diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Missing scope", $"Configuration key '{kvp.Key}' is missing a 'scope' field in supported-configurations.yaml. Use: managed, native, or managed, native.", DiagnosticSeverity.Error));
+                diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Missing scope", $"Configuration key '{kvp.Key}' is missing a 'scope' field in supported-configurations.yaml. Use: managed and/or native.", DiagnosticSeverity.Error));
             }
             else
             {

--- a/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
@@ -130,7 +130,7 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
             {
                 foreach (var scopeValue in entry.Scope)
                 {
-                    if (!ValidScopeValues.Any(v => string.Equals(v, scopeValue, StringComparison.OrdinalIgnoreCase)))
+                    if (scopeValue is not "managed" or "native")
                     {
                         diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Invalid scope", $"Configuration key '{kvp.Key}' has unrecognized scope value '{scopeValue}'. Valid values: managed, native.", DiagnosticSeverity.Error));
                     }

--- a/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
@@ -116,11 +116,12 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
         var configurations = new Dictionary<string, ConfigEntry>();
         var diagnostics = new List<DiagnosticInfo>();
 
+        // Validate every entry's scope and documentation, regardless of scope.
         foreach (var kvp in parsedData.Configurations)
         {
             var entry = kvp.Value;
 
-            // Validate scope: required, non-empty, and must contain only recognized tokens.
+            // Scope is required, non-empty, and must contain only recognized tokens.
             if (entry.Scope is null || entry.Scope.Length == 0)
             {
                 diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Missing scope", $"Configuration key '{kvp.Key}' is missing a 'scope' field in supported-configurations.yaml. Use: managed, native, or managed, native.", DiagnosticSeverity.Error));
@@ -136,19 +137,20 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
                 }
             }
 
-            // Generate a C# constant only when scope includes "managed".
-            // native-only entries are registered for coverage tracking but have no C# constant.
-            var skipConstantGeneration = entry.Scope is null ||
-                                         !entry.Scope.Any(s => string.Equals(s, "managed", StringComparison.OrdinalIgnoreCase));
-
             // Documentation is mandatory for all configuration keys, including native-only ones.
             if (string.IsNullOrEmpty(entry.Documentation))
             {
                 diagnostics.Add(CreateDiagnosticInfo("DDSG0008", "Missing documentation", $"Configuration key '{kvp.Key}' is missing a 'documentation' field in supported-configurations.yaml", DiagnosticSeverity.Error));
             }
+        }
 
-            // Native-only vars are registered for coverage tracking but don't generate C# constants.
-            if (skipConstantGeneration)
+        // Generate C# constants only for managed-scoped keys. native-only keys are registered
+        // for coverage tracking (enforced by the ValidateNativeConfigurations Nuke step) and
+        // produce no constant. Scope is already validated above, so filtering on "managed" is safe.
+        foreach (var kvp in parsedData.Configurations)
+        {
+            var entry = kvp.Value;
+            if (entry.Scope is null || !entry.Scope.Any(s => string.Equals(s, "managed", StringComparison.OrdinalIgnoreCase)))
             {
                 continue;
             }

--- a/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
@@ -25,6 +25,7 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
     private const string SupportedConfigurationsFileName = "supported-configurations.yaml";
     private const string GeneratedClassName = "ConfigurationKeys";
     private const string Namespace = "Datadog.Trace.Configuration";
+    private static readonly string[] ValidScopeValues = ["managed", "native"];
 
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -118,16 +119,44 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
         foreach (var kvp in parsedData.Configurations)
         {
             var entry = kvp.Value;
-            string? deprecationMessage = null;
 
-            // Check if this key has a deprecation message
-            parsedData.Deprecations?.TryGetValue(kvp.Key, out deprecationMessage);
+            // Validate scope: required, non-empty, and must contain only recognized tokens.
+            if (entry.Scope is null || entry.Scope.Length == 0)
+            {
+                diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Missing scope", $"Configuration key '{kvp.Key}' is missing a 'scope' field in supported-configurations.yaml. Use: managed, native, or managed, native.", DiagnosticSeverity.Error));
+            }
+            else
+            {
+                foreach (var scopeValue in entry.Scope)
+                {
+                    if (!ValidScopeValues.Any(v => string.Equals(v, scopeValue, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Invalid scope", $"Configuration key '{kvp.Key}' has unrecognized scope value '{scopeValue}'. Valid values: managed, native.", DiagnosticSeverity.Error));
+                    }
+                }
+            }
 
-            // Documentation is mandatory for all configuration keys
+            // Generate a C# constant only when scope includes "managed".
+            // native-only entries are registered for coverage tracking but have no C# constant.
+            var skipConstantGeneration = entry.Scope is null ||
+                                         !entry.Scope.Any(s => string.Equals(s, "managed", StringComparison.OrdinalIgnoreCase));
+
+            // Documentation is mandatory for all configuration keys, including native-only ones.
             if (string.IsNullOrEmpty(entry.Documentation))
             {
                 diagnostics.Add(CreateDiagnosticInfo("DDSG0008", "Missing documentation", $"Configuration key '{kvp.Key}' is missing a 'documentation' field in supported-configurations.yaml", DiagnosticSeverity.Error));
             }
+
+            // Native-only vars are registered for coverage tracking but don't generate C# constants.
+            if (skipConstantGeneration)
+            {
+                continue;
+            }
+
+            string? deprecationMessage = null;
+
+            // Check if this key has a deprecation message
+            parsedData.Deprecations?.TryGetValue(kvp.Key, out deprecationMessage);
 
             configurations[kvp.Key] = new ConfigEntry(
                 entry.Key,

--- a/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Configuration/ConfigurationKeysGenerator.cs
@@ -25,7 +25,6 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
     private const string SupportedConfigurationsFileName = "supported-configurations.yaml";
     private const string GeneratedClassName = "ConfigurationKeys";
     private const string Namespace = "Datadog.Trace.Configuration";
-    private static readonly string[] ValidScopeValues = ["managed", "native"];
 
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -122,15 +121,15 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
             var entry = kvp.Value;
 
             // Scope is required, non-empty, and must contain only recognized tokens.
-            if (entry.Scope is null || entry.Scope.Length == 0)
+            if (entry.Scope.Count == 0)
             {
                 diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Missing scope", $"Configuration key '{kvp.Key}' is missing a 'scope' field in supported-configurations.yaml. Use: managed, native, or managed, native.", DiagnosticSeverity.Error));
             }
             else
             {
-                foreach (var scopeValue in entry.Scope)
+                foreach (var scopeValue in entry.Scope.AsSpan())
                 {
-                    if (scopeValue is not "managed" or "native")
+                    if (scopeValue is not ("managed" or "native"))
                     {
                         diagnostics.Add(CreateDiagnosticInfo("DDSG0009", "Invalid scope", $"Configuration key '{kvp.Key}' has unrecognized scope value '{scopeValue}'. Valid values: managed, native.", DiagnosticSeverity.Error));
                     }
@@ -150,7 +149,7 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
         foreach (var kvp in parsedData.Configurations)
         {
             var entry = kvp.Value;
-            if (entry.Scope is null || !entry.Scope.Any(s => string.Equals(s, "managed", StringComparison.OrdinalIgnoreCase)))
+            if (!ScopeContains(entry.Scope, "managed"))
             {
                 continue;
             }
@@ -169,6 +168,21 @@ public class ConfigurationKeysGenerator : IIncrementalGenerator
         }
 
         return new Result<ConfigurationData>(new ConfigurationData(configurations), new EquatableArray<DiagnosticInfo>(diagnostics.ToArray()));
+    }
+
+    // Allocation-free, case-sensitive membership check over a scope array. Avoids LINQ since the
+    // generator runs on every compilation (including IDE keystrokes).
+    private static bool ScopeContains(EquatableArray<string> scope, string value)
+    {
+        foreach (var s in scope.AsSpan())
+        {
+            if (s == value)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string GenerateProductPartialClass(string product, List<KeyValuePair<string, ConfigEntry>> entries)

--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
@@ -244,7 +244,7 @@ namespace Datadog.Trace.SourceGenerators.Helpers
                                     // Comma-separated scope values: managed | native | managed, native
                                     currentScope = propValue.Split(',')
                                                             .Select(s => s.Trim())
-                                                            .Where(s => s.Length > 0)
+                                                            .Where(s => !string.IsNullOrEmpty(s))
                                                             .ToArray();
                                     break;
                                 case "aliases":

--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
@@ -242,10 +242,18 @@ namespace Datadog.Trace.SourceGenerators.Helpers
                                     break;
                                 case "scope":
                                     // Comma-separated scope values: managed | native | managed, native
-                                    currentScope = propValue.Split(',')
-                                                            .Select(s => s.Trim())
-                                                            .Where(s => !string.IsNullOrEmpty(s))
-                                                            .ToArray();
+                                    var scopeParts = propValue.Split(',');
+                                    var scopeValues = new List<string>(scopeParts.Length);
+                                    foreach (var part in scopeParts)
+                                    {
+                                        var trimmed = part.Trim();
+                                        if (trimmed.Length > 0)
+                                        {
+                                            scopeValues.Add(trimmed);
+                                        }
+                                    }
+
+                                    currentScope = scopeValues.ToArray();
                                     break;
                                 case "aliases":
                                     inAliases = true;

--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
@@ -367,8 +367,8 @@ namespace Datadog.Trace.SourceGenerators.Helpers
                 Product = product;
                 Documentation = documentation;
                 ConstName = constName;
-                Scope = scope;
-                Aliases = aliases;
+                Scope = scope is null ? default : new EquatableArray<string>(scope);
+                Aliases = aliases is null ? default : new EquatableArray<string>(aliases);
             }
 
             public string Key { get; }
@@ -379,71 +379,21 @@ namespace Datadog.Trace.SourceGenerators.Helpers
 
             public string? ConstName { get; }
 
-            public string[]? Scope { get; }
+            public EquatableArray<string> Scope { get; }
 
-            public string[]? Aliases { get; }
+            public EquatableArray<string> Aliases { get; }
 
             public bool Equals(ConfigurationEntry other)
-            {
-                if (Key != other.Key || Product != other.Product || Documentation != other.Documentation || ConstName != other.ConstName)
-                {
-                    return false;
-                }
-
-                if (!ArraysEqual(Scope, other.Scope) || !ArraysEqual(Aliases, other.Aliases))
-                {
-                    return false;
-                }
-
-                return true;
-            }
-
-            private static bool ArraysEqual(string[]? a, string[]? b)
-            {
-                if (ReferenceEquals(a, b))
-                {
-                    return true;
-                }
-
-                if (a is null || b is null || a.Length != b.Length)
-                {
-                    return a is null && b is null;
-                }
-
-                for (var i = 0; i < a.Length; i++)
-                {
-                    if (a[i] != b[i])
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
+                => Key == other.Key
+                && Product == other.Product
+                && Documentation == other.Documentation
+                && ConstName == other.ConstName
+                && Scope == other.Scope
+                && Aliases == other.Aliases;
 
             public override bool Equals(object? obj) => obj is ConfigurationEntry other && Equals(other);
 
-            public override int GetHashCode()
-            {
-                var hash = HashCode.Combine(Key, Product, Documentation, ConstName);
-                if (Scope is not null)
-                {
-                    foreach (var s in Scope)
-                    {
-                        hash = HashCode.Combine(hash, s);
-                    }
-                }
-
-                if (Aliases is not null)
-                {
-                    foreach (var alias in Aliases)
-                    {
-                        hash = HashCode.Combine(hash, alias);
-                    }
-                }
-
-                return hash;
-            }
+            public override int GetHashCode() => HashCode.Combine(Key, Product, Documentation, ConstName, Scope, Aliases);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/YamlReader.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.SourceGenerators.Helpers
             string? currentProduct = null;
             string? currentDocumentation = null;
             string? currentConstName = null;
+            string[]? currentScope = null;
             var currentAliases = new List<string>();
             var inDocumentation = false;
             var inAliases = false;
@@ -62,7 +63,7 @@ namespace Datadog.Trace.SourceGenerators.Helpers
                     if (currentConfigKey != null)
                     {
                         var doc = inDocumentation ? documentationBuilder.ToString().TrimEnd() : currentDocumentation;
-                        configurations[currentConfigKey] = new ConfigurationEntry(currentConfigKey, currentProduct ?? string.Empty, doc, currentConstName, currentAliases.Count > 0 ? currentAliases.ToArray() : null);
+                        configurations[currentConfigKey] = new ConfigurationEntry(currentConfigKey, currentProduct ?? string.Empty, doc, currentConstName, currentScope, currentAliases.Count > 0 ? currentAliases.ToArray() : null);
                     }
 
                     inSupportedConfigurations = false;
@@ -115,13 +116,14 @@ namespace Datadog.Trace.SourceGenerators.Helpers
                             if (currentConfigKey != null)
                             {
                                 var doc = inDocumentation ? documentationBuilder.ToString().TrimEnd() : currentDocumentation;
-                                configurations[currentConfigKey] = new ConfigurationEntry(currentConfigKey, currentProduct ?? string.Empty, doc, currentConstName, currentAliases.Count > 0 ? currentAliases.ToArray() : null);
+                                configurations[currentConfigKey] = new ConfigurationEntry(currentConfigKey, currentProduct ?? string.Empty, doc, currentConstName, currentScope, currentAliases.Count > 0 ? currentAliases.ToArray() : null);
                             }
 
                             currentConfigKey = potentialKey;
                             currentProduct = null;
                             currentDocumentation = null;
                             currentConstName = null;
+                            currentScope = null;
                             currentAliases.Clear();
                             inDocumentation = false;
                             inAliases = false;
@@ -238,6 +240,13 @@ namespace Datadog.Trace.SourceGenerators.Helpers
                                 case "const_name":
                                     currentConstName = propValue;
                                     break;
+                                case "scope":
+                                    // Comma-separated scope values: managed | native | managed, native
+                                    currentScope = propValue.Split(',')
+                                                            .Select(s => s.Trim())
+                                                            .Where(s => s.Length > 0)
+                                                            .ToArray();
+                                    break;
                                 case "aliases":
                                     inAliases = true;
                                     break;
@@ -284,7 +293,7 @@ namespace Datadog.Trace.SourceGenerators.Helpers
             if (currentConfigKey != null)
             {
                 var doc = inDocumentation ? documentationBuilder.ToString().TrimEnd() : currentDocumentation;
-                configurations[currentConfigKey] = new ConfigurationEntry(currentConfigKey, currentProduct ?? string.Empty, doc, currentConstName, currentAliases.Count > 0 ? currentAliases.ToArray() : null);
+                configurations[currentConfigKey] = new ConfigurationEntry(currentConfigKey, currentProduct ?? string.Empty, doc, currentConstName, currentScope, currentAliases.Count > 0 ? currentAliases.ToArray() : null);
             }
 
             return new ParsedConfigurationData(configurations, deprecations);
@@ -352,12 +361,13 @@ namespace Datadog.Trace.SourceGenerators.Helpers
         /// </summary>
         internal readonly struct ConfigurationEntry : IEquatable<ConfigurationEntry>
         {
-            public ConfigurationEntry(string key, string? product, string? documentation, string? constName, string[]? aliases = null)
+            public ConfigurationEntry(string key, string? product, string? documentation, string? constName, string[]? scope, string[]? aliases = null)
             {
                 Key = key;
                 Product = product;
                 Documentation = documentation;
                 ConstName = constName;
+                Scope = scope;
                 Aliases = aliases;
             }
 
@@ -369,6 +379,8 @@ namespace Datadog.Trace.SourceGenerators.Helpers
 
             public string? ConstName { get; }
 
+            public string[]? Scope { get; }
+
             public string[]? Aliases { get; }
 
             public bool Equals(ConfigurationEntry other)
@@ -378,19 +390,29 @@ namespace Datadog.Trace.SourceGenerators.Helpers
                     return false;
                 }
 
-                if (ReferenceEquals(Aliases, other.Aliases))
+                if (!ArraysEqual(Scope, other.Scope) || !ArraysEqual(Aliases, other.Aliases))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            private static bool ArraysEqual(string[]? a, string[]? b)
+            {
+                if (ReferenceEquals(a, b))
                 {
                     return true;
                 }
 
-                if (Aliases is null || other.Aliases is null || Aliases.Length != other.Aliases.Length)
+                if (a is null || b is null || a.Length != b.Length)
                 {
-                    return Aliases is null && other.Aliases is null;
+                    return a is null && b is null;
                 }
 
-                for (var i = 0; i < Aliases.Length; i++)
+                for (var i = 0; i < a.Length; i++)
                 {
-                    if (Aliases[i] != other.Aliases[i])
+                    if (a[i] != b[i])
                     {
                         return false;
                     }
@@ -404,6 +426,14 @@ namespace Datadog.Trace.SourceGenerators.Helpers
             public override int GetHashCode()
             {
                 var hash = HashCode.Combine(Key, Product, Documentation, ConstName);
+                if (Scope is not null)
+                {
+                    foreach (var s in Scope)
+                    {
+                        hash = HashCode.Combine(hash, s);
+                    }
+                }
+
                 if (Aliases is not null)
                 {
                     foreach (var alias in Aliases)

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/ConfigurationKeysGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/ConfigurationKeysGeneratorTests.cs
@@ -479,4 +479,69 @@ public class ConfigurationKeysGeneratorTests
         diagnostics.Where(d => d.Id == "DDSG0008").Should().HaveCount(1);
         diagnostics.First(d => d.Id == "DDSG0008").GetMessage().Should().Contain("DD_TRACE_ENABLED").And.Contain("documentation");
     }
+
+    [Fact]
+    public void NativeScopeOnlyEntryIsExcludedFromGeneratedOutput()
+    {
+        const string supportedConfigYaml = """
+                                           version: '2'
+                                           supportedConfigurations:
+                                             DD_MANAGED_ONLY:
+                                             - implementation: A
+                                               scope: managed
+                                               product: Tracer
+                                               documentation: A managed-only config.
+                                             DD_NATIVE_ONLY:
+                                             - implementation: A
+                                               scope: native
+                                               product: Tracer
+                                               documentation: A native-only config.
+                                             DD_BOTH:
+                                             - implementation: A
+                                               scope: managed, native
+                                               product: Tracer
+                                               documentation: A config read by both.
+                                           """;
+
+        var (diagnostics, outputs) = TestHelpers.GetGeneratedTrees<ConfigurationKeysGenerator>(
+            [],
+            [],
+            [("supported-configurations.yaml", supportedConfigYaml)],
+            assertOutput: false);
+
+        diagnostics.Should().BeEmpty();
+
+        var allOutput = string.Join("\n", outputs);
+        allOutput.Should().Contain("DD_MANAGED_ONLY", because: "managed-only entry must generate a constant");
+        allOutput.Should().Contain("DD_BOTH", because: "managed+native entry must generate a constant");
+        allOutput.Should().NotContain("DD_NATIVE_ONLY", because: "native-only entry must not generate a constant");
+    }
+
+    [Fact]
+    public void EmitsErrorForEmptyOrInvalidScopeArray()
+    {
+        const string supportedConfigYaml = """
+                                           version: '2'
+                                           supportedConfigurations:
+                                             DD_EMPTY_SCOPE:
+                                             - implementation: A
+                                               scope:
+                                               product: Tracer
+                                               documentation: Entry with empty scope array.
+                                             DD_TYPO_SCOPE:
+                                             - implementation: A
+                                               scope: managd
+                                               product: Tracer
+                                               documentation: Entry with a typo in scope.
+                                           """;
+
+        var (diagnostics, _) = TestHelpers.GetGeneratedTrees<ConfigurationKeysGenerator>(
+            [],
+            [],
+            [("supported-configurations.yaml", supportedConfigYaml)],
+            assertOutput: false);
+
+        diagnostics.Should().Contain(d => d.Id == "DDSG0009", because: "empty or unrecognized scope must produce a diagnostic");
+        diagnostics.Count(d => d.Id == "DDSG0009").Should().Be(2, because: "both DD_EMPTY_SCOPE and DD_TYPO_SCOPE are invalid");
+    }
 }


### PR DESCRIPTION
## Summary of changes

Adds the scope field infrastructure to the configuration registry: parsing, source-generator enforcement, tests, and documentation.

Stack:
- **PR 1** (merged): `scope: managed` on all existing entries
- **PR 2 (this)**: scope infrastructure — parsing, enforcement, tests, docs
- **PR 3**: all native config variables

## Reason for change

Lets the registry distinguish managed-only, native-only, and dual-scope (`managed, native`) config variables. The generator emits C# constants only for entries whose scope includes `managed`; native-only entries are registered for coverage tracking and produce no constant. A build error (DDSG0009) is emitted for any entry missing a valid scope.

## Implementation details

- `YamlReader.cs`: `ConfigurationEntry.Scope`/`Aliases` are now `EquatableArray<string>` for value-based equality (the incremental generator caches on it); comma-separated scope parsing (`managed`, `native`, `managed, native`).
- `ConfigurationKeysGenerator.cs`: a validation pass emits DDSG0009 for missing/empty/unrecognized scope (`scopeValue is not ("managed" or "native")`); a separate generation pass emits constants only for managed-scoped keys, via an allocation-free, case-sensitive `ScopeContains` helper.
- `ConfigKeyAliasesSwitcherGenerator.cs`: updated for the `EquatableArray<string>` aliases.
- `ConfigurationKeysGeneratorTests.cs`: tests for native-only exclusion, `managed, native` inclusion, and DDSG0009 on empty/invalid scope; existing YAML fixtures carry `scope`.
- `AddingConfigurationKeys.md`: `scope` documented as a Required field.

## Test coverage

Source-generator unit tests pass, including the native-only exclusion and DDSG0009 cases. The native-coverage enforcement (a Nuke build step) lands in PR 3 alongside the data it validates.

## Other details

Safe to merge onto master: all existing entries carry `scope: managed`, so DDSG0009 does not fire.