### PR TITLE
[Profiler] add RunProfilerScenario Nuke target for local iteration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,6 +356,9 @@ shared/src/Datadog.Trace.ClrProfiler.Native/cmake-build-debug/
 !shared/src/Datadog.Trace.ClrProfiler.Native/lib/**
 cmake-build-debug/*
 
+#profiler build files
+profiler/_build/
+
 # global build folder
 obj/*
 obj_arm64/*
@@ -402,3 +405,6 @@ tools/dumps/
 
 # test optimization temp/run folder
 .dd/
+
+# Output of tracer/profiler-run.sh
+.profiler-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,10 +79,44 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 
 ## Build & Development
 
-**Quick start:**
+**Quick start (managed-only, all platforms, no Docker):**
 - Build: `./tracer/build.sh` (Linux/macOS) or `.\tracer\build.cmd` (Windows)
 - Unit tests: `./tracer/build.sh BuildAndRunManagedUnitTests`
-- Integration tests: `BuildAndRunIntegrationTests`
+- Integration tests: `./tracer/build.sh BuildAndRunIntegrationTests`
+
+### Linux profiler iteration (host: macOS or Linux)
+
+> Applies only to the **Linux** profiler / native loader / native tracer / API wrapper. For Windows-host profiler development (Windows native code, Visual Studio debugging) see `profiler/README.md`.
+
+The native Linux components must be built inside the Alpine builder image — direct `cmake` does not work. From macOS this needs Docker (Colima, Docker Desktop, …).
+
+**Initial / cold build** (once per fresh clone, or after pulling a large change):
+
+```bash
+./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples
+```
+
+All five targets are required to run a scenario end-to-end: tracer home (managed tracer + native tracer), native loader (CorProfiler entry point), API wrapper (`LD_PRELOAD`), profiler home (`Datadog.Profiler.Native.so`), and samples (the `Samples.Computer01` demo app).
+
+**Iterative rebuild** after editing native profiler code (the common case):
+
+```bash
+./tracer/build_in_docker.sh BuildProfilerHome
+```
+
+Only rebuild more targets if you edited their source: `BuildNativeLoader` for `shared/src/Datadog.Trace.ClrProfiler.Native/`, `BuildTracerHome` for the managed tracer or `tracer/src/Datadog.Tracer.Native/`, `BuildNativeWrapper` for `profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/`, `BuildProfilerSamples` for `profiler/src/Demos/Samples.Computer01/`.
+
+**Run a scenario** with the freshly-built profiler attached:
+
+```bash
+./tracer/build_in_docker.sh RunProfilerScenario                                # default: PiComputation
+./tracer/build_in_docker.sh RunProfilerScenario --scenario 5 --scenario-timeout 30  # FibonacciComputation, 30s
+./tracer/build_in_docker.sh RunProfilerScenario --scenario 13 --scenario-args "--param 1"
+```
+
+On a Linux host with the build deps available locally, drop the `_in_docker` prefix and call `./tracer/build.sh RunProfilerScenario ...` directly.
+
+`RunProfilerScenario` is a Nuke target (`tracer/build/_build/Build.Profiler.RunScenario.cs`) that sets the CorProfiler env vars, `LD_PRELOAD`s the API wrapper, sets `DD_INTERNAL_PROFILING_ENABLED_ARM64=1` on arm64 hosts, and runs `Samples.Computer01.dll`. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files land under `.profiler-out/` (gitignored). The target surfaces a clear warning if `Datadog.Profiler.Native.so` fails to load.
 
 - **`tracer/README.md`** — Complete development setup guide (VS requirements, Docker, Dev Containers, platform-specific build commands, and Nuke targets)
 

--- a/tracer/build/_build/Build.Profiler.RunScenario.cs
+++ b/tracer/build/_build/Build.Profiler.RunScenario.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.DotNet;
+using static Nuke.Common.EnvironmentInfo;
+using static Nuke.Common.IO.FileSystemTasks;
+using Logger = Serilog.Log;
+
+// Developer-facing target to run a Samples.Computer01 scenario with the locally-built
+// profiler attached. Linux-only (the profiler runtime is Linux-musl); from macOS / Windows
+// hosts, invoke via tracer/build_in_docker.{sh,ps1}. See AGENTS.md for the full loop.
+
+partial class Build
+{
+    [Parameter("Profiler scenario ID to run (Scenario enum value in Samples.Computer01/Program.cs). Default: 4 = PiComputation.")]
+    readonly int Scenario = 4;
+
+    [Parameter("Scenario timeout, in seconds. Default: 30.")]
+    readonly int ScenarioTimeout = 30;
+
+    [Parameter("Extra args appended after --scenario / --timeout (e.g. \"--param 1\").")]
+    readonly string ScenarioArgs = string.Empty;
+
+    Target RunProfilerScenario => _ => _
+        .Description("Run a Samples.Computer01 scenario with the locally-built profiler attached. Outputs to .profiler-out/.")
+        .OnlyWhenStatic(() => IsLinux)
+        .After(BuildProfilerHome, BuildProfilerSamples, BuildTracerHome, BuildNativeLoader, BuildNativeWrapper)
+        .Executes(() =>
+        {
+            var (arch, ext) = GetUnixArchitectureAndExtension();
+            var mhArch = MonitoringHomeDirectory / arch;
+
+            // Sanity-check the monitoring home — fail fast with a clear hint if a Build*Home target was skipped.
+            var requiredFiles = new[]
+            {
+                $"{FileNames.NativeLoader}.{ext}",
+                $"{FileNames.NativeProfiler}.{ext}",
+                $"{FileNames.NativeTracer}.{ext}",
+                FileNames.ProfilerLinuxApiWrapper,
+                FileNames.LoaderConf,
+            };
+            foreach (var file in requiredFiles)
+            {
+                var path = mhArch / file;
+                if (!File.Exists(path))
+                {
+                    throw new Exception(
+                        $"Missing {path}. Run the relevant Build*Home / BuildNative* target first. " +
+                        "For a cold checkout: BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples.");
+                }
+            }
+
+            // Locate Samples.Computer01.dll for the current platform / configuration.
+            // Prefer Release; fall back to Debug if a Debug-only build is present.
+            var sampleRel = ProfilerOutputDirectory / "bin" / $"{Configuration.Release}-{TargetPlatform}" / "profiler" / "src" / "Demos" / "Samples.Computer01" / "net10.0";
+            var sampleDir = File.Exists(sampleRel / "Samples.Computer01.dll")
+                ? sampleRel
+                : ProfilerOutputDirectory / "bin" / $"{Configuration.Debug}-{TargetPlatform}" / "profiler" / "src" / "Demos" / "Samples.Computer01" / "net10.0";
+
+            var sampleDll = sampleDir / "Samples.Computer01.dll";
+            if (!File.Exists(sampleDll))
+            {
+                throw new Exception($"Sample not found under {sampleRel} or Debug equivalent. Run BuildProfilerSamples first.");
+            }
+
+            // Output directories (gitignored).
+            var outDir = RootDirectory / ".profiler-out";
+            var logsDir = outDir / "logs";
+            var pprofDir = outDir / "pprof";
+            EnsureExistingDirectory(logsDir);
+            EnsureExistingDirectory(pprofDir);
+
+            var envVars = new Dictionary<string, string>();
+            AddContinuousProfilerEnvironmentVariables(envVars);
+            envVars["DD_NATIVELOADER_CONFIGFILE"] = mhArch / FileNames.LoaderConf;
+            envVars["LD_PRELOAD"] = mhArch / FileNames.ProfilerLinuxApiWrapper;
+            envVars["DD_PROFILING_ENABLED"] = "1";
+            envVars["DD_PROFILING_MANAGED_ACTIVATION_ENABLED"] = "0";
+            envVars["DD_TRACE_ENABLED"] = "0";
+            envVars["DD_TRACE_LOG_DIRECTORY"] = logsDir;
+            envVars["DD_INTERNAL_PROFILING_OUTPUT_DIR"] = pprofDir;
+            if (IsArm64)
+            {
+                // Profiler is opt-in on arm64 via this internal flag.
+                envVars["DD_INTERNAL_PROFILING_ENABLED_ARM64"] = "1";
+            }
+
+            var args = $"{sampleDll} --scenario {Scenario} --timeout {ScenarioTimeout}";
+            if (!string.IsNullOrWhiteSpace(ScenarioArgs))
+            {
+                args += " " + ScenarioArgs;
+            }
+
+            Logger.Information("Running scenario {Scenario} (timeout {Timeout}s) on {Arch}.", Scenario, ScenarioTimeout, arch);
+            Logger.Information("Logs:   {Logs}", logsDir);
+            Logger.Information("Pprofs: {Pprofs}", pprofDir);
+
+            var dotnetPath = DotNetSettingsExtensions.GetDotNetPath(TargetPlatform);
+            using var process = ProcessTasks.StartProcess(
+                toolPath: dotnetPath,
+                arguments: args,
+                workingDirectory: sampleDir,
+                environmentVariables: envVars,
+                customLogger: DotNetTasks.DotNetLogger);
+            process.AssertZeroExitCode();
+
+            // Post-run sanity check: surface profiler-load failures clearly. Without this the only
+            // symptom is "no .pprof appeared".
+            var loaderLog = logsDir / "dotnet-native-loader-dotnet-1.log";
+            if (File.Exists(loaderLog))
+            {
+                var content = File.ReadAllText(loaderLog);
+                if (content.Contains("Error loading dynamic library") && content.Contains(FileNames.NativeProfiler))
+                {
+                    Logger.Warning("The native profiler library failed to load — no .pprof will be produced.");
+                    Logger.Warning("Hint: rebuild the profiler home (BuildProfilerHome).");
+                }
+            }
+        });
+}

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -16,7 +16,11 @@ $IMAGE_NAME="dd-trace-dotnet/alpine-base"
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"
 
-&docker run -it --rm `
+# Use -t only when stdin is a terminal so this script works in CI / no-TTY agent harnesses.
+# Mirrors the bash sibling's `[[ -t 0 ]]` check (stdin / fd 0).
+$ttyFlags = if ([Console]::IsInputRedirected) { @('-i') } else { @('-i','-t') }
+
+&docker run @ttyFlags --rm `
     --mount "type=bind,source=$ROOT_DIR,target=/project" `
     --env NugetPackageDirectory=/project/packages `
     --env artifacts=/project/tracer/bin/artifacts `

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -12,7 +12,11 @@ docker build \
    --file "$BUILD_DIR/docker/alpine.dockerfile" \
    "$BUILD_DIR"
 
-docker run -it --rm \
+# Use -t only when stdin is a terminal so this script works in CI / no-TTY agent harnesses.
+TTY_FLAGS=(-i)
+[[ -t 0 ]] && TTY_FLAGS+=(-t)
+
+docker run "${TTY_FLAGS[@]}" --rm \
     --mount type=bind,source="$ROOT_DIR",target=/project \
     --env NugetPackageDirectory=/project/packages \
     --env artifacts=/project/tracer/bin/artifacts \


### PR DESCRIPTION
## Summary of changes

- New Nuke target `RunProfilerScenario` (`tracer/build/_build/Build.Profiler.RunScenario.cs`) that runs a Samples.Computer01 scenario with the locally built profiler attached.
- `tracer/build_in_docker.{sh,ps1}`: skip `-t` when stdin is not a TTY, so the wrappers work in CI / agent harnesses.
- AGENTS.md `Build & Development` section rewritten around a two-command iteration loop.
- `.gitignore` picks up `.profiler-out/` (where the target writes logs / pprofs).

## Reason for change

Profiler iteration today means assembling a multi-line `docker run` invocation with ~10 env vars and a generated `loader.conf` reference. Easy to drift, easy to mistype, hard to share. This PR collapses that to:

```bash
# Cold build (one-time, ~10 min on a fresh checkout):
./tracer/build_in_docker.sh BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples

# Iterate (rebuild what you changed, then run):
./tracer/build_in_docker.sh BuildProfilerHome RunProfilerScenario --scenario 5 --scenario-timeout 30
```

On a Linux host with the build deps available locally, drop the `_in_docker` prefix and call `./tracer/build.sh RunProfilerScenario ...` directly.

This is a follow-up to #8573 / supersedes the bash-helper approaches in #8727 and #8730; review feedback on #8727 was that "this sort of thing should be in Nuke" — agreed. Both bash PRs will be closed once this one is reviewed.

## Implementation details

`RunProfilerScenario` reuses existing build infra so it stays consistent with the rest of `Build.Profiler.Steps.cs`:

- `GetUnixArchitectureAndExtension()` for RID resolution.
- `AddContinuousProfilerEnvironmentVariables(envVars)` for the CorProfiler env-var dance.
- `MonitoringHomeDirectory`, `ProfilerOutputDirectory`, `FileNames.*`, `Configuration.Release`, `TargetPlatform` — same conventions as `RunSampleWithSanitizer`.
- `DD_INTERNAL_PROFILING_ENABLED_ARM64=1` on arm64.
- Post-run scan of the native-loader log surfaces a clear warning if `Datadog.Profiler.Native` fails to load (otherwise the only symptom is "no .pprof appeared").

Parameters: `--scenario` (int, default 4 = PiComputation), `--scenario-timeout` (int seconds, default 30), `--scenario-args` (string, appended after `--timeout`).

Guarded by `OnlyWhenStatic(() => IsLinux)` since the profiler runtime is Linux-musl only. Windows-host profiler development continues to use `profiler/README.md` (Visual Studio solution).

TTY fix is in a separate commit since it's independently useful for any Nuke target run through the docker wrappers.

## Test coverage

Manually validated on macOS + Colima + arm64, no TTY:

```bash
bash -c '</dev/null ./tracer/build_in_docker.sh BuildProfilerSamples'                                     # 21 s
bash -c '</dev/null ./tracer/build_in_docker.sh RunProfilerScenario --scenario 4 --scenario-timeout 5'   # 6 s
```

Result: one `.pprof` produced under `.profiler-out/pprof/`, profiler log shows "explicitly enabled" + "Wall-time profiler is enabled".

## Other details

No product code changes. No CI changes.