### PR TITLE
[Profiler] share sample runner between RunProfilerScenario and sanitizer jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -405,6 +405,3 @@ tools/dumps/
 
 # test optimization temp/run folder
 .dd/
-
-# Output of tracer/profiler-run.sh
-.profiler-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,12 +111,12 @@ Only rebuild more targets if you edited their source: `BuildNativeLoader` for `s
 ```bash
 ./tracer/build_in_docker.sh RunProfilerScenario                                # default: PiComputation
 ./tracer/build_in_docker.sh RunProfilerScenario --scenario 5 --scenario-timeout 30  # FibonacciComputation, 30s
-./tracer/build_in_docker.sh RunProfilerScenario --scenario 13 --scenario-args "--param 1"
+./tracer/build_in_docker.sh RunProfilerScenario --scenario 14 --scenario-param 5 --scenario-timeout 10  # QuicklyDeadThreads, 5 threads
 ```
 
 On a Linux host with the build deps available locally, drop the `_in_docker` prefix and call `./tracer/build.sh RunProfilerScenario ...` directly.
 
-`RunProfilerScenario` is a Nuke target (`tracer/build/_build/Build.Profiler.RunScenario.cs`) that sets the CorProfiler env vars, `LD_PRELOAD`s the API wrapper, sets `DD_INTERNAL_PROFILING_ENABLED_ARM64=1` on arm64 hosts, and runs `Samples.Computer01.dll`. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files land under `.profiler-out/` (gitignored). The target surfaces a clear warning if `Datadog.Profiler.Native.so` fails to load.
+`RunProfilerScenario` is a Nuke target (`tracer/build/_build/Build.Profiler.RunScenario.cs`) that shares its sample-runner with the CI ASAN/UBSAN jobs (`RunSampleWithProfiler` in `Build.Profiler.Steps.cs`). It sets the CorProfiler env vars, `LD_PRELOAD`s the API wrapper, sets `DD_INTERNAL_PROFILING_ENABLED_ARM64=1` on arm64, and runs `Samples.Computer01.dll`. Scenario IDs are values of the `Scenario` enum in `profiler/src/Demos/Samples.Computer01/Program.cs`. Logs and `.pprof` files land under `artifacts/build_data/profiler-scenario/{logs,pprofs}/` (already gitignored via `artifacts/`). The run fails with `::error::` if no pprof / no native log was produced, so a silently broken profiler is caught.
 
 - **`tracer/README.md`** — Complete development setup guide (VS requirements, Docker, Dev Containers, platform-specific build commands, and Nuke targets)
 

--- a/tracer/build/_build/Build.Profiler.RunScenario.cs
+++ b/tracer/build/_build/Build.Profiler.RunScenario.cs
@@ -1,17 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
+using System.Linq;
 using Nuke.Common;
 using Nuke.Common.IO;
-using Nuke.Common.Tooling;
-using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.MSBuild;
 using static Nuke.Common.EnvironmentInfo;
-using static Nuke.Common.IO.FileSystemTasks;
-using Logger = Serilog.Log;
 
-// Developer-facing target to run a Samples.Computer01 scenario with the locally-built
-// profiler attached. Linux-only (the profiler runtime is Linux-musl); from macOS / Windows
-// hosts, invoke via tracer/build_in_docker.{sh,ps1}. See AGENTS.md for the full loop.
+// Developer-facing iteration target for the Linux profiler. See AGENTS.md.
 
 partial class Build
 {
@@ -21,103 +14,43 @@ partial class Build
     [Parameter("Scenario timeout, in seconds. Default: 30.")]
     readonly int ScenarioTimeout = 30;
 
-    [Parameter("Extra args appended after --scenario / --timeout (e.g. \"--param 1\").")]
-    readonly string ScenarioArgs = string.Empty;
+    [Parameter("Scenario parameter forwarded as --param N to the sample (used by GarbageCollection, MemoryLeak, ContentionGenerator, etc.).")]
+    readonly int? ScenarioParam;
+
+    [Parameter("Extra args appended verbatim after --scenario / --timeout (one Nuke arg = one sample arg). Values starting with '--' should be prefixed with a space to bypass Nuke's flag detection, e.g. --scenario-args \" --iterations\" 100.")]
+    readonly string[] ScenarioArgs;
+
+    AbsolutePath ProfilerScenarioOutputDirectory => BuildDataDirectory / "profiler-scenario";
 
     Target RunProfilerScenario => _ => _
-        .Description("Run a Samples.Computer01 scenario with the locally-built profiler attached. Outputs to .profiler-out/.")
+        .Description("Run a Samples.Computer01 scenario with the locally-built profiler attached. Outputs to artifacts/build_data/profiler-scenario/.")
         .OnlyWhenStatic(() => IsLinux)
         .After(BuildProfilerHome, BuildProfilerSamples, BuildTracerHome, BuildNativeLoader, BuildNativeWrapper)
         .Executes(() =>
         {
-            var (arch, ext) = GetUnixArchitectureAndExtension();
-            var mhArch = MonitoringHomeDirectory / arch;
-
-            // Sanity-check the monitoring home — fail fast with a clear hint if a Build*Home target was skipped.
-            var requiredFiles = new[]
+            var args = string.Empty;
+            if (ScenarioParam is { } p)
             {
-                $"{FileNames.NativeLoader}.{ext}",
-                $"{FileNames.NativeProfiler}.{ext}",
-                $"{FileNames.NativeTracer}.{ext}",
-                FileNames.ProfilerLinuxApiWrapper,
-                FileNames.LoaderConf,
-            };
-            foreach (var file in requiredFiles)
+                args = $"--param {p}";
+            }
+            if (ScenarioArgs is { Length: > 0 })
             {
-                var path = mhArch / file;
-                if (!File.Exists(path))
-                {
-                    throw new Exception(
-                        $"Missing {path}. Run the relevant Build*Home / BuildNative* target first. " +
-                        "For a cold checkout: BuildTracerHome BuildNativeLoader BuildNativeWrapper BuildProfilerHome BuildProfilerSamples.");
-                }
+                // Trim the per-arg leading space used to bypass Nuke's --flag detection.
+                var joined = string.Join(" ", ScenarioArgs.Select(a => a.TrimStart()));
+                args = string.IsNullOrEmpty(args) ? joined : $"{args} {joined}";
             }
 
-            // Locate Samples.Computer01.dll for the current platform / configuration.
-            // Prefer Release; fall back to Debug if a Debug-only build is present.
-            var sampleRel = ProfilerOutputDirectory / "bin" / $"{Configuration.Release}-{TargetPlatform}" / "profiler" / "src" / "Demos" / "Samples.Computer01" / "net10.0";
-            var sampleDir = File.Exists(sampleRel / "Samples.Computer01.dll")
-                ? sampleRel
-                : ProfilerOutputDirectory / "bin" / $"{Configuration.Debug}-{TargetPlatform}" / "profiler" / "src" / "Demos" / "Samples.Computer01" / "net10.0";
+            // Configuration is left null so the helper resolves it (BuildConfiguration first, with a
+            // fallback to the opposite if only that one is locally built). Framework defaults to the
+            // latest declared TargetFramework so the dev loop doesn't need bumping at each .NET release.
+            RunSampleWithProfiler(
+                platform: IsArm64 ? ARM64TargetPlatform : MSBuildTargetPlatform.x64,
+                framework: Framework ?? TargetFramework.GetFrameworks().Last(),
+                scenario: Scenario,
+                timeoutSeconds: ScenarioTimeout,
+                outputBaseDir: ProfilerScenarioOutputDirectory,
+                extraArgs: args);
 
-            var sampleDll = sampleDir / "Samples.Computer01.dll";
-            if (!File.Exists(sampleDll))
-            {
-                throw new Exception($"Sample not found under {sampleRel} or Debug equivalent. Run BuildProfilerSamples first.");
-            }
-
-            // Output directories (gitignored).
-            var outDir = RootDirectory / ".profiler-out";
-            var logsDir = outDir / "logs";
-            var pprofDir = outDir / "pprof";
-            EnsureExistingDirectory(logsDir);
-            EnsureExistingDirectory(pprofDir);
-
-            var envVars = new Dictionary<string, string>();
-            AddContinuousProfilerEnvironmentVariables(envVars);
-            envVars["DD_NATIVELOADER_CONFIGFILE"] = mhArch / FileNames.LoaderConf;
-            envVars["LD_PRELOAD"] = mhArch / FileNames.ProfilerLinuxApiWrapper;
-            envVars["DD_PROFILING_ENABLED"] = "1";
-            envVars["DD_PROFILING_MANAGED_ACTIVATION_ENABLED"] = "0";
-            envVars["DD_TRACE_ENABLED"] = "0";
-            envVars["DD_TRACE_LOG_DIRECTORY"] = logsDir;
-            envVars["DD_INTERNAL_PROFILING_OUTPUT_DIR"] = pprofDir;
-            if (IsArm64)
-            {
-                // Profiler is opt-in on arm64 via this internal flag.
-                envVars["DD_INTERNAL_PROFILING_ENABLED_ARM64"] = "1";
-            }
-
-            var args = $"{sampleDll} --scenario {Scenario} --timeout {ScenarioTimeout}";
-            if (!string.IsNullOrWhiteSpace(ScenarioArgs))
-            {
-                args += " " + ScenarioArgs;
-            }
-
-            Logger.Information("Running scenario {Scenario} (timeout {Timeout}s) on {Arch}.", Scenario, ScenarioTimeout, arch);
-            Logger.Information("Logs:   {Logs}", logsDir);
-            Logger.Information("Pprofs: {Pprofs}", pprofDir);
-
-            var dotnetPath = DotNetSettingsExtensions.GetDotNetPath(TargetPlatform);
-            using var process = ProcessTasks.StartProcess(
-                toolPath: dotnetPath,
-                arguments: args,
-                workingDirectory: sampleDir,
-                environmentVariables: envVars,
-                customLogger: DotNetTasks.DotNetLogger);
-            process.AssertZeroExitCode();
-
-            // Post-run sanity check: surface profiler-load failures clearly. Without this the only
-            // symptom is "no .pprof appeared".
-            var loaderLog = logsDir / "dotnet-native-loader-dotnet-1.log";
-            if (File.Exists(loaderLog))
-            {
-                var content = File.ReadAllText(loaderLog);
-                if (content.Contains("Error loading dynamic library") && content.Contains(FileNames.NativeProfiler))
-                {
-                    Logger.Warning("The native profiler library failed to load — no .pprof will be produced.");
-                    Logger.Warning("Hint: rebuild the profiler home (BuildProfilerHome).");
-                }
-            }
+            AssertProfilerOutputs(ProfilerScenarioOutputDirectory);
         });
 }

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -704,34 +704,30 @@ partial class Build
 
             foreach (var platform in platforms)
             {
-                var baseOutputDir = ProfilerBuildDataDirectory / platform.ToString();
-                var pprofsOutputDir = baseOutputDir / "pprofs";
-                Logger.Information($"Check if pprofs file(s) was/were generated at {pprofsOutputDir}");
-
-                var pprofFiles = pprofsOutputDir.GlobFiles(
-                    $"*.pprof"
-                );
-
-                if (pprofFiles.Count == 0)
-                {
-                    Logger.Error("::error::No pprof file(s) was/were generated. Maybe the profiler is not correctly attached.");
-                    throw new Exception("No pprof file(s) was/were generated.");
-                }
-
-                var logsOutputDir = baseOutputDir / "logs";
-                Logger.Information($"Look for profiler log file(s) in {logsOutputDir}");
-
-                var logFiles = logsOutputDir.GlobFiles(
-                    $"DD-DotNet-Profiler-Native-*.log"
-                );
-
-                if (logFiles.Count == 0)
-                {
-                    Logger.Error("::error::No profiler log files was/were found. Was the profiler attached to the app?");
-                    throw new Exception("No profiler log files was/were found.");
-                }
+                AssertProfilerOutputs(ProfilerBuildDataDirectory / platform.ToString());
             }
         });
+
+    // Asserts that the profiler produced at least one pprof and at least one native log under outputBaseDir.
+    // Shared between RunSampleWithSanitizer (CI sanitizer jobs) and RunProfilerScenario (dev iteration loop).
+    void AssertProfilerOutputs(AbsolutePath outputBaseDir)
+    {
+        var pprofsOutputDir = outputBaseDir / "pprofs";
+        Logger.Information($"Check if pprofs file(s) was/were generated at {pprofsOutputDir}");
+        if (pprofsOutputDir.GlobFiles("*.pprof").Count == 0)
+        {
+            Logger.Error("::error::No pprof file(s) was/were generated. Maybe the profiler is not correctly attached.");
+            throw new Exception($"No pprof file(s) was/were generated under {pprofsOutputDir}.");
+        }
+
+        var logsOutputDir = outputBaseDir / "logs";
+        Logger.Information($"Look for profiler log file(s) in {logsOutputDir}");
+        if (logsOutputDir.GlobFiles("DD-DotNet-Profiler-Native-*.log").Count == 0)
+        {
+            Logger.Error("::error::No profiler log files was/were found. Was the profiler attached to the app?");
+            throw new Exception($"No profiler log files was/were found under {logsOutputDir}.");
+        }
+    }
 
     Target BuildProfilerUbsanTest => _ => _
         .Unlisted()
@@ -905,62 +901,139 @@ partial class Build
 
     void RunSampleWithSanitizer(MSBuildTargetPlatform platform, SanitizerKind sanitizer)
     {
+        if (sanitizer is SanitizerKind.None)
+        {
+            throw new Exception("No sanitizer has been selected. This job must run with a sanitizer.");
+        }
+
+        // Sanitizer jobs run with extra DD_PROFILING_*_ENABLED toggles so the sanitized binary exercises every profiler.
+        var extraEnv = new Dictionary<string, string>
+        {
+            ["DD_PROFILING_EXCEPTION_ENABLED"] = "1",
+            ["DD_PROFILING_ALLOCATION_ENABLED"] = "1",
+            ["DD_PROFILING_LOCK_ENABLED"] = "1",
+            ["DD_PROFILING_HEAP_ENABLED"] = "1",
+            ["DD_INTERNAL_PROFILING_DEBUG_INFO_ENABLED"] = "1",
+            ["DD_INTERNAL_GC_THREADS_CPUTIME_ENABLED"] = "1",
+        };
+
+        RunSampleWithProfiler(
+            platform,
+            framework: Framework,
+            scenario: 1,
+            timeoutSeconds: 120,
+            outputBaseDir: ProfilerBuildDataDirectory / platform.ToString(),
+            sanitizer: sanitizer,
+            extraEnv: extraEnv,
+            configuration: Configuration.Release); // BuildProfilerSampleForSanitiserTests always builds the sample in Release.
+    }
+
+    // Runs Samples.Computer01 with the profiler attached. Shared between CI sanitizer jobs
+    // (RunSampleWithSanitizer) and the developer iteration target (RunProfilerScenario).
+    //
+    // - sanitizer=None      : production LD_PRELOAD path (Datadog.Linux.ApiWrapper).
+    // - sanitizer=Asan/Ubsan: LD_PRELOAD set to libasan/libubsan instead (skips the wrapper, which is what we want for sanitizer runs).
+    //
+    // outputBaseDir receives DD_INTERNAL_PROFILING_OUTPUT_DIR (pprofs/) and DD_TRACE_LOG_DIRECTORY (logs/).
+    // Call AssertProfilerOutputs(outputBaseDir) afterwards to fail fast if the profiler didn't actually attach.
+    AbsolutePath SampleAppDllPath(Nuke.Common.ProjectModel.Project sampleApp, MSBuildTargetPlatform platform, TargetFramework framework, Configuration configuration) =>
+        ProfilerOutputDirectory / "bin" / $"{configuration}-{platform}" / "profiler" / "src" / "Demos" / sampleApp.Name / framework / $"{sampleApp.Name}.dll";
+
+    void RunSampleWithProfiler(
+        MSBuildTargetPlatform platform,
+        TargetFramework framework,
+        int scenario,
+        int timeoutSeconds,
+        AbsolutePath outputBaseDir,
+        SanitizerKind sanitizer = SanitizerKind.None,
+        string extraArgs = null,
+        IReadOnlyDictionary<string, string> extraEnv = null,
+        Configuration configuration = null)
+    {
+        var callerProvidedConfiguration = configuration is not null;
+        configuration ??= BuildConfiguration;
+
         var sampleApp = ProfilerSamplesSolution.GetProject("Samples.Computer01");
 
-        var envVars = new Dictionary<string, string>()
-            {
-                { "DD_TRACE_ENABLED", "0" }, // Disable tracer for this test
-                { "DD_PROFILING_ENABLED", "1" },
-                { "DD_PROFILING_EXCEPTION_ENABLED", "1" },
-                { "DD_PROFILING_ALLOCATION_ENABLED", "1"},
-                { "DD_PROFILING_LOCK_ENABLED","1" },
-                { "DD_PROFILING_HEAP_ENABLED", "1"},
-                { "DD_INTERNAL_PROFILING_DEBUG_INFO_ENABLED", "1" },
-                { "DD_INTERNAL_GC_THREADS_CPUTIME_ENABLED", "1" },
-                { "DD_PROFILING_MANAGED_ACTIVATION_ENABLED", "0" },  // disable StableConfig (i.e. don't wait for the tracer to set the configuration)
-            };
+        var envVars = new Dictionary<string, string>
+        {
+            ["DD_TRACE_ENABLED"] = "0",
+            ["DD_PROFILING_ENABLED"] = "1",
+            ["DD_PROFILING_MANAGED_ACTIVATION_ENABLED"] = "0", // disable StableConfig (don't wait for tracer to set configuration)
+        };
 
         if (IsArm64)
         {
-            // Temporary flag to enable profiling on arm64. This will be removed when the native profiler is updated to support arm64.
+            // Temporary flag to enable profiling on arm64. To be removed when the native profiler is updated to support arm64 by default.
             envVars["DD_INTERNAL_PROFILING_ENABLED_ARM64"] = "1";
         }
 
         if (IsLinux)
         {
-            if (sanitizer is SanitizerKind.Asan)
+            switch (sanitizer)
             {
-                // libasan SONAME differs between the two ASAN CI images:
-                //   - arm64: older Ubuntu/Debian base shipping gcc 9 -> libasan.so.5.
-                //   - x64:   newer image shipping gcc 10+ -> libasan.so.6.
-                // If/when the arm64 image is upgraded to gcc 10+, this can be
-                // collapsed to libasan.so.6 unconditionally.
-                envVars["LD_PRELOAD"] = IsArm64 ? "libasan.so.5" : "libasan.so.6";
-                // detect_leaks set to 0 to avoid false positive since not all libs are compiled against ASAN (ex. CLR binaries)
-                envVars["ASAN_OPTIONS"] = "detect_leaks=0";
-            }
-            else if (sanitizer is SanitizerKind.Ubsan)
-            {
-                envVars["LD_PRELOAD"] = "libubsan.so.1";
-                envVars["UBSAN_OPTIONS"] = "print_stacktrace=1";
-            }
-            else if (sanitizer is SanitizerKind.None)
-            {
-                throw new Exception($"No sanitizer has been selected. This job must run with a sanitizer");
+                case SanitizerKind.Asan:
+                    // libasan SONAME differs between ASAN CI images:
+                    //   arm64: older Ubuntu/Debian base shipping gcc 9 -> libasan.so.5
+                    //   x64:   newer image shipping gcc 10+ -> libasan.so.6
+                    envVars["LD_PRELOAD"] = IsArm64 ? "libasan.so.5" : "libasan.so.6";
+                    envVars["ASAN_OPTIONS"] = "detect_leaks=0"; // false positives: not all libs are compiled against ASAN (e.g. CLR binaries)
+                    break;
+                case SanitizerKind.Ubsan:
+                    envVars["LD_PRELOAD"] = "libubsan.so.1";
+                    envVars["UBSAN_OPTIONS"] = "print_stacktrace=1";
+                    break;
+                case SanitizerKind.None:
+                    // Production LD_PRELOAD path: the API wrapper next to the monitoring home.
+                    // (DD_NATIVELOADER_CONFIGFILE is not set: the native loader picks loader.conf up next to itself.)
+                    var (arch, _) = GetUnixArchitectureAndExtension();
+                    envVars["LD_PRELOAD"] = MonitoringHomeDirectory / arch / FileNames.ProfilerLinuxApiWrapper;
+                    break;
             }
         }
 
         AddContinuousProfilerEnvironmentVariables(envVars);
 
-        var baseOutputDir = ProfilerBuildDataDirectory / platform.ToString();
+        // Clear stale outputs so AssertProfilerOutputs can't pass on artifacts from a previous run
+        // (a sample that exits 0 without the profiler attached would otherwise look successful).
+        var pprofsDir = outputBaseDir / "pprofs";
+        var logsDir = outputBaseDir / "logs";
+        if (pprofsDir.DirectoryExists()) DeleteDirectory(pprofsDir);
+        if (logsDir.DirectoryExists()) DeleteDirectory(logsDir);
+        EnsureExistingDirectory(pprofsDir);
+        EnsureExistingDirectory(logsDir);
+        envVars["DD_INTERNAL_PROFILING_OUTPUT_DIR"] = pprofsDir;
+        envVars["DD_TRACE_LOG_DIRECTORY"] = logsDir;
 
-        envVars["DD_INTERNAL_PROFILING_OUTPUT_DIR"] = baseOutputDir / "pprofs";
-        envVars["DD_TRACE_LOG_DIRECTORY"] = baseOutputDir / "logs";
+        if (extraEnv != null)
+        {
+            foreach (var kv in extraEnv) envVars[kv.Key] = kv.Value;
+        }
 
-        var sampleBaseOutputDir = ProfilerOutputDirectory / "bin" / $"{Configuration.Release}-{platform}" / "profiler" / "src" / "Demos";
-        var sampleAppDll = sampleBaseOutputDir / sampleApp.Name / Framework / $"{sampleApp.Name}.dll";
+        // If the caller didn't pin a configuration and the primary build is missing, fall back to
+        // the opposite (so a dev with only a Debug build doesn't have to pass --build-configuration).
+        var sampleAppDll = SampleAppDllPath(sampleApp, platform, framework, configuration);
+        if (!File.Exists(sampleAppDll) && callerProvidedConfiguration == false)
+        {
+            var fallback = configuration == Configuration.Release ? Configuration.Debug : Configuration.Release;
+            var fallbackDll = SampleAppDllPath(sampleApp, platform, framework, fallback);
+            if (File.Exists(fallbackDll))
+            {
+                sampleAppDll = fallbackDll;
+            }
+        }
+        if (!File.Exists(sampleAppDll))
+        {
+            throw new Exception($"Sample not found: {sampleAppDll}. Run BuildProfilerSamples first.");
+        }
 
-        DotNet($"{sampleAppDll} --scenario 1 --timeout 120", platform, environmentVariables: envVars);
+        var args = $"{sampleAppDll} --scenario {scenario} --timeout {timeoutSeconds}";
+        if (!string.IsNullOrWhiteSpace(extraArgs))
+        {
+            args += " " + extraArgs;
+        }
+
+        DotNet(args, platform, environmentVariables: envVars);
 
         static IReadOnlyCollection<Output> DotNet(string arguments, MSBuildTargetPlatform platform, IReadOnlyDictionary<string, string> environmentVariables)
         {
@@ -968,7 +1041,6 @@ partial class Build
             using var process = ProcessTasks.StartProcess(toolPath: dotnetPath, arguments: arguments, environmentVariables: environmentVariables, customLogger: DotNetTasks.DotNetLogger);
             process.AssertZeroExitCode();
             return process.Output;
-
         }
     }
 


### PR DESCRIPTION
Stacked on #8735.

## Summary of changes

- New shared helpers `RunSampleWithProfiler` and `AssertProfilerOutputs` in `Build.Profiler.Steps.cs`.
- `RunSampleWithSanitizer` and `RunProfilerScenario` both call them.
- `RunProfilerScenario` now `AssertProfilerOutputs` after the run.
- `--scenario-args` (free-form string) replaced by typed `--scenario-param <int>` (Nuke's CLI parser eats string values starting with `--`).

## Reason for change

`RunProfilerScenario` (from #8735) and `RunSampleWithSanitizer` (existing CI ASAN/UBSAN) were ~90 % the same code: Samples.Computer01 + profiler env wiring + same DLL path resolution. Sharing the helper removes the duplication, and the ASAN/UBSAN jobs that already run on every CI cycle now also exercise the same code path the dev loop uses.

## Implementation details

`RunSampleWithProfiler(platform, framework, scenario, timeoutSeconds, outputBaseDir, sanitizer, extraArgs, extraEnv, configuration)`:
- `sanitizer = None` (default): production `LD_PRELOAD` (`Datadog.Linux.ApiWrapper.x64.so`) and `DD_NATIVELOADER_CONFIGFILE`.
- `sanitizer = Asan / Ubsan`: `LD_PRELOAD` set to `libasan/libubsan` (CI sanitizer path).
- `configuration` is explicit because `BuildProfilerSampleForSanitiserTests` hardcodes Release; defaulting to `BuildConfiguration` would break sanitizer runs with `--build-configuration Debug`.

`AssertProfilerOutputs(outputBaseDir)`:
- Globs `*.pprof` and `DD-DotNet-Profiler-Native-*.log` (PID-agnostic — addresses @gleocadie's review comment on #8735).
- Fails with `::error::` if either is missing.

Output conventions preserved: sanitizer uses `ProfilerBuildDataDirectory/<platform>/{pprofs,logs}`; dev-loop uses `.profiler-out/{pprofs,logs}`.

## Test coverage

Validated locally on macOS + Colima + arm64 (closed stdin):

- Release / Debug builds: pprof produced, target succeeds.
- Scenarios 4 / 5 / 14, frameworks net6.0 / net8.0 / net10.0, `--scenario-param N` forwarding: all green.
- Failure path (renamed `Datadog.Profiler.Native.so` aside): target fails with `::error::No pprof file(s)…`.

Sanitizer compile fails locally on arm64 (alpine builder image lacks `libclang_rt.{asan,ubsan}-aarch64.a` — CI uses dedicated images that ship these). Helper signature preserves the original `RunSampleWithSanitizer` behaviour (same scenario 1, 120 s timeout, sanitizer-specific `LD_PRELOAD`).

## Other details

No product code changes. No CI configuration changes.