### PR TITLE
[Debugger] Fix probe file test waits

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -278,7 +278,7 @@ public class DynamicInstrumentationTests
         rcmSubscriptionManagerMock.ProductKeys.Contains(RcmProducts.LiveDebugging).Should().BeFalse();
     }
 
-    private static async Task WaitForInitializationAsync(DynamicInstrumentation debugger, int timeoutSeconds = 5)
+    private static async Task WaitForInitializationAsync(DynamicInstrumentation debugger, int timeoutSeconds = 30)
     {
         var initializationTask = debugger.GetInitializationTask();
         var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeoutSeconds));

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -280,13 +280,12 @@ public class DynamicInstrumentationTests
 
     private static async Task WaitForInitializationAsync(DynamicInstrumentation debugger, int timeoutSeconds = 5)
     {
-        var timeout = TimeSpan.FromSeconds(timeoutSeconds);
-        var startTime = DateTime.UtcNow;
+        var initializationTask = debugger.GetInitializationTask();
+        var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeoutSeconds));
 
-        while (!debugger.IsInitialized && DateTime.UtcNow - startTime < timeout)
-        {
-            await Task.Delay(50);
-        }
+        var completedTask = await Task.WhenAny(initializationTask, timeoutTask);
+        completedTask.Should().Be(initializationTask, "Dynamic Instrumentation initialization should complete");
+        await initializationTask;
     }
 
     private static async Task WaitUntilAsync(Func<bool> condition, int timeoutSeconds = 5)
@@ -379,14 +378,7 @@ public class DynamicInstrumentationTests
 
             var debugger = CreateDebugger(settings);
             debugger.Initialize();
-
-            var timeout = TimeSpan.FromSeconds(5);
-            var startTime = DateTime.UtcNow;
-
-            while (GetFileProbes(debugger) is null && DateTime.UtcNow - startTime < timeout)
-            {
-                await Task.Delay(50);
-            }
+            await WaitForInitializationAsync(debugger);
 
             var fileProbes = GetFileProbes(debugger);
             fileProbes.Should().NotBeNull("Probe file should be loaded and applied");
@@ -869,14 +861,7 @@ public class DynamicInstrumentationTests
 
             var debugger = CreateDebugger(settings);
             debugger.Initialize();
-
-            var timeout = TimeSpan.FromSeconds(5);
-            var startTime = DateTime.UtcNow;
-
-            while (GetFileProbes(debugger) is null && DateTime.UtcNow - startTime < timeout)
-            {
-                await Task.Delay(50);
-            }
+            await WaitForInitializationAsync(debugger);
 
             var fileProbes = GetFileProbes(debugger);
             fileProbes.Should().NotBeNull("Valid probes should be loaded");
@@ -924,14 +909,7 @@ public class DynamicInstrumentationTests
 
             var debugger = CreateDebugger(settings);
             debugger.Initialize();
-
-            var timeout = TimeSpan.FromSeconds(5);
-            var startTime = DateTime.UtcNow;
-
-            while (GetFileProbes(debugger) is null && DateTime.UtcNow - startTime < timeout)
-            {
-                await Task.Delay(50);
-            }
+            await WaitForInitializationAsync(debugger);
 
             var fileProbes = GetFileProbes(debugger);
             fileProbes.Should().NotBeNull("Probes should be loaded");
@@ -969,7 +947,7 @@ public class DynamicInstrumentationTests
 
             var debugger = CreateDebugger(settings, new DiscoveryServiceWithoutRcmMock());
             debugger.Initialize();
-            await WaitForInitializationAsync(debugger);
+            await WaitUntilAsync(() => GetFileProbes(debugger) is not null);
 
             debugger.IsInitialized.Should().BeTrue("file probes should not wait for the RCM availability timeout");
             GetFileProbes(debugger).Should().NotBeNull();


### PR DESCRIPTION
## Summary of changes
- Make debugger probe-file tests wait for Dynamic Instrumentation initialization to complete before checking loaded file probes.
- Keep the no-RCM file-probe test waiting only for file probes to be accepted, since full initialization can remain pending until shutdown.

## Reason for change
- The probe-file tests could observe `_fileConfiguration` before the async initialization flow had accepted the loaded file probes.

## Implementation details
- `WaitForInitializationAsync` now waits on `GetInitializationTask()` with a timeout instead of polling `IsInitialized`.
- Tests with RCM available use the initialization task as the synchronization point.

## Test coverage
- `dotnet test "tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj" -f netcoreapp3.1 --filter "FullyQualifiedName~DynamicInstrumentationTests|FullyQualifiedName~ProbeConfigurationFileLoaderTests"`
- Repeated 5x: `dotnet test "tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj" -f netcoreapp3.1 --filter "FullyQualifiedName~ProbeFile_DuplicateIdsWithinFile_KeepsFirstOccurrence|FullyQualifiedName~ProbeFile_MultipleProbeTypes_LoadsAll" --no-restore --no-build`

## Other details
<!-- Fixes #{issue} -->