### PR TITLE
[Debugger] Avoid spurious timeout on empty collection serialization

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -418,8 +418,13 @@ namespace Datadog.Trace.Debugger.Snapshots
                     }
                 }
 
-                // Track the reason but don't write yet if we're still inside the array
-                if (cts.IsCancellationRequested)
+                // Track the reason but don't write yet if we're still inside the array.
+                // Only report a timeout when we actually stopped short of serializing the collection,
+                // i.e. there are still elements we didn't get to (itemIndex < collection.Count). An
+                // empty (Count == 0) or fully-serialized collection must never be reported as a
+                // timeout, even if the serialization budget happened to elapse in the meantime on a
+                // slow/loaded machine.
+                if (cts.IsCancellationRequested && itemIndex < collection.Count)
                 {
                     notCapturedReason = NotCapturedReason.timeout;
                 }


### PR DESCRIPTION
## Summary of changes

Only report `notCapturedReason: timeout` for a collection when there are still elements left to serialize (`itemIndex < collection.Count`).

## Reason for change

Flaky test `Datadog.Trace.Tests.Debugger.DebuggerSnapshotCreatorTests.ObjectStructure_EmptyArray`. Logs [here](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/202513/logs/7844)

The serializer starts a wall-clock cancellation budget (`DD_DYNAMIC_INSTRUMENTATION_MAX_TIME_TO_SERIALIZE`, default 200ms) at the start of serialization. For an empty collection there's nothing to serialize, but if that budget happened to elapse before the post-loop `cts.IsCancellationRequested` check (slow/loaded CI machine, GC pause), the empty array was wrongly stamped with `timeout`:

```
VerifyException : Results do not match.
Received Content:
{
  local0: {
    elements: [],
    notCapturedReason: timeout,
    size: 0,
    type: Int32[]
  }
}
Verified Content:
{
  local0: {
    elements: [],
    size: 0,
    type: Int32[]
  }
}
```

## Implementation details

`SerializeEnumerable` now guards the timeout branch with `itemIndex < collection.Count`, so an empty (`Count == 0`) or fully-serialized collection can never be reported as a timeout regardless of the budget. A collection cancelled mid-serialization still reports `timeout`.

## Test coverage

Covered by the existing `ObjectStructure_EmptyArray` / `ObjectStructure_EmptyList` verified tests.

## Other details

Replaces the earlier mitigation that bumped the test timeout to 1000ms — a shared mutable static that could still be clobbered (by `DebuggerManager.SetConfig`) or exceeded, so it only reduced the probability rather than fixing the spurious behavior.
