### PR TITLE
[DO NOT MERGE - WIP] Use assembly metadata for AssemblyVersion; revision .999 for local builds

### DIFF
--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Text;
 
 namespace Datadog.Trace
 {
@@ -11,9 +12,11 @@ namespace Datadog.Trace
     {
         public const string TelemetrySdkName = "datadog";
         public const string Language = "dotnet";
-        public const string AssemblyVersion = "3.46.0.0";
+        public static readonly string AssemblyVersion = typeof(TracerConstants).Assembly.GetName().Version?.ToString() ?? "0.0.0.0";
         public const string ThreePartVersion = "3.46.0";
 
-        public static ReadOnlySpan<byte> AssemblyVersionBytes => "3.46.0.0"u8;
+        private static readonly byte[] AssemblyVersionBytesArray = Encoding.UTF8.GetBytes(AssemblyVersion);
+
+        public static ReadOnlySpan<byte> AssemblyVersionBytes => AssemblyVersionBytesArray;
     }
 }

--- a/tracer/src/Directory.Build.props
+++ b/tracer/src/Directory.Build.props
@@ -5,6 +5,9 @@
     <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>3.46.0</Version>
+    <!-- Local builds use revision 999 so they sort above release builds (revision 0) when side-by-side. -->
+    <AssemblyVersion Condition="'$(TF_BUILD)' != 'True'">$(Version).999</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TF_BUILD)' == 'True'">$(Version).0</AssemblyVersion>
 
     <!-- Code analysis -->
     <AnalysisLevel>latest</AnalysisLevel>


### PR DESCRIPTION
## Summary of changes

- `TracerConstants.AssemblyVersion` is now derived from the actual assembly's `AssemblyVersionAttribute` via reflection instead of a separate hardcoded string, eliminating the risk of them diverging.
- `Directory.Build.props` sets `<AssemblyVersion>` to `$(Version).999` for local builds and `$(Version).0` for CI builds (keyed on `TF_BUILD`).
- `AssemblyVersionBytes` is now cached as a `static readonly byte[]` derived from `AssemblyVersion` (was a `u8` compile-time literal).

## Reason for change

Local builds were indistinguishable from release builds by assembly version. Using revision `.999` makes local builds sort above release builds when running side-by-side, and makes it easy to tell in telemetry/logs whether a trace came from a dev build.

## Implementation details

`SetAllVersions.cs` requires no changes — `<AssemblyVersion>` is expressed as `$(Version).{suffix}`, so version bumps automatically propagate via the existing `<Version>` update. The `FourPartVersionReplace` call on `TracerConstants.cs` becomes a no-op (no 4-part literal to match) but causes no harm.

## Test coverage

All existing tests reference `TracerConstants.AssemblyVersion` dynamically, so they automatically adapt to whichever value the assembly carries.

## Other details

No breaking changes. `AssemblyVersion` changes from `const` to `static readonly` — all call sites are runtime uses (no attribute arguments or `switch` cases).