### PR TITLE
Stamp -dev suffix on tracer_version for PR CI and local builds

### DIFF
--- a/tracer/src/Datadog.Trace/DogStatsd/StatsdFactory.cs
+++ b/tracer/src/Datadog.Trace/DogStatsd/StatsdFactory.cs
@@ -33,7 +33,7 @@ internal static class StatsdFactory
             constantTags.Add("lang:.NET");
             constantTags.Add($"lang_interpreter:{FrameworkDescription.Instance.Name}");
             constantTags.Add($"lang_version:{FrameworkDescription.Instance.ProductVersion}");
-            constantTags.Add($"tracer_version:{TracerConstants.AssemblyVersion}");
+            constantTags.Add($"tracer_version:{TracerConstants.ReportedVersion}");
             constantTags.Add($"{Tags.RuntimeId}:{Tracer.RuntimeId}");
             // update count above if adding new tags
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientTracer.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientTracer.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
                 tags.Add($"version:{serviceVersion}");
             }
 
-            tags.Add($"tracer_version:{TracerConstants.ThreePartVersion}");
+            tags.Add($"tracer_version:{TracerConstants.ReportedVersion}");
 
             var hostName = PlatformHelpers.HostMetadata.Instance?.Hostname;
             if (!string.IsNullOrEmpty(hostName))

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             {
                 var rcmTracer = RcmClientTracer.Create(
                     runtimeId: Util.RuntimeId.Get(),
-                    tracerVersion: TracerConstants.ThreePartVersion,
+                    tracerVersion: TracerConstants.ReportedVersion,
                     // Service Name must be lowercase, otherwise the agent will not be able to find the service
                     service: TraceUtil.NormalizeTag(mutable.DefaultServiceName),
                     env: TraceUtil.NormalizeTag(mutable.Environment),

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -14,6 +14,14 @@ namespace Datadog.Trace
         public const string AssemblyVersion = "3.46.0.0";
         public const string ThreePartVersion = "3.46.0";
 
+        // ReportedVersion is used for telemetry tags only — not for native/managed version matching.
+        // PR CI and local builds get a -dev suffix so monitors can filter them out automatically.
+#if DD_CI_BUILD
+        public const string ReportedVersion = "3.46.0-dev";
+#else
+        public const string ReportedVersion = "3.46.0";
+#endif
+
         public static ReadOnlySpan<byte> AssemblyVersionBytes => "3.46.0.0"u8;
     }
 }

--- a/tracer/src/Directory.Build.props
+++ b/tracer/src/Directory.Build.props
@@ -1,6 +1,14 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
+  <!-- Stamp -dev suffix on tracer_version for non-release builds (PR CI and local)
+       so telemetry monitors can filter them using the existing *dev* exclusion.
+       TF_BUILD=True on all Azure DevOps pipeline runs; SYSTEM_PULLREQUEST_SOURCEBRANCH
+       is only set for PR-triggered pipelines, not master/release builds. -->
+  <PropertyGroup Condition="'$(TF_BUILD)' != 'True' OR '$(SYSTEM_PULLREQUEST_SOURCEBRANCH)' != ''">
+    <DefineConstants>$(DefineConstants);DD_CI_BUILD</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary of changes

Adds a `ReportedVersion` compile-time constant to `TracerConstants` that appends `-dev` to the tracer version when building in a PR CI or local (non-pipeline) context. This constant is used for telemetry tags only.

## Reason for change

Telemetry monitors for other languages already filter dev/pre-release builds using version string patterns (`*dev*`, `*snapshot*`, `*rc*`, etc.). The .NET tracer has no such convention — PR CI builds report a clean version (e.g. `3.46.0.0`) indistinguishable from a release, causing the `[Instrumentation Telemetry Info] Configs from [dotnet] are not normalized` monitor to fire on dev traffic. See discussion in #apm-config-registry.

## Implementation details

- `Directory.Build.props`: sets `DD_CI_BUILD` compile-time define when `TF_BUILD != True` (local builds) or `SYSTEM_PULLREQUEST_SOURCEBRANCH` is set (PR CI builds). Master/release pipeline builds have `TF_BUILD=True` and no PR branch → no suffix.
- `TracerConstants.ReportedVersion`: `#if DD_CI_BUILD` stamps `"3.46.0-dev"`, otherwise `"3.46.0"`. `ThreePartVersion` is left unchanged — it's used for native/managed version mismatch detection in `Instrumentation.cs` and must stay clean.
- `StatsdFactory`, `RcmClientTracer`, `RemoteConfigurationManager`: switched from `AssemblyVersion`/`ThreePartVersion` to `ReportedVersion` for the `tracer_version` telemetry tag.
- `SetAllVersions.cs` requires no changes — the version bump regex matches `3.46.0` within `"3.46.0-dev"` and updates it correctly.

## Test coverage

No new tests — the constant value is determined at compile time and the logic is trivially verifiable by checking the define condition.

## Other details

- No runtime code changes — `ReportedVersion` is a `const`, not a property or field
- No release pipeline changes — master builds are unaffected
- Local builds also get `-dev` since `TF_BUILD` is not set outside Azure DevOps