### PR TITLE
[Debugger] Improve no capture reason in collection serializer

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -342,32 +342,37 @@ namespace Datadog.Trace.Debugger.Snapshots
             try
             {
                 var isDictionary = Redaction.IsSupportedDictionary(source);
+                var collectionCount = collection.Count;
                 jsonWriter.WritePropertyName("type");
                 jsonWriter.WriteValue(type.Name);
                 jsonWriter.WritePropertyName("size");
-                jsonWriter.WriteValue(collection.Count);
+                jsonWriter.WriteValue(collectionCount);
                 jsonWriter.WritePropertyName(isDictionary ? "entries" : "elements");
                 jsonWriter.WriteStartArray();
                 arrayOpened = true;
 
-                var itemIndex = 0;
+                var enumeratedItemCount = 0;
+                var enumerationCompleted = false;
+                var stoppedByTimeout = false;
                 enumerator = enumerable.GetEnumerator();
 
-                bool hasNext = false;
-                while (itemIndex < limitInfo.MaxCollectionSize)
+                while (!enumerationCompleted && enumeratedItemCount < limitInfo.MaxCollectionSize)
                 {
                     if (cts.IsCancellationRequested)
                     {
+                        stoppedByTimeout = true;
                         break;
                     }
 
                     try
                     {
-                        hasNext = enumerator.MoveNext();
-                        if (!hasNext)
+                        if (!enumerator.MoveNext())
                         {
+                            enumerationCompleted = true;
                             break;
                         }
+
+                        enumeratedItemCount++;
                     }
                     catch (InvalidOperationException e)
                     {
@@ -411,24 +416,25 @@ namespace Datadog.Trace.Debugger.Snapshots
                             collectionsBeingSerialized);
                     }
 
-                    itemIndex++;
                     if (!serialized)
                     {
+                        if (cts.IsCancellationRequested)
+                        {
+                            stoppedByTimeout = true;
+                        }
+
                         break;
                     }
                 }
 
                 // Track the reason but don't write yet if we're still inside the array.
-                // Only report a timeout when we actually stopped short of serializing the collection,
-                // i.e. there are still elements we didn't get to (itemIndex < collection.Count). An
-                // empty (Count == 0) or fully-serialized collection must never be reported as a
-                // timeout, even if the serialization budget happened to elapse in the meantime on a
-                // slow/loaded machine.
-                if (cts.IsCancellationRequested && itemIndex < collection.Count)
+                if (stoppedByTimeout && enumeratedItemCount < collectionCount)
                 {
                     notCapturedReason = NotCapturedReason.timeout;
                 }
-                else if (hasNext && itemIndex >= limitInfo.MaxCollectionSize)
+                else if (!enumerationCompleted &&
+                         enumeratedItemCount >= limitInfo.MaxCollectionSize &&
+                         enumeratedItemCount < collectionCount)
                 {
                     notCapturedReason = NotCapturedReason.collectionSize;
                 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -4,16 +4,19 @@
 // </copyright>
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.Snapshots;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using VerifyTests;
 using VerifyXunit;
@@ -102,6 +105,47 @@ namespace Datadog.Trace.Tests.Debugger
 
             Assert.NotNull(snapshot);
             Assert.Contains("\"notCapturedReason\":\"depth\"", snapshot);
+        }
+
+        [Fact]
+        public void Limits_CollectionAtCaptureLimit_DoesNotSetCollectionSizeReason()
+        {
+            var collection = new List<object> { 1, null, 2 };
+            var collectionJson = SerializeCollection(collection, maxCollectionSize: collection.Count);
+
+            Assert.Equal(collection.Count, collectionJson["size"]?.Value<int>());
+            Assert.Equal(2, collectionJson["elements"]?.Value<JArray>()?.Count);
+            Assert.Null(collectionJson["notCapturedReason"]);
+        }
+
+        [Fact]
+        public void Limits_CollectionWithTooManyItems_SetsCollectionSizeReason()
+        {
+            var collectionJson = SerializeCollection(new List<object> { 1, null, 2, 3 }, maxCollectionSize: 3);
+
+            Assert.Equal("collectionSize", collectionJson["notCapturedReason"]?.Value<string>());
+            Assert.Equal(2, collectionJson["elements"]?.Value<JArray>()?.Count);
+        }
+
+        [Fact]
+        public void Limits_CollectionCanceledBeforeVisitingAllItems_SetsTimeoutReason()
+        {
+            using var cts = new CancellationTokenSource();
+            var collectionJson = SerializeCollection(new CancelingCollection([1, 2, 3], cancelAfterVisitedItems: 2, cts), maxCollectionSize: 10, cts);
+
+            Assert.Equal("timeout", collectionJson["notCapturedReason"]?.Value<string>());
+            Assert.Equal(2, collectionJson["elements"]?.Value<JArray>()?.Count);
+        }
+
+        [Fact]
+        public void Limits_CollectionCanceledAfterVisitingAllItems_DoesNotSetTimeoutReason()
+        {
+            using var cts = new CancellationTokenSource();
+            var collectionJson = SerializeCollection(new CancelingCollection([1, null, 2], cancelAfterVisitedItems: 3, cts), maxCollectionSize: 10, cts);
+
+            Assert.Equal(3, collectionJson["size"]?.Value<int>());
+            Assert.Equal(2, collectionJson["elements"]?.Value<JArray>()?.Count);
+            Assert.Null(collectionJson["notCapturedReason"]);
         }
 
         [Fact]
@@ -401,6 +445,39 @@ namespace Datadog.Trace.Tests.Debugger
         {
         }
 
+        private static JObject SerializeCollection(ICollection collection, int maxCollectionSize, CancellationTokenSource cts = null)
+        {
+            cts ??= new CancellationTokenSource();
+
+            var serializeEnumerable = typeof(DebuggerSnapshotSerializer).GetMethod("SerializeEnumerable", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(serializeEnumerable);
+
+            var limitInfo = new CaptureLimitInfo(
+                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                MaxCollectionSize: maxCollectionSize,
+                MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+
+            using var stringWriter = new System.IO.StringWriter();
+            using var jsonWriter = new JsonTextWriter(stringWriter);
+            jsonWriter.WriteStartObject();
+            serializeEnumerable!.Invoke(
+                null,
+                [
+                    collection,
+                    collection.GetType(),
+                    jsonWriter,
+                    collection,
+                    0,
+                    cts,
+                    limitInfo,
+                    new HashSet<object>()
+                ]);
+            jsonWriter.WriteEndObject();
+
+            return JObject.Parse(stringWriter.ToString());
+        }
+
         private static CaptureLimitInfo CreateCaptureLimitInfo()
         {
             return new CaptureLimitInfo(
@@ -479,6 +556,75 @@ namespace Datadog.Trace.Tests.Debugger
         private static bool HasContent(JToken token)
         {
             return token != null && token.HasValues;
+        }
+
+        private sealed class CancelingCollection : ICollection
+        {
+            private readonly object[] _items;
+            private readonly int _cancelAfterVisitedItems;
+            private readonly CancellationTokenSource _cts;
+
+            public CancelingCollection(object[] items, int cancelAfterVisitedItems, CancellationTokenSource cts)
+            {
+                _items = items;
+                _cancelAfterVisitedItems = cancelAfterVisitedItems;
+                _cts = cts;
+            }
+
+            public int Count => _items.Length;
+
+            public bool IsSynchronized => false;
+
+            public object SyncRoot => this;
+
+            public void CopyTo(Array array, int index)
+            {
+                _items.CopyTo(array, index);
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                return new CancelingEnumerator(_items, _cancelAfterVisitedItems, _cts);
+            }
+
+            private sealed class CancelingEnumerator : IEnumerator
+            {
+                private readonly object[] _items;
+                private readonly int _cancelAfterVisitedItems;
+                private readonly CancellationTokenSource _cts;
+                private int _index = -1;
+
+                public CancelingEnumerator(object[] items, int cancelAfterVisitedItems, CancellationTokenSource cts)
+                {
+                    _items = items;
+                    _cancelAfterVisitedItems = cancelAfterVisitedItems;
+                    _cts = cts;
+                }
+
+                public object Current
+                {
+                    get
+                    {
+                        if (_index + 1 == _cancelAfterVisitedItems)
+                        {
+                            _cts.Cancel();
+                        }
+
+                        return _items[_index];
+                    }
+                }
+
+                public bool MoveNext()
+                {
+                    _index++;
+                    return _index < _items.Length;
+                }
+
+                public void Reset()
+                {
+                    _index = -1;
+                }
+            }
         }
 
         private class InfiniteRecursion

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -447,35 +447,46 @@ namespace Datadog.Trace.Tests.Debugger
 
         private static JObject SerializeCollection(ICollection collection, int maxCollectionSize, CancellationTokenSource cts = null)
         {
+            var ownsCancellationTokenSource = cts is null;
             cts ??= new CancellationTokenSource();
 
-            var serializeEnumerable = typeof(DebuggerSnapshotSerializer).GetMethod("SerializeEnumerable", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.NotNull(serializeEnumerable);
+            try
+            {
+                var serializeEnumerable = typeof(DebuggerSnapshotSerializer).GetMethod("SerializeEnumerable", BindingFlags.NonPublic | BindingFlags.Static);
+                Assert.NotNull(serializeEnumerable);
 
-            var limitInfo = new CaptureLimitInfo(
-                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
-                MaxCollectionSize: maxCollectionSize,
-                MaxLength: DebuggerSettings.DefaultMaxStringLength,
-                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+                var limitInfo = new CaptureLimitInfo(
+                    MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                    MaxCollectionSize: maxCollectionSize,
+                    MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                    MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
 
-            using var stringWriter = new System.IO.StringWriter();
-            using var jsonWriter = new JsonTextWriter(stringWriter);
-            jsonWriter.WriteStartObject();
-            serializeEnumerable!.Invoke(
-                null,
-                [
-                    collection,
-                    collection.GetType(),
-                    jsonWriter,
-                    collection,
-                    0,
-                    cts,
-                    limitInfo,
-                    new HashSet<object>()
-                ]);
-            jsonWriter.WriteEndObject();
+                using var stringWriter = new System.IO.StringWriter();
+                using var jsonWriter = new JsonTextWriter(stringWriter);
+                jsonWriter.WriteStartObject();
+                serializeEnumerable!.Invoke(
+                    null,
+                    [
+                        collection,
+                        collection.GetType(),
+                        jsonWriter,
+                        collection,
+                        0,
+                        cts,
+                        limitInfo,
+                        new HashSet<object>()
+                    ]);
+                jsonWriter.WriteEndObject();
 
-            return JObject.Parse(stringWriter.ToString());
+                return JObject.Parse(stringWriter.ToString());
+            }
+            finally
+            {
+                if (ownsCancellationTokenSource)
+                {
+                    cts.Dispose();
+                }
+            }
         }
 
         private static CaptureLimitInfo CreateCaptureLimitInfo()


### PR DESCRIPTION
## Summary of changes

- Fix collection snapshot limit handling in `DebuggerSnapshotSerializer`.
- Track visited collection items separately from serialized output, so skipped null entries still count toward collection limits.
- Avoid setting collection-level `timeout` or `collectionSize` when all collection items were already visited.
- Add focused debugger snapshot tests for exact limits, null items, oversized collections, and timeout boundaries.

## Reason for change

- Collection snapshots could report incorrect `notCapturedReason` values around timeout and collection-size boundaries.
- Empty or fully visited collections should not be marked as timed out if cancellation is observed after traversal completes.
- Null entries should not let serialization walk past `maxCollectionSize`.

## Implementation details

- Uses `ICollection.Count` as the source of truth for total collection size.
- Uses a separate enumerated item counter for limit and timeout decisions.
- Keeps existing behavior where null collection entries are skipped from JSON output.
- Applies to the shared supported collection/dictionary serializer path.

## Test coverage

- `DebuggerSnapshotCreatorTests.Limits_Collection`
- `DebuggerSnapshotCreatorTests.ObjectStructure_EmptyArray|DebuggerSnapshotCreatorTests.ObjectStructure_EmptyList|DebuggerSnapshotCreatorTests.Limits_LargeCollection`