### PR TITLE
[Debugger] Fix safe ToString handling for debugger collections

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -201,8 +201,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
 
             return TypeExtensions.IsSimple(effectiveType) ||
-                   AllowedTypesSafeToCallToString.Contains(effectiveType) ||
-                   IsSupportedCollection(type);
+                   AllowedTypesSafeToCallToString.Contains(effectiveType);
         }
 
         internal static bool IsSupportedDictionary(object? o)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
@@ -4,9 +4,12 @@
 // </copyright>
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 // ReSharper disable once RedundantUsingDirective
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Datadog.Trace.Debugger.Snapshots;
 using FluentAssertions;
 using Xunit;
@@ -37,6 +40,17 @@ namespace Datadog.Trace.Tests.Debugger
             {
                 Redaction.IsSafeToCallToString(type).Should().BeTrue($"Type {type} should be safe to call ToString on");
             }
+        }
+
+        [Theory]
+        [InlineData(typeof(List<int>))]
+        [InlineData(typeof(HashSet<int>))]
+        [InlineData(typeof(Dictionary<string, int>))]
+        [InlineData(typeof(Hashtable))]
+        [InlineData(typeof(ConditionalWeakTable<object, object>))]
+        public void CollectionTypesAreNotSafeToCallToString(Type type)
+        {
+            Redaction.IsSafeToCallToString(type).Should().BeFalse($"Type {type} should use structural handling instead of ToString()");
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Updates debugger redaction safety checks so collection support no longer implies `ToString()` is safe to call.
- Keeps `Redaction.IsSafeToCallToString()` limited to simple types and explicitly allowlisted scalar-like types.
- Adds focused tests documenting that collections and dictionaries should not rely on `ToString()` for safe string fallback behavior.

## Reason for change

- `IsSafeToCallToString()` was reusing `IsSupportedCollection()`, which mixed two separate concepts: whether a type can be structurally handled as a debugger collection, and whether calling `ToString()` is safe/useful.
- This caused supported collection types, including problematic collection-like types, to be treated as safe for string fallback paths.
- Separating this now keeps the first fix small and leaves broader collection/dictionary serializer support for a follow-up PR.

## Implementation details

- Removed the `IsSupportedCollection(type)` check from `Redaction.IsSafeToCallToString()`.
- This reduces work in the helper by avoiding the collection allowlist scan.
- Added deterministic unit coverage for `List<T>`, `HashSet<T>`, `Dictionary<TKey,TValue>`, `Hashtable`, and `ConditionalWeakTable<TKey,TValue>`.
- No serializer collection support is changed in this PR.

## Test coverage

- `SupportedTypesServiceTests`
- `DebuggerExpressionLanguageTests`
- `DebuggerSnapshotCreatorTests`