### PR TITLE
Capture smoke tests container after error

### DIFF
--- a/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
+++ b/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
@@ -155,11 +155,16 @@ public static partial class SmokeTestRunner
             // 10. Run crash test
             if (scenario.RunCrashTest)
             {
-                crashTestContainerId = await RunCrashTestAsync(
+                // Capture the container id via callback (not the return value) so that if the
+                // crash test throws (e.g. the wait times out), the finally block can still dump
+                // its logs and clean it up. Otherwise the container leaks and keeps the network
+                // alive, masking the real failure behind a "network has active endpoints" warning.
+                await RunCrashTestAsync(
                     imageTag, networkName,
                     environment.ToHostPath(logsDir),
                     environment.ToHostPath(dumpsDir),
-                    scenario.GetEnvironment(isCrashTest: true));
+                    scenario.GetEnvironment(isCrashTest: true),
+                    id => crashTestContainerId = id);
             }
         }
         finally
@@ -380,12 +385,13 @@ public static partial class SmokeTestRunner
         Logger.Information("Snapshot verification passed");
     }
 
-    static async Task<string> RunCrashTestAsync(
+    static async Task RunCrashTestAsync(
         string imageTag,
         string networkName,
         string logsDir,
         string dumpsDir,
-        Dictionary<string, string> environmentVariables)
+        Dictionary<string, string> environmentVariables,
+        Action<string> onContainerStarted)
     {
         LogSection("Running crash test");
         using var crashCts = new CancellationTokenSource(TimeSpan.FromMinutes(4));
@@ -400,6 +406,10 @@ public static partial class SmokeTestRunner
             environmentVariables);
         var containerId = await DockerService.CreateAndStartContainerWithRetryAsync(
             "crash-test", containerParams, ct);
+
+        // Register the container id immediately so the caller can clean it up / dump its logs
+        // even if the wait below times out and throws.
+        onContainerStarted(containerId);
 
         // Wait for the container to exit (non-zero exit is expected)
         var statusCode = await DockerService.WaitForContainerAsync("Crash test", containerId, ct);
@@ -422,8 +432,6 @@ public static partial class SmokeTestRunner
             throw new InvalidOperationException(
                 $"Crash test failed: did not find '{expectedMessage}' in container logs");
         }
-
-        return containerId;
     }
 
 


### PR DESCRIPTION
## Summary of changes

Capture the crash-test container id via a callback the moment the container starts, instead of only through `RunCrashTestAsync`'s return value.

## Reason for change

When the crash test exceeded its 4-minute timeout, `WaitForContainerAsync` threw `TaskCanceledException` *before* the return value was assigned, so `crashTestContainerId` stayed `null`. As a result the `finally` block never cleaned up or dumped logs for that container. The orphaned container kept the Docker network alive, surfacing as a confusing `Failed to remove network ... has active endpoints` warning that masked the real failure.

## Implementation details

- `RunCrashTestAsync` now reports the id through an `onContainerStarted` callback right after the container starts; return type changed from `Task<string>` to `Task`.
- The 4-minute timeout is intentionally left fatal — a crash + report should complete in seconds, so a timeout is genuine signal that the container hung, not CI slowness.

## Test coverage

Covered by the existing artifact smoke tests that exercise the crash-test path.

## Other details

This makes a hanging crash test *diagnosable* (logs are now dumped on failure) but does not change the underlying flakiness — investigating why the container occasionally hangs >4 min is follow-up work.