### PR TITLE
Reduce artifact size by not pre-restoring dd-trace tool

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -6,3 +6,7 @@
 !artifacts/monitoring-home/**
 !artifacts/ProfilerResources/**
 !packages/**
+
+# vcpkg's working dirs land under artifacts/obj/vcpkg during the native build
+# (downloads/, buildtrees/, packages/). They're only needed at native-compile time.
+artifacts/obj/vcpkg/**

--- a/.artifactignore
+++ b/.artifactignore
@@ -6,7 +6,3 @@
 !artifacts/monitoring-home/**
 !artifacts/ProfilerResources/**
 !packages/**
-
-# vcpkg's working dirs land under artifacts/obj/vcpkg during the native build
-# (downloads/, buildtrees/, packages/). They're only needed at native-compile time.
-artifacts/obj/vcpkg/**

--- a/Datadog.Trace.Build.g.sln
+++ b/Datadog.Trace.Build.g.sln
@@ -205,14 +205,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.SourceGenerat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNet.VersionConflict", "tracer\test\test-applications\aspnet\Samples.AspNet.VersionConflict\Samples.AspNet.VersionConflict.csproj", "{FAB2B108-E5BE-4647-869B-1DC5D362252E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner", "tracer\src\Datadog.Trace.Tools.Runner\Datadog.Trace.Tools.Runner.csproj", "{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.IntegrationTests", "tracer\test\Datadog.Trace.Tools.Runner.IntegrationTests\Datadog.Trace.Tools.Runner.IntegrationTests.csproj", "{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.ArtifactTests", "tracer\test\Datadog.Trace.Tools.Runner.ArtifactTests\Datadog.Trace.Tools.Runner.ArtifactTests.csproj", "{8D4DA889-124E-4164-AD90-F9480E43F685}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.Tests", "tracer\test\Datadog.Trace.Tools.Runner.Tests\Datadog.Trace.Tools.Runner.Tests.csproj", "{595BB494-CD26-4A51-8E5B-009219E3F2AE}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Coverage.collector", "tracer\src\Datadog.Trace.Coverage.collector\Datadog.Trace.Coverage.collector.csproj", "{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Security.WebApi", "tracer\test\test-applications\security\aspnet\Samples.Security.WebApi\Samples.Security.WebApi.csproj", "{B02AA609-811D-478B-94CE-D614CCAA687E}"
@@ -236,18 +228,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Security.IntegrationTests", "tracer\test\Datadog.Trace.Security.IntegrationTests\Datadog.Trace.Security.IntegrationTests.csproj", "{E774F1F8-B87C-4082-BD15-04B880B4C016}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Trimming", "tracer\src\Datadog.Trace.Trimming\Datadog.Trace.Trimming.csproj", "{CEAC4ECE-1BFA-4C88-BED5-E4DE054D70A4}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.dd_dotnet", "tracer\src\Datadog.Trace.Tools.dd_dotnet\Datadog.Trace.Tools.dd_dotnet.csproj", "{B28A33A4-C694-4514-BC30-2680605B0B3D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.dd_dotnet.ArtifactTests", "tracer\test\Datadog.Trace.Tools.dd_dotnet.ArtifactTests\Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj", "{604CE6F2-9E90-4D0B-91CB-EBA06880A7D7}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.dd_dotnet.IntegrationTests", "tracer\test\Datadog.Trace.Tools.dd_dotnet.IntegrationTests\Datadog.Trace.Tools.dd_dotnet.IntegrationTests.csproj", "{A9632530-0FB8-4156-BD3C-DD432527768E}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.dd_dotnet.SourceGenerators", "tracer\src\Datadog.Trace.Tools.dd_dotnet.SourceGenerators\Datadog.Trace.Tools.dd_dotnet.SourceGenerators.csproj", "{F594BFBE-1F71-4B3A-BBDA-C4372A6501E9}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Shared", "tracer\src\Datadog.Trace.Tools.Shared\Datadog.Trace.Tools.Shared.csproj", "{7A1B9BFE-052D-435E-B27F-72AF3DDCC0A0}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.dd_dotnet.Tests", "tracer\test\Datadog.Trace.Tools.dd_dotnet.Tests\Datadog.Trace.Tools.dd_dotnet.Tests.csproj", "{4E9535E2-C918-4C39-9F1B-F182C185DE64}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Manual", "tracer\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj", "{D18A4340-268E-4EAA-8603-38EA998EBDF2}"
 EndProject
@@ -425,22 +405,6 @@ Global
 		{FAB2B108-E5BE-4647-869B-1DC5D362252E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FAB2B108-E5BE-4647-869B-1DC5D362252E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAB2B108-E5BE-4647-869B-1DC5D362252E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8D4DA889-124E-4164-AD90-F9480E43F685}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8D4DA889-124E-4164-AD90-F9480E43F685}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8D4DA889-124E-4164-AD90-F9480E43F685}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8D4DA889-124E-4164-AD90-F9480E43F685}.Release|Any CPU.Build.0 = Release|Any CPU
-		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -489,30 +453,6 @@ Global
 		{CEAC4ECE-1BFA-4C88-BED5-E4DE054D70A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CEAC4ECE-1BFA-4C88-BED5-E4DE054D70A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CEAC4ECE-1BFA-4C88-BED5-E4DE054D70A4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B28A33A4-C694-4514-BC30-2680605B0B3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B28A33A4-C694-4514-BC30-2680605B0B3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B28A33A4-C694-4514-BC30-2680605B0B3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B28A33A4-C694-4514-BC30-2680605B0B3D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{604CE6F2-9E90-4D0B-91CB-EBA06880A7D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{604CE6F2-9E90-4D0B-91CB-EBA06880A7D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{604CE6F2-9E90-4D0B-91CB-EBA06880A7D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{604CE6F2-9E90-4D0B-91CB-EBA06880A7D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A9632530-0FB8-4156-BD3C-DD432527768E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A9632530-0FB8-4156-BD3C-DD432527768E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A9632530-0FB8-4156-BD3C-DD432527768E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A9632530-0FB8-4156-BD3C-DD432527768E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F594BFBE-1F71-4B3A-BBDA-C4372A6501E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F594BFBE-1F71-4B3A-BBDA-C4372A6501E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F594BFBE-1F71-4B3A-BBDA-C4372A6501E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F594BFBE-1F71-4B3A-BBDA-C4372A6501E9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7A1B9BFE-052D-435E-B27F-72AF3DDCC0A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7A1B9BFE-052D-435E-B27F-72AF3DDCC0A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7A1B9BFE-052D-435E-B27F-72AF3DDCC0A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7A1B9BFE-052D-435E-B27F-72AF3DDCC0A0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4E9535E2-C918-4C39-9F1B-F182C185DE64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4E9535E2-C918-4C39-9F1B-F182C185DE64}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4E9535E2-C918-4C39-9F1B-F182C185DE64}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4E9535E2-C918-4C39-9F1B-F182C185DE64}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D18A4340-268E-4EAA-8603-38EA998EBDF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D18A4340-268E-4EAA-8603-38EA998EBDF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D18A4340-268E-4EAA-8603-38EA998EBDF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -611,10 +551,6 @@ Global
 		{C49095FE-A186-4DED-8DC1-02CE8A42F56B} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{8D337CD2-9D76-46FE-8AD3-EBDA8F43CD77} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{FAB2B108-E5BE-4647-869B-1DC5D362252E} = {AFA0AB23-64F0-4AC1-9050-6CE8FE06F580}
-		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
-		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC} = {8CEC2042-F11C-49F5-A674-2355793B600A}
-		{8D4DA889-124E-4164-AD90-F9480E43F685} = {8CEC2042-F11C-49F5-A674-2355793B600A}
-		{595BB494-CD26-4A51-8E5B-009219E3F2AE} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{B02AA609-811D-478B-94CE-D614CCAA687E} = {AAFFA51D-1357-4560-97DC-43AD039442E6}
 		{C861221D-9C3B-441F-BBD5-343F49B9DD10} = {AAFFA51D-1357-4560-97DC-43AD039442E6}
@@ -627,12 +563,6 @@ Global
 		{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{E774F1F8-B87C-4082-BD15-04B880B4C016} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{CEAC4ECE-1BFA-4C88-BED5-E4DE054D70A4} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
-		{B28A33A4-C694-4514-BC30-2680605B0B3D} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
-		{604CE6F2-9E90-4D0B-91CB-EBA06880A7D7} = {8CEC2042-F11C-49F5-A674-2355793B600A}
-		{A9632530-0FB8-4156-BD3C-DD432527768E} = {8CEC2042-F11C-49F5-A674-2355793B600A}
-		{F594BFBE-1F71-4B3A-BBDA-C4372A6501E9} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
-		{7A1B9BFE-052D-435E-B27F-72AF3DDCC0A0} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
-		{4E9535E2-C918-4C39-9F1B-F182C185DE64} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{D18A4340-268E-4EAA-8603-38EA998EBDF2} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{A82EB6F8-D8D0-4763-B252-08CA3F39D153} = {AFA0AB23-64F0-4AC1-9050-6CE8FE06F580}
 		{47C1970A-0098-45A2-9D65-7790607D9A68} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -193,10 +193,12 @@ partial class Build
         Solution.GetProject(Projects.FleetInstallerTests),
     };
 
+    // DdTrace/DdDotnet integration tests are looked up in FullSolution because they live outside
+    // Build.g.sln (along with the rest of the Tools.Runner / Tools.dd_dotnet families).
     Project[] ClrProfilerIntegrationTests
         => IsOsx
-               ? new[] { Solution.GetProject(Projects.ClrProfilerIntegrationTests), Solution.GetProject(Projects.AppSecIntegrationTests), Solution.GetProject(Projects.DdTraceIntegrationTests) }
-               : new[] { Solution.GetProject(Projects.ClrProfilerIntegrationTests), Solution.GetProject(Projects.AppSecIntegrationTests), Solution.GetProject(Projects.DdTraceIntegrationTests), Solution.GetProject(Projects.DdDotnetIntegrationTests) };
+               ? new[] { Solution.GetProject(Projects.ClrProfilerIntegrationTests), Solution.GetProject(Projects.AppSecIntegrationTests), FullSolution.GetProject(Projects.DdTraceIntegrationTests) }
+               : new[] { Solution.GetProject(Projects.ClrProfilerIntegrationTests), Solution.GetProject(Projects.AppSecIntegrationTests), FullSolution.GetProject(Projects.DdTraceIntegrationTests), FullSolution.GetProject(Projects.DdDotnetIntegrationTests) };
 
     TargetFramework[] TestingFrameworks => GetTestingFrameworks(Platform, IsArm64);
 
@@ -488,6 +490,8 @@ partial class Build
                 "src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj",     // no code, used to generate nuget package
                 "src/Datadog.AzureFunctions/Datadog.AzureFunctions.csproj", // no code, used to generate nuget package
                 "src/Datadog.Trace.Tools.Runner/*.csproj",
+                "src/Datadog.Trace.Tools.dd_dotnet*/*.csproj",              // dd_dotnet + dd_dotnet.SourceGenerators; built by BuildDdDotnet (analyzer ref pulls in source generators)
+                "src/Datadog.Trace.Tools.Shared/*.csproj",                  // only consumed by tool projects (Runner / dd_dotnet)
                 "src/**/Datadog.InstrumentedAssembly*.csproj",
                 "src/Datadog.AutoInstrumentation.Generator/*.csproj",
                 $"src/{Projects.ManagedLoader}/*.csproj"
@@ -733,13 +737,15 @@ partial class Build
         .Executes(() =>
         {
             // Copy the native files to all the test projects for simplicity.
-            var testProjects = Solution.GetProjects("*Tests")
+            // Use FullSolution so we also copy native files into tool test projects
+            // (Tools.Runner.Tests, Tools.dd_dotnet.Tests, etc.) which live outside Build.g.sln.
+            var testProjects = FullSolution.GetProjects("*Tests")
                                        .Where(p => p.SolutionFolder.Name == "test"
                                                &&  p.Path.ToString().EndsWith(".csproj")); // exclude native test projects
             foreach(var projectName in testProjects)
             {
                 Logger.Information("Copying native files for project {ProjectName}", projectName);
-                var project = Solution.GetProject(projectName);
+                var project = FullSolution.GetProject(projectName);
                 var testDir = project!.Directory;
                 var frameworks = project.GetTargetFrameworks();
 
@@ -1423,7 +1429,22 @@ partial class Build
         .DependsOn(CompileManagedLoader)
         .Executes(() =>
         {
-            DotnetBuild(TracerDirectory.GlobFiles("test/**/*.Tests.csproj"));
+            // Tool unit tests (Tools.Runner.Tests, Tools.dd_dotnet.Tests) live outside Build.g.sln
+            // and aren't covered by the upstream solution-wide Restore. Build them with restore on demand.
+            var allTests = TracerDirectory.GlobFiles("test/**/*.Tests.csproj").ToList();
+            bool IsToolUnitTest(AbsolutePath path) =>
+                ((string)path).Contains(Projects.DdTrace + ".Tests")
+                || ((string)path).Contains(Projects.DdDotnet + ".Tests");
+
+            var toolTests = allTests.Where(IsToolUnitTest).ToList();
+            var otherTests = allTests.Where(p => !IsToolUnitTest(p)).ToList();
+
+            if (toolTests.Count > 0)
+            {
+                DotnetBuild(toolTests, noRestore: false, noDependencies: false);
+            }
+
+            DotnetBuild(otherTests);
         });
 
     Target RunManagedUnitTests => _ => _
@@ -1432,8 +1453,10 @@ partial class Build
         .DependsOn(CleanTestLogs)
         .Executes(() =>
         {
+            // Use FullSolution: tool unit tests (Tools.Runner.Tests, Tools.dd_dotnet.Tests) live
+            // outside Build.g.sln and would resolve to null via Solution.GetProject(...).
             var testProjects = TracerDirectory.GlobFiles("test/**/*.Tests.csproj")
-                .Select(x => Solution.GetProject(x))
+                .Select(x => FullSolution.GetProject(x))
                 .ToList();
 
             testProjects.ForEach(EnsureResultsDirectory);
@@ -1566,7 +1589,8 @@ partial class Build
             var projects = TracerDirectory
                     .GlobFiles("test/*.IntegrationTests/*.csproj")
                     .Where(path => !((string)path).Contains(Projects.DebuggerIntegrationTests))
-                    .Where(project => Solution.GetProject(project).GetTargetFrameworks().Contains(Framework));
+                    // Tool integration test projects live outside Build.g.sln, so resolve via FullSolution.
+                    .Where(project => FullSolution.GetProject(project).GetTargetFrameworks().Contains(Framework));
 
             if (!IsWin)
             {
@@ -1574,7 +1598,24 @@ partial class Build
                                    .Where(path => !((string)path).Contains(Projects.DdDotnetIntegrationTests));
             }
 
-            DotnetBuild(projects, framework: Framework, noRestore: IsWin);
+            // Tool integration tests (DdTrace/DdDotnet) live outside Build.g.sln, so their packages
+            // aren't in the upstream solution-wide restore. Build them with restore enabled.
+            // The other integration tests keep the existing perf optimisation (noRestore on Windows
+            // where the build-stage Restore has already populated the cache).
+            bool IsToolIntegrationTest(AbsolutePath path) =>
+                ((string)path).Contains(Projects.DdTraceIntegrationTests)
+                || ((string)path).Contains(Projects.DdDotnetIntegrationTests);
+
+            var allProjects = projects.ToList();
+            var toolTestProjects = allProjects.Where(IsToolIntegrationTest).ToList();
+            var otherProjects = allProjects.Where(p => !IsToolIntegrationTest(p)).ToList();
+
+            if (toolTestProjects.Count > 0)
+            {
+                DotnetBuild(toolTestProjects, framework: Framework, noRestore: false, noDependencies: false);
+            }
+
+            DotnetBuild(otherProjects, framework: Framework, noRestore: IsWin);
 
             IntegrationTestLinuxOrOsxProfilerDirFudge(Projects.ClrProfilerIntegrationTests);
             IntegrationTestLinuxOrOsxProfilerDirFudge(Projects.AppSecIntegrationTests);
@@ -2143,7 +2184,9 @@ partial class Build
         .Requires(() => MonitoringHomeDirectory != null)
         .Executes(() =>
         {
-            DotnetBuild(Solution.GetProject(Projects.DdDotnetIntegrationTests), noRestore: false);
+            // noDependencies: false so transitive ProjectReferences (Tools.dd_dotnet, Tools.Shared)
+            // are built — they live outside Build.g.sln and weren't built by CompileManagedSrc.
+            DotnetBuild(FullSolution.GetProject(Projects.DdDotnetIntegrationTests), noRestore: false, noDependencies: false);
         });
 
     Target RunLinuxDdDotnetIntegrationTests => _ => _
@@ -2153,7 +2196,7 @@ partial class Build
         .OnlyWhenStatic(() => IsLinux)
         .Executes(() =>
         {
-            var project = Solution.GetProject(Projects.DdTraceIntegrationTests);
+            var project = FullSolution.GetProject(Projects.DdTraceIntegrationTests);
             EnsureResultsDirectory(project);
 
             try
@@ -2208,7 +2251,8 @@ partial class Build
          .After(InstallDdTraceTool)
          .Executes(() =>
           {
-              DotnetBuild(Solution.GetProject(Projects.DdTraceArtifactsTests));
+              // DdTraceArtifactsTests is outside Build.g.sln, so restore on demand.
+              DotnetBuild(FullSolution.GetProject(Projects.DdTraceArtifactsTests), noRestore: false, noDependencies: false);
           });
 
     Target BuildDdDotnetArtifactTests => _ => _
@@ -2217,7 +2261,8 @@ partial class Build
      .Requires(() => Framework)
      .Executes(() =>
      {
-         DotnetBuild(Solution.GetProject(Projects.DdDotnetArtifactsTests), Framework);
+         // DdDotnetArtifactsTests is outside Build.g.sln, so restore on demand.
+         DotnetBuild(FullSolution.GetProject(Projects.DdDotnetArtifactsTests), Framework, noRestore: false, noDependencies: false);
 
          // Compile the required samples
          var sampleProjects = new List<AbsolutePath>
@@ -2252,7 +2297,7 @@ partial class Build
        .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
-            var project = Solution.GetProject(Projects.DdTraceArtifactsTests);
+            var project = FullSolution.GetProject(Projects.DdTraceArtifactsTests);
 
             DotNetTest(config => config
                 .SetProjectFile(project)
@@ -2276,7 +2321,7 @@ partial class Build
            try
            {
                var isDebugRun = IsDebugRun();
-               var project = Solution.GetProject(Projects.DdDotnetArtifactsTests);
+               var project = FullSolution.GetProject(Projects.DdDotnetArtifactsTests);
 
                DotNetTest(config => config
                        .SetProjectFile(project)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -649,10 +649,13 @@ partial class Build
                             var triplet = $"{arch}-windows";
                             // note that the following are all quoted when entered into the vcpkg call itself
                             // this is necessary to support cases where we have a space in the folder name
+                            // Working dirs live under artifacts/deps/vcpkg (alongside the install root) so
+                            // they're outside the .artifactignore include list — without this they were
+                            // landing in build-windows-working-directory (~389 MB / 8.6k files of cache).
                             var installRoot = $@"{BuildArtifactsDirectory}\deps\vcpkg\{triplet}";
-                            var downloads = $@"{BuildArtifactsDirectory}\obj\vcpkg\downloads";
-                            var packages = $@"{BuildArtifactsDirectory}\obj\vcpkg\packages";
-                            var buildTrees = $@"{BuildArtifactsDirectory}\obj\vcpkg\buildtrees";
+                            var downloads = $@"{BuildArtifactsDirectory}\deps\vcpkg\downloads";
+                            var packages = $@"{BuildArtifactsDirectory}\deps\vcpkg\packages";
+                            var buildTrees = $@"{BuildArtifactsDirectory}\deps\vcpkg\buildtrees";
 
                             const int maxRetries = 3;
 

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -564,17 +564,24 @@ partial class Build
 
                     samplesSln.Save();
 
-                    // Create a copy of the "full solution" containing everything EXCEPT the standalone test-application projects.
-                    // This is the inverse of Samples.g.sln; together they cover the full project graph with zero overlap.
-                    // It is the default Nuke Solution used by CI/build targets — restoring it does not pull in sample-only NuGet
-                    // dependencies (MongoDB, Elasticsearch, etc.), which dominate the local packages folder shipped via working-directory artifacts.
+                    // Create a copy of the "full solution" containing everything EXCEPT:
+                    //  - standalone test-application projects (covered by Samples.g.sln, see IsTestApplication)
+                    //  - the Datadog.Trace.Tools.Runner / Tools.dd_dotnet families and Tools.Shared (see IsToolProject)
+                    // The tool projects are NOT compiled by the upstream tracer build (CompileManagedSrc in Build.Steps.cs
+                    // explicitly excludes them); they're built later by dedicated Nuke targets (BuildRunnerTool,
+                    // PackRunnerToolNuget, BuildStandaloneTool, BuildDdDotnet, ...) which look the projects up via
+                    // FullSolution.GetProject(...). Keeping them out of Build.g.sln means the upstream solution-wide
+                    // Restore doesn't pull in their (large) multi-RID / multi-TFM dependencies — runtime packs,
+                    // ASP.NET / Windows-desktop runtime, and reference assemblies for older TFMs.
+                    // Tool projects are intentionally in neither Build.g.sln nor Samples.g.sln; the FullSolution
+                    // (Datadog.Trace.sln) remains the source of truth for them.
                     var buildSln = ProjectModelTasks.CreateSolution(
                         fileName: RootDirectory / "Datadog.Trace.Build.g.sln",
                         solutions: new[] { FullSolution },
                         randomizeProjectIds: false);
 
                     buildSln.AllProjects
-                       .Where(IsTestApplication)
+                       .Where(x => IsTestApplication(x) || IsToolProject(x))
                        .ForEach(x =>
                         {
                             Logger.Information("Build sln: removing project '{Name}'", x.Name);
@@ -582,6 +589,18 @@ partial class Build
                         });
 
                     buildSln.Save();
+
+                    bool IsToolProject(Project x) =>
+                        x.Name is "Datadog.Trace.Tools.Runner"
+                            or "Datadog.Trace.Tools.Runner.Tests"
+                            or "Datadog.Trace.Tools.Runner.IntegrationTests"
+                            or "Datadog.Trace.Tools.Runner.ArtifactTests"
+                            or "Datadog.Trace.Tools.dd_dotnet"
+                            or "Datadog.Trace.Tools.dd_dotnet.Tests"
+                            or "Datadog.Trace.Tools.dd_dotnet.IntegrationTests"
+                            or "Datadog.Trace.Tools.dd_dotnet.ArtifactTests"
+                            or "Datadog.Trace.Tools.dd_dotnet.SourceGenerators"
+                            or "Datadog.Trace.Tools.Shared";
 
                     bool IsTestApplication(Project x)
                     {

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -443,8 +443,10 @@ partial class Build : NukeBuild
             // So we publish to a different folder than copy only the executable
             var publishFolder = ArtifactsDirectory / "dd-dotnet" / rid;
 
+            // Look up the tool project via FullSolution: it lives outside Build.g.sln so the upstream
+            // solution-wide Restore doesn't pull in its runtime packs; this target restores on demand.
             DotNetPublish(x => x
-                .SetProject(Solution.GetProject(Projects.DdDotnet))
+                .SetProject(FullSolution.GetProject(Projects.DdDotnet))
                 .SetFramework(framework)
                 .SetNoWarnDotNetCore3()
                 .SetRuntime(rid)
@@ -461,10 +463,11 @@ partial class Build : NukeBuild
         .After(CreateBundleHome, ExtractDebugInfoLinux)
         .Executes(() =>
         {
+            // Look up the tool project via FullSolution: it lives outside Build.g.sln so the upstream
+            // solution-wide Restore doesn't pull in its (large multi-TFM) dependencies. This target
+            // therefore allows restore + ProjectReference resolution to run here.
             DotNetBuild(x => x
-                .SetProjectFile(Solution.GetProject(Projects.DdTrace))
-                .EnableNoRestore()
-                .EnableNoDependencies()
+                .SetProjectFile(FullSolution.GetProject(Projects.DdTrace))
                 .SetConfiguration(BuildConfiguration)
                 .SetNoWarnDotNetCore3()
                 .SetDDEnvironmentVariables("dd-trace-dotnet-runner-tool")
@@ -479,7 +482,7 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             DotNetPack(x => x
-                .SetProject(Solution.GetProject(Projects.DdTrace))
+                .SetProject(FullSolution.GetProject(Projects.DdTrace))
                 .SetConfiguration(BuildConfiguration)
                 .EnableNoDependencies()
                 .EnableNoBuild()
@@ -514,7 +517,7 @@ partial class Build : NukeBuild
             runtimes.ForEach(runtime => DeleteFile(runtime.archive));
 
             DotNetPublish(x => x
-                .SetProject(Solution.GetProject(Projects.DdTrace))
+                .SetProject(FullSolution.GetProject(Projects.DdTrace))
                 // Have to do a restore currently as we're specifying specific runtime
                 // .EnableNoRestore()
                 .EnableNoDependencies()


### PR DESCRIPTION
## Summary of changes

Reduce the size of the working directory build artifacts, by delaying restore for some projects.

## Reason for change

The `dd-trace` and `dd-dotnet` tools build for many platforms, and do native AOT and various other builds, which require a bunch of extra packages that aren't used by any other projects. By delaying the restore of those projects, we reduce the size of the working directory that needs to be copied between all subsequent stages 

## Implementation details

- Remove the "tools" projects from the `Build.g.sln` solution file, which is used for initial build and restore.. They remain in the "full" solution.
- Update places that build the tool to use the full solution, and to not use `--no-restore` (to 
- Exclude vcpkg assets from the working directory. These are only needed in the native build stage, so don't need carrying through to other stages


## Test coverage

Covered by existing tests. Checking the artifact sizes, we get a decent reduction:

| Artifact                                 | baseline | This PR |                  delta |
| ---------------------------------------- | ----------------: | -----------------: | ---------------------: |
| build-linux-arm64-r2r-working-directory  |          3,785 MB |           3,121 MB |       −664 MB (−17.5%) |
| build-linux-arm64-working-directory      |          3,765 MB |           3,101 MB |       −664 MB (−17.6%) |
| build-linux-musl-arm64-working-directory |          3,761 MB |           3,099 MB |       −661 MB (−17.6%) |
| build-linux-musl-x64-working-directory   |          3,763 MB |           3,104 MB |       −659 MB (−17.5%) |
| build-linux-x64-r2r-working-directory    |          3,786 MB |           3,121 MB |       −665 MB (−17.6%) |
| build-linux-x64-working-directory        |          3,772 MB |           3,106 MB |       −665 MB (−17.6%) |
| build-macos-working-directory            |          3,151 MB |           3,099 MB |         −52 MB (−1.6%) |
| build-windows-working-directory          |          4,828 MB |           3,685 MB |      −1,143 MB (−23.7%) |
| **TOTAL**                                |     **30,610 MB** |      **26,214 MB** | **−5,174 MB (−16.9%)** |


## Other details

It's a decent reduction, but I'm not _entirely_ sold that the added complexity makes this worth it. I'm open to vibes one-way-or-another...

One "annoying" thing is that we reference (for example) the AWS SDK in our unit test projects, and those packages are _hundreds_ of MB, so reducing the base further means restricting the build of those test projects to the test stages, but that's _more_ complexity (and we'd have to manage he dependency build order ourselves, which is the opposite direction to the way I'd like to go 😅 

Another alternative is that we
- Cache/bake the package versions into the VM
- Stop copying the packages between stages
- Do a restore at the start of _every_ stage...


I'm not even sure that will work, and if it does, I'm not sure it's _better_ to do 100 restores instead of 1 😅 