### PR TITLE
[Debugger] Improve debugger collection serialization

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.CollectionDescriptors.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.CollectionDescriptors.cs
@@ -1,0 +1,234 @@
+// <copyright file="DebuggerSnapshotSerializer.CollectionDescriptors.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Utilities;
+
+namespace Datadog.Trace.Debugger.Snapshots
+{
+    internal static partial class DebuggerSnapshotSerializer
+    {
+        // Cache only supported descriptors. If the cache fills up, additional supported types still
+        // serialize correctly but rebuild their descriptor; unsupported IEnumerable types are never cached.
+        private const int MaxSupportedEnumerableDescriptorCacheSize = 64;
+
+        // Dictionary entry descriptors are only requested while serializing supported dictionaries.
+        // If the cache fills up, entries still serialize correctly but rebuild their descriptor.
+        private const int MaxDictionaryEntryDescriptorCacheSize = 64;
+
+        private static readonly object SupportedEnumerableDescriptorCacheLock = new();
+        private static readonly object DictionaryEntryDescriptorCacheLock = new();
+
+        private static SupportedEnumerableDescriptor[] _supportedEnumerableDescriptors = [];
+        private static DictionaryEntryDescriptor[] _dictionaryEntryDescriptors = [];
+
+        private static DictionaryEntryDescriptor GetDictionaryEntryDescriptor(Type runtimeType)
+        {
+            var descriptors = Volatile.Read(ref _dictionaryEntryDescriptors);
+            for (var i = 0; i < descriptors.Length; i++)
+            {
+                if (descriptors[i].RuntimeType == runtimeType)
+                {
+                    return descriptors[i];
+                }
+            }
+
+            lock (DictionaryEntryDescriptorCacheLock)
+            {
+                descriptors = _dictionaryEntryDescriptors;
+                for (var i = 0; i < descriptors.Length; i++)
+                {
+                    if (descriptors[i].RuntimeType == runtimeType)
+                    {
+                        return descriptors[i];
+                    }
+                }
+
+                var descriptor = CreateDictionaryEntryDescriptor(runtimeType);
+                if (descriptors.Length < MaxDictionaryEntryDescriptorCacheSize)
+                {
+                    var newDescriptors = new DictionaryEntryDescriptor[descriptors.Length + 1];
+                    Array.Copy(descriptors, newDescriptors, descriptors.Length);
+                    newDescriptors[descriptors.Length] = descriptor;
+                    Volatile.Write(ref _dictionaryEntryDescriptors, newDescriptors);
+                }
+
+                return descriptor;
+            }
+        }
+
+        private static DictionaryEntryDescriptor CreateDictionaryEntryDescriptor(Type runtimeType)
+        {
+            var reflectionObject = ReflectionObject.Create(runtimeType, "Key", "Value");
+            return new DictionaryEntryDescriptor(
+                runtimeType,
+                reflectionObject,
+                reflectionObject.GetType("Key"),
+                reflectionObject.GetType("Value"));
+        }
+
+        private static bool TryGetSupportedEnumerableInfo(
+            object source,
+            out SupportedEnumerableInfo enumerableInfo)
+        {
+            var runtimeType = source.GetType();
+
+            if (source is ICollection collection)
+            {
+                var isDictionary = Redaction.IsSupportedDictionary(runtimeType);
+                if (!isDictionary && !Redaction.IsSupportedCollection(runtimeType))
+                {
+                    enumerableInfo = default;
+                    return false;
+                }
+
+                enumerableInfo = new SupportedEnumerableInfo(collection.Count, isDictionary);
+                return true;
+            }
+
+            if (!TryGetSupportedEnumerableDescriptor(runtimeType, out var descriptor))
+            {
+                enumerableInfo = default;
+                return false;
+            }
+
+            enumerableInfo = new SupportedEnumerableInfo(descriptor.GetCount(source), descriptor.IsDictionary);
+            return true;
+        }
+
+        private static bool TryGetSupportedEnumerableDescriptor(Type runtimeType, out SupportedEnumerableDescriptor descriptor)
+        {
+            var descriptors = Volatile.Read(ref _supportedEnumerableDescriptors);
+            for (var i = 0; i < descriptors.Length; i++)
+            {
+                if (descriptors[i].RuntimeType == runtimeType)
+                {
+                    descriptor = descriptors[i];
+                    return true;
+                }
+            }
+
+            lock (SupportedEnumerableDescriptorCacheLock)
+            {
+                descriptors = _supportedEnumerableDescriptors;
+                for (var i = 0; i < descriptors.Length; i++)
+                {
+                    if (descriptors[i].RuntimeType == runtimeType)
+                    {
+                        descriptor = descriptors[i];
+                        return true;
+                    }
+                }
+
+                descriptor = CreateSupportedEnumerableDescriptor(runtimeType);
+                if (!descriptor.IsSupported)
+                {
+                    return false;
+                }
+
+                if (descriptors.Length < MaxSupportedEnumerableDescriptorCacheSize)
+                {
+                    var newDescriptors = new SupportedEnumerableDescriptor[descriptors.Length + 1];
+                    Array.Copy(descriptors, newDescriptors, descriptors.Length);
+                    newDescriptors[descriptors.Length] = descriptor;
+                    Volatile.Write(ref _supportedEnumerableDescriptors, newDescriptors);
+                }
+            }
+
+            return true;
+        }
+
+        private static SupportedEnumerableDescriptor CreateSupportedEnumerableDescriptor(Type runtimeType)
+        {
+            var isDictionary = Redaction.IsSupportedDictionary(runtimeType);
+            if (!isDictionary && !Redaction.IsSupportedCollection(runtimeType))
+            {
+                return SupportedEnumerableDescriptor.NotSupported;
+            }
+
+            var countProperty = runtimeType.GetProperty(nameof(ICollection.Count));
+            if (countProperty == null || countProperty.PropertyType != typeof(int))
+            {
+                return SupportedEnumerableDescriptor.NotSupported;
+            }
+
+            return new SupportedEnumerableDescriptor(runtimeType, CreateCountAccessor(runtimeType, countProperty), isDictionary);
+        }
+
+        private static Func<object, int> CreateCountAccessor(Type runtimeType, PropertyInfo countProperty)
+        {
+            var sourceParameter = Expression.Parameter(typeof(object), "source");
+            var castSource = Expression.Convert(sourceParameter, runtimeType);
+            var count = Expression.Property(castSource, countProperty);
+            return Expression.Lambda<Func<object, int>>(count, sourceParameter).Compile();
+        }
+
+        private readonly struct SupportedEnumerableInfo
+        {
+            internal SupportedEnumerableInfo(int count, bool isDictionary)
+            {
+                Count = count;
+                IsDictionary = isDictionary;
+            }
+
+            internal int Count { get; }
+
+            internal bool IsDictionary { get; }
+        }
+
+        private readonly struct SupportedEnumerableDescriptor
+        {
+            internal static readonly SupportedEnumerableDescriptor NotSupported = new(null, null, isDictionary: false);
+
+            private readonly Func<object, int> _getCount;
+
+            internal SupportedEnumerableDescriptor(Type runtimeType, Func<object, int> getCount, bool isDictionary)
+            {
+                RuntimeType = runtimeType;
+                _getCount = getCount;
+                IsDictionary = isDictionary;
+            }
+
+            internal Type RuntimeType { get; }
+
+            internal bool IsSupported => _getCount != null;
+
+            internal bool IsDictionary { get; }
+
+            internal int GetCount(object source) => _getCount(source);
+        }
+
+        private readonly struct DictionaryEntryDescriptor
+        {
+            private readonly ReflectionObject _reflectionObject;
+
+            internal DictionaryEntryDescriptor(
+                Type runtimeType,
+                ReflectionObject reflectionObject,
+                Type keyType,
+                Type valueType)
+            {
+                RuntimeType = runtimeType;
+                _reflectionObject = reflectionObject;
+                KeyType = keyType;
+                ValueType = valueType;
+            }
+
+            internal Type RuntimeType { get; }
+
+            internal Type KeyType { get; }
+
+            internal Type ValueType { get; }
+
+            internal object GetKey(object source) => _reflectionObject.GetValue(source, "Key");
+
+            internal object GetValue(object source) => _reflectionObject.GetValue(source, "Value");
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.CollectionDescriptors.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.CollectionDescriptors.cs
@@ -10,6 +10,8 @@ using System.Reflection;
 using System.Threading;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Utilities;
 
+#nullable enable
+
 namespace Datadog.Trace.Debugger.Snapshots
 {
     internal static partial class DebuggerSnapshotSerializer
@@ -186,22 +188,22 @@ namespace Datadog.Trace.Debugger.Snapshots
         {
             internal static readonly SupportedEnumerableDescriptor NotSupported = new(null, null, isDictionary: false);
 
-            private readonly Func<object, int> _getCount;
+            private readonly Func<object, int>? _getCount;
 
-            internal SupportedEnumerableDescriptor(Type runtimeType, Func<object, int> getCount, bool isDictionary)
+            internal SupportedEnumerableDescriptor(Type? runtimeType, Func<object, int>? getCount, bool isDictionary)
             {
                 RuntimeType = runtimeType;
                 _getCount = getCount;
                 IsDictionary = isDictionary;
             }
 
-            internal Type RuntimeType { get; }
+            internal Type? RuntimeType { get; }
 
             internal bool IsSupported => _getCount != null;
 
             internal bool IsDictionary { get; }
 
-            internal int GetCount(object source) => _getCount(source);
+            internal int GetCount(object source) => _getCount!(source);
         }
 
         private readonly struct DictionaryEntryDescriptor
@@ -226,9 +228,9 @@ namespace Datadog.Trace.Debugger.Snapshots
 
             internal Type ValueType { get; }
 
-            internal object GetKey(object source) => _reflectionObject.GetValue(source, "Key");
+            internal object? GetKey(object source) => _reflectionObject.GetValue(source, "Key");
 
-            internal object GetValue(object source) => _reflectionObject.GetValue(source, "Value");
+            internal object? GetValue(object source) => _reflectionObject.GetValue(source, "Value");
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.CollectionDescriptors.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.CollectionDescriptors.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Utilities;
 
 #nullable enable
@@ -27,12 +26,12 @@ namespace Datadog.Trace.Debugger.Snapshots
         private static readonly object SupportedEnumerableDescriptorCacheLock = new();
         private static readonly object DictionaryEntryDescriptorCacheLock = new();
 
-        private static SupportedEnumerableDescriptor[] _supportedEnumerableDescriptors = [];
-        private static DictionaryEntryDescriptor[] _dictionaryEntryDescriptors = [];
+        private static volatile SupportedEnumerableDescriptor[] _supportedEnumerableDescriptors = [];
+        private static volatile DictionaryEntryDescriptor[] _dictionaryEntryDescriptors = [];
 
         private static DictionaryEntryDescriptor GetDictionaryEntryDescriptor(Type runtimeType)
         {
-            var descriptors = Volatile.Read(ref _dictionaryEntryDescriptors);
+            var descriptors = _dictionaryEntryDescriptors;
             for (var i = 0; i < descriptors.Length; i++)
             {
                 if (descriptors[i].RuntimeType == runtimeType)
@@ -58,7 +57,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                     var newDescriptors = new DictionaryEntryDescriptor[descriptors.Length + 1];
                     Array.Copy(descriptors, newDescriptors, descriptors.Length);
                     newDescriptors[descriptors.Length] = descriptor;
-                    Volatile.Write(ref _dictionaryEntryDescriptors, newDescriptors);
+                    _dictionaryEntryDescriptors = newDescriptors;
                 }
 
                 return descriptor;
@@ -106,7 +105,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         private static bool TryGetSupportedEnumerableDescriptor(Type runtimeType, out SupportedEnumerableDescriptor descriptor)
         {
-            var descriptors = Volatile.Read(ref _supportedEnumerableDescriptors);
+            var descriptors = _supportedEnumerableDescriptors;
             for (var i = 0; i < descriptors.Length; i++)
             {
                 if (descriptors[i].RuntimeType == runtimeType)
@@ -139,7 +138,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                     var newDescriptors = new SupportedEnumerableDescriptor[descriptors.Length + 1];
                     Array.Copy(descriptors, newDescriptors, descriptors.Length);
                     newDescriptors[descriptors.Length] = descriptor;
-                    Volatile.Write(ref _supportedEnumerableDescriptors, newDescriptors);
+                    _supportedEnumerableDescriptors = newDescriptors;
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -94,8 +94,8 @@ namespace Datadog.Trace.Debugger.Snapshots
                     return true;
                 }
 
-                if (source is IEnumerable enumerable && (Redaction.IsSupportedCollection(source) ||
-                                                         Redaction.IsSupportedDictionary(source)))
+                if (source is IEnumerable enumerable &&
+                    TryGetSupportedEnumerableInfo(source, out var enumerableInfo))
                 {
                     if (variableName != null)
                     {
@@ -103,7 +103,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                     }
 
                     jsonWriter.WriteStartObject();
-                    SerializeEnumerable(source, type, jsonWriter, enumerable, currentDepth, cts, limitInfo, collectionsBeingSerialized);
+                    SerializeEnumerable(source, type, jsonWriter, enumerable, enumerableInfo, currentDepth, cts, limitInfo, collectionsBeingSerialized);
                     jsonWriter.WriteEndObject();
 
                     return true;
@@ -298,24 +298,19 @@ namespace Datadog.Trace.Debugger.Snapshots
             Type type,
             JsonWriter jsonWriter,
             IEnumerable enumerable,
+            SupportedEnumerableInfo enumerableInfo,
             int currentDepth,
             CancellationTokenSource cts,
             CaptureLimitInfo limitInfo,
             HashSet<object> collectionsBeingSerialized)
         {
-            if (source is not ICollection collection)
-            {
-                return;
-            }
-
             if (currentDepth >= limitInfo.MaxReferenceDepth)
             {
-                var isDictionary = Redaction.IsSupportedDictionary(source);
                 jsonWriter.WritePropertyName("type");
                 jsonWriter.WriteValue(type.Name);
                 jsonWriter.WritePropertyName("size");
-                jsonWriter.WriteValue(collection.Count);
-                jsonWriter.WritePropertyName(isDictionary ? "entries" : "elements");
+                jsonWriter.WriteValue(enumerableInfo.Count);
+                jsonWriter.WritePropertyName(enumerableInfo.IsDictionary ? "entries" : "elements");
                 jsonWriter.WriteStartArray();
                 jsonWriter.WriteEndArray();
                 WriteNotCapturedReason(jsonWriter, NotCapturedReason.depth);
@@ -324,12 +319,11 @@ namespace Datadog.Trace.Debugger.Snapshots
 
             if (!collectionsBeingSerialized.Add(source))
             {
-                var isDictionary = Redaction.IsSupportedDictionary(source);
                 jsonWriter.WritePropertyName("type");
                 jsonWriter.WriteValue(type.Name);
                 jsonWriter.WritePropertyName("size");
-                jsonWriter.WriteValue(collection.Count);
-                jsonWriter.WritePropertyName(isDictionary ? "entries" : "elements");
+                jsonWriter.WriteValue(enumerableInfo.Count);
+                jsonWriter.WritePropertyName(enumerableInfo.IsDictionary ? "entries" : "elements");
                 jsonWriter.WriteStartArray();
                 jsonWriter.WriteEndArray();
                 WriteNotCapturedReason(jsonWriter, NotCapturedReason.depth);
@@ -341,13 +335,12 @@ namespace Datadog.Trace.Debugger.Snapshots
             NotCapturedReason? notCapturedReason = null;
             try
             {
-                var isDictionary = Redaction.IsSupportedDictionary(source);
-                var collectionCount = collection.Count;
+                var collectionCount = enumerableInfo.Count;
                 jsonWriter.WritePropertyName("type");
                 jsonWriter.WriteValue(type.Name);
                 jsonWriter.WritePropertyName("size");
                 jsonWriter.WriteValue(collectionCount);
-                jsonWriter.WritePropertyName(isDictionary ? "entries" : "elements");
+                jsonWriter.WritePropertyName(enumerableInfo.IsDictionary ? "entries" : "elements");
                 jsonWriter.WriteStartArray();
                 arrayOpened = true;
 
@@ -398,7 +391,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                     }
 
                     bool serialized;
-                    if (isDictionary)
+                    if (enumerableInfo.IsDictionary)
                     {
                         serialized = SerializeKeyValuePair(current, jsonWriter, cts, currentDepth, limitInfo, collectionsBeingSerialized);
                     }
@@ -483,14 +476,19 @@ namespace Datadog.Trace.Debugger.Snapshots
             CaptureLimitInfo limitInfo,
             HashSet<object> collectionsBeingSerialized)
         {
-            var reflectionObject = ReflectionObject.Create(current.GetType(), "Key", "Value");
+            var descriptor = GetDictionaryEntryDescriptor(current.GetType());
             jsonWriter.WriteStartArray();
 
-            bool serializedKey = SerializeInternal(reflectionObject.GetValue(current, "Key"), reflectionObject.GetType("Key"), jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
-            bool serializedValue = SerializeInternal(reflectionObject.GetValue(current, "Value"), reflectionObject.GetType("Value"), jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
+            var key = descriptor.GetKey(current);
+            var keyType = key?.GetType() ?? descriptor.KeyType;
+            var value = descriptor.GetValue(current);
+            var valueType = value?.GetType() ?? descriptor.ValueType;
+
+            bool serializedKey = SerializeInternal(key, keyType, jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
+            bool serializedValue = SerializeInternal(value, valueType, jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
 
             jsonWriter.WriteEndArray();
-            return serializedKey;
+            return serializedKey && serializedValue;
         }
 
         private static void WriteNotCapturedReason(JsonWriter writer, NotCapturedReason notCapturedReason)

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -39,8 +39,6 @@ namespace Datadog.Trace.Debugger.Snapshots
             typeof(List<>),
             typeof(ArrayList),
             typeof(LinkedList<>),
-            typeof(SortedList),
-            typeof(SortedList<,>),
             typeof(Stack),
             typeof(Stack<>),
             typeof(ConcurrentStack<>),
@@ -50,13 +48,14 @@ namespace Datadog.Trace.Debugger.Snapshots
             typeof(HashSet<>),
             typeof(SortedSet<>),
             typeof(ConcurrentBag<>),
-            typeof(BlockingCollection<>),
-            typeof(ConditionalWeakTable<,>)
+            typeof(BlockingCollection<>)
         ];
 
         private static readonly Type[] AllowedDictionaryTypes =
         [
             typeof(Dictionary<,>),
+            typeof(SortedList),
+            typeof(SortedList<,>),
             typeof(SortedDictionary<,>),
             typeof(ConcurrentDictionary<,>),
             typeof(Hashtable)
@@ -201,7 +200,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
 
             return TypeExtensions.IsSimple(effectiveType) ||
-                   AllowedTypesSafeToCallToString.Contains(effectiveType);
+                   IsAllowedTypeSafeToCallToString(effectiveType);
         }
 
         internal static bool IsSupportedDictionary(object? o)
@@ -211,8 +210,17 @@ namespace Datadog.Trace.Debugger.Snapshots
                 return false;
             }
 
-            var type = o.GetType();
-            return AllowedDictionaryTypes.Any(whiteType => whiteType == type || (type.IsGenericType && whiteType == type.GetGenericTypeDefinition()));
+            return IsSupportedDictionary(o.GetType());
+        }
+
+        internal static bool IsSupportedDictionary(Type? type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            return IsSupportedType(type, AllowedDictionaryTypes);
         }
 
         internal static bool IsSupportedCollection(object? o)
@@ -237,8 +245,54 @@ namespace Datadog.Trace.Debugger.Snapshots
                 return true;
             }
 
-            return AllowedCollectionTypes.Any(whiteType => whiteType == type || (type.IsGenericType && whiteType == type.GetGenericTypeDefinition())) ||
-                   AllowedSpecialCasedCollectionTypeNames.Any(white => white.Equals(type.Name, StringComparison.OrdinalIgnoreCase));
+            if (IsSupportedType(type, AllowedCollectionTypes))
+            {
+                return true;
+            }
+
+            for (var i = 0; i < AllowedSpecialCasedCollectionTypeNames.Length; i++)
+            {
+                if (AllowedSpecialCasedCollectionTypeNames[i].Equals(type.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsSupportedType(Type type, Type[] allowedTypes)
+        {
+            Type? genericDefinition = null;
+            if (type.IsGenericType)
+            {
+                genericDefinition = type.GetGenericTypeDefinition();
+            }
+
+            for (var i = 0; i < allowedTypes.Length; i++)
+            {
+                var allowedType = allowedTypes[i];
+                if (allowedType == type ||
+                    (genericDefinition != null && allowedType == genericDefinition))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsAllowedTypeSafeToCallToString(Type type)
+        {
+            for (var i = 0; i < AllowedTypesSafeToCallToString.Length; i++)
+            {
+                if (AllowedTypesSafeToCallToString[i] == type)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal bool IsRedactedType(Type? type)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -567,6 +567,11 @@ namespace Datadog.Trace.Tests.Debugger
             {
                 var serializeEnumerable = typeof(DebuggerSnapshotSerializer).GetMethod("SerializeEnumerable", BindingFlags.NonPublic | BindingFlags.Static);
                 Assert.NotNull(serializeEnumerable);
+                var enumerableInfoType = typeof(DebuggerSnapshotSerializer).GetNestedType("SupportedEnumerableInfo", BindingFlags.NonPublic);
+                Assert.NotNull(enumerableInfoType);
+                var enumerableInfoConstructor = enumerableInfoType!.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, binder: null, types: [typeof(int), typeof(bool)], modifiers: null);
+                Assert.NotNull(enumerableInfoConstructor);
+                var enumerableInfo = enumerableInfoConstructor!.Invoke([collection.Count, false]);
 
                 var limitInfo = new CaptureLimitInfo(
                     MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
@@ -584,6 +589,7 @@ namespace Datadog.Trace.Tests.Debugger
                         collection.GetType(),
                         jsonWriter,
                         collection,
+                        enumerableInfo,
                         0,
                         cts,
                         limitInfo,

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -5,9 +5,11 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,6 +32,26 @@ namespace Datadog.Trace.Tests.Debugger
     [UsesVerify]
     public class DebuggerSnapshotCreatorTests(ITestOutputHelper output)
     {
+        public static IEnumerable<object[]> SupportedCollectionSamples()
+        {
+            yield return [new List<int> { 1 }, "List`1", 1];
+            yield return [new[] { 1 }, "Int32[]", 1];
+            yield return [new Queue<int>(new[] { 1 }), "Queue`1", 1];
+            yield return [new Stack<int>(new[] { 1 }), "Stack`1", 1];
+            yield return [new ConcurrentQueue<int>(new[] { 1 }), "ConcurrentQueue`1", 1];
+            yield return [new ConcurrentBag<int>(new[] { 1 }), "ConcurrentBag`1", 1];
+            yield return [new BlockingCollection<int>(new ConcurrentQueue<int>(new[] { 1 })), "BlockingCollection`1", 1];
+            yield return [new SortedSet<int> { 1 }, "SortedSet`1", 1];
+        }
+
+        public static IEnumerable<object[]> SupportedDictionarySamples()
+        {
+            yield return [new Dictionary<string, int> { { "one", 1 } }, "Dictionary`2", 1];
+            yield return [new SortedDictionary<string, int> { { "one", 1 } }, "SortedDictionary`2", 1];
+            yield return [new ConcurrentDictionary<string, int>(new[] { new KeyValuePair<string, int>("one", 1) }), "ConcurrentDictionary`2", 1];
+            yield return [new Hashtable { { "one", 1 } }, "Hashtable", 1];
+        }
+
         [Fact]
         public async Task Limits_LargeCollection()
         {
@@ -164,6 +186,91 @@ namespace Datadog.Trace.Tests.Debugger
         public async Task ObjectStructure_EmptyList()
         {
             await ValidateSingleValue(new List<int>());
+        }
+
+        [Fact]
+        public void ObjectStructure_HashSet()
+        {
+            var local = GetLocalToken(new HashSet<int> { 1, 2 });
+
+            Assert.Equal("HashSet`1", local["type"]?.Value<string>());
+            Assert.Equal(2, local["size"]?.Value<int>());
+            Assert.Null(local["entries"]);
+
+            var elements = local["elements"] as JArray;
+            Assert.NotNull(elements);
+            Assert.Equal(2, elements!.Count);
+            Assert.Equal(new[] { 1, 2 }, elements.Select(e => e["value"]!.Value<int>()).OrderBy(i => i).ToArray());
+        }
+
+        [Theory]
+        [MemberData(nameof(SupportedCollectionSamples))]
+        public void ObjectStructure_SupportedCollections(object collection, string expectedType, int expectedSize)
+        {
+            var local = GetLocalToken(collection);
+
+            Assert.Equal(expectedType, local["type"]?.Value<string>());
+            Assert.Equal(expectedSize, local["size"]?.Value<int>());
+            Assert.NotNull(local["elements"]);
+            Assert.Null(local["entries"]);
+        }
+
+        [Theory]
+        [MemberData(nameof(SupportedDictionarySamples))]
+        public void ObjectStructure_SupportedDictionaries(object dictionary, string expectedType, int expectedSize)
+        {
+            var local = GetLocalToken(dictionary);
+
+            Assert.Equal(expectedType, local["type"]?.Value<string>());
+            Assert.Equal(expectedSize, local["size"]?.Value<int>());
+            Assert.NotNull(local["entries"]);
+            Assert.Null(local["elements"]);
+        }
+
+        [Fact]
+        public void ObjectStructure_SortedList_IsSerializedAsDictionary()
+        {
+            var local = GetLocalToken(new SortedList { { "one", 1 }, { "two", 2 } });
+
+            Assert.Equal("SortedList", local["type"]?.Value<string>());
+            Assert.Equal(2, local["size"]?.Value<int>());
+            Assert.Null(local["elements"]);
+
+            var entries = local["entries"] as JArray;
+            Assert.NotNull(entries);
+            Assert.Equal(2, entries!.Count);
+            Assert.Contains(entries, entry => entry[0]?["value"]?.Value<string>() == "one" && entry[1]?["value"]?.Value<int>() == 1);
+            Assert.Contains(entries, entry => entry[0]?["value"]?.Value<string>() == "two" && entry[1]?["value"]?.Value<int>() == 2);
+        }
+
+        [Fact]
+        public void ObjectStructure_GenericSortedList_IsSerializedAsDictionary()
+        {
+            var local = GetLocalToken(new SortedList<string, int> { { "one", 1 }, { "two", 2 } });
+
+            Assert.Equal("SortedList`2", local["type"]?.Value<string>());
+            Assert.Equal(2, local["size"]?.Value<int>());
+            Assert.Null(local["elements"]);
+
+            var entries = local["entries"] as JArray;
+            Assert.NotNull(entries);
+            Assert.Equal(2, entries!.Count);
+            Assert.Contains(entries, entry => entry[0]?["value"]?.Value<string>() == "one" && entry[1]?["value"]?.Value<int>() == 1);
+            Assert.Contains(entries, entry => entry[0]?["value"]?.Value<string>() == "two" && entry[1]?["value"]?.Value<int>() == 2);
+        }
+
+        [Fact]
+        public void ObjectStructure_ConditionalWeakTable_IsNotSupportedCollection()
+        {
+            var table = new ConditionalWeakTable<object, object>();
+            table.Add(new object(), new object());
+
+            var local = GetLocalToken(table);
+
+            Assert.Equal("ConditionalWeakTable`2", local["type"]?.Value<string>());
+            Assert.Null(local["size"]);
+            Assert.Null(local["elements"]);
+            Assert.Null(local["entries"]);
         }
 
         [Fact]
@@ -439,6 +546,12 @@ namespace Datadog.Trace.Tests.Debugger
             verifierSettings.ScrubLinesContaining(new[] { "id", "timestamp", "duration" });
             var localVariableAsJson = JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return.locals");
             await Verifier.Verify(localVariableAsJson, verifierSettings);
+        }
+
+        private static JToken GetLocalToken(object local)
+        {
+            var snapshot = SnapshotHelper.GenerateSnapshot(local, prettify: false);
+            return JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return.locals.local0");
         }
 
         private static void DummyMethod()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -228,6 +228,30 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ObjectStructure_ObjectTypedDictionaryEntries_UseRuntimeTypeAndNullFallback()
+        {
+            var local = GetLocalToken(new Dictionary<object, object> { { 42, null }, { "name", "value" } });
+
+            Assert.Equal("Dictionary`2", local["type"]?.Value<string>());
+            Assert.Equal(2, local["size"]?.Value<int>());
+            Assert.Null(local["elements"]);
+
+            var entries = local["entries"] as JArray;
+            Assert.NotNull(entries);
+            Assert.Equal(2, entries!.Count);
+            Assert.Contains(entries, entry =>
+                entry[0]?["type"]?.Value<string>() == "Int32" &&
+                entry[0]?["value"]?.Value<int>() == 42 &&
+                entry[1]?["type"]?.Value<string>() == "Object" &&
+                entry[1]?["isNull"]?.Value<string>() == "true");
+            Assert.Contains(entries, entry =>
+                entry[0]?["type"]?.Value<string>() == "String" &&
+                entry[0]?["value"]?.Value<string>() == "name" &&
+                entry[1]?["type"]?.Value<string>() == "String" &&
+                entry[1]?["value"]?.Value<string>() == "value");
+        }
+
+        [Fact]
         public void ObjectStructure_SortedList_IsSerializedAsDictionary()
         {
             var local = GetLocalToken(new SortedList { { "one", 1 }, { "two", 2 } });

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
@@ -52,8 +52,8 @@ namespace Datadog.Trace.Tests.Debugger
         {
             Redaction.IsSafeToCallToString(type).Should().BeFalse($"Type {type} should use structural handling instead of ToString()");
         }
-		
-		[Theory]
+
+        [Theory]
         [InlineData(typeof(List<int>), true)]
         [InlineData(typeof(HashSet<int>), true)]
         [InlineData(typeof(SortedList), false)]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
@@ -52,5 +52,30 @@ namespace Datadog.Trace.Tests.Debugger
         {
             Redaction.IsSafeToCallToString(type).Should().BeFalse($"Type {type} should use structural handling instead of ToString()");
         }
+		
+		[Theory]
+        [InlineData(typeof(List<int>), true)]
+        [InlineData(typeof(HashSet<int>), true)]
+        [InlineData(typeof(SortedList), false)]
+        [InlineData(typeof(SortedList<string, int>), false)]
+        [InlineData(typeof(Dictionary<string, int>), false)]
+        [InlineData(typeof(ConditionalWeakTable<object, object>), false)]
+        public void SupportedCollectionTypes(Type type, bool expected)
+        {
+            Redaction.IsSupportedCollection(type).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(typeof(Dictionary<string, int>), true)]
+        [InlineData(typeof(SortedDictionary<string, int>), true)]
+        [InlineData(typeof(SortedList), true)]
+        [InlineData(typeof(SortedList<string, int>), true)]
+        [InlineData(typeof(Hashtable), true)]
+        [InlineData(typeof(List<int>), false)]
+        [InlineData(typeof(HashSet<int>), false)]
+        public void SupportedDictionaryTypes(Type type, bool expected)
+        {
+            Redaction.IsSupportedDictionary(type).Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Fix debugger snapshot serialization for supported `IEnumerable` collection types that do not implement non-generic `ICollection`.
- Add cached collection and dictionary-entry descriptors so snapshot serialization can read `Count`, dictionary keys, and dictionary values consistently.
- Serialize `SortedList` / `SortedList<TKey, TValue>` as dictionary `entries` instead of collection `elements`.
- Stop treating `ConditionalWeakTable<TKey, TValue>` as a supported collection for debugger snapshots.
- Add debugger snapshot and supported-type tests for common collection and dictionary shapes.

## Reason for change

- Live Debugger snapshots should preserve useful structure for supported generic collections such as `HashSet<T>`, `ConcurrentQueue<T>`, `ConcurrentBag<T>`, `BlockingCollection<T>`, and sorted collections.
- Dictionary-like types should be represented as key/value entries, and null/object-typed dictionary entries should keep the best available type information.

## Implementation details

- Introduces `DebuggerSnapshotSerializer.CollectionDescriptors.cs` with small bounded caches for supported enumerable descriptors and dictionary entry descriptors.
- Uses type-based collection support checks and compiled `Count` accessors for supported enumerable types that expose an `int Count` property.
- Reuses descriptor metadata when serializing dictionary entries, falling back to declared key/value types when runtime values are null.
- Refactors supported collection/dictionary checks in `Redaction` to avoid LINQ and to share type-based matching logic.

## Test coverage

- `Datadog.Trace.Tests.Debugger.DebuggerSnapshotCreatorTests`
- `Datadog.Trace.Tests.Debugger.SupportedTypesServiceTests`