### PR TITLE
[CI] Retry docker pull of ddapm-test-agent image on transient failure

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2405,6 +2405,7 @@ stages:
     - script: |
         docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
       displayName: docker pull latest ddapm-test-agent image (we rely on a newer version than the one in the base image)
+      retryCountOnTaskFailure: 3
 
     - script: |
         docker-compose -p $(DockerComposeProjectName)-g$(dockerGroup) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
@@ -3433,6 +3434,7 @@ stages:
         - script: |
             docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
           displayName: docker pull latest ddapm-test-agent image (we rely on a newer version than the one in the base image)
+          retryCountOnTaskFailure: 3
 
         - script: |
             docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) IntegrationTests.ARM64


### PR DESCRIPTION
## Summary of changes

Add `retryCountOnTaskFailure: 3` to both `docker pull ddapm-test-agent:latest` steps (x64 and ARM64) in `ultimate-pipeline.yml`.

## Reason for change

These standalone `script` steps had no retry, so [a transient registry/network error](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/202885/logs/6041) during the pull (e.g. `failed to copy: failed to send write: EOF`) failed the whole job. Retry mechanisms exist elsewhere in the pipeline (`retryCountOnTaskFailure`, `retryCountForRunCommand`) but were never wired into these two steps.

## Implementation details

`retryCountOnTaskFailure` is the native Azure DevOps step-level retry; it re-runs the step up to 3 times on failure.

## Test coverage

N/A — CI configuration change.

## Other details