### PR TITLE
[Profiler] Measure LibrariesInfoCache performance

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -3,10 +3,15 @@
 
 #include "LibrariesInfoCache.h"
 
+#include "IConfiguration.h"
 #include "Log.h"
+#include "MeanMaxMetric.h"
+#include "MetricsRegistry.h"
 #include "OpSysTools.h"
+#include "ProxyMetric.h"
 
 #include <algorithm>
+#include <chrono>
 #include <elf.h>
 #include <fcntl.h>
 #include <string.h>
@@ -42,13 +47,7 @@ struct ScopedMmap
 
     explicit operator bool() const { return data != MAP_FAILED; }
 };
-} // anonymous namespace
 
-std::atomic<LibrariesInfoCache*> LibrariesInfoCache::s_instance{nullptr};
-
-extern "C" void (*volatile dd_notify_libraries_cache_update)() __attribute__((weak));
-
-namespace {
 std::atomic<std::uint64_t>* s_cpuTicksPtr = nullptr;
 
 void CpuTickSignalHandler(int /*sig*/)
@@ -61,44 +60,144 @@ void CpuTickSignalHandler(int /*sig*/)
 }
 } // anonymous namespace
 
-LibrariesInfoCache::LibrariesInfoCache(shared::pmr::memory_resource* resource, MetricsRegistry& metricsRegistry) :
-    _trackingResource{resource},
-    _wrappersAllocator{&_trackingResource},
-    _librariesInfo{&_trackingResource},
-    _newCache{&_trackingResource},
+// --------------------------------------------------------------------------
+// TrackingMemoryResource: wraps an upstream allocator to track memory usage.
+// --------------------------------------------------------------------------
+
+class TrackingMemoryResource : public shared::pmr::memory_resource
+{
+public:
+    explicit TrackingMemoryResource(shared::pmr::memory_resource* upstream) :
+        _upstream{upstream}
+    {
+    }
+
+    std::size_t GetCurrentUsage() const { return _currentUsage.load(std::memory_order_relaxed); }
+    std::size_t GetPeakUsage() const { return _peakUsage.load(std::memory_order_relaxed); }
+    std::size_t GetTotalAllocated() const { return _totalAllocated.load(std::memory_order_relaxed); }
+    std::size_t GetTotalDeallocated() const { return _totalDeallocated.load(std::memory_order_relaxed); }
+    std::size_t GetAllocationCount() const { return _allocationCount.load(std::memory_order_relaxed); }
+
+    void ResetPerReloadStats()
+    {
+        _reloadAllocations.store(0, std::memory_order_relaxed);
+        _reloadBytes.store(0, std::memory_order_relaxed);
+    }
+
+    std::size_t GetReloadAllocations() const { return _reloadAllocations.load(std::memory_order_relaxed); }
+    std::size_t GetReloadBytes() const { return _reloadBytes.load(std::memory_order_relaxed); }
+
+protected:
+    void* do_allocate(std::size_t bytes, std::size_t alignment) override
+    {
+        _reloadAllocations.fetch_add(1, std::memory_order_relaxed);
+        _reloadBytes.fetch_add(bytes, std::memory_order_relaxed);
+        _allocationCount.fetch_add(1, std::memory_order_relaxed);
+        _totalAllocated.fetch_add(bytes, std::memory_order_relaxed);
+        auto current = _currentUsage.fetch_add(bytes, std::memory_order_relaxed) + bytes;
+        auto peak = _peakUsage.load(std::memory_order_relaxed);
+        while (current > peak && !_peakUsage.compare_exchange_weak(peak, current, std::memory_order_relaxed))
+        {
+        }
+        return _upstream->allocate(bytes, alignment);
+    }
+
+    void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
+    {
+        _currentUsage.fetch_sub(bytes, std::memory_order_relaxed);
+        _totalDeallocated.fetch_add(bytes, std::memory_order_relaxed);
+        _upstream->deallocate(p, bytes, alignment);
+    }
+
+    bool do_is_equal(const memory_resource& other) const noexcept override
+    {
+        return this == &other;
+    }
+
+private:
+    shared::pmr::memory_resource* _upstream;
+    std::atomic<std::size_t> _currentUsage{0};
+    std::atomic<std::size_t> _peakUsage{0};
+    std::atomic<std::size_t> _totalAllocated{0};
+    std::atomic<std::size_t> _totalDeallocated{0};
+    std::atomic<std::size_t> _allocationCount{0};
+    std::atomic<std::size_t> _reloadAllocations{0};
+    std::atomic<std::size_t> _reloadBytes{0};
+};
+
+// --------------------------------------------------------------------------
+// FootprintTracker: encapsulates all memory/CPU tracking and metrics.
+// Only instantiated when IsMemoryFootprintEnabled() is true.
+// --------------------------------------------------------------------------
+
+struct FootprintTracker
+{
+    TrackingMemoryResource trackingResource;
+
+    std::atomic<std::uint64_t> cpuTicks{0};
+    timer_t cpuTimerId{};
+    bool cpuTimerCreated{false};
+
+    std::uint32_t reloadCount{0};
+    std::uint32_t notificationCount{0};
+    std::chrono::steady_clock::duration totalReloadDuration{0};
+    std::chrono::steady_clock::duration maxReloadDuration{0};
+    std::chrono::steady_clock::duration totalLockHoldDuration{0};
+    std::chrono::steady_clock::duration maxLockHoldDuration{0};
+
+    std::shared_ptr<ProxyMetric> libCountMetric;
+    std::shared_ptr<ProxyMetric> memoryFootprintMetric;
+    std::shared_ptr<ProxyMetric> memoryPeakMetric;
+    std::shared_ptr<ProxyMetric> cpuTicksMetric;
 #ifdef ARM64
-    _moduleRegions{&_trackingResource},
-    _symbols{&_trackingResource},
-    _newRegions{&_trackingResource},
-    _newSymbols{&_trackingResource},
+    std::shared_ptr<ProxyMetric> moduleCountMetric;
+    std::shared_ptr<ProxyMetric> symbolCountMetric;
+#endif
+    std::shared_ptr<MeanMaxMetric> updateCpuMetric;
+    std::shared_ptr<MeanMaxMetric> reloadDurationMetric;
+    std::shared_ptr<MeanMaxMetric> lockHoldDurationMetric;
+    std::shared_ptr<MeanMaxMetric> reloadAllocationsMetric;
+
+    explicit FootprintTracker(shared::pmr::memory_resource* upstream) :
+        trackingResource{upstream}
+    {
+    }
+
+    void RegisterMetrics(MetricsRegistry& registry, LibrariesInfoCache* cache);
+    void SetupCpuTimer();
+    void TeardownCpuTimer();
+    void LogStats(std::size_t libCount);
+    void RecordReload(std::chrono::steady_clock::duration reloadDuration,
+                      std::chrono::steady_clock::duration lockDuration,
+                      struct timespec cpuStart, struct timespec cpuEnd);
+};
+
+// --------------------------------------------------------------------------
+// LibrariesInfoCache
+// --------------------------------------------------------------------------
+
+std::atomic<LibrariesInfoCache*> LibrariesInfoCache::s_instance{nullptr};
+
+extern "C" void (*volatile dd_notify_libraries_cache_update)() __attribute__((weak));
+
+LibrariesInfoCache::LibrariesInfoCache(IConfiguration* configuration, shared::pmr::memory_resource* resource, MetricsRegistry& metricsRegistry) :
+    _tracker{configuration->IsMemoryFootprintEnabled() ? std::make_unique<FootprintTracker>(resource) : nullptr},
+    _wrappersAllocator{_tracker ? &_tracker->trackingResource : resource},
+    _librariesInfo{_wrappersAllocator},
+    _newCache{_wrappersAllocator},
+#ifdef ARM64
+    _moduleRegions{_wrappersAllocator},
+    _symbols{_wrappersAllocator},
+    _newRegions{_wrappersAllocator},
+    _newSymbols{_wrappersAllocator},
 #endif
     _stopRequested{false},
-    _event(true) // set the event to force updating the cache the first time Wait is called
+    _event(true)
 {
-    _libCountMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_count", [this]() {
-        return static_cast<double_t>(_librariesInfo.size());
-    });
-    _memoryFootprintMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_memory_footprint_libs_cache", [this]() {
-        return static_cast<double_t>(_trackingResource.GetCurrentUsage());
-    });
-    _memoryPeakMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_memory_peak", [this]() {
-        return static_cast<double_t>(_trackingResource.GetPeakUsage());
-    });
-    _cpuTicksMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_cpu_ticks", [this]() {
-        return static_cast<double_t>(_cpuTicks.load(std::memory_order_relaxed));
-    });
-#ifdef ARM64
-    _moduleCountMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_module_regions", [this]() {
-        return static_cast<double_t>(_moduleRegions.size());
-    });
-    _symbolCountMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_symbols", [this]() {
-        return static_cast<double_t>(_symbols.size());
-    });
-#endif
-    _updateCpuMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_update_cpu_ns");
-    _reloadDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_duration_ns");
-    _lockHoldDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_lock_hold_duration_ns");
-    _reloadAllocationsMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_allocations");
+    if (_tracker)
+    {
+        _tracker->RegisterMetrics(metricsRegistry, this);
+    }
 }
 
 LibrariesInfoCache::~LibrariesInfoCache() = default;
@@ -195,7 +294,11 @@ bool LibrariesInfoCache::StopImpl()
     Log::Debug("Notification to stop the worker has been sent.");
     _worker.join();
 
-    LogStats();
+    if (_tracker)
+    {
+        _tracker->LogStats(_librariesInfo.size());
+    }
+
     _librariesInfo.clear();
 #ifdef ARM64
     _moduleRegions.clear();
@@ -205,101 +308,14 @@ bool LibrariesInfoCache::StopImpl()
     return true;
 }
 
-void LibrariesInfoCache::LogStats()
-{
-    if (!Log::IsDebugEnabled())
-    {
-        return;
-    }
-
-    auto cpuTime = CpuTimerInterval * _cpuTicks.load(std::memory_order_relaxed);
-    auto avgReloadDuration = _reloadCount > 0
-        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalReloadDuration) / _reloadCount
-        : std::chrono::microseconds{0};
-    auto maxReloadDuration = std::chrono::duration_cast<std::chrono::microseconds>(_maxReloadDuration);
-    auto avgLockDuration = _reloadCount > 0
-        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalLockHoldDuration) / _reloadCount
-        : std::chrono::microseconds{0};
-    auto maxLockDuration = std::chrono::duration_cast<std::chrono::microseconds>(_maxLockHoldDuration);
-
-    Log::Info("LibrariesInfoCache stats:");
-    Log::Info("  CPU time (worker thread): ", cpuTime);
-    Log::Info("  Notifications received: ", _notificationCount);
-    Log::Info("  Cache reloads: ", _reloadCount);
-    Log::Info("  Reload duration avg: ", avgReloadDuration, ", max: ", maxReloadDuration);
-    Log::Info("  Lock hold duration avg: ", avgLockDuration, ", max: ", maxLockDuration);
-    Log::Info("  Libraries in cache: ", _librariesInfo.size());
-    Log::Info("  Memory current: ", _trackingResource.GetCurrentUsage(), " bytes");
-    Log::Info("  Memory peak: ", _trackingResource.GetPeakUsage(), " bytes");
-    Log::Info("  Memory total allocated: ", _trackingResource.GetTotalAllocated(), " bytes");
-    Log::Info("  Memory total deallocated: ", _trackingResource.GetTotalDeallocated(), " bytes");
-    Log::Info("  Memory allocation count: ", _trackingResource.GetAllocationCount());
-}
-
-void LibrariesInfoCache::SetupCpuTimer()
-{
-    const int cpuTimerSignal = SIGRTMIN + 10;
-
-    struct sigaction sa = {};
-    sa.sa_handler = CpuTickSignalHandler;
-    sa.sa_flags = SA_RESTART;
-    sigemptyset(&sa.sa_mask);
-    if (sigaction(cpuTimerSignal, &sa, nullptr) != 0)
-    {
-        Log::Warn("LibrariesInfoCache: Failed to install signal handler (signal=", cpuTimerSignal, ") for CPU measurement: ", strerror(errno));
-        return;
-    }
-
-    s_cpuTicksPtr = &_cpuTicks;
-
-    auto tid = static_cast<int>(syscall(SYS_gettid));
-
-    struct sigevent sev = {};
-    sev.sigev_signo = cpuTimerSignal;
-    sev.sigev_notify = SIGEV_THREAD_ID;
-    ((int*)&sev.sigev_notify)[1] = tid;
-
-    clockid_t clock = ((~tid) << 3) | 6; // CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK
-    if (syscall(__NR_timer_create, clock, &sev, &_cpuTimerId) < 0)
-    {
-        Log::Warn("LibrariesInfoCache: Failed to create CPU timer: ", strerror(errno));
-        s_cpuTicksPtr = nullptr;
-        return;
-    }
-
-    _cpuTimerCreated = true;
-
-    struct itimerspec its = {};
-
-    constexpr auto cpuTimerIntervalNs = std::chrono::duration_cast<std::chrono::nanoseconds>(CpuTimerInterval).count();
-    its.it_interval = {0, cpuTimerIntervalNs};
-    its.it_value = {0, cpuTimerIntervalNs};
-    if (syscall(__NR_timer_settime, _cpuTimerId, 0, &its, nullptr) < 0)
-    {
-        Log::Warn("LibrariesInfoCache: Failed to arm CPU timer: ", strerror(errno));
-        syscall(__NR_timer_delete, _cpuTimerId);
-        _cpuTimerCreated = false;
-        s_cpuTicksPtr = nullptr;
-        return;
-    }
-
-    Log::Info("LibrariesInfoCache: CPU timer armed on worker thread (tid=", tid, ")");
-}
-
-void LibrariesInfoCache::TeardownCpuTimer()
-{
-    if (_cpuTimerCreated)
-    {
-        syscall(__NR_timer_delete, _cpuTimerId);
-        _cpuTimerCreated = false;
-    }
-    s_cpuTicksPtr = nullptr;
-}
-
 void LibrariesInfoCache::Work(std::shared_ptr<AutoResetEvent> startEvent)
 {
     OpSysTools::SetNativeThreadName(WStr("DD_LibsCache"));
-    SetupCpuTimer();
+
+    if (_tracker)
+    {
+        _tracker->SetupCpuTimer();
+    }
 
     auto timeout = InfiniteTimeout;
     if (&dd_notify_libraries_cache_update != nullptr) [[likely]]
@@ -341,7 +357,10 @@ void LibrariesInfoCache::Work(std::shared_ptr<AutoResetEvent> startEvent)
         dd_notify_libraries_cache_update = nullptr;
     }
 
-    TeardownCpuTimer();
+    if (_tracker)
+    {
+        _tracker->TeardownCpuTimer();
+    }
 }
 
 void LibrariesInfoCache::UpdateCache()
@@ -354,13 +373,15 @@ void LibrariesInfoCache::UpdateCache()
     // But the Cache Thread is blocked (T1 owns the malloc lock)
     // T1 is blocked when libwunding calls DlIteratePhdr.
 
-    _reloadCount++;
-    _trackingResource.ResetPerReloadStats();
-    auto reloadStart = std::chrono::steady_clock::now();
-
-    // use to measure how much CPU ONE reload is consuming
     struct timespec cpuStart = {};
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpuStart);
+    std::chrono::steady_clock::time_point reloadStart;
+    if (_tracker)
+    {
+        _tracker->reloadCount++;
+        _tracker->trackingResource.ResetPerReloadStats();
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpuStart);
+        reloadStart = std::chrono::steady_clock::now();
+    }
 
     _newCache.reserve(_librariesInfo.capacity());
 
@@ -387,7 +408,11 @@ void LibrariesInfoCache::UpdateCache()
     BuildSymbolCache(_newCache, _newRegions, _newSymbols);
 #endif
 
-    auto lockStart = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point lockStart;
+    if (_tracker)
+    {
+        lockStart = std::chrono::steady_clock::now();
+    }
     {
         std::unique_lock l{_cacheLock};
         _librariesInfo.swap(_newCache);
@@ -396,7 +421,11 @@ void LibrariesInfoCache::UpdateCache()
         _symbols.swap(_newSymbols);
 #endif
     }
-    auto lockEnd = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point lockEnd;
+    if (_tracker)
+    {
+        lockEnd = std::chrono::steady_clock::now();
+    }
 
     _newCache.clear();
 #ifdef ARM64
@@ -404,32 +433,17 @@ void LibrariesInfoCache::UpdateCache()
     _newSymbols.clear();
 #endif
 
-    auto reloadEnd = std::chrono::steady_clock::now();
-    auto reloadDuration = reloadEnd - reloadStart;
-    auto lockDuration = lockEnd - lockStart;
-
-    _totalReloadDuration += reloadDuration;
-    _totalLockHoldDuration += lockDuration;
-    if (reloadDuration > _maxReloadDuration)
+    if (_tracker)
     {
-        _maxReloadDuration = reloadDuration;
-    }
-    if (lockDuration > _maxLockHoldDuration)
-    {
-        _maxLockHoldDuration = lockDuration;
-    }
+        auto reloadEnd = std::chrono::steady_clock::now();
+        auto reloadDuration = reloadEnd - reloadStart;
+        auto lockDuration = lockEnd - lockStart;
 
-    struct timespec cpuEnd = {};
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpuEnd);
-    auto cpuNs = static_cast<double_t>(
-        (cpuEnd.tv_sec - cpuStart.tv_sec) * 1'000'000'000LL + (cpuEnd.tv_nsec - cpuStart.tv_nsec));
+        struct timespec cpuEnd = {};
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpuEnd);
 
-    _updateCpuMetric->Add(cpuNs);
-    _reloadDurationMetric->Add(static_cast<double_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(reloadDuration).count()));
-    _lockHoldDurationMetric->Add(static_cast<double_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(lockDuration).count()));
-    _reloadAllocationsMetric->Add(static_cast<double_t>(_trackingResource.GetReloadAllocations()));
+        _tracker->RecordReload(reloadDuration, lockDuration, cpuStart, cpuEnd);
+    }
 }
 
 #ifdef ARM64
@@ -656,7 +670,10 @@ void LibrariesInfoCache::NotifyCacheUpdate()
 
 void LibrariesInfoCache::NotifyCacheUpdateImpl()
 {
-    _notificationCount++;
+    if (_tracker)
+    {
+        _tracker->notificationCount++;
+    }
     _event.Set();
 }
 
@@ -666,3 +683,147 @@ void* LibrariesInfoCache::GetLocalAddressSpace()
     return unw_local_addr_space;
 }
 #endif
+
+// --------------------------------------------------------------------------
+// FootprintTracker method implementations
+// --------------------------------------------------------------------------
+
+void FootprintTracker::RegisterMetrics(MetricsRegistry& registry, LibrariesInfoCache* cache)
+{
+    libCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_count", [cache]() {
+        return static_cast<double_t>(cache->_librariesInfo.size());
+    });
+    memoryFootprintMetric = registry.GetOrRegister<ProxyMetric>("dotnet_memory_footprint_libs_cache", [this]() {
+        return static_cast<double_t>(trackingResource.GetCurrentUsage());
+    });
+    memoryPeakMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_memory_peak", [this]() {
+        return static_cast<double_t>(trackingResource.GetPeakUsage());
+    });
+    cpuTicksMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_cpu_ticks", [this]() {
+        return static_cast<double_t>(cpuTicks.load(std::memory_order_relaxed));
+    });
+#ifdef ARM64
+    moduleCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_module_regions", [cache]() {
+        return static_cast<double_t>(cache->_moduleRegions.size());
+    });
+    symbolCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_symbols", [cache]() {
+        return static_cast<double_t>(cache->_symbols.size());
+    });
+#endif
+    updateCpuMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_update_cpu_ns");
+    reloadDurationMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_duration_ns");
+    lockHoldDurationMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_lock_hold_duration_ns");
+    reloadAllocationsMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_allocations");
+}
+
+void FootprintTracker::SetupCpuTimer()
+{
+    const int cpuTimerSignal = SIGRTMIN + 10;
+
+    struct sigaction sa = {};
+    sa.sa_handler = CpuTickSignalHandler;
+    sa.sa_flags = SA_RESTART;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(cpuTimerSignal, &sa, nullptr) != 0)
+    {
+        Log::Warn("LibrariesInfoCache: Failed to install signal handler (signal=", cpuTimerSignal, ") for CPU measurement: ", strerror(errno));
+        return;
+    }
+
+    s_cpuTicksPtr = &cpuTicks;
+
+    auto tid = static_cast<int>(syscall(SYS_gettid));
+
+    struct sigevent sev = {};
+    sev.sigev_signo = cpuTimerSignal;
+    sev.sigev_notify = SIGEV_THREAD_ID;
+    ((int*)&sev.sigev_notify)[1] = tid;
+
+    clockid_t clock = ((~tid) << 3) | 6; // CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK
+    if (syscall(__NR_timer_create, clock, &sev, &cpuTimerId) < 0)
+    {
+        Log::Warn("LibrariesInfoCache: Failed to create CPU timer: ", strerror(errno));
+        s_cpuTicksPtr = nullptr;
+        return;
+    }
+
+    cpuTimerCreated = true;
+
+    struct itimerspec its = {};
+
+    constexpr auto cpuTimerIntervalNs = std::chrono::duration_cast<std::chrono::nanoseconds>(CpuTimerInterval).count();
+    its.it_interval = {0, cpuTimerIntervalNs};
+    its.it_value = {0, cpuTimerIntervalNs};
+    if (syscall(__NR_timer_settime, cpuTimerId, 0, &its, nullptr) < 0)
+    {
+        Log::Warn("LibrariesInfoCache: Failed to arm CPU timer: ", strerror(errno));
+        syscall(__NR_timer_delete, cpuTimerId);
+        cpuTimerCreated = false;
+        s_cpuTicksPtr = nullptr;
+        return;
+    }
+
+    Log::Info("LibrariesInfoCache: CPU timer armed on worker thread (tid=", tid, ")");
+}
+
+void FootprintTracker::TeardownCpuTimer()
+{
+    if (cpuTimerCreated)
+    {
+        syscall(__NR_timer_delete, cpuTimerId);
+        cpuTimerCreated = false;
+    }
+    s_cpuTicksPtr = nullptr;
+}
+
+void FootprintTracker::LogStats(std::size_t libCount)
+{
+    auto cpuTime = CpuTimerInterval * cpuTicks.load(std::memory_order_relaxed);
+    auto avgReloadDuration = reloadCount > 0
+        ? std::chrono::duration_cast<std::chrono::microseconds>(totalReloadDuration) / reloadCount
+        : std::chrono::microseconds{0};
+    auto maxReload = std::chrono::duration_cast<std::chrono::microseconds>(maxReloadDuration);
+    auto avgLockDuration = reloadCount > 0
+        ? std::chrono::duration_cast<std::chrono::microseconds>(totalLockHoldDuration) / reloadCount
+        : std::chrono::microseconds{0};
+    auto maxLock = std::chrono::duration_cast<std::chrono::microseconds>(maxLockHoldDuration);
+
+    Log::Info("LibrariesInfoCache stats:");
+    Log::Info("  CPU time (worker thread): ", cpuTime);
+    Log::Info("  Notifications received: ", notificationCount);
+    Log::Info("  Cache reloads: ", reloadCount);
+    Log::Info("  Reload duration avg: ", avgReloadDuration, ", max: ", maxReload);
+    Log::Info("  Lock hold duration avg: ", avgLockDuration, ", max: ", maxLock);
+    Log::Info("  Libraries in cache: ", libCount);
+    Log::Info("  Memory current: ", trackingResource.GetCurrentUsage(), " bytes");
+    Log::Info("  Memory peak: ", trackingResource.GetPeakUsage(), " bytes");
+    Log::Info("  Memory total allocated: ", trackingResource.GetTotalAllocated(), " bytes");
+    Log::Info("  Memory total deallocated: ", trackingResource.GetTotalDeallocated(), " bytes");
+    Log::Info("  Memory allocation count: ", trackingResource.GetAllocationCount());
+}
+
+void FootprintTracker::RecordReload(std::chrono::steady_clock::duration reloadDuration,
+                                    std::chrono::steady_clock::duration lockDuration,
+                                    struct timespec cpuStart, struct timespec cpuEnd)
+{
+    totalReloadDuration += reloadDuration;
+    totalLockHoldDuration += lockDuration;
+    if (reloadDuration > maxReloadDuration)
+    {
+        maxReloadDuration = reloadDuration;
+    }
+    if (lockDuration > maxLockHoldDuration)
+    {
+        maxLockHoldDuration = lockDuration;
+    }
+
+    auto cpuNs = static_cast<double_t>(
+        (cpuEnd.tv_sec - cpuStart.tv_sec) * 1'000'000'000LL + (cpuEnd.tv_nsec - cpuStart.tv_nsec));
+
+    updateCpuMetric->Add(cpuNs);
+    reloadDurationMetric->Add(static_cast<double_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(reloadDuration).count()));
+    lockHoldDurationMetric->Add(static_cast<double_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(lockDuration).count()));
+    reloadAllocationsMetric->Add(static_cast<double_t>(trackingResource.GetReloadAllocations()));
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -63,6 +63,12 @@ LibrariesInfoCache::LibrariesInfoCache(shared::pmr::memory_resource* resource) :
     _wrappersAllocator{&_trackingResource},
     _librariesInfo{&_trackingResource},
     _newCache{&_trackingResource},
+#ifdef ARM64
+    _moduleRegions{&_trackingResource},
+    _symbols{&_trackingResource},
+    _newRegions{&_trackingResource},
+    _newSymbols{&_trackingResource},
+#endif
     _stopRequested{false},
     _event(true) // set the event to force updating the cache the first time Wait is called
 {
@@ -338,30 +344,27 @@ void LibrariesInfoCache::UpdateCache()
         &data);
 
 #ifdef ARM64
-    static std::vector<ModuleRegion> newRegions;
-    static std::vector<FuncEntry> newSymbols;
-    newRegions.clear();
-    newSymbols.clear();
-    BuildSymbolCache(_newCache, newRegions, newSymbols);
+    _newRegions.clear();
+    _newSymbols.clear();
+    BuildSymbolCache(_newCache, _newRegions, _newSymbols);
 #endif
-
 
     auto lockStart = std::chrono::steady_clock::now();
     {
         std::unique_lock l{_cacheLock};
-        _librariesInfo.swap(newCache);
+        _librariesInfo.swap(_newCache);
 #ifdef ARM64
-        _moduleRegions.swap(newRegions);
-        _symbols.swap(newSymbols);
+        _moduleRegions.swap(_newRegions);
+        _symbols.swap(_newSymbols);
 #endif
     }
     auto lockEnd = std::chrono::steady_clock::now();
 
     _newCache.clear();
-    #ifdef ARM64
-        newRegions.clear();
-        newSymbols.clear();
-    #endif
+#ifdef ARM64
+    _newRegions.clear();
+    _newSymbols.clear();
+#endif
 
     auto reloadEnd = std::chrono::steady_clock::now();
     auto reloadDuration = reloadEnd - reloadStart;
@@ -381,9 +384,9 @@ void LibrariesInfoCache::UpdateCache()
 
 #ifdef ARM64
 void LibrariesInfoCache::BuildSymbolCache(
-    std::vector<DlPhdrInfoWrapper>& phdrCache,
-    std::vector<ModuleRegion>& outRegions,
-    std::vector<FuncEntry>& outSymbols)
+    std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>>& phdrCache,
+    std::vector<ModuleRegion, shared::pmr::polymorphic_allocator<ModuleRegion>>& outRegions,
+    std::vector<FuncEntry, shared::pmr::polymorphic_allocator<FuncEntry>>& outSymbols)
 {
     std::vector<FuncEntry> moduleSymbols;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -95,6 +95,12 @@ struct FootprintTracker
     std::uint32_t reloadCount{0};
     std::uint64_t totalCpuNs{0};
 
+    std::atomic<uint32_t> libCount{0};
+#ifdef ARM64
+    std::atomic<uint32_t> moduleRegionCount{0};
+    std::atomic<uint32_t> symbolCount{0};
+#endif
+
     std::shared_ptr<ProxyMetric> libCountMetric;
     std::shared_ptr<ProxyMetric> memoryFootprintMetric;
 #ifdef ARM64
@@ -110,7 +116,7 @@ struct FootprintTracker
     {
     }
 
-    void RegisterMetrics(MetricsRegistry& registry, LibrariesInfoCache* cache);
+    void RegisterMetrics(MetricsRegistry& registry);
     void LogStats(std::size_t libCount);
     void RecordReload(std::chrono::steady_clock::duration reloadDuration,
                       std::chrono::steady_clock::duration lockDuration,
@@ -141,7 +147,7 @@ LibrariesInfoCache::LibrariesInfoCache(IConfiguration* configuration, shared::pm
 {
     if (_tracker)
     {
-        _tracker->RegisterMetrics(metricsRegistry, this);
+        _tracker->RegisterMetrics(metricsRegistry);
     }
 }
 
@@ -354,6 +360,14 @@ void LibrariesInfoCache::UpdateCache()
         _moduleRegions.swap(_newRegions);
         _symbols.swap(_newSymbols);
 #endif
+        if (_tracker)
+        {
+            _tracker->libCount.store(static_cast<uint32_t>(_librariesInfo.size()), std::memory_order_relaxed);
+#ifdef ARM64
+            _tracker->moduleRegionCount.store(static_cast<uint32_t>(_moduleRegions.size()), std::memory_order_relaxed);
+            _tracker->symbolCount.store(static_cast<uint32_t>(_symbols.size()), std::memory_order_relaxed);
+#endif
+        }
     }
     std::chrono::steady_clock::time_point lockEnd;
     if (_tracker)
@@ -618,20 +632,20 @@ void* LibrariesInfoCache::GetLocalAddressSpace()
 // FootprintTracker method implementations
 // --------------------------------------------------------------------------
 
-void FootprintTracker::RegisterMetrics(MetricsRegistry& registry, LibrariesInfoCache* cache)
+void FootprintTracker::RegisterMetrics(MetricsRegistry& registry)
 {
-    libCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_count", [cache]() {
-        return static_cast<double_t>(cache->_librariesInfo.size());
+    libCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_count", [this]() {
+        return static_cast<double_t>(libCount.load(std::memory_order_relaxed));
     });
     memoryFootprintMetric = registry.GetOrRegister<ProxyMetric>("dotnet_memory_footprint_libs_cache", [this]() {
         return static_cast<double_t>(trackingResource.GetCurrentUsage());
     });
 #ifdef ARM64
-    moduleCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_module_regions", [cache]() {
-        return static_cast<double_t>(cache->_moduleRegions.size());
+    moduleCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_module_regions", [this]() {
+        return static_cast<double_t>(moduleRegionCount.load(std::memory_order_relaxed));
     });
-    symbolCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_symbols", [cache]() {
-        return static_cast<double_t>(cache->_symbols.size());
+    symbolCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_symbols", [this]() {
+        return static_cast<double_t>(symbolCount.load(std::memory_order_relaxed));
     });
 #endif
     updateCpuMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_update_cpu_ns");
@@ -645,6 +659,10 @@ void FootprintTracker::LogStats(std::size_t libCount)
     Log::Info("  Cache reloads: ", reloadCount);
     Log::Info("  Total CPU (worker): ", totalCpuNs / 1'000'000, " ms");
     Log::Info("  Libraries in cache: ", libCount);
+#ifdef ARM64
+    Log::Info("  Module regions: ", moduleRegionCount.load(std::memory_order_relaxed));
+    Log::Info("  Symbol entries: ", symbolCount.load(std::memory_order_relaxed));
+#endif
     Log::Info("  Memory current: ", trackingResource.GetCurrentUsage(), " bytes");
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -20,6 +20,9 @@
 using namespace std::chrono_literals;
 
 namespace {
+
+constexpr auto CpuTimerInterval = 10ms;
+
 struct ScopedMmap
 {
     void* data;
@@ -58,7 +61,7 @@ void CpuTickSignalHandler(int /*sig*/)
 }
 } // anonymous namespace
 
-LibrariesInfoCache::LibrariesInfoCache(shared::pmr::memory_resource* resource) :
+LibrariesInfoCache::LibrariesInfoCache(shared::pmr::memory_resource* resource, MetricsRegistry& metricsRegistry) :
     _trackingResource{resource},
     _wrappersAllocator{&_trackingResource},
     _librariesInfo{&_trackingResource},
@@ -72,6 +75,30 @@ LibrariesInfoCache::LibrariesInfoCache(shared::pmr::memory_resource* resource) :
     _stopRequested{false},
     _event(true) // set the event to force updating the cache the first time Wait is called
 {
+    _libCountMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_count", [this]() {
+        return static_cast<double_t>(_librariesInfo.size());
+    });
+    _memoryFootprintMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_memory_footprint_libs_cache", [this]() {
+        return static_cast<double_t>(_trackingResource.GetCurrentUsage());
+    });
+    _memoryPeakMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_memory_peak", [this]() {
+        return static_cast<double_t>(_trackingResource.GetPeakUsage());
+    });
+    _cpuTicksMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_cpu_ticks", [this]() {
+        return static_cast<double_t>(_cpuTicks.load(std::memory_order_relaxed));
+    });
+#ifdef ARM64
+    _moduleCountMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_module_regions", [this]() {
+        return static_cast<double_t>(_moduleRegions.size());
+    });
+    _symbolCountMetric = metricsRegistry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_symbols", [this]() {
+        return static_cast<double_t>(_symbols.size());
+    });
+#endif
+    _updateCpuMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_update_cpu_ns");
+    _reloadDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_duration_ns");
+    _lockHoldDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_lock_hold_duration_ns");
+    _reloadAllocationsMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_allocations");
 }
 
 LibrariesInfoCache::~LibrariesInfoCache() = default;
@@ -180,22 +207,27 @@ bool LibrariesInfoCache::StopImpl()
 
 void LibrariesInfoCache::LogStats()
 {
-    auto cpuMs = _cpuTicks.load(std::memory_order_relaxed) * 10;
-    auto avgReloadUs = _reloadCount > 0
-        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalReloadDuration).count() / _reloadCount
-        : 0;
-    auto maxReloadUs = std::chrono::duration_cast<std::chrono::microseconds>(_maxReloadDuration).count();
-    auto avgLockUs = _reloadCount > 0
-        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalLockHoldDuration).count() / _reloadCount
-        : 0;
-    auto maxLockUs = std::chrono::duration_cast<std::chrono::microseconds>(_maxLockHoldDuration).count();
+    if (!Log::IsDebugEnabled())
+    {
+        return;
+    }
+
+    auto cpuTime = CpuTimerInterval * _cpuTicks.load(std::memory_order_relaxed);
+    auto avgReloadDuration = _reloadCount > 0
+        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalReloadDuration) / _reloadCount
+        : std::chrono::microseconds{0};
+    auto maxReloadDuration = std::chrono::duration_cast<std::chrono::microseconds>(_maxReloadDuration);
+    auto avgLockDuration = _reloadCount > 0
+        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalLockHoldDuration) / _reloadCount
+        : std::chrono::microseconds{0};
+    auto maxLockDuration = std::chrono::duration_cast<std::chrono::microseconds>(_maxLockHoldDuration);
 
     Log::Info("LibrariesInfoCache stats:");
-    Log::Info("  CPU time (worker thread): ", cpuMs, "ms");
+    Log::Info("  CPU time (worker thread): ", cpuTime);
     Log::Info("  Notifications received: ", _notificationCount);
     Log::Info("  Cache reloads: ", _reloadCount);
-    Log::Info("  Reload duration avg: ", avgReloadUs, "us, max: ", maxReloadUs, "us");
-    Log::Info("  Lock hold duration avg: ", avgLockUs, "us, max: ", maxLockUs, "us");
+    Log::Info("  Reload duration avg: ", avgReloadDuration, ", max: ", maxReloadDuration);
+    Log::Info("  Lock hold duration avg: ", avgLockDuration, ", max: ", maxLockDuration);
     Log::Info("  Libraries in cache: ", _librariesInfo.size());
     Log::Info("  Memory current: ", _trackingResource.GetCurrentUsage(), " bytes");
     Log::Info("  Memory peak: ", _trackingResource.GetPeakUsage(), " bytes");
@@ -238,8 +270,10 @@ void LibrariesInfoCache::SetupCpuTimer()
     _cpuTimerCreated = true;
 
     struct itimerspec its = {};
-    its.it_interval = {0, 10'000'000}; // 10ms
-    its.it_value = {0, 10'000'000};
+
+    constexpr auto cpuTimerIntervalNs = std::chrono::duration_cast<std::chrono::nanoseconds>(CpuTimerInterval).count();
+    its.it_interval = {0, cpuTimerIntervalNs};
+    its.it_value = {0, cpuTimerIntervalNs};
     if (syscall(__NR_timer_settime, _cpuTimerId, 0, &its, nullptr) < 0)
     {
         Log::Warn("LibrariesInfoCache: Failed to arm CPU timer: ", strerror(errno));
@@ -324,6 +358,10 @@ void LibrariesInfoCache::UpdateCache()
     _trackingResource.ResetPerReloadStats();
     auto reloadStart = std::chrono::steady_clock::now();
 
+    // use to measure how much CPU ONE reload is consuming
+    struct timespec cpuStart = {};
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpuStart);
+
     _newCache.reserve(_librariesInfo.capacity());
 
     struct Data
@@ -380,6 +418,18 @@ void LibrariesInfoCache::UpdateCache()
     {
         _maxLockHoldDuration = lockDuration;
     }
+
+    struct timespec cpuEnd = {};
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpuEnd);
+    auto cpuNs = static_cast<double_t>(
+        (cpuEnd.tv_sec - cpuStart.tv_sec) * 1'000'000'000LL + (cpuEnd.tv_nsec - cpuStart.tv_nsec));
+
+    _updateCpuMetric->Add(cpuNs);
+    _reloadDurationMetric->Add(static_cast<double_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(reloadDuration).count()));
+    _lockHoldDurationMetric->Add(static_cast<double_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(lockDuration).count()));
+    _reloadAllocationsMetric->Add(static_cast<double_t>(_trackingResource.GetReloadAllocations()));
 }
 
 #ifdef ARM64

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -200,13 +200,15 @@ void LibrariesInfoCache::LogStats()
 
 void LibrariesInfoCache::SetupCpuTimer()
 {
+    const int cpuTimerSignal = SIGRTMIN + 10;
+
     struct sigaction sa = {};
     sa.sa_handler = CpuTickSignalHandler;
     sa.sa_flags = SA_RESTART;
     sigemptyset(&sa.sa_mask);
-    if (sigaction(SIGUSR2, &sa, nullptr) != 0)
+    if (sigaction(cpuTimerSignal, &sa, nullptr) != 0)
     {
-        Log::Warn("LibrariesInfoCache: Failed to install SIGUSR2 handler for CPU measurement: ", strerror(errno));
+        Log::Warn("LibrariesInfoCache: Failed to install signal handler (signal=", cpuTimerSignal, ") for CPU measurement: ", strerror(errno));
         return;
     }
 
@@ -215,7 +217,7 @@ void LibrariesInfoCache::SetupCpuTimer()
     auto tid = static_cast<int>(syscall(SYS_gettid));
 
     struct sigevent sev = {};
-    sev.sigev_signo = SIGUSR2;
+    sev.sigev_signo = cpuTimerSignal;
     sev.sigev_notify = SIGEV_THREAD_ID;
     ((int*)&sev.sigev_notify)[1] = tid;
 
@@ -232,7 +234,16 @@ void LibrariesInfoCache::SetupCpuTimer()
     struct itimerspec its = {};
     its.it_interval = {0, 10'000'000}; // 10ms
     its.it_value = {0, 10'000'000};
-    syscall(__NR_timer_settime, _cpuTimerId, 0, &its, nullptr);
+    if (syscall(__NR_timer_settime, _cpuTimerId, 0, &its, nullptr) < 0)
+    {
+        Log::Warn("LibrariesInfoCache: Failed to arm CPU timer: ", strerror(errno));
+        syscall(__NR_timer_delete, _cpuTimerId);
+        _cpuTimerCreated = false;
+        s_cpuTicksPtr = nullptr;
+        return;
+    }
+
+    Log::Info("LibrariesInfoCache: CPU timer armed on worker thread (tid=", tid, ")");
 }
 
 void LibrariesInfoCache::TeardownCpuTimer()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -12,6 +12,9 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <signal.h>
+#include <sys/syscall.h>
+#include <time.h>
 #include <unistd.h>
 
 using namespace std::chrono_literals;
@@ -42,10 +45,26 @@ std::atomic<LibrariesInfoCache*> LibrariesInfoCache::s_instance{nullptr};
 
 extern "C" void (*volatile dd_notify_libraries_cache_update)() __attribute__((weak));
 
+namespace {
+std::atomic<std::uint64_t>* s_cpuTicksPtr = nullptr;
+
+void CpuTickSignalHandler(int /*sig*/)
+{
+    auto* ptr = s_cpuTicksPtr;
+    if (ptr != nullptr)
+    {
+        ptr->fetch_add(1, std::memory_order_relaxed);
+    }
+}
+} // anonymous namespace
+
 LibrariesInfoCache::LibrariesInfoCache(shared::pmr::memory_resource* resource) :
+    _trackingResource{resource},
+    _wrappersAllocator{&_trackingResource},
+    _librariesInfo{&_trackingResource},
+    _newCache{&_trackingResource},
     _stopRequested{false},
-    _event(true), // set the event to force updating the cache the first time Wait is called
-    _wrappersAllocator{resource}
+    _event(true) // set the event to force updating the cache the first time Wait is called
 {
 }
 
@@ -142,6 +161,8 @@ bool LibrariesInfoCache::StopImpl()
     NotifyCacheUpdateImpl();
     Log::Debug("Notification to stop the worker has been sent.");
     _worker.join();
+
+    LogStats();
     _librariesInfo.clear();
 #ifdef ARM64
     _moduleRegions.clear();
@@ -151,9 +172,83 @@ bool LibrariesInfoCache::StopImpl()
     return true;
 }
 
+void LibrariesInfoCache::LogStats()
+{
+    auto cpuMs = _cpuTicks.load(std::memory_order_relaxed) * 10;
+    auto avgReloadUs = _reloadCount > 0
+        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalReloadDuration).count() / _reloadCount
+        : 0;
+    auto maxReloadUs = std::chrono::duration_cast<std::chrono::microseconds>(_maxReloadDuration).count();
+    auto avgLockUs = _reloadCount > 0
+        ? std::chrono::duration_cast<std::chrono::microseconds>(_totalLockHoldDuration).count() / _reloadCount
+        : 0;
+    auto maxLockUs = std::chrono::duration_cast<std::chrono::microseconds>(_maxLockHoldDuration).count();
+
+    Log::Info("LibrariesInfoCache stats:");
+    Log::Info("  CPU time (worker thread): ", cpuMs, "ms");
+    Log::Info("  Notifications received: ", _notificationCount);
+    Log::Info("  Cache reloads: ", _reloadCount);
+    Log::Info("  Reload duration avg: ", avgReloadUs, "us, max: ", maxReloadUs, "us");
+    Log::Info("  Lock hold duration avg: ", avgLockUs, "us, max: ", maxLockUs, "us");
+    Log::Info("  Libraries in cache: ", _librariesInfo.size());
+    Log::Info("  Memory current: ", _trackingResource.GetCurrentUsage(), " bytes");
+    Log::Info("  Memory peak: ", _trackingResource.GetPeakUsage(), " bytes");
+    Log::Info("  Memory total allocated: ", _trackingResource.GetTotalAllocated(), " bytes");
+    Log::Info("  Memory total deallocated: ", _trackingResource.GetTotalDeallocated(), " bytes");
+    Log::Info("  Memory allocation count: ", _trackingResource.GetAllocationCount());
+}
+
+void LibrariesInfoCache::SetupCpuTimer()
+{
+    struct sigaction sa = {};
+    sa.sa_handler = CpuTickSignalHandler;
+    sa.sa_flags = SA_RESTART;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGUSR2, &sa, nullptr) != 0)
+    {
+        Log::Warn("LibrariesInfoCache: Failed to install SIGUSR2 handler for CPU measurement: ", strerror(errno));
+        return;
+    }
+
+    s_cpuTicksPtr = &_cpuTicks;
+
+    auto tid = static_cast<int>(syscall(SYS_gettid));
+
+    struct sigevent sev = {};
+    sev.sigev_signo = SIGUSR2;
+    sev.sigev_notify = SIGEV_THREAD_ID;
+    ((int*)&sev.sigev_notify)[1] = tid;
+
+    clockid_t clock = ((~tid) << 3) | 6; // CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK
+    if (syscall(__NR_timer_create, clock, &sev, &_cpuTimerId) < 0)
+    {
+        Log::Warn("LibrariesInfoCache: Failed to create CPU timer: ", strerror(errno));
+        s_cpuTicksPtr = nullptr;
+        return;
+    }
+
+    _cpuTimerCreated = true;
+
+    struct itimerspec its = {};
+    its.it_interval = {0, 10'000'000}; // 10ms
+    its.it_value = {0, 10'000'000};
+    syscall(__NR_timer_settime, _cpuTimerId, 0, &its, nullptr);
+}
+
+void LibrariesInfoCache::TeardownCpuTimer()
+{
+    if (_cpuTimerCreated)
+    {
+        syscall(__NR_timer_delete, _cpuTimerId);
+        _cpuTimerCreated = false;
+    }
+    s_cpuTicksPtr = nullptr;
+}
+
 void LibrariesInfoCache::Work(std::shared_ptr<AutoResetEvent> startEvent)
 {
     OpSysTools::SetNativeThreadName(WStr("DD_LibsCache"));
+    SetupCpuTimer();
 
     auto timeout = InfiniteTimeout;
     if (&dd_notify_libraries_cache_update != nullptr) [[likely]]
@@ -194,6 +289,8 @@ void LibrariesInfoCache::Work(std::shared_ptr<AutoResetEvent> startEvent)
     {
         dd_notify_libraries_cache_update = nullptr;
     }
+
+    TeardownCpuTimer();
 }
 
 void LibrariesInfoCache::UpdateCache()
@@ -206,19 +303,20 @@ void LibrariesInfoCache::UpdateCache()
     // But the Cache Thread is blocked (T1 owns the malloc lock)
     // T1 is blocked when libwunding calls DlIteratePhdr.
 
-    // OPTIM: make it static to reuse buffer overtime
-    // Safe to make it static to the function, this variable is accessed only by one thread.
-    static std::vector<DlPhdrInfoWrapper> newCache;
-    newCache.reserve(_librariesInfo.capacity());
+    _reloadCount++;
+    _trackingResource.ResetPerReloadStats();
+    auto reloadStart = std::chrono::steady_clock::now();
+
+    _newCache.reserve(_librariesInfo.capacity());
 
     struct Data
     {
     public:
-        std::vector<DlPhdrInfoWrapper>* Cache;
+        std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>>* Cache;
         shared::pmr::memory_resource* Allocator;
     };
 
-    auto data = Data{.Cache = &newCache, .Allocator = _wrappersAllocator};
+    auto data = Data{.Cache = &_newCache, .Allocator = _wrappersAllocator};
 
     dl_iterate_phdr(
         [](struct dl_phdr_info* info, std::size_t size, void* data) {
@@ -233,9 +331,11 @@ void LibrariesInfoCache::UpdateCache()
     static std::vector<FuncEntry> newSymbols;
     newRegions.clear();
     newSymbols.clear();
-    BuildSymbolCache(newCache, newRegions, newSymbols);
+    BuildSymbolCache(_newCache, newRegions, newSymbols);
 #endif
 
+
+    auto lockStart = std::chrono::steady_clock::now();
     {
         std::unique_lock l{_cacheLock};
         _librariesInfo.swap(newCache);
@@ -244,12 +344,28 @@ void LibrariesInfoCache::UpdateCache()
         _symbols.swap(newSymbols);
 #endif
     }
+    auto lockEnd = std::chrono::steady_clock::now();
 
-    newCache.clear();
-#ifdef ARM64
-    newRegions.clear();
-    newSymbols.clear();
-#endif
+    _newCache.clear();
+    #ifdef ARM64
+        newRegions.clear();
+        newSymbols.clear();
+    #endif
+
+    auto reloadEnd = std::chrono::steady_clock::now();
+    auto reloadDuration = reloadEnd - reloadStart;
+    auto lockDuration = lockEnd - lockStart;
+
+    _totalReloadDuration += reloadDuration;
+    _totalLockHoldDuration += lockDuration;
+    if (reloadDuration > _maxReloadDuration)
+    {
+        _maxReloadDuration = reloadDuration;
+    }
+    if (lockDuration > _maxLockHoldDuration)
+    {
+        _maxLockHoldDuration = lockDuration;
+    }
 }
 
 #ifdef ARM64
@@ -476,6 +592,7 @@ void LibrariesInfoCache::NotifyCacheUpdate()
 
 void LibrariesInfoCache::NotifyCacheUpdateImpl()
 {
+    _notificationCount++;
     _event.Set();
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -17,16 +17,12 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <signal.h>
-#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 
 using namespace std::chrono_literals;
 
 namespace {
-
-constexpr auto CpuTimerInterval = 10ms;
 
 struct ScopedMmap
 {
@@ -48,16 +44,6 @@ struct ScopedMmap
     explicit operator bool() const { return data != MAP_FAILED; }
 };
 
-std::atomic<std::uint64_t>* s_cpuTicksPtr = nullptr;
-
-void CpuTickSignalHandler(int /*sig*/)
-{
-    auto* ptr = s_cpuTicksPtr;
-    if (ptr != nullptr)
-    {
-        ptr->fetch_add(1, std::memory_order_relaxed);
-    }
-}
 } // anonymous namespace
 
 // --------------------------------------------------------------------------
@@ -73,39 +59,17 @@ public:
     }
 
     std::size_t GetCurrentUsage() const { return _currentUsage.load(std::memory_order_relaxed); }
-    std::size_t GetPeakUsage() const { return _peakUsage.load(std::memory_order_relaxed); }
-    std::size_t GetTotalAllocated() const { return _totalAllocated.load(std::memory_order_relaxed); }
-    std::size_t GetTotalDeallocated() const { return _totalDeallocated.load(std::memory_order_relaxed); }
-    std::size_t GetAllocationCount() const { return _allocationCount.load(std::memory_order_relaxed); }
-
-    void ResetPerReloadStats()
-    {
-        _reloadAllocations.store(0, std::memory_order_relaxed);
-        _reloadBytes.store(0, std::memory_order_relaxed);
-    }
-
-    std::size_t GetReloadAllocations() const { return _reloadAllocations.load(std::memory_order_relaxed); }
-    std::size_t GetReloadBytes() const { return _reloadBytes.load(std::memory_order_relaxed); }
 
 protected:
     void* do_allocate(std::size_t bytes, std::size_t alignment) override
     {
-        _reloadAllocations.fetch_add(1, std::memory_order_relaxed);
-        _reloadBytes.fetch_add(bytes, std::memory_order_relaxed);
-        _allocationCount.fetch_add(1, std::memory_order_relaxed);
-        _totalAllocated.fetch_add(bytes, std::memory_order_relaxed);
-        auto current = _currentUsage.fetch_add(bytes, std::memory_order_relaxed) + bytes;
-        auto peak = _peakUsage.load(std::memory_order_relaxed);
-        while (current > peak && !_peakUsage.compare_exchange_weak(peak, current, std::memory_order_relaxed))
-        {
-        }
+        _currentUsage.fetch_add(bytes, std::memory_order_relaxed);
         return _upstream->allocate(bytes, alignment);
     }
 
     void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
     {
         _currentUsage.fetch_sub(bytes, std::memory_order_relaxed);
-        _totalDeallocated.fetch_add(bytes, std::memory_order_relaxed);
         _upstream->deallocate(p, bytes, alignment);
     }
 
@@ -117,12 +81,6 @@ protected:
 private:
     shared::pmr::memory_resource* _upstream;
     std::atomic<std::size_t> _currentUsage{0};
-    std::atomic<std::size_t> _peakUsage{0};
-    std::atomic<std::size_t> _totalAllocated{0};
-    std::atomic<std::size_t> _totalDeallocated{0};
-    std::atomic<std::size_t> _allocationCount{0};
-    std::atomic<std::size_t> _reloadAllocations{0};
-    std::atomic<std::size_t> _reloadBytes{0};
 };
 
 // --------------------------------------------------------------------------
@@ -134,21 +92,11 @@ struct FootprintTracker
 {
     TrackingMemoryResource trackingResource;
 
-    std::atomic<std::uint64_t> cpuTicks{0};
-    timer_t cpuTimerId{};
-    bool cpuTimerCreated{false};
-
     std::uint32_t reloadCount{0};
-    std::uint32_t notificationCount{0};
-    std::chrono::steady_clock::duration totalReloadDuration{0};
-    std::chrono::steady_clock::duration maxReloadDuration{0};
-    std::chrono::steady_clock::duration totalLockHoldDuration{0};
-    std::chrono::steady_clock::duration maxLockHoldDuration{0};
+    std::uint64_t totalCpuNs{0};
 
     std::shared_ptr<ProxyMetric> libCountMetric;
     std::shared_ptr<ProxyMetric> memoryFootprintMetric;
-    std::shared_ptr<ProxyMetric> memoryPeakMetric;
-    std::shared_ptr<ProxyMetric> cpuTicksMetric;
 #ifdef ARM64
     std::shared_ptr<ProxyMetric> moduleCountMetric;
     std::shared_ptr<ProxyMetric> symbolCountMetric;
@@ -156,7 +104,6 @@ struct FootprintTracker
     std::shared_ptr<MeanMaxMetric> updateCpuMetric;
     std::shared_ptr<MeanMaxMetric> reloadDurationMetric;
     std::shared_ptr<MeanMaxMetric> lockHoldDurationMetric;
-    std::shared_ptr<MeanMaxMetric> reloadAllocationsMetric;
 
     explicit FootprintTracker(shared::pmr::memory_resource* upstream) :
         trackingResource{upstream}
@@ -164,8 +111,6 @@ struct FootprintTracker
     }
 
     void RegisterMetrics(MetricsRegistry& registry, LibrariesInfoCache* cache);
-    void SetupCpuTimer();
-    void TeardownCpuTimer();
     void LogStats(std::size_t libCount);
     void RecordReload(std::chrono::steady_clock::duration reloadDuration,
                       std::chrono::steady_clock::duration lockDuration,
@@ -312,11 +257,6 @@ void LibrariesInfoCache::Work(std::shared_ptr<AutoResetEvent> startEvent)
 {
     OpSysTools::SetNativeThreadName(WStr("DD_LibsCache"));
 
-    if (_tracker)
-    {
-        _tracker->SetupCpuTimer();
-    }
-
     auto timeout = InfiniteTimeout;
     if (&dd_notify_libraries_cache_update != nullptr) [[likely]]
     {
@@ -356,11 +296,6 @@ void LibrariesInfoCache::Work(std::shared_ptr<AutoResetEvent> startEvent)
     {
         dd_notify_libraries_cache_update = nullptr;
     }
-
-    if (_tracker)
-    {
-        _tracker->TeardownCpuTimer();
-    }
 }
 
 void LibrariesInfoCache::UpdateCache()
@@ -378,7 +313,6 @@ void LibrariesInfoCache::UpdateCache()
     if (_tracker)
     {
         _tracker->reloadCount++;
-        _tracker->trackingResource.ResetPerReloadStats();
         clock_gettime(CLOCK_THREAD_CPUTIME_ID, &cpuStart);
         reloadStart = std::chrono::steady_clock::now();
     }
@@ -670,10 +604,6 @@ void LibrariesInfoCache::NotifyCacheUpdate()
 
 void LibrariesInfoCache::NotifyCacheUpdateImpl()
 {
-    if (_tracker)
-    {
-        _tracker->notificationCount++;
-    }
     _event.Set();
 }
 
@@ -696,12 +626,6 @@ void FootprintTracker::RegisterMetrics(MetricsRegistry& registry, LibrariesInfoC
     memoryFootprintMetric = registry.GetOrRegister<ProxyMetric>("dotnet_memory_footprint_libs_cache", [this]() {
         return static_cast<double_t>(trackingResource.GetCurrentUsage());
     });
-    memoryPeakMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_memory_peak", [this]() {
-        return static_cast<double_t>(trackingResource.GetPeakUsage());
-    });
-    cpuTicksMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_cpu_ticks", [this]() {
-        return static_cast<double_t>(cpuTicks.load(std::memory_order_relaxed));
-    });
 #ifdef ARM64
     moduleCountMetric = registry.GetOrRegister<ProxyMetric>("dotnet_libs_cache_module_regions", [cache]() {
         return static_cast<double_t>(cache->_moduleRegions.size());
@@ -713,117 +637,29 @@ void FootprintTracker::RegisterMetrics(MetricsRegistry& registry, LibrariesInfoC
     updateCpuMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_update_cpu_ns");
     reloadDurationMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_duration_ns");
     lockHoldDurationMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_lock_hold_duration_ns");
-    reloadAllocationsMetric = registry.GetOrRegister<MeanMaxMetric>("dotnet_libs_cache_reload_allocations");
-}
-
-void FootprintTracker::SetupCpuTimer()
-{
-    const int cpuTimerSignal = SIGRTMIN + 10;
-
-    struct sigaction sa = {};
-    sa.sa_handler = CpuTickSignalHandler;
-    sa.sa_flags = SA_RESTART;
-    sigemptyset(&sa.sa_mask);
-    if (sigaction(cpuTimerSignal, &sa, nullptr) != 0)
-    {
-        Log::Warn("LibrariesInfoCache: Failed to install signal handler (signal=", cpuTimerSignal, ") for CPU measurement: ", strerror(errno));
-        return;
-    }
-
-    s_cpuTicksPtr = &cpuTicks;
-
-    auto tid = static_cast<int>(syscall(SYS_gettid));
-
-    struct sigevent sev = {};
-    sev.sigev_signo = cpuTimerSignal;
-    sev.sigev_notify = SIGEV_THREAD_ID;
-    ((int*)&sev.sigev_notify)[1] = tid;
-
-    clockid_t clock = ((~tid) << 3) | 6; // CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK
-    if (syscall(__NR_timer_create, clock, &sev, &cpuTimerId) < 0)
-    {
-        Log::Warn("LibrariesInfoCache: Failed to create CPU timer: ", strerror(errno));
-        s_cpuTicksPtr = nullptr;
-        return;
-    }
-
-    cpuTimerCreated = true;
-
-    struct itimerspec its = {};
-
-    constexpr auto cpuTimerIntervalNs = std::chrono::duration_cast<std::chrono::nanoseconds>(CpuTimerInterval).count();
-    its.it_interval = {0, cpuTimerIntervalNs};
-    its.it_value = {0, cpuTimerIntervalNs};
-    if (syscall(__NR_timer_settime, cpuTimerId, 0, &its, nullptr) < 0)
-    {
-        Log::Warn("LibrariesInfoCache: Failed to arm CPU timer: ", strerror(errno));
-        syscall(__NR_timer_delete, cpuTimerId);
-        cpuTimerCreated = false;
-        s_cpuTicksPtr = nullptr;
-        return;
-    }
-
-    Log::Info("LibrariesInfoCache: CPU timer armed on worker thread (tid=", tid, ")");
-}
-
-void FootprintTracker::TeardownCpuTimer()
-{
-    if (cpuTimerCreated)
-    {
-        syscall(__NR_timer_delete, cpuTimerId);
-        cpuTimerCreated = false;
-    }
-    s_cpuTicksPtr = nullptr;
 }
 
 void FootprintTracker::LogStats(std::size_t libCount)
 {
-    auto cpuTime = CpuTimerInterval * cpuTicks.load(std::memory_order_relaxed);
-    auto avgReloadDuration = reloadCount > 0
-        ? std::chrono::duration_cast<std::chrono::microseconds>(totalReloadDuration) / reloadCount
-        : std::chrono::microseconds{0};
-    auto maxReload = std::chrono::duration_cast<std::chrono::microseconds>(maxReloadDuration);
-    auto avgLockDuration = reloadCount > 0
-        ? std::chrono::duration_cast<std::chrono::microseconds>(totalLockHoldDuration) / reloadCount
-        : std::chrono::microseconds{0};
-    auto maxLock = std::chrono::duration_cast<std::chrono::microseconds>(maxLockHoldDuration);
-
     Log::Info("LibrariesInfoCache stats:");
-    Log::Info("  CPU time (worker thread): ", cpuTime);
-    Log::Info("  Notifications received: ", notificationCount);
     Log::Info("  Cache reloads: ", reloadCount);
-    Log::Info("  Reload duration avg: ", avgReloadDuration, ", max: ", maxReload);
-    Log::Info("  Lock hold duration avg: ", avgLockDuration, ", max: ", maxLock);
+    Log::Info("  Total CPU (worker): ", totalCpuNs / 1'000'000, " ms");
     Log::Info("  Libraries in cache: ", libCount);
     Log::Info("  Memory current: ", trackingResource.GetCurrentUsage(), " bytes");
-    Log::Info("  Memory peak: ", trackingResource.GetPeakUsage(), " bytes");
-    Log::Info("  Memory total allocated: ", trackingResource.GetTotalAllocated(), " bytes");
-    Log::Info("  Memory total deallocated: ", trackingResource.GetTotalDeallocated(), " bytes");
-    Log::Info("  Memory allocation count: ", trackingResource.GetAllocationCount());
 }
 
 void FootprintTracker::RecordReload(std::chrono::steady_clock::duration reloadDuration,
                                     std::chrono::steady_clock::duration lockDuration,
                                     struct timespec cpuStart, struct timespec cpuEnd)
 {
-    totalReloadDuration += reloadDuration;
-    totalLockHoldDuration += lockDuration;
-    if (reloadDuration > maxReloadDuration)
-    {
-        maxReloadDuration = reloadDuration;
-    }
-    if (lockDuration > maxLockHoldDuration)
-    {
-        maxLockHoldDuration = lockDuration;
-    }
-
     auto cpuNs = static_cast<double_t>(
         (cpuEnd.tv_sec - cpuStart.tv_sec) * 1'000'000'000LL + (cpuEnd.tv_nsec - cpuStart.tv_nsec));
+
+    totalCpuNs += static_cast<std::uint64_t>(cpuNs);
 
     updateCpuMetric->Add(cpuNs);
     reloadDurationMetric->Add(static_cast<double_t>(
         std::chrono::duration_cast<std::chrono::nanoseconds>(reloadDuration).count()));
     lockHoldDurationMetric->Add(static_cast<double_t>(
         std::chrono::duration_cast<std::chrono::nanoseconds>(lockDuration).count()));
-    reloadAllocationsMetric->Add(static_cast<double_t>(trackingResource.GetReloadAllocations()));
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -14,10 +14,12 @@
 #include "shared/src/native-src/dd_memory_resource.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <link.h>
 #include <memory>
 #include <shared_mutex>
 #include <thread>
+#include <time.h>
 #include <vector>
 
 #ifdef ARM64
@@ -35,6 +37,67 @@ struct ModuleRegion
     uint32_t sym_count;
 };
 #endif
+
+class TrackingMemoryResource : public shared::pmr::memory_resource
+{
+public:
+    explicit TrackingMemoryResource(shared::pmr::memory_resource* upstream) :
+        _upstream{upstream}
+    {
+    }
+
+    std::size_t GetCurrentUsage() const { return _currentUsage.load(std::memory_order_relaxed); }
+    std::size_t GetPeakUsage() const { return _peakUsage.load(std::memory_order_relaxed); }
+    std::size_t GetTotalAllocated() const { return _totalAllocated.load(std::memory_order_relaxed); }
+    std::size_t GetTotalDeallocated() const { return _totalDeallocated.load(std::memory_order_relaxed); }
+    std::size_t GetAllocationCount() const { return _allocationCount.load(std::memory_order_relaxed); }
+
+    void ResetPerReloadStats()
+    {
+        _reloadAllocations.store(0, std::memory_order_relaxed);
+        _reloadBytes.store(0, std::memory_order_relaxed);
+    }
+
+    std::size_t GetReloadAllocations() const { return _reloadAllocations.load(std::memory_order_relaxed); }
+    std::size_t GetReloadBytes() const { return _reloadBytes.load(std::memory_order_relaxed); }
+
+protected:
+    void* do_allocate(std::size_t bytes, std::size_t alignment) override
+    {
+        _reloadAllocations.fetch_add(1, std::memory_order_relaxed);
+        _reloadBytes.fetch_add(bytes, std::memory_order_relaxed);
+        _allocationCount.fetch_add(1, std::memory_order_relaxed);
+        _totalAllocated.fetch_add(bytes, std::memory_order_relaxed);
+        auto current = _currentUsage.fetch_add(bytes, std::memory_order_relaxed) + bytes;
+        auto peak = _peakUsage.load(std::memory_order_relaxed);
+        while (current > peak && !_peakUsage.compare_exchange_weak(peak, current, std::memory_order_relaxed))
+        {
+        }
+        return _upstream->allocate(bytes, alignment);
+    }
+
+    void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
+    {
+        _currentUsage.fetch_sub(bytes, std::memory_order_relaxed);
+        _totalDeallocated.fetch_add(bytes, std::memory_order_relaxed);
+        _upstream->deallocate(p, bytes, alignment);
+    }
+
+    bool do_is_equal(const memory_resource& other) const noexcept override
+    {
+        return this == &other;
+    }
+
+private:
+    shared::pmr::memory_resource* _upstream;
+    std::atomic<std::size_t> _currentUsage{0};
+    std::atomic<std::size_t> _peakUsage{0};
+    std::atomic<std::size_t> _totalAllocated{0};
+    std::atomic<std::size_t> _totalDeallocated{0};
+    std::atomic<std::size_t> _allocationCount{0};
+    std::atomic<std::size_t> _reloadAllocations{0};
+    std::atomic<std::size_t> _reloadBytes{0};
+};
 
 class LibrariesInfoCache : public ServiceBase
 {
@@ -90,11 +153,18 @@ private:
 #endif
     int DlIteratePhdrImpl(unw_iterate_phdr_callback_t callback, void* data);
     void Work(std::shared_ptr<AutoResetEvent> startEvent);
+    void LogStats();
+    void SetupCpuTimer();
+    void TeardownCpuTimer();
 
     static std::atomic<LibrariesInfoCache*> s_instance;
 
+    TrackingMemoryResource _trackingResource;
+    shared::pmr::memory_resource* _wrappersAllocator;
+
     std::shared_mutex _cacheLock;
-    std::vector<DlPhdrInfoWrapper> _librariesInfo;
+    std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>> _librariesInfo;
+    std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>> _newCache;
 
 #ifdef ARM64
 #ifdef DD_TEST
@@ -113,5 +183,15 @@ private:
     std::thread _worker;
     std::atomic<bool> _stopRequested;
     AutoResetEvent _event;
-    shared::pmr::memory_resource* _wrappersAllocator;
+
+    // Stats
+    std::atomic<std::uint64_t> _cpuTicks{0};
+    std::uint32_t _reloadCount{0};
+    std::uint32_t _notificationCount{0};
+    std::chrono::steady_clock::duration _totalReloadDuration{0};
+    std::chrono::steady_clock::duration _maxReloadDuration{0};
+    std::chrono::steady_clock::duration _totalLockHoldDuration{0};
+    std::chrono::steady_clock::duration _maxLockHoldDuration{0};
+    timer_t _cpuTimerId{};
+    bool _cpuTimerCreated{false};
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -140,9 +140,9 @@ private:
 #ifdef DD_TEST
 public:
 #endif
-    void BuildSymbolCache(std::vector<DlPhdrInfoWrapper>& phdrCache,
-                          std::vector<ModuleRegion>& outRegions,
-                          std::vector<FuncEntry>& outSymbols);
+    void BuildSymbolCache(std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>>& phdrCache,
+                          std::vector<ModuleRegion, shared::pmr::polymorphic_allocator<ModuleRegion>>& outRegions,
+                          std::vector<FuncEntry, shared::pmr::polymorphic_allocator<FuncEntry>>& outSymbols);
 #ifdef DD_TEST
 private:
 #endif
@@ -170,8 +170,10 @@ private:
 #ifdef DD_TEST
 public:
 #endif
-    std::vector<ModuleRegion> _moduleRegions;
-    std::vector<FuncEntry> _symbols;
+    std::vector<ModuleRegion, shared::pmr::polymorphic_allocator<ModuleRegion>> _moduleRegions;
+    std::vector<FuncEntry, shared::pmr::polymorphic_allocator<FuncEntry>> _symbols;
+    std::vector<ModuleRegion, shared::pmr::polymorphic_allocator<ModuleRegion>> _newRegions;
+    std::vector<FuncEntry, shared::pmr::polymorphic_allocator<FuncEntry>> _newSymbols;
 #ifdef DD_TEST
 private:
 #endif

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -8,21 +8,15 @@
 #include "DlPhdrInfoWrapper.h"
 
 #include "AutoResetEvent.h"
-#include "MeanMaxMetric.h"
-#include "MemoryResourceManager.h"
-#include "MetricsRegistry.h"
-#include "ProxyMetric.h"
 #include "ServiceBase.h"
 
 #include "shared/src/native-src/dd_memory_resource.hpp"
 
 #include <atomic>
-#include <chrono>
 #include <link.h>
 #include <memory>
 #include <shared_mutex>
 #include <thread>
-#include <time.h>
 #include <vector>
 
 #ifdef ARM64
@@ -41,71 +35,16 @@ struct ModuleRegion
 };
 #endif
 
-class TrackingMemoryResource : public shared::pmr::memory_resource
-{
-public:
-    explicit TrackingMemoryResource(shared::pmr::memory_resource* upstream) :
-        _upstream{upstream}
-    {
-    }
-
-    std::size_t GetCurrentUsage() const { return _currentUsage.load(std::memory_order_relaxed); }
-    std::size_t GetPeakUsage() const { return _peakUsage.load(std::memory_order_relaxed); }
-    std::size_t GetTotalAllocated() const { return _totalAllocated.load(std::memory_order_relaxed); }
-    std::size_t GetTotalDeallocated() const { return _totalDeallocated.load(std::memory_order_relaxed); }
-    std::size_t GetAllocationCount() const { return _allocationCount.load(std::memory_order_relaxed); }
-
-    void ResetPerReloadStats()
-    {
-        _reloadAllocations.store(0, std::memory_order_relaxed);
-        _reloadBytes.store(0, std::memory_order_relaxed);
-    }
-
-    std::size_t GetReloadAllocations() const { return _reloadAllocations.load(std::memory_order_relaxed); }
-    std::size_t GetReloadBytes() const { return _reloadBytes.load(std::memory_order_relaxed); }
-
-protected:
-    void* do_allocate(std::size_t bytes, std::size_t alignment) override
-    {
-        _reloadAllocations.fetch_add(1, std::memory_order_relaxed);
-        _reloadBytes.fetch_add(bytes, std::memory_order_relaxed);
-        _allocationCount.fetch_add(1, std::memory_order_relaxed);
-        _totalAllocated.fetch_add(bytes, std::memory_order_relaxed);
-        auto current = _currentUsage.fetch_add(bytes, std::memory_order_relaxed) + bytes;
-        auto peak = _peakUsage.load(std::memory_order_relaxed);
-        while (current > peak && !_peakUsage.compare_exchange_weak(peak, current, std::memory_order_relaxed))
-        {
-        }
-        return _upstream->allocate(bytes, alignment);
-    }
-
-    void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) override
-    {
-        _currentUsage.fetch_sub(bytes, std::memory_order_relaxed);
-        _totalDeallocated.fetch_add(bytes, std::memory_order_relaxed);
-        _upstream->deallocate(p, bytes, alignment);
-    }
-
-    bool do_is_equal(const memory_resource& other) const noexcept override
-    {
-        return this == &other;
-    }
-
-private:
-    shared::pmr::memory_resource* _upstream;
-    std::atomic<std::size_t> _currentUsage{0};
-    std::atomic<std::size_t> _peakUsage{0};
-    std::atomic<std::size_t> _totalAllocated{0};
-    std::atomic<std::size_t> _totalDeallocated{0};
-    std::atomic<std::size_t> _allocationCount{0};
-    std::atomic<std::size_t> _reloadAllocations{0};
-    std::atomic<std::size_t> _reloadBytes{0};
-};
+class IConfiguration;
+class MetricsRegistry;
+struct FootprintTracker;
 
 class LibrariesInfoCache : public ServiceBase
 {
+    friend struct FootprintTracker;
+
 public:
-    LibrariesInfoCache(shared::pmr::memory_resource* resource, MetricsRegistry& metricsRegistry);
+    LibrariesInfoCache(IConfiguration* configuration, shared::pmr::memory_resource* resource, MetricsRegistry& metricsRegistry);
     ~LibrariesInfoCache();
 
     LibrariesInfoCache(LibrariesInfoCache const&) = delete;
@@ -156,13 +95,10 @@ private:
 #endif
     int DlIteratePhdrImpl(unw_iterate_phdr_callback_t callback, void* data);
     void Work(std::shared_ptr<AutoResetEvent> startEvent);
-    void LogStats();
-    void SetupCpuTimer();
-    void TeardownCpuTimer();
 
     static std::atomic<LibrariesInfoCache*> s_instance;
 
-    TrackingMemoryResource _trackingResource;
+    std::unique_ptr<FootprintTracker> _tracker;
     shared::pmr::memory_resource* _wrappersAllocator;
 
     std::shared_mutex _cacheLock;
@@ -188,29 +124,4 @@ private:
     std::thread _worker;
     std::atomic<bool> _stopRequested;
     AutoResetEvent _event;
-
-    // Stats
-    std::atomic<std::uint64_t> _cpuTicks{0};
-    std::uint32_t _reloadCount{0};
-    std::uint32_t _notificationCount{0};
-    std::chrono::steady_clock::duration _totalReloadDuration{0};
-    std::chrono::steady_clock::duration _maxReloadDuration{0};
-    std::chrono::steady_clock::duration _totalLockHoldDuration{0};
-    std::chrono::steady_clock::duration _maxLockHoldDuration{0};
-    timer_t _cpuTimerId{};
-    bool _cpuTimerCreated{false};
-
-    // Metrics (emitted via DogStatsD)
-    std::shared_ptr<ProxyMetric> _libCountMetric;
-    std::shared_ptr<ProxyMetric> _memoryFootprintMetric;
-    std::shared_ptr<ProxyMetric> _memoryPeakMetric;
-    std::shared_ptr<ProxyMetric> _cpuTicksMetric;
-#ifdef ARM64
-    std::shared_ptr<ProxyMetric> _moduleCountMetric;
-    std::shared_ptr<ProxyMetric> _symbolCountMetric;
-#endif
-    std::shared_ptr<MeanMaxMetric> _updateCpuMetric;
-    std::shared_ptr<MeanMaxMetric> _reloadDurationMetric;
-    std::shared_ptr<MeanMaxMetric> _lockHoldDurationMetric;
-    std::shared_ptr<MeanMaxMetric> _reloadAllocationsMetric;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -8,7 +8,10 @@
 #include "DlPhdrInfoWrapper.h"
 
 #include "AutoResetEvent.h"
+#include "MeanMaxMetric.h"
 #include "MemoryResourceManager.h"
+#include "MetricsRegistry.h"
+#include "ProxyMetric.h"
 #include "ServiceBase.h"
 
 #include "shared/src/native-src/dd_memory_resource.hpp"
@@ -102,7 +105,7 @@ private:
 class LibrariesInfoCache : public ServiceBase
 {
 public:
-    LibrariesInfoCache(shared::pmr::memory_resource* resource);
+    LibrariesInfoCache(shared::pmr::memory_resource* resource, MetricsRegistry& metricsRegistry);
     ~LibrariesInfoCache();
 
     LibrariesInfoCache(LibrariesInfoCache const&) = delete;
@@ -196,4 +199,18 @@ private:
     std::chrono::steady_clock::duration _maxLockHoldDuration{0};
     timer_t _cpuTimerId{};
     bool _cpuTimerCreated{false};
+
+    // Metrics (emitted via DogStatsD)
+    std::shared_ptr<ProxyMetric> _libCountMetric;
+    std::shared_ptr<ProxyMetric> _memoryFootprintMetric;
+    std::shared_ptr<ProxyMetric> _memoryPeakMetric;
+    std::shared_ptr<ProxyMetric> _cpuTicksMetric;
+#ifdef ARM64
+    std::shared_ptr<ProxyMetric> _moduleCountMetric;
+    std::shared_ptr<ProxyMetric> _symbolCountMetric;
+#endif
+    std::shared_ptr<MeanMaxMetric> _updateCpuMetric;
+    std::shared_ptr<MeanMaxMetric> _reloadDurationMetric;
+    std::shared_ptr<MeanMaxMetric> _lockHoldDurationMetric;
+    std::shared_ptr<MeanMaxMetric> _reloadAllocationsMetric;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -41,8 +41,6 @@ struct FootprintTracker;
 
 class LibrariesInfoCache : public ServiceBase
 {
-    friend struct FootprintTracker;
-
 public:
     LibrariesInfoCache(IConfiguration* configuration, shared::pmr::memory_resource* resource, MetricsRegistry& metricsRegistry);
     ~LibrariesInfoCache();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -182,7 +182,7 @@ void CorProfilerCallback::InitializeServices()
     // Like the SystemCallsShield, this service must be started before any profiler.
     // For now we asked for a memory resource that will have maximum 100 blocks of 1KiB per block.
     // (before it uses the default memory resource a.k.a new/delete for allocation)
-    RegisterService<LibrariesInfoCache>(_memoryResourceManager.GetSynchronizedPool(100, 1024), _metricsRegistry);
+    RegisterService<LibrariesInfoCache>(_pConfiguration.get(), _memoryResourceManager.GetSynchronizedPool(100, 1024), _metricsRegistry);
 #endif
 
     _pFrameStore = std::make_unique<FrameStore>(

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -182,8 +182,7 @@ void CorProfilerCallback::InitializeServices()
     // Like the SystemCallsShield, this service must be started before any profiler.
     // For now we asked for a memory resource that will have maximum 100 blocks of 1KiB per block.
     // (before it uses the default memory resource a.k.a new/delete for allocation)
-    // TODO add metrics to measure if it's ok or not
-    RegisterService<LibrariesInfoCache>(_memoryResourceManager.GetSynchronizedPool(100, 1024));
+    RegisterService<LibrariesInfoCache>(_memoryResourceManager.GetSynchronizedPool(100, 1024), _metricsRegistry);
 #endif
 
     _pFrameStore = std::make_unique<FrameStore>(

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -222,21 +222,23 @@ TEST(LibrariesInfoCacheTests, GetProcNameReplacesAndRestoresOriginalAccessor)
 
 TEST(LibrariesInfoCacheTests, BuildSymbolCacheProducesNoDuplicates)
 {
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    auto* resource = MemoryResourceManager::GetDefault();
+    LibrariesInfoCache libCache(resource);
     ServiceWrapper serviceWrapper(&libCache);
 
-    std::vector<DlPhdrInfoWrapper> phdrCache;
-    
+    using PhdrVector = std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>>;
+    PhdrVector phdrCache(resource);
+
     dl_iterate_phdr(
         [](struct dl_phdr_info* info, std::size_t size, void* data) {
-            auto* cache = static_cast<std::vector<DlPhdrInfoWrapper>*>(data);
+            auto* cache = static_cast<PhdrVector*>(data);
             cache->emplace_back(info, size, MemoryResourceManager::GetDefault());
             return 0;
         },
         &phdrCache);
 
-    std::vector<ModuleRegion> regions;
-    std::vector<FuncEntry> symbols;
+    std::vector<ModuleRegion, shared::pmr::polymorphic_allocator<ModuleRegion>> regions(resource);
+    std::vector<FuncEntry, shared::pmr::polymorphic_allocator<FuncEntry>> symbols(resource);
     libCache.BuildSymbolCache(phdrCache, regions, symbols);
 
     ASSERT_FALSE(symbols.empty()) << "Expected at least some symbols from the test binary";

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 
 #include "MemoryResourceManager.h"
+#include "MetricsRegistry.h"
 #include "LibrariesInfoCache.h"
 
 #include <chrono>
@@ -39,7 +40,8 @@ struct ServiceWrapper
 // For that we need to use the default memory resource (new/delete)
 TEST(LibrariesInfoCacheTests, MakeSureWeDoNotLeakMemory)
 {
-    auto cache = LibrariesInfoCache(MemoryResourceManager::GetDefault());
+    MetricsRegistry metricsRegistry;
+    auto cache = LibrariesInfoCache(MemoryResourceManager::GetDefault(), metricsRegistry);
 
     for(auto i = 0; i < 5; i++)
     {
@@ -76,7 +78,8 @@ TEST(LibrariesInfoCacheTests, CheckBehaviorAgainstDlIteratePhdr)
         &cache);
 
     std::vector<Info> cache2;
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    MetricsRegistry metricsRegistry;
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
     LibrariesInfoCache::DlIteratePhdr(
         [](struct dl_phdr_info* info, std::size_t size, void* data) {
@@ -121,7 +124,8 @@ __attribute__((noinline)) int KnownTestFunction_Third(int x, int y)
 
 TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForKnownFunction)
 {
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    MetricsRegistry metricsRegistry;
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     auto ip = reinterpret_cast<unw_word_t>(&KnownTestFunction_ForGetProcNameTest);
@@ -138,7 +142,8 @@ TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForKnownFunction)
 
 TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForMultipleKnownFunctions)
 {
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    MetricsRegistry metricsRegistry;
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     auto* as = static_cast<unw_addr_space_t>(LibrariesInfoCache::GetLocalAddressSpace());
@@ -167,7 +172,8 @@ TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForMultipleKnownFun
 
 TEST(LibrariesInfoCacheTests, GetProcNameReturnsOffsetForAddressInsideFunction)
 {
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    MetricsRegistry metricsRegistry;
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     auto funcAddr = reinterpret_cast<unw_word_t>(&KnownTestFunction_Third);
@@ -185,7 +191,8 @@ TEST(LibrariesInfoCacheTests, GetProcNameReturnsOffsetForAddressInsideFunction)
 
 TEST(LibrariesInfoCacheTests, GetProcNameFailsForBogusAddress)
 {
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+    MetricsRegistry metricsRegistry;
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     unw_word_t ip = 0x1;
@@ -207,7 +214,8 @@ TEST(LibrariesInfoCacheTests, GetProcNameReplacesAndRestoresOriginalAccessor)
     auto originalGetProcName = acc->get_proc_name;
 
     {
-        LibrariesInfoCache libCache(MemoryResourceManager::GetDefault());
+        MetricsRegistry metricsRegistry;
+    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
         ServiceWrapper serviceWrapper(&libCache);
 
         ASSERT_EQ(acc->get_proc_name, &LibrariesInfoCache::GetProcName)
@@ -223,7 +231,8 @@ TEST(LibrariesInfoCacheTests, GetProcNameReplacesAndRestoresOriginalAccessor)
 TEST(LibrariesInfoCacheTests, BuildSymbolCacheProducesNoDuplicates)
 {
     auto* resource = MemoryResourceManager::GetDefault();
-    LibrariesInfoCache libCache(resource);
+    MetricsRegistry metricsRegistry;
+    LibrariesInfoCache libCache(resource, metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     using PhdrVector = std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>>;

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -6,6 +6,7 @@
 #include "MemoryResourceManager.h"
 #include "MetricsRegistry.h"
 #include "LibrariesInfoCache.h"
+#include "ProfilerMockedInterface.h"
 
 #include <chrono>
 #include <cstdlib>
@@ -40,8 +41,9 @@ struct ServiceWrapper
 // For that we need to use the default memory resource (new/delete)
 TEST(LibrariesInfoCacheTests, MakeSureWeDoNotLeakMemory)
 {
+    testing::NiceMock<MockConfiguration> config;
     MetricsRegistry metricsRegistry;
-    auto cache = LibrariesInfoCache(MemoryResourceManager::GetDefault(), metricsRegistry);
+    auto cache = LibrariesInfoCache(&config, MemoryResourceManager::GetDefault(), metricsRegistry);
 
     for(auto i = 0; i < 5; i++)
     {
@@ -78,8 +80,9 @@ TEST(LibrariesInfoCacheTests, CheckBehaviorAgainstDlIteratePhdr)
         &cache);
 
     std::vector<Info> cache2;
+    testing::NiceMock<MockConfiguration> config;
     MetricsRegistry metricsRegistry;
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
+    LibrariesInfoCache libCache(&config, MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
     LibrariesInfoCache::DlIteratePhdr(
         [](struct dl_phdr_info* info, std::size_t size, void* data) {
@@ -124,8 +127,9 @@ __attribute__((noinline)) int KnownTestFunction_Third(int x, int y)
 
 TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForKnownFunction)
 {
+    testing::NiceMock<MockConfiguration> config;
     MetricsRegistry metricsRegistry;
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
+    LibrariesInfoCache libCache(&config, MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     auto ip = reinterpret_cast<unw_word_t>(&KnownTestFunction_ForGetProcNameTest);
@@ -142,8 +146,9 @@ TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForKnownFunction)
 
 TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForMultipleKnownFunctions)
 {
+    testing::NiceMock<MockConfiguration> config;
     MetricsRegistry metricsRegistry;
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
+    LibrariesInfoCache libCache(&config, MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     auto* as = static_cast<unw_addr_space_t>(LibrariesInfoCache::GetLocalAddressSpace());
@@ -172,8 +177,9 @@ TEST(LibrariesInfoCacheTests, GetProcNameReturnsCorrectOffsetForMultipleKnownFun
 
 TEST(LibrariesInfoCacheTests, GetProcNameReturnsOffsetForAddressInsideFunction)
 {
+    testing::NiceMock<MockConfiguration> config;
     MetricsRegistry metricsRegistry;
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
+    LibrariesInfoCache libCache(&config, MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     auto funcAddr = reinterpret_cast<unw_word_t>(&KnownTestFunction_Third);
@@ -191,8 +197,9 @@ TEST(LibrariesInfoCacheTests, GetProcNameReturnsOffsetForAddressInsideFunction)
 
 TEST(LibrariesInfoCacheTests, GetProcNameFailsForBogusAddress)
 {
+    testing::NiceMock<MockConfiguration> config;
     MetricsRegistry metricsRegistry;
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
+    LibrariesInfoCache libCache(&config, MemoryResourceManager::GetDefault(), metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     unw_word_t ip = 0x1;
@@ -214,8 +221,9 @@ TEST(LibrariesInfoCacheTests, GetProcNameReplacesAndRestoresOriginalAccessor)
     auto originalGetProcName = acc->get_proc_name;
 
     {
+        testing::NiceMock<MockConfiguration> config;
         MetricsRegistry metricsRegistry;
-    LibrariesInfoCache libCache(MemoryResourceManager::GetDefault(), metricsRegistry);
+    LibrariesInfoCache libCache(&config, MemoryResourceManager::GetDefault(), metricsRegistry);
         ServiceWrapper serviceWrapper(&libCache);
 
         ASSERT_EQ(acc->get_proc_name, &LibrariesInfoCache::GetProcName)
@@ -231,8 +239,9 @@ TEST(LibrariesInfoCacheTests, GetProcNameReplacesAndRestoresOriginalAccessor)
 TEST(LibrariesInfoCacheTests, BuildSymbolCacheProducesNoDuplicates)
 {
     auto* resource = MemoryResourceManager::GetDefault();
+    testing::NiceMock<MockConfiguration> config;
     MetricsRegistry metricsRegistry;
-    LibrariesInfoCache libCache(resource, metricsRegistry);
+    LibrariesInfoCache libCache(&config, resource, metricsRegistry);
     ServiceWrapper serviceWrapper(&libCache);
 
     using PhdrVector = std::vector<DlPhdrInfoWrapper, shared::pmr::polymorphic_allocator<DlPhdrInfoWrapper>>;

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -178,7 +178,9 @@ public:
         SignalHandlerForTest::_instance = std::make_unique<SignalHandlerForTest>();
         inside_wrapped_functions = 0;
 
-        _librariesInfoCache = std::make_unique<LibrariesInfoCache>(MemoryResourceManager::GetDefault());
+        auto [configuration, mockConfiguration] = CreateConfiguration();
+        _configuration = std::move(configuration);
+        _librariesInfoCache = std::make_unique<LibrariesInfoCache>(_configuration.get(), MemoryResourceManager::GetDefault(), _metricsRegistry);
         _librariesInfoCache->Start();
     }
 
@@ -365,6 +367,8 @@ private:
     std::future<void> _callbackCalledFuture;
     std::unique_ptr<WorkerThread> _workerThread;
     std::unique_ptr<LibrariesInfoCache> _librariesInfoCache;
+    std::unique_ptr<IConfiguration> _configuration;
+    MetricsRegistry _metricsRegistry;
 #ifdef ARM64
     std::unique_ptr<ManagedCodeCache> _pManagedCodeCache;
 #endif


### PR DESCRIPTION
## Summary of changes

Add metrics to measure the cpu and memory consumption of the `LibrariesInfoCache`

## Reason for change

We are add caches to the `LibrariesInfoCache` and we need to measure and watch the memory consumption.

## Implementation details

Add a `FootprintTracker` to track the cpu, memory.
Use `MetricsRegistry` to report them as profiling metrics.

## Test coverage
The tests we have should suffice.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
