### PR TITLE
Fix ObjectDisposedException race in DataStreamsWriter disposal

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -195,8 +195,17 @@ internal sealed class DataStreamsWriter : IDataStreamsWriter
         _flushTimer?.Dispose();
 #endif
         await FlushAndCloseAsync().ConfigureAwait(false);
-        _flushSemaphore.Dispose();
-        _drainSignal.Dispose();
+
+        // We deliberately do NOT dispose _flushSemaphore or _drainSignal here.
+        // FlushAndCloseAsync waits for the process/flush tasks to complete, but has a 1s
+        // fallback so process exit can never hang. On an overloaded host that fallback can
+        // fire while the flush task is still inside FlushAggregatorAsync (e.g. blocked in
+        // _api.SendAsync). Disposing the primitives would then cause the task's
+        // _flushSemaphore.Release()/_drainSignal.Wait() to throw ObjectDisposedException,
+        // faulting the task and logging a spurious error during shutdown.
+        // Neither primitive's wait handle is ever materialized (we only use
+        // WaitAsync/Wait/Release/Set/Reset/IsSet, never AvailableWaitHandle/WaitHandle), so
+        // they hold no unmanaged resources and Dispose() is unnecessary here.
     }
 
     private async Task FlushAndCloseAsync()


### PR DESCRIPTION
## Summary of changes

Stop disposing the `_flushSemaphore` and `_drainSignal` synchronization primitives in `DataStreamsWriter.DisposeAsync`.

## Reason for change

Flaky CI failures (e.g. `DataStreamsMonitoringRabbitMQTests`) where `CheckBuildLogsForErrors` finds:

```
[Error] Error in data streams flush task System.AggregateException: ... (The semaphore has been disposed.)
 ---> System.ObjectDisposedException: The semaphore has been disposed.
   at System.Threading.SemaphoreSlim.Release(Int32 releaseCount)
   at Datadog.Trace.DataStreamsMonitoring.DataStreamsWriter.FlushAggregatorAsync()
```

This is a third variant of the disposal race partially addressed by #7968 and #7984. `FlushAndCloseAsync` waits for both the process and flush tasks, but with a 1-second fallback that must exist so process exit can never hang. On an overloaded CI host, the flush task can still be inside `FlushAggregatorAsync` (blocked in `_api.SendAsync`) when the fallback fires. `DisposeAsync` then disposes `_flushSemaphore`, and when the send returns, the `finally` block's `_flushSemaphore.Release()` throws `ObjectDisposedException`, faulting `_flushTask` and logging a spurious `[Error]` during shutdown. The same race exists latently for `_drainSignal` via `ProcessQueueLoop`.

The 1-second fallback is load-bearing, so the race can't be closed by waiting longer.

## Implementation details

`SemaphoreSlim` and `ManualResetEventSlim` only hold an unmanaged resource (a lazily-created wait handle) if their `AvailableWaitHandle`/`WaitHandle` property is accessed. This class never does — it only uses `WaitAsync`/`Wait`/`Release`/`Set`/`Reset`/`IsSet`. So `Dispose()` here is a no-op apart from arming the `ObjectDisposedException`. Removing both `Dispose()` calls eliminates the race at its source with no resource leak. Added a comment so the calls aren't reintroduced.

## Test coverage

Covered by existing DSM tests; this removes the spurious shutdown error that `CheckBuildLogsForErrors` was flagging.

## Other details
