### PR TITLE
Exclude InMemoryAssembly from dependency collection

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -201,6 +201,7 @@ namespace Datadog.Trace.Telemetry
             //    a43d8b99ea (10 hex chars)
             //    akkynf62 (8 base32 chars)
             //    dynamicclasses254
+            //    InMemoryAssembly
             return (assemblyName.Length == 8
                  && IsBase32Char(assemblyName[0])
                  && IsBase32Char(assemblyName[1])
@@ -210,6 +211,7 @@ namespace Datadog.Trace.Telemetry
                  && IsBase32Char(assemblyName[5])
                  && IsBase32Char(assemblyName[6])
                  && IsBase32Char(assemblyName[7]))
+                || assemblyName.Equals("InMemoryAssembly", StringComparison.OrdinalIgnoreCase)
                 || (assemblyName.Length is 10 or >= 32 && IsHexString(assemblyName, 0))
                 || IsDynamicClassesPattern(assemblyName);
         }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -257,6 +257,24 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.HasChanges().Should().BeTrue($"{name} should not be filtered as it doesn't match dynamicclasses pattern");
         }
 
+        [Theory]
+        [InlineData("InMemoryAssembly")]
+        [InlineData("inmemoryassembly")]
+        [InlineData("INMEMORYASSEMBLY")]
+        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndNameIsInMemoryAssembly(string name)
+        {
+            var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
+
+            var collector = new DependencyTelemetryCollector();
+            collector.AssemblyLoaded(ignoredName, "some-guid");
+
+            collector.HasChanges().Should().BeFalse($"{name} has a zero version and matches InMemoryAssembly");
+
+            var nonIgnoredName = CreateAssemblyName(new Version(1, 0, 0, 0), name: name);
+            collector.AssemblyLoaded(nonIgnoredName, "some-guid");
+            collector.HasChanges().Should().BeTrue($"{nonIgnoredName} has a non-zero version");
+        }
+
         [Fact]
         public void HasChangesWhenAddingSameAssemblyWithDifferentVersion()
         {


### PR DESCRIPTION
## Summary of changes

exclude assemblies called `InMemoryAssembly` from dependency version collection

## Reason for change

These are dynamically emitted assemblies, with high cardinality, so we should skip them

## Implementation details

Add `InMemoryAssembly` to the list of excluded assemblies

## Test coverage

Added a unit test

## Other details

Fixes https://datadoghq.atlassian.net/browse/K9VULN-15902