### PR TITLE
Flaky test fixing

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -4,13 +4,13 @@
 // </copyright>
 using System;
 using System.Diagnostics;
-using System.Net;
-using System.Net.Sockets;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Demos.Util;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -56,35 +56,17 @@ namespace BuggyBits
 
             using (var host = CreateHostBuilder(args).Build())
             {
-                // ASP.NET Core accepts listening url via what is set by Visual Studio
-                // (from the launchsettings.json). It could be overriden by --Urls
-                // on the command line
-                var configuration = host.Services.GetService(typeof(IConfiguration)) as IConfiguration;
-                var rootUrl = configuration["urls"];
-
-                // otherwise, use the default ASP.NET Core value
-                if (string.IsNullOrEmpty(rootUrl))
-                {
-                    rootUrl = "http://localhost:5000";
-                }
-
-                // avoid race condition in CI to find an available port
-                int port = -1;
-                if (int.TryParse(rootUrl.Substring(rootUrl.LastIndexOf(':') + 1), out port))
-                {
-                    port = GetValidPort(port, 3);
-                    if (port != -1)
-                    {
-                        rootUrl = rootUrl.Substring(0, rootUrl.LastIndexOf(':') + 1) + port;
-                    }
-                }
-
-                WriteLine($"Listening to {rootUrl}");
-
                 var cts = new CancellationTokenSource();
                 using (var selfInvoker = new SelfInvoker(cts.Token, scenario, nbIdleThreads, _disableLogs))
                 {
                     await host.StartAsync();
+
+                    var server = (IServer)host.Services.GetService(typeof(IServer));
+                    var addressFeature = server.Features.Get<IServerAddressesFeature>();
+                    var rootUrl = addressFeature.Addresses.FirstOrDefault() ?? "http://localhost:5000";
+
+                    WriteLine($"Listening to {rootUrl}");
+                    Console.WriteLine($"##LISTENING_URL:{rootUrl}##");
 
                     WriteLine();
                     WriteLine($"Started at {DateTime.UtcNow}.");
@@ -160,64 +142,6 @@ namespace BuggyBits
                         logging.ClearProviders();
                     }
                 });
-
-        public static int GetOpenPort()
-        {
-            TcpListener tcpListener = null;
-            try
-            {
-                tcpListener = new TcpListener(IPAddress.Loopback, 0);
-                tcpListener.Start();
-                var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
-                return port;
-            }
-            finally
-            {
-                tcpListener?.Stop();
-            }
-        }
-
-        private static int GetValidPort(int initialPort, int retries)
-        {
-            var port = initialPort;
-            bool isPortValid = false;
-            while (true)
-            {
-                // seems like we can't reuse a listener if it fails to start,
-                // so create a new listener each time we retry
-                var listener = new HttpListener();
-                listener.Prefixes.Add($"http://127.0.0.1:{port}/");
-                listener.Prefixes.Add($"http://localhost:{port}/");
-
-                try
-                {
-                    listener.Start();
-
-                    // success
-                    isPortValid = true;
-                    break;
-                }
-                catch (HttpListenerException) when (retries > 0)
-                {
-                    // only catch the exception if there are retries left
-                    port = GetOpenPort();
-                    retries--;
-                }
-                finally
-                {
-                    listener.Close();
-                }
-            }
-
-            if (isPortValid)
-            {
-                return port;
-            }
-            else
-            {
-                return -1; // no valid port found
-            }
-        }
 
         private static void ParseCommandLine(string[] args, out bool disableLogs, out TimeSpan timeout, out int iterations, out Scenario scenario, out int nbIdleThreads)
         {

--- a/profiler/src/Demos/Samples.HttpRequest/Program.cs
+++ b/profiler/src/Demos/Samples.HttpRequest/Program.cs
@@ -76,6 +76,7 @@ Thread runner = new Thread(() =>
         // send the requests
         var client = new System.Net.Http.HttpClient();
         var baseUrl = app.Urls.First();
+        Console.WriteLine($"##LISTENING_URL:{baseUrl}##");
         for (int iteration = 0; iteration < iterations; iteration++)
         {
             var url = BuildUrl($"{baseUrl}/endpoint", code, redirections, requestDuration, responseDuration, output);

--- a/profiler/src/Demos/Samples.Website-AspNetCore01/Program.cs
+++ b/profiler/src/Demos/Samples.Website-AspNetCore01/Program.cs
@@ -5,11 +5,13 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Demos.Util;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.Hosting;
 
 namespace Samples.Website_AspNetCore01
@@ -46,20 +48,6 @@ namespace Samples.Website_AspNetCore01
                 WriteLine($"host built in {sw.ElapsedMilliseconds} ms");
                 sw.Restart();
 
-                // ASP.NET Core accepts listening url via what is set by Visual Studio
-                // (from the launchsettings.json). It could be overriden by --Urls
-                // on the command line
-                var configuration = host.Services.GetService(typeof(IConfiguration)) as IConfiguration;
-                var rootUrl = configuration["Urls"];
-
-                // otherwise, use the default ASP.NET Core value
-                if (string.IsNullOrEmpty(rootUrl))
-                {
-                    rootUrl = "http://localhost:5000";
-                }
-
-                WriteLine($"Listening to {rootUrl}");
-
                 var cts = new CancellationTokenSource();
                 using (var selfInvoker = new SelfInvoker(cts.Token))
                 {
@@ -71,6 +59,13 @@ namespace Samples.Website_AspNetCore01
 
                     sw.Stop();
                     WriteLine($"host started in {sw.ElapsedMilliseconds} ms");
+
+                    var server = (IServer)host.Services.GetService(typeof(IServer));
+                    var addressFeature = server.Features.Get<IServerAddressesFeature>();
+                    var rootUrl = addressFeature.Addresses.FirstOrDefault() ?? "http://localhost:5000";
+
+                    WriteLine($"Listening to {rootUrl}");
+                    Console.WriteLine($"##LISTENING_URL:{rootUrl}##");
 
                     WriteLine();
                     WriteLine($"Started at {DateTime.UtcNow}.");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -152,7 +152,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 throw new Exception($"Unable to find executing assembly at {applicationPath}");
             }
 
-            var arguments = $"--timeout {TestDurationInSeconds} --urls http://localhost:0";
+            var arguments = $"--timeout {TestDurationInSeconds} --urls http://127.0.0.1:0";
             if (!string.IsNullOrEmpty(_commandLine))
             {
                 arguments += $" {_commandLine}";

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -151,10 +152,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 throw new Exception($"Unable to find executing assembly at {applicationPath}");
             }
 
-            // Look for a free open port to pass to the ASP.NET Core applications
-            // that accept --urls on their command line
-            _appListenerPort = $"http://localhost:{TcpPortProvider.GetOpenPort()}";
-            var arguments = $"--timeout {TestDurationInSeconds} --urls {_appListenerPort}";
+            var arguments = $"--timeout {TestDurationInSeconds} --urls http://localhost:0";
             if (!string.IsNullOrEmpty(_commandLine))
             {
                 arguments += $" {_commandLine}";
@@ -195,6 +193,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             var standardOutput = processHelper.StandardOutput;
             var errorOutput = processHelper.ErrorOutput;
             ProcessOutput = standardOutput;
+            _appListenerPort = ParseListeningUrl(standardOutput);
 
             if (!ranToCompletion)
             {
@@ -245,6 +244,17 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                     false,
                     $"Exit code of \"{Path.GetFileName(process.StartInfo?.FileName ?? string.Empty)}\" should be 0 instead of {process.ExitCode} (= 0x{process.ExitCode:X})");
             }
+        }
+
+        private static string ParseListeningUrl(string output)
+        {
+            if (output is null)
+            {
+                return null;
+            }
+
+            var match = Regex.Match(output, @"##LISTENING_URL:(.+?)##");
+            return match.Success ? match.Groups[1].Value : null;
         }
 
         private void SetEnvironmentVariables(StringDictionary environmentVariables, MockDatadogAgent agent)


### PR DESCRIPTION
## Summary of changes

Fix flaky test

## Reason for change


We have test failing because the ASP.NET Core app failed to bind to a specific port.

```
08:03:06 [DBG]  [TestRunner] Error output:
08:03:06 [DBG]  Unhandled exception. System.IO.IOException: Failed to bind to address http://127.0.0.1:45273: address already in use.
08:03:06 [DBG]   ---> Microsoft.AspNetCore.Connections.AddressInUseException: Address in use
08:03:06 [DBG]   ---> System.Net.Sockets.SocketException (98): Address in use
08:03:06 [DBG]     at System.Net.Sockets.Socket.UpdateStatusAfterSocketErrorAndThrowException(SocketError error, String callerName)
08:03:06 [DBG]     at System.Net.Sockets.Socket.DoBind(EndPoint endPointSnapshot, SocketAddress socketAddress)
08:03:06 [DBG]     at System.Net.Sockets.Socket.Bind(EndPoint localEP)
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketConnectionListener.Bind()
08:03:06 [DBG]     --- End of inner exception stack trace ---
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketConnectionListener.Bind()
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.SocketTransportFactory.BindAsync(EndPoint endpoint, Cancellation*** cancellation***)
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer.<>c__DisplayClass21_0`1.<<StartAsync>g__OnBind|0>d.MoveNext()
08:03:06 [DBG]  --- End of stack trace from previous location where exception was thrown ---
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindEndpointAsync(ListenOptions endpoint, AddressBindContext context)
08:03:06 [DBG]     --- End of inner exception stack trace ---
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindEndpointAsync(ListenOptions endpoint, AddressBindContext context)
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Core.LocalhostListenOptions.BindAsync(AddressBindContext context)
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.AddressesStrategy.BindAsync(AddressBindContext context)
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.AddressBinder.BindAsync(IServerAddressesFeature addresses, KestrelServerOptions serverOptions, ILogger logger, Func`2 createBinding)
08:03:06 [DBG]     at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer.StartAsync[TContext](IHttpApplication`1 application, Cancellation*** cancellation***)
08:03:06 [DBG]     at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync(Cancellation*** cancellation***)
08:03:06 [DBG]     at Microsoft.Extensions.Hosting.Internal.Host.StartAsync(Cancellation*** cancellation***)
08:03:06 [DBG]     at BuggyBits.Program.Main(String[] args) in /project/profiler/src/Demos/Samples.BuggyBits/Program.cs:line 89
08:03:06 [DBG]     at BuggyBits.Program.<Main>(String[] args)
08:03:06 [DBG]
```

## Implementation details

Let kestrel decides which port to use and parse the application output to get it for the tests.

## Test coverage

Nothing more to do.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
