### PR TITLE
[Debugger] Avoid noisy async state machine metadata warnings

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1997,13 +1997,23 @@ HRESULT DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine(const ComPtr<I
         return E_FAIL;
     }
 
+    // The Interface column is a TypeDefOrRef coded token. For debugger-instrumented application modules,
+    // IAsyncStateMachine is imported from corelib and should therefore be a TypeRef. TypeDef/TypeSpec tokens
+    // represent other interfaces for our purposes, so they are not async state machines and should not be logged.
+    if (TypeFromToken(interfaceToken) != mdtTypeRef)
+    {
+        isTypeImplementIAsyncStateMachine = false;
+        return S_OK;
+    }
+
     // get the interface type props
     WCHAR type_name[kNameMaxSize]{};
     DWORD type_name_len = 0;
     mdAssembly assemblyToken;
     if (metadataImport->GetTypeRefProps(interfaceToken, &assemblyToken, type_name, kNameMaxSize, &type_name_len) != S_OK)
     {
-        Logger::Warn("DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine: failed to get type ref props");
+        // The token is a TypeRef but could not be resolved, so keep this diagnostic at Debug.
+        Logger::Debug("DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine: failed to get type ref props");
         return E_FAIL;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1970,6 +1970,8 @@ bool DebuggerMethodRewriter::DoesILContainUnsupportedInstructions(ILRewriter& re
 HRESULT DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine(const ComPtr<IMetaDataImport2>& metadataImport,
                                                                   const ULONG32 typeToken, bool& isTypeImplementIAsyncStateMachine)
 {
+    isTypeImplementIAsyncStateMachine = false;
+
     HCORENUM interfaceImplsEnum = nullptr;
     ULONG actualImpls;
     mdInterfaceImpl impls;
@@ -1985,7 +1987,6 @@ HRESULT DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine(const ComPtr<I
     if (actualImpls != 1)
     {
         // our compiler generated nested type should implement exactly one interface
-        isTypeImplementIAsyncStateMachine = false;
         return S_OK;
     }
 
@@ -2002,7 +2003,6 @@ HRESULT DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine(const ComPtr<I
     // represent other interfaces for our purposes, so they are not async state machines and should not be logged.
     if (TypeFromToken(interfaceToken) != mdtTypeRef)
     {
-        isTypeImplementIAsyncStateMachine = false;
         return S_OK;
     }
 
@@ -2025,7 +2025,6 @@ HRESULT DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine(const ComPtr<I
         return S_OK;
     }
 
-    isTypeImplementIAsyncStateMachine = false;
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
@@ -954,7 +954,8 @@ void DebuggerProbesInstrumentationRequester::ModuleLoadFinished_AddMetadataToMod
                                                                        isImplementStateMAchineInterface);
         if (FAILED(hr))
         {
-            Logger::Warn(
+            // Non-TypeRef interface tokens are handled as "not IAsyncStateMachine"; remaining failures are diagnostic only.
+            Logger::Debug(
                 "DebuggerProbesInstrumentationRequester::ModuleLoadFinished_AddMetadataToModule: failed in call to "
                 "DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine");
             continue;


### PR DESCRIPTION
## Summary of changes

- Avoids noisy debugger native logs during Dynamic Instrumentation / Exception Replay hot-standby module scans.
- Treats non-`TypeRef` interface tokens as “not `IAsyncStateMachine`” instead of attempting `GetTypeRefProps` on tokens that cannot be resolved that way.
- Lowers the remaining unexpected metadata-resolution diagnostics from `Warn` to `Debug`.

## Reason for change

- A customer reported large volumes of native tracer logs after upgrading from `3.20.1` to `3.43.0`.
- The logs came from the debugger hot-standby path, even though Dynamic Instrumentation / Exception Replay were not actively being used.
- The noisy case is benign: `InterfaceImpl.Interface` is a `TypeDefOrRef` coded token, and `TypeDef` / `TypeSpec` values are normal metadata shapes for other interfaces.

## Implementation details

- `IAsyncStateMachine` is imported from corelib for debugger-instrumented application modules, so the expected token kind is `mdtTypeRef`.
- If the interface token is not a `TypeRef`, the helper now returns `S_OK` with `isTypeImplementIAsyncStateMachine = false` without logging.
- If the token is a `TypeRef` but `GetTypeRefProps` still fails, we keep a diagnostic log at `Debug`.
- The hot-standby caller also logs remaining helper failures at `Debug`, since the common non-`TypeRef` case is now handled as a normal non-match.