### PR TITLE
[AAP] Fix response status sent to waf

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -140,7 +140,6 @@ internal readonly partial struct SecurityCoordinator
         var addressesDictionary = new Dictionary<string, object>
         {
             { AddressesConstants.RequestMethod, request.Method },
-            { AddressesConstants.ResponseStatus, request.HttpContext.Response.StatusCode.ToString() },
             { AddressesConstants.RequestUriRaw, request.GetUrlForWaf() },
             { AddressesConstants.RequestClientIp, _localRootSpan.GetTag(Tags.HttpClientIp) ?? _localRootSpan.GetTag(Tags.NetworkClientIp) }
         };

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -452,7 +452,6 @@ internal readonly partial struct SecurityCoordinator
         var dict = new Dictionary<string, object>(capacity: 7)
         {
             { AddressesConstants.RequestMethod, request.HttpMethod },
-            { AddressesConstants.ResponseStatus, request.RequestContext.HttpContext.Response.StatusCode.ToString() },
             { AddressesConstants.RequestClientIp, _localRootSpan.GetTag(Tags.HttpClientIp) ?? _localRootSpan.GetTag(Tags.NetworkClientIp) }
         };
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -19,6 +19,8 @@ namespace Datadog.Trace.AppSec.Coordinator;
 
 internal static class SecurityCoordinatorHelpers
 {
+    internal const string ResponseBodyItemKey = "DD_AppSec_ResponseBody";
+
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SecurityCoordinatorHelpers));
 
     internal static readonly Type? SessionFeature = Assembly.GetAssembly(typeof(IHeaderDictionary))?.GetType("Microsoft.AspNetCore.Http.Features.ISessionFeature", throwOnError: false);
@@ -52,6 +54,11 @@ internal static class SecurityCoordinatorHelpers
                     {
                         { AddressesConstants.ResponseStatus, httpContext.Response.StatusCode.ToString() },
                     };
+
+                    if (httpContext.Items.TryGetValue(ResponseBodyItemKey, out var responseBody) && responseBody is not null)
+                    {
+                        args.Add(AddressesConstants.ResponseBody, responseBody);
+                    }
 
                     var extractedHeaders = SecurityCoordinator.ExtractHeadersFromRequest(headers);
                     if (extractedHeaders is not null)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -308,6 +308,7 @@ namespace Datadog.Trace.AspNet
                             var securityCoordinator = SecurityCoordinator.Get(security, rootSpan, app.Context);
                             var args = securityCoordinator.GetBasicRequestArgsForWaf();
                             args.Add(AddressesConstants.RequestPathParams, securityCoordinator.GetPathParams());
+                            args.Add(AddressesConstants.ResponseStatus, app.Context.Response.StatusCode.ToString());
 
                             if (HttpRuntime.UsingIntegratedPipeline && _canReadHttpResponseHeaders)
                             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/ActionResponseFilter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/ActionResponseFilter.cs
@@ -28,7 +28,11 @@ internal sealed class ActionResponseFilter : IActionFilter
             && result.Value is not null
             && Tracer.Instance.ActiveScope?.Span is Span currentSpan)
         {
-            security.CheckBody(context.HttpContext, currentSpan, result.Value, response: true);
+            var extractedBody = security.CheckBody(context.HttpContext, currentSpan, result.Value, response: true);
+            if (extractedBody is not null)
+            {
+                context.HttpContext.Items[SecurityCoordinatorHelpers.ResponseBodyItemKey] = extractedBody;
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -179,5 +179,45 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
         }
     }
+
+    public class AspNetCore5TestsResponseStatusBodyCombined : AspNetCoreWithExternalRulesFileBase
+    {
+        private const string CombinedRuleFile = "ruleset.response-status-body.json";
+
+        public AspNetCore5TestsResponseStatusBodyCombined(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+            : base("AspNetCore5", fixture, outputHelper, "/shutdown", enableSecurity: true, ruleFile: CombinedRuleFile, testName: "AspNetCore5.ResponseStatusBodyCombined")
+        {
+            Fixture.SetOutput(outputHelper);
+        }
+
+        // Regression test for: server.response.status seeded as stale "200" at begin-request would
+        // prevent a combined body+status WAF rule from ever firing.
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task TestResponseBodyAndStatusCombinedRuleFires()
+        {
+            await TryStartApp();
+            var agent = Fixture.Agent;
+
+            const string url = "/status/404/body";
+            var minDateTime = DateTime.UtcNow;
+
+            // The endpoint returns StatusCode(404, { message = "waf_sentinel_response_body" }).
+            // The combined rule requires server.response.status == "404" AND server.response.body
+            // contains "waf_sentinel_response_body". With the stale-200 bug, this rule could never fire.
+            var (statusCode, _) = await SubmitRequest(url, body: null, contentType: null);
+            ((int)statusCode).Should().Be((int)HttpStatusCode.Forbidden, "WAF should block the response when body+status combined rule fires");
+
+            var spans = await WaitForSpansAsync(agent, 1, string.Empty, minDateTime, url);
+            var appsecSpan = spans.FirstOrDefault(s => s.Tags.ContainsKey("appsec.event"));
+            appsecSpan.Should().NotBeNull("a WAF event span must be produced");
+            appsecSpan!.Tags.Should().ContainKey("appsec.blocked").WhoseValue.Should().Be("true");
+
+            var appsecJson = appsecSpan.Tags[Tags.AppSecJson];
+            appsecJson.Should().Contain("test-response-status-body-001", "the combined body+status rule must have fired");
+            appsecJson.Should().Contain("server.response.status", "the status condition must appear in the WAF match");
+            appsecJson.Should().Contain("server.response.body", "the body condition must appear in the WAF match");
+        }
+    }
 }
 #endif

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -179,45 +179,5 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
         }
     }
-
-    public class AspNetCore5TestsResponseStatusBodyCombined : AspNetCoreWithExternalRulesFileBase
-    {
-        private const string CombinedRuleFile = "ruleset.response-status-body.json";
-
-        public AspNetCore5TestsResponseStatusBodyCombined(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore5", fixture, outputHelper, "/shutdown", enableSecurity: true, ruleFile: CombinedRuleFile, testName: "AspNetCore5.ResponseStatusBodyCombined")
-        {
-            Fixture.SetOutput(outputHelper);
-        }
-
-        // Regression test for: server.response.status seeded as stale "200" at begin-request would
-        // prevent a combined body+status WAF rule from ever firing.
-        [SkippableFact]
-        [Trait("RunOnWindows", "True")]
-        public async Task TestResponseBodyAndStatusCombinedRuleFires()
-        {
-            await TryStartApp();
-            var agent = Fixture.Agent;
-
-            const string url = "/status/404/body";
-            var minDateTime = DateTime.UtcNow;
-
-            // The endpoint returns StatusCode(404, { message = "waf_sentinel_response_body" }).
-            // The combined rule requires server.response.status == "404" AND server.response.body
-            // contains "waf_sentinel_response_body". With the stale-200 bug, this rule could never fire.
-            var (statusCode, _) = await SubmitRequest(url, body: null, contentType: null);
-            ((int)statusCode).Should().Be((int)HttpStatusCode.Forbidden, "WAF should block the response when body+status combined rule fires");
-
-            var spans = await WaitForSpansAsync(agent, 1, string.Empty, minDateTime, url);
-            var appsecSpan = spans.FirstOrDefault(s => s.Tags.ContainsKey("appsec.event"));
-            appsecSpan.Should().NotBeNull("a WAF event span must be produced");
-            appsecSpan!.Tags.Should().ContainKey("appsec.blocked").WhoseValue.Should().Be("true");
-
-            var appsecJson = appsecSpan.Tags[Tags.AppSecJson];
-            appsecJson.Should().Contain("test-response-status-body-001", "the combined body+status rule must have fired");
-            appsecJson.Should().Contain("server.response.status", "the status condition must appear in the WAF match");
-            appsecJson.Should().Contain("server.response.body", "the body condition must appear in the WAF match");
-        }
-    }
 }
 #endif

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
@@ -115,6 +115,9 @@
     <None Update="ruleset.3.0.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="ruleset.response-status-body.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="wrong-tags-name-rule-set.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.response-status-body.json
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.response-status-body.json
@@ -1,0 +1,49 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.0.0"
+  },
+  "rules": [
+    {
+      "id": "test-response-status-body-001",
+      "name": "Test: combined response status and body rule",
+      "tags": {
+        "type": "test_response_status_body",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "operator": "match_regex",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.status"
+              }
+            ],
+            "regex": "^404$",
+            "options": {
+              "case_sensitive": true
+            }
+          }
+        },
+        {
+          "operator": "phrase_match",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "list": [
+              "waf_sentinel_response_body"
+            ]
+          }
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "block"
+      ]
+    }
+  ]
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Datadog.Trace.Security.Unit.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Datadog.Trace.Security.Unit.Tests.csproj
@@ -59,6 +59,9 @@
     <None Update="remote-rules.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="response-status-body-rules.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Content Include="..\Datadog.Trace.Security.IntegrationTests\trace-tagging-rules.json">
       <Link>trace-tagging-rules.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -122,6 +122,75 @@ namespace Datadog.Trace.Security.Unit.Tests
                 schemaExtraction: """{"_dd.appsec.s.req.headers":[{"Content-Type":[8]}]}""");
         }
 
+        // Validates that libddwaf treats persistent addresses as immutable once set in a context:
+        // the status supplied at the body run must be the first (real) supply, not a stale begin-request 200.
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ResponseBodyAndStatusCombinedRule_BodyFirst_ThenStatus_Fires(bool useUnsafeEncoder)
+        {
+            var ruleFile = "response-status-body-rules.json";
+            var initResult = CreateWaf(useUnsafeEncoder, ruleFile);
+            using var waf = initResult.Waf!;
+            using var context = waf.CreateContext();
+
+            // Run 1: body with sentinel — no status yet, rule should not fire
+            var bodyArgs = new Dictionary<string, object>
+            {
+                { AddressesConstants.ResponseBody, new Dictionary<string, string> { { "message", "waf_sentinel_response_body" } } },
+                { AddressesConstants.RequestMethod, "GET" },
+                { AddressesConstants.RequestUriRaw, "http://localhost/" },
+            };
+            var result1 = context.Run(bodyArgs, TimeoutMicroSeconds);
+            result1.Timeout.Should().BeFalse();
+            result1.ReturnCode.Should().Be(WafReturnCode.Ok, "rule should not fire without a matching status");
+
+            // Run 2: supply the real (non-200) status — rule should now fire because body persists
+            var statusArgs = new Dictionary<string, object>
+            {
+                { AddressesConstants.ResponseStatus, "404" },
+            };
+            var result2 = context.Run(statusArgs, TimeoutMicroSeconds);
+            result2.Timeout.Should().BeFalse();
+            result2.ReturnCode.Should().Be(WafReturnCode.Match, "rule must fire when the real status is supplied after the body");
+            var jsonString = JsonConvert.SerializeObject(result2.Data);
+            var match = JsonConvert.DeserializeObject<WafMatch[]>(jsonString)!.First();
+            match.Rule.Id.Should().Be("test-response-status-body-001");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ResponseBodyAndStatusCombinedRule_StaleStatus200_ThenBody_DoesNotFire(bool useUnsafeEncoder)
+        {
+            // Regression guard: a stale 200 seeded first (the old begin-request behaviour)
+            // must NOT allow the rule to fire even when the body arrives later.
+            var ruleFile = "response-status-body-rules.json";
+            var initResult = CreateWaf(useUnsafeEncoder, ruleFile);
+            using var waf = initResult.Waf!;
+            using var context = waf.CreateContext();
+
+            // Run 1: stale 200 (was seeded at begin-request before this fix)
+            var staleStatusArgs = new Dictionary<string, object>
+            {
+                { AddressesConstants.ResponseStatus, "200" },
+                { AddressesConstants.RequestMethod, "GET" },
+                { AddressesConstants.RequestUriRaw, "http://localhost/" },
+            };
+            var result1 = context.Run(staleStatusArgs, TimeoutMicroSeconds);
+            result1.Timeout.Should().BeFalse();
+            result1.ReturnCode.Should().Be(WafReturnCode.Ok);
+
+            // Run 2: body arrives — the stale 200 is sticky; rule must not fire (404 required)
+            var bodyArgs = new Dictionary<string, object>
+            {
+                { AddressesConstants.ResponseBody, new Dictionary<string, string> { { "message", "waf_sentinel_response_body" } } },
+            };
+            var result2 = context.Run(bodyArgs, TimeoutMicroSeconds);
+            result2.Timeout.Should().BeFalse();
+            result2.ReturnCode.Should().Be(WafReturnCode.Ok, "rule must not fire when the only status supplied was the stale 200");
+        }
+
         private void Execute(string address, object value, string flow = null, string rule = null, string schemaExtraction = null)
         {
             ExecuteInternal(address, value, flow, rule, schemaExtraction, false);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/response-status-body-rules.json
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/response-status-body-rules.json
@@ -1,0 +1,46 @@
+{
+  "version": "2.2",
+  "metadata": {
+    "rules_version": "1.0.0"
+  },
+  "rules": [
+    {
+      "id": "test-response-status-body-001",
+      "name": "Test: combined response status and body rule",
+      "tags": {
+        "type": "test_response_status_body",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.status"
+              }
+            ],
+            "regex": "^404$"
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "list": [
+              "waf_sentinel_response_body"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "block"
+      ]
+    }
+  ]
+}

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/StatusController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/StatusController.cs
@@ -14,5 +14,11 @@ public class StatusController : Controller
 
         return Content("Hello, World!\\n");
     }
+
+    [HttpGet("{status}/body")]
+    public IActionResult IndexFormWithBody(int status)
+    {
+        return StatusCode(status, new { message = "waf_sentinel_response_body" });
+    }
 }
 


### PR DESCRIPTION
### Summary of changes

Remove the premature seeding of server.response.status in the WAF begin-request run for both ASP.NET Core and ASP.NET Framework coordinators. The status is now supplied only at end-of-request, where the real status code is known.

### Reason for change

libddwaf treats persistent addresses as immutable once set in a WAF context. Both coordinators were seeding server.response.status with the current (alw-request time — before the response waswritten. This caused WAF rules that combine server.response.status with server.response.body to never fire: the stale 200 was locked in, so a rule requiring 404 could never match even when the actual response ended up being 404.

### Implementation details

- SecurityCoordinator.Core.cs / SecurityCoordinator.Framework.cs: removed { AddressesConstants.ResponseStatus, ... } from the GetBasicRequestArgsForWaf() dictionaries that are used in the begin-request WAF run.
- TracingHttpModule.cs (ASP.NET Framework): added args.Add(AddressesConstants.ResponseStatus, ...) at the end-of-request point (after GetBasicRequestArgsForWaf()), where Response.StatusCode reflects the final status.

The ASP.NET Core path already supplies server.response.status separately at end-of-request; removing it from the begin-request dictionary is sufficient there.

### Test coverage

- Unit tests (WafTests.cs): two new WAF-level tests that exercise a combined server.response.status + server.response.body rule directly against libddwaf:
  - ResponseBodyAndStatusCombinedRule_BodyFirst_ThenStatus_Fires — verifies the rule fires when body arrives first and the real non-200 status follows.
  - ResponseBodyAndStatusCombinedRule_StaleStatus200_ThenBody_DoesNotFire — regression guard confirming that seeding 200 first (old behavior) prevents the rule flater.
- Integration test (AspNetCore5TestsResponseStatusBodyCombined): end-to-end test against a new /status/{code}/body endpoint that returns 404 + a sentinel body  the response and the span contains theexpected rule match.
- New test rule files: ruleset.response-status-body.json (integration) and response-status-body-rules.json (unit).
- New sample app endpoint: StatusController.IndexFormWithBody in Samples.Security.AspNetCore5.