### PR TITLE
Implement span-derived primary tags (AKA Additional tags) on Client-Side-Stats computation

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -51,7 +51,8 @@ namespace Datadog.Trace.Agent
                 httpEndpoint: string.Empty,
                 grpcStatusCode: string.Empty,
                 serviceSource: string.Empty,
-                peerTagsHash: 0);
+                peerTagsHash: 0,
+                additionalMetricTagsHash: 0);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
@@ -66,6 +66,30 @@ namespace Datadog.Trace.Agent
             AdditionalMetricTagsHash = additionalMetricTagsHash;
         }
 
+        /// <summary>
+        /// Returns a copy of this key with a different <see cref="AdditionalMetricTagsHash"/>.
+        /// Used by the per-flush-bucket cardinality cap to redirect a span into the "blocked" bucket
+        /// (same dimensions, masked additional-tag values).
+        /// </summary>
+        public StatsAggregationKey WithAdditionalMetricTagsHash(ulong additionalMetricTagsHash)
+            => new(
+                Resource,
+                Service,
+                OperationName,
+                Type,
+                HttpStatusCode,
+                IsSyntheticsRequest,
+                SpanKind,
+                IsError,
+                IsTopLevel,
+                IsTraceRoot,
+                HttpMethod,
+                HttpEndpoint,
+                GrpcStatusCode,
+                ServiceSource,
+                PeerTagsHash,
+                additionalMetricTagsHash);
+
         public bool Equals(StatsAggregationKey other)
         {
             return

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregationKey.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.Agent
         public readonly string GrpcStatusCode;
         public readonly string ServiceSource;
         public readonly ulong PeerTagsHash;
+        public readonly ulong AdditionalMetricTagsHash;
 
         // Constructs a StatsAgregationKey that represents the aggregation key used by Datadog,
         // which does not include IsError and IsTopLevel, since these should be part of the same timeseries
@@ -44,7 +45,8 @@ namespace Datadog.Trace.Agent
             string httpEndpoint,
             string grpcStatusCode,
             string serviceSource,
-            ulong peerTagsHash)
+            ulong peerTagsHash,
+            ulong additionalMetricTagsHash)
         {
             Resource = resource;
             Service = service;
@@ -61,6 +63,7 @@ namespace Datadog.Trace.Agent
             GrpcStatusCode = grpcStatusCode;
             ServiceSource = serviceSource;
             PeerTagsHash = peerTagsHash;
+            AdditionalMetricTagsHash = additionalMetricTagsHash;
         }
 
         public bool Equals(StatsAggregationKey other)
@@ -80,7 +83,8 @@ namespace Datadog.Trace.Agent
                 && HttpEndpoint == other.HttpEndpoint
                 && GrpcStatusCode == other.GrpcStatusCode
                 && ServiceSource == other.ServiceSource
-                && PeerTagsHash == other.PeerTagsHash;
+                && PeerTagsHash == other.PeerTagsHash
+                && AdditionalMetricTagsHash == other.AdditionalMetricTagsHash;
         }
 
         public override bool Equals(object? obj)
@@ -106,6 +110,7 @@ namespace Datadog.Trace.Agent
             hashCode.Add(GrpcStatusCode);
             hashCode.Add(ServiceSource);
             hashCode.Add(PeerTagsHash);
+            hashCode.Add(AdditionalMetricTagsHash);
             return hashCode.ToHashCode();
         }
     }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Agent
         private List<PeerTagKey> _peerTagKeys = [];
         private int _computeStatsState;
 
-        private int _numberOfBucketsContainingAdditionalTags;
+        private int _numberOfHitBucketsContainingAdditionalTags;
         private int _additionalTagsBlockLoggedThisBucket;
 
         internal StatsAggregator(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
@@ -645,7 +645,7 @@ namespace Datadog.Trace.Agent
                     _currentBuffer = (_currentBuffer + 1) % BufferCount;
 
                     // Reset per-flush values
-                    _numberOfBucketsContainingAdditionalTags = 0;
+                    _numberOfHitBucketsContainingAdditionalTags = 0;
                     _additionalTagsBlockLoggedThisBucket = 0;
                 }
 
@@ -703,51 +703,58 @@ namespace Datadog.Trace.Agent
             var peerTagKeys = Volatile.Read(ref _peerTagKeys);
             var key = BuildKey(span, peerTagKeys, out var peerTagResults, out var additionalTagResults);
 
-            if (!buffer.Buckets.TryGetValue(key, out var bucket))
-            {
-                // New MetricKey. Spans whose full key already exists merge above regardless of the cap,
-                // so values admitted earlier in this bucket keep accurate per-value attribution.
-                var hasAdditionalTags = additionalTagResults.TagCount > 0;
+            // Buckets that contain additional tags are "blocked" once we exceed the threshold number of buckets.
+            // This includes net-new buckets, as well as buckets that were retained in the previous Reset(), which are
+            // now receiving their first hit.
+            var hasAdditionalTags = additionalTagResults.TagCount > 0;
+            var isNewBucketBlocked = hasAdditionalTags && _numberOfHitBucketsContainingAdditionalTags >= _additionalTagsBucketCountLimit;
 
-                if (!hasAdditionalTags || _numberOfBucketsContainingAdditionalTags < _additionalTagsBucketCountLimit)
+            if (buffer.Buckets.TryGetValue(key, out var bucket) && (bucket.Hits != 0 || !isNewBucketBlocked))
+            {
+                if (hasAdditionalTags && bucket.Hits == 0)
                 {
-                    // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket
+                    // Bucket that was retained during Reset() that now has hits
+                    _numberOfHitBucketsContainingAdditionalTags++;
+                }
+            }
+            else if (bucket is null && !isNewBucketBlocked)
+            {
+                // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket
+                bucket = new StatsBucket(
+                    key,
+                    GetEncodedPeerTags(span, peerTagKeys, in peerTagResults),
+                    GetEncodedAdditionalTags(span, in additionalTagResults, forceBlocked: false));
+                buffer.Buckets.Add(key, bucket);
+
+                if (hasAdditionalTags)
+                {
+                    _numberOfHitBucketsContainingAdditionalTags++;
+                }
+
+                // A per-value length block also counts as a block event for observability.
+                if (additionalTagResults.FirstBlockedTagName is not null)
+                {
+                    OnAdditionalTagsBlocked(additionalTagResults.FirstBlockedTagName);
+                }
+            }
+            else
+            {
+                // Maximum number of buckets containing additional tag values is reached.
+                // Collapse into a single "blocked" bucket whose values. Only additional tags
+                // are blocked, the other properties are still added normally
+                key = key.WithAdditionalMetricTagsHash(ComputeBlockedAdditionalMetricTagsHash(span));
+
+                if (!buffer.Buckets.TryGetValue(key, out bucket))
+                {
+                    // The blocked bucket is itself the overflow sink, so it doesn't count against the cap.
                     bucket = new StatsBucket(
                         key,
                         GetEncodedPeerTags(span, peerTagKeys, in peerTagResults),
-                        GetEncodedAdditionalTags(span, in additionalTagResults, forceBlocked: false));
+                        GetEncodedAdditionalTags(span, in additionalTagResults, forceBlocked: true));
                     buffer.Buckets.Add(key, bucket);
-
-                    if (hasAdditionalTags)
-                    {
-                        _numberOfBucketsContainingAdditionalTags++;
-                    }
-
-                    // A per-value length block also counts as a block event for observability.
-                    if (additionalTagResults.FirstBlockedTagName is not null)
-                    {
-                        OnAdditionalTagsBlocked(additionalTagResults.FirstBlockedTagName);
-                    }
                 }
-                else
-                {
-                    // Maximum number of buckets containing additional tag values is reached.
-                    // Collapse into a single "blocked" bucket whose values. Only additional tags
-                    // are blocked, the other properties are still added normally
-                    key = key.WithAdditionalMetricTagsHash(ComputeBlockedAdditionalMetricTagsHash(span));
 
-                    if (!buffer.Buckets.TryGetValue(key, out bucket))
-                    {
-                        // The blocked bucket is itself the overflow sink, so it doesn't count against the cap.
-                        bucket = new StatsBucket(
-                            key,
-                            GetEncodedPeerTags(span, peerTagKeys, in peerTagResults),
-                            GetEncodedAdditionalTags(span, in additionalTagResults, forceBlocked: true));
-                        buffer.Buckets.Add(key, bucket);
-                    }
-
-                    OnAdditionalTagsBlocked(additionalTagResults.FirstPresentTagName);
-                }
+                OnAdditionalTagsBlocked(additionalTagResults.FirstPresentTagName);
             }
 
             bucket.Hits++;

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Agent
         private const int BufferCount = 2;
 
         private const int AdditionalTagMaxValueLength = 200;
-        private const string BlockedByTracerSentinel = "blocked_by_tracer";
+        private const string BlockedByTracerSentinel = "tracer_blocked_value";
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
         private static readonly List<byte[]> EmptyTags = [];
@@ -132,7 +132,7 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        private static ReadOnlySpan<byte> BlockedByTracerSentinelUtf8 => "blocked_by_tracer"u8;
+        private static ReadOnlySpan<byte> BlockedByTracerSentinelUtf8 => "tracer_blocked_value"u8;
 
         /// <summary>
         /// Gets the current buffer.

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -364,7 +364,8 @@ namespace Datadog.Trace.Agent
                 httpEndpoint,
                 grpcStatusCode,
                 serviceSource,
-                peerTagsHash);
+                peerTagsHash,
+                additionalMetricTagsHash: 0);
         }
 
         /// <summary>
@@ -547,7 +548,7 @@ namespace Datadog.Trace.Agent
             if (!buffer.Buckets.TryGetValue(key, out var bucket))
             {
                 // Cold path: encode the peer tags for storage in the new bucket
-                bucket = new StatsBucket(key, GetEncodedPeerTags(span, peerTagKeys, in peerTagResults));
+                bucket = new StatsBucket(key, GetEncodedPeerTags(span, peerTagKeys, in peerTagResults), EmptyPeerTags);
                 buffer.Buckets.Add(key, bucket);
             }
 

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.Agent
         private readonly AnalyticsEventsSampler _analyticsEventSampler;
         private readonly IDisposable _settingSubscription;
         private readonly AdditionalTagKey[] _additionalTagKeys;
+        private readonly int _additionalTagsBucketCountLimit;
 
         private int _currentBuffer;
 
@@ -62,6 +63,9 @@ namespace Datadog.Trace.Agent
         private TraceFilter _traceFilter;
         private List<PeerTagKey> _peerTagKeys = [];
         private int _computeStatsState;
+
+        private int _numberOfBucketsContainingAdditionalTags;
+        private int _additionalTagsBlockLoggedThisBucket;
 
         internal StatsAggregator(IApi api, TracerSettings settings, IDiscoveryService discoveryService, bool isOtlp)
         {
@@ -77,6 +81,7 @@ namespace Datadog.Trace.Agent
             _errorSampler = new ErrorSampler();
             _rareSampler = new RareSampler(settings, this);
             _analyticsEventSampler = new AnalyticsEventsSampler();
+            _additionalTagsBucketCountLimit = settings.StatsAdditionalTagsCardinalityLimit;
 
             // StatsAdditionalTags is already deduplicated, sorted, and capped.
             // Pre-encode the UTF-8 key prefixes so BuildKey can hash without per-call string encoding.
@@ -517,6 +522,8 @@ namespace Datadog.Trace.Agent
             // Hash should be generated as TAGNAME:TAGVALUE, in sorted order (_additionalTagKeys is pre-sorted).
             ulong? previousHash = null;
             var presentTagCount = 0;
+            string firstPresentTagName = null;
+            string firstBlockedTagName = null;
             foreach (var tagKey in _additionalTagKeys)
             {
                 var tagValue = span.GetTag(tagKey.Name);
@@ -525,9 +532,12 @@ namespace Datadog.Trace.Agent
                     continue;
                 }
 
+                firstPresentTagName ??= tagKey.Name;
+
                 if (tagValue.Length > AdditionalTagMaxValueLength)
                 {
                     tagValue = BlockedByTracerSentinel;
+                    firstBlockedTagName ??= tagKey.Name;
                 }
 
                 if (previousHash.HasValue)
@@ -540,7 +550,39 @@ namespace Datadog.Trace.Agent
                 presentTagCount++;
             }
 
-            results = new AdditionalTagResults { TagCount = presentTagCount };
+            results = new AdditionalTagResults
+            {
+                TagCount = presentTagCount,
+                FirstPresentTagName = firstPresentTagName,
+                FirstBlockedTagName = firstBlockedTagName,
+            };
+            return previousHash ?? 0;
+        }
+
+        /// <summary>
+        /// Computes the masked-value hash for the per-flush-bucket cardinality cap: every present tag's
+        /// value is replaced with <see cref="BlockedByTracerSentinel"/>. Spans that share the same set of
+        /// present keys collapse into a single "blocked" bucket.
+        /// </summary>
+        private ulong ComputeBlockedAdditionalMetricTagsHash(Span span)
+        {
+            ulong? previousHash = null;
+            foreach (var tagKey in _additionalTagKeys)
+            {
+                var tagValue = span.GetTag(tagKey.Name);
+                if (string.IsNullOrEmpty(tagValue))
+                {
+                    continue;
+                }
+
+                if (previousHash.HasValue)
+                {
+                    previousHash = FnvHash64.GenerateHash(PeerTagSeparator, FnvHash64.Version.V1A, previousHash.Value);
+                }
+
+                previousHash = HashTag(tagKey.Utf8Prefix, BlockedByTracerSentinel, FnvHash64.Version.V1A, previousHash);
+            }
+
             return previousHash ?? 0;
         }
 
@@ -549,8 +591,10 @@ namespace Datadog.Trace.Agent
         /// "key:value" byte arrays, in configured (pre-sorted) order. Called only on the cold path
         /// (new bucket creation). Values exceeding <see cref="AdditionalTagMaxValueLength"/> are
         /// substituted with <see cref="BlockedByTracerSentinel"/>, matching the hash computation.
+        /// When <paramref name="forceBlocked"/> is true (per-bucket cardinality cap hit), every value
+        /// is masked.
         /// </summary>
-        private List<byte[]> GetEncodedAdditionalTags(Span span, in AdditionalTagResults results)
+        private List<byte[]> GetEncodedAdditionalTags(Span span, in AdditionalTagResults results, bool forceBlocked)
         {
             if (results.TagCount == 0)
             {
@@ -566,7 +610,7 @@ namespace Datadog.Trace.Agent
                     continue;
                 }
 
-                if (tagValue.Length > AdditionalTagMaxValueLength)
+                if (forceBlocked || tagValue.Length > AdditionalTagMaxValueLength)
                 {
                     // Sentinel is a constant; copy its pre-encoded bytes rather than re-encoding the string.
                     result.Add([..tagKey.Utf8Prefix, ..BlockedByTracerSentinelUtf8]);
@@ -599,6 +643,10 @@ namespace Datadog.Trace.Agent
                 lock (_buffers)
                 {
                     _currentBuffer = (_currentBuffer + 1) % BufferCount;
+
+                    // Reset per-flush values
+                    _numberOfBucketsContainingAdditionalTags = 0;
+                    _additionalTagsBlockLoggedThisBucket = 0;
                 }
 
                 TelemetryFactory.Metrics.RecordGaugeStatsBuckets(buffer.Buckets.Count);
@@ -657,12 +705,49 @@ namespace Datadog.Trace.Agent
 
             if (!buffer.Buckets.TryGetValue(key, out var bucket))
             {
-                // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket
-                bucket = new StatsBucket(
-                    key,
-                    GetEncodedPeerTags(span, peerTagKeys, in peerTagResults),
-                    GetEncodedAdditionalTags(span, in additionalTagResults));
-                buffer.Buckets.Add(key, bucket);
+                // New MetricKey. Spans whose full key already exists merge above regardless of the cap,
+                // so values admitted earlier in this bucket keep accurate per-value attribution.
+                var hasAdditionalTags = additionalTagResults.TagCount > 0;
+
+                if (!hasAdditionalTags || _numberOfBucketsContainingAdditionalTags < _additionalTagsBucketCountLimit)
+                {
+                    // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket
+                    bucket = new StatsBucket(
+                        key,
+                        GetEncodedPeerTags(span, peerTagKeys, in peerTagResults),
+                        GetEncodedAdditionalTags(span, in additionalTagResults, forceBlocked: false));
+                    buffer.Buckets.Add(key, bucket);
+
+                    if (hasAdditionalTags)
+                    {
+                        _numberOfBucketsContainingAdditionalTags++;
+                    }
+
+                    // A per-value length block also counts as a block event for observability.
+                    if (additionalTagResults.FirstBlockedTagName is not null)
+                    {
+                        OnAdditionalTagsBlocked(additionalTagResults.FirstBlockedTagName);
+                    }
+                }
+                else
+                {
+                    // Maximum number of buckets containing additional tag values is reached.
+                    // Collapse into a single "blocked" bucket whose values. Only additional tags
+                    // are blocked, the other properties are still added normally
+                    key = key.WithAdditionalMetricTagsHash(ComputeBlockedAdditionalMetricTagsHash(span));
+
+                    if (!buffer.Buckets.TryGetValue(key, out bucket))
+                    {
+                        // The blocked bucket is itself the overflow sink, so it doesn't count against the cap.
+                        bucket = new StatsBucket(
+                            key,
+                            GetEncodedPeerTags(span, peerTagKeys, in peerTagResults),
+                            GetEncodedAdditionalTags(span, in additionalTagResults, forceBlocked: true));
+                        buffer.Buckets.Add(key, bucket);
+                    }
+
+                    OnAdditionalTagsBlocked(additionalTagResults.FirstPresentTagName);
+                }
             }
 
             bucket.Hits++;
@@ -686,6 +771,25 @@ namespace Datadog.Trace.Agent
             else
             {
                 bucket.OkSummary.Add(ConvertTimestamp(duration));
+            }
+
+            void OnAdditionalTagsBlocked(string triggeringTagName)
+            {
+                // One-shot warn per flush bucket, so an attack-shaped workload can't flood the logs.
+                // Both the per-value length cap and the per-bucket cardinality cap funnel through here.
+                if (_additionalTagsBlockLoggedThisBucket == 0)
+                {
+                    // TODO: logging this once per log cycle might be too much...
+                    _additionalTagsBlockLoggedThisBucket = 1;
+                    Log.Warning(
+                        "Span-derived additional tag values are being masked with '{Sentinel}' in the current stats flush bucket " +
+                        "(triggered by tag: {TagName}). This is caused by a tag value exceeding 200 characters or " +
+                        "by exceeding DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT.",
+                        BlockedByTracerSentinel,
+                        triggeringTagName ?? "<unknown>");
+                }
+
+                // TODO: emit a tracer-internal health metric counting block events
             }
         }
 
@@ -760,6 +864,12 @@ namespace Datadog.Trace.Agent
         internal readonly struct AdditionalTagResults
         {
             public int TagCount { get; init; }
+
+            // First configured tag present on the span (for cap-block diagnostics); null if none present.
+            public string FirstPresentTagName { get; init; }
+
+            // First configured tag whose value was masked by the per-value length cap; null if none.
+            public string FirstBlockedTagName { get; init; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -26,8 +26,11 @@ namespace Datadog.Trace.Agent
     {
         private const int BufferCount = 2;
 
+        private const int AdditionalTagMaxValueLength = 200;
+        private const string BlockedByTracerSentinel = "blocked_by_tracer";
+
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
-        private static readonly List<byte[]> EmptyPeerTags = [];
+        private static readonly List<byte[]> EmptyTags = [];
         private static readonly byte[] PeerTagSeparator = [0];
         private static readonly byte[] BaseServiceUtf8Prefix = EncodingHelpers.Utf8NoBom.GetBytes(Tags.BaseService + ":");
 
@@ -51,6 +54,7 @@ namespace Datadog.Trace.Agent
         private readonly RareSampler _rareSampler;
         private readonly AnalyticsEventsSampler _analyticsEventSampler;
         private readonly IDisposable _settingSubscription;
+        private readonly AdditionalTagKey[] _additionalTagKeys;
 
         private int _currentBuffer;
 
@@ -73,6 +77,22 @@ namespace Datadog.Trace.Agent
             _errorSampler = new ErrorSampler();
             _rareSampler = new RareSampler(settings, this);
             _analyticsEventSampler = new AnalyticsEventsSampler();
+
+            // StatsAdditionalTags is already deduplicated, sorted, and capped.
+            // Pre-encode the UTF-8 key prefixes so BuildKey can hash without per-call string encoding.
+            var additionalTagCount = settings.StatsAdditionalTags.Length;
+            if (additionalTagCount == 0)
+            {
+                _additionalTagKeys = [];
+            }
+            else
+            {
+                _additionalTagKeys = new AdditionalTagKey[additionalTagCount];
+                for (var i = 0; i < additionalTagCount; i++)
+                {
+                    _additionalTagKeys[i] = new AdditionalTagKey(settings.StatsAdditionalTags[i]);
+                }
+            }
 
             // Create with the initial mutable settings, but be aware that this could change later
             var header = new ClientStatsPayload(settings.Manager.InitialMutableSettings)
@@ -106,6 +126,8 @@ namespace Datadog.Trace.Agent
                 discoveryService.SubscribeToChanges(HandleConfigUpdate);
             }
         }
+
+        private static ReadOnlySpan<byte> BlockedByTracerSentinelUtf8 => "blocked_by_tracer"u8;
 
         /// <summary>
         /// Gets the current buffer.
@@ -258,15 +280,17 @@ namespace Datadog.Trace.Agent
         }
 
         public StatsAggregationKey BuildKey(Span span)
-            => BuildKey(span, Volatile.Read(ref _peerTagKeys), out _);
+            => BuildKey(span, Volatile.Read(ref _peerTagKeys), out _, out _);
 
         /// <summary>
-        /// Computes a <see cref="StatsAggregationKey"/> for the given span, including the peer tags hash.
+        /// Computes a <see cref="StatsAggregationKey"/> for the given span, including the peer tags hash
+        /// and the span-derived additional-tags hash.
         /// The <paramref name="peerTagResults"/> carries context to <see cref="GetEncodedPeerTags"/>
         /// so the cold path can skip re-deriving spanKind/baseService and pre-allocate the result list.
+        /// The <paramref name="additionalTagResults"/> carries context to <see cref="GetEncodedAdditionalTags"/>.
         /// </summary>
         [TestingAndPrivateOnly]
-        internal StatsAggregationKey BuildKey(Span span, List<PeerTagKey> peerTagKeys, out PeerTagResults peerTagResults)
+        internal StatsAggregationKey BuildKey(Span span, List<PeerTagKey> peerTagKeys, out PeerTagResults peerTagResults, out AdditionalTagResults additionalTagResults)
         {
             var rawHttpStatusCode = span.GetTag(Tags.HttpStatusCode);
 
@@ -345,6 +369,18 @@ namespace Datadog.Trace.Agent
                 peerTagResults = default;
             }
 
+            // Span-derived additional tags: hash the configured tag values present on the span.
+            ulong additionalTagsHash;
+            if (_additionalTagKeys.Length == 0)
+            {
+                additionalTagsHash = 0;
+                additionalTagResults = default;
+            }
+            else
+            {
+                additionalTagsHash = ComputeSpanDerivedAdditionalTagsHash(span, out additionalTagResults);
+            }
+
             // When submitting trace metrics over OTLP, we must create inidividual timeseries
             // timeseries for each unique set of attributes, including the Error and IsTopLevel attributes.
             // As a result, we must create distinct Aggregation keys (and consequently, unique stats) by these attributes.
@@ -365,7 +401,7 @@ namespace Datadog.Trace.Agent
                 grpcStatusCode,
                 serviceSource,
                 peerTagsHash,
-                additionalMetricTagsHash: 0);
+                additionalTagsHash);
         }
 
         /// <summary>
@@ -422,7 +458,7 @@ namespace Datadog.Trace.Agent
         /// <summary>
         /// Encodes the peer tags for a span into a <see cref="List{T}"/> of UTF-8 byte arrays.
         /// Called only on the cold path (new bucket creation).
-        /// Uses <paramref name="results"/> from <see cref="BuildKey(Span, List{PeerTagKey}, out PeerTagResults)"/>
+        /// Uses <paramref name="results"/> from <see cref="BuildKey(Span, List{PeerTagKey}, out PeerTagResults, out AdditionalTagResults)"/>
         /// to skip re-deriving spanKind/baseService and to pre-allocate the result list.
         /// </summary>
         internal static List<byte[]> GetEncodedPeerTags(Span span, List<PeerTagKey> peerTagKeys, in PeerTagResults results)
@@ -434,7 +470,7 @@ namespace Datadog.Trace.Agent
 
             if (results.PeerTagCount == 0)
             {
-                return EmptyPeerTags;
+                return EmptyTags;
             }
 
             var result = new List<byte[]>(results.PeerTagCount);
@@ -468,6 +504,80 @@ namespace Datadog.Trace.Agent
             EncodingHelpers.Utf8NoBom.GetBytes(tagValue, charIndex: 0, charCount: tagValue.Length, encoded, byteIndex: utf8KeyPrefix.Length);
 
             return encoded;
+        }
+
+        /// <summary>
+        /// Computes the FNV-64 hash of the span-derived additional tags present on the span, in the
+        /// configured (pre-sorted) order. Values exceeding <see cref="AdditionalTagMaxValueLength"/>
+        /// are substituted with <see cref="BlockedByTracerSentinel"/> so the hash matches the encoded value.
+        /// Tags that are missing or empty on the span are skipped (not part of the dimension set).
+        /// </summary>
+        private ulong ComputeSpanDerivedAdditionalTagsHash(Span span, out AdditionalTagResults results)
+        {
+            // Hash should be generated as TAGNAME:TAGVALUE, in sorted order (_additionalTagKeys is pre-sorted).
+            ulong? previousHash = null;
+            var presentTagCount = 0;
+            foreach (var tagKey in _additionalTagKeys)
+            {
+                var tagValue = span.GetTag(tagKey.Name);
+                if (string.IsNullOrEmpty(tagValue))
+                {
+                    continue;
+                }
+
+                if (tagValue.Length > AdditionalTagMaxValueLength)
+                {
+                    tagValue = BlockedByTracerSentinel;
+                }
+
+                if (previousHash.HasValue)
+                {
+                    // add the separator between tags
+                    previousHash = FnvHash64.GenerateHash(PeerTagSeparator, FnvHash64.Version.V1A, previousHash.Value);
+                }
+
+                previousHash = HashTag(tagKey.Utf8Prefix, tagValue, FnvHash64.Version.V1A, previousHash);
+                presentTagCount++;
+            }
+
+            results = new AdditionalTagResults { TagCount = presentTagCount };
+            return previousHash ?? 0;
+        }
+
+        /// <summary>
+        /// Encodes the span-derived additional tags for a span into a <see cref="List{T}"/> of UTF-8
+        /// "key:value" byte arrays, in configured (pre-sorted) order. Called only on the cold path
+        /// (new bucket creation). Values exceeding <see cref="AdditionalTagMaxValueLength"/> are
+        /// substituted with <see cref="BlockedByTracerSentinel"/>, matching the hash computation.
+        /// </summary>
+        private List<byte[]> GetEncodedAdditionalTags(Span span, in AdditionalTagResults results)
+        {
+            if (results.TagCount == 0)
+            {
+                return EmptyTags;
+            }
+
+            var result = new List<byte[]>(results.TagCount);
+            foreach (var tagKey in _additionalTagKeys)
+            {
+                var tagValue = span.GetTag(tagKey.Name);
+                if (string.IsNullOrEmpty(tagValue))
+                {
+                    continue;
+                }
+
+                if (tagValue.Length > AdditionalTagMaxValueLength)
+                {
+                    // Sentinel is a constant; copy its pre-encoded bytes rather than re-encoding the string.
+                    result.Add([..tagKey.Utf8Prefix, ..BlockedByTracerSentinelUtf8]);
+                }
+                else
+                {
+                    result.Add(EncodeKeyValue(tagKey.Utf8Prefix, tagValue));
+                }
+            }
+
+            return result;
         }
 
         internal async Task Flush()
@@ -543,12 +653,15 @@ namespace Datadog.Trace.Agent
 
             var buffer = CurrentBuffer;
             var peerTagKeys = Volatile.Read(ref _peerTagKeys);
-            var key = BuildKey(span, peerTagKeys, out var peerTagResults);
+            var key = BuildKey(span, peerTagKeys, out var peerTagResults, out var additionalTagResults);
 
             if (!buffer.Buckets.TryGetValue(key, out var bucket))
             {
-                // Cold path: encode the peer tags for storage in the new bucket
-                bucket = new StatsBucket(key, GetEncodedPeerTags(span, peerTagKeys, in peerTagResults), EmptyPeerTags);
+                // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket
+                bucket = new StatsBucket(
+                    key,
+                    GetEncodedPeerTags(span, peerTagKeys, in peerTagResults),
+                    GetEncodedAdditionalTags(span, in additionalTagResults));
                 buffer.Buckets.Add(key, bucket);
             }
 
@@ -636,6 +749,17 @@ namespace Datadog.Trace.Agent
             public int PeerTagCount { get; init; }
 
             public string BaseService { get; init; }
+        }
+
+        internal readonly struct AdditionalTagKey(string name)
+        {
+            public readonly string Name = name;
+            public readonly byte[] Utf8Prefix = EncodingHelpers.Utf8NoBom.GetBytes(name + ":");
+        }
+
+        internal readonly struct AdditionalTagResults
+        {
+            public int TagCount { get; init; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
@@ -12,12 +12,13 @@ namespace Datadog.Trace.Agent
 {
     internal sealed class StatsBucket
     {
-        public StatsBucket(StatsAggregationKey key, List<byte[]> peerTags)
+        public StatsBucket(StatsAggregationKey key, List<byte[]> peerTags, List<byte[]> additionalMetricTags)
         {
             Key = key;
             OkSummary = CreateSketch();
             ErrorSummary = CreateSketch();
             PeerTags = peerTags;
+            AdditionalMetricTags = additionalMetricTags;
         }
 
         public StatsAggregationKey Key { get; }
@@ -35,6 +36,8 @@ namespace Datadog.Trace.Agent
         public long TopLevelHits { get; set; }
 
         public List<byte[]> PeerTags { get; }
+
+        public List<byte[]> AdditionalMetricTags { get; }
 
         public void Clear()
         {

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -64,6 +64,7 @@ namespace Datadog.Trace.Agent
         private static ReadOnlySpan<byte> GrpcStatusCodeKeyBytes => "GRPCStatusCode"u8;
         private static ReadOnlySpan<byte> ServiceSourceKeyBytes => "srv_src"u8; // Wire name per the Go agent's generated msgpack code
         private static ReadOnlySpan<byte> PeerTagsKeyBytes => "PeerTags"u8;
+        private static ReadOnlySpan<byte> AdditionalMetricTagsKeyBytes => "AdditionalMetricTags"u8;
 
         // shared keys (used in multiple maps)
         private static ReadOnlySpan<byte> StatsKeyBytes => "Stats"u8;
@@ -191,7 +192,7 @@ namespace Datadog.Trace.Agent
 
         private static void SerializeBucket(Stream stream, StatsBucket bucket)
         {
-            var fieldCount = 18;
+            var fieldCount = 19;
             if (bucket.PeerTags.Count != 0)
             {
                 fieldCount++;
@@ -264,6 +265,13 @@ namespace Datadog.Trace.Agent
                 {
                     MessagePackBinary.WriteStringBytes(stream, tag);
                 }
+            }
+
+            MessagePackBinary.WriteStringBytes(stream, AdditionalMetricTagsKeyBytes);
+            MessagePackBinary.WriteArrayHeader(stream, bucket.AdditionalMetricTags.Count);
+            foreach (var tag in bucket.AdditionalMetricTags)
+            {
+                MessagePackBinary.WriteStringBytes(stream, tag);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Configuration
     public partial record TracerSettings
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerSettings>();
-        private static readonly HashSet<string> DefaultExperimentalFeatures = ["DD_TAGS"];
+        private static readonly HashSet<string> DefaultExperimentalFeatures = ["DD_TAGS", ConfigurationKeys.StatsAdditionalTags];
 
         private readonly Lazy<string> _fallbackApplicationName;
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -610,6 +610,82 @@ namespace Datadog.Trace.Configuration
                 StatsComputationEnabled = false;
             }
 
+            if (!ExperimentalFeaturesEnabled.Contains(ConfigurationKeys.StatsAdditionalTags))
+            {
+                StatsAdditionalTags = [];
+            }
+            else
+            {
+                // Deduplicate and sort up front so the aggregator receives a frozen, normalized list
+                // and so the configured-key cap drops a deterministic (alphabetical) set.
+                var statsAdditionalTags = config
+                                         .WithKeys(ConfigurationKeys.StatsAdditionalTags)
+                                         .AsString();
+                if (StringUtil.IsNullOrWhiteSpace(statsAdditionalTags))
+                {
+                    StatsAdditionalTags = [];
+                }
+                else
+                {
+                    HashSet<string>? entries = null;
+                    const int maxStatsAdditionalTagKeys = 4; // backend stats pipeline only supports a few primary tag dimensions
+
+                    // split the string value to find the tags
+                    foreach (var splitValue in statsAdditionalTags.SplitIntoSpans(','))
+                    {
+                        var span = splitValue.AsSpan().Trim();
+                        if (span.IsEmpty)
+                        {
+                            continue;
+                        }
+
+                        entries ??= [];
+                        entries.Add(span.ToString());
+                    }
+
+                    if (entries is { Count: > 0 })
+                    {
+                        // If we have more than maxStatsAdditionalTagKeys, we need to drop the remaining
+                        List<string>? dropped = null;
+                        var entryCount = Math.Min(entries.Count, maxStatsAdditionalTagKeys);
+                        var tags = new string[entryCount];
+                        var i = 0;
+
+                        // We order by the tags here, to ensure the stats aggregation key stats are consistent
+                        foreach (var entry in entries.OrderBy(static x => x, StringComparer.Ordinal))
+                        {
+                            if (i >= maxStatsAdditionalTagKeys)
+                            {
+                                dropped ??= [];
+                                dropped.Add(entry);
+                            }
+                            else
+                            {
+                                tags[i] = entry;
+                                i++;
+                            }
+                        }
+
+                        StatsAdditionalTags = tags;
+                        if (dropped is not null)
+                        {
+                            Log.Warning<int, string>(
+                                "DD_TRACE_STATS_ADDITIONAL_TAGS exceeds the maximum of {Max} keys. The following keys were dropped: {Dropped}",
+                                maxStatsAdditionalTagKeys,
+                                string.Join(",", dropped));
+                        }
+                    }
+                    else
+                    {
+                        StatsAdditionalTags = [];
+                    }
+                }
+            }
+
+            StatsAdditionalTagsCardinalityLimit = config
+                                                 .WithKeys(ConfigurationKeys.StatsAdditionalTagsCardinalityLimit)
+                                                 .AsInt32(defaultValue: 100, validator: x => x > 0).Value;
+
             var urlSubstringSkips = config
                                    .WithKeys(ConfigurationKeys.HttpClientExcludedUrlSubstrings)
                                    .AsString(GetDefaultHttpClientExclusions());
@@ -947,6 +1023,21 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether stats are computed on the tracer side
         /// </summary>
         public bool StatsComputationEnabled { get; }
+
+        /// <summary>
+        /// Gets the span tag keys to extract and include as additional aggregation dimensions
+        /// for client-side stats. Deduplicated, sorted, and capped at 4 keys.
+        /// Empty unless the feature is enabled via <see cref="ExperimentalFeaturesEnabled"/>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.StatsAdditionalTags"/>
+        internal string[] StatsAdditionalTags { get; }
+
+        /// <summary>
+        /// Gets the maximum number of distinct stat entries with additional tags admitted
+        /// into each flush bucket.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.StatsAdditionalTagsCardinalityLimit"/>
+        internal int StatsAdditionalTagsCardinalityLimit { get; }
 
         /// <summary>
         /// Gets a value indicating whether to enable span linking for individual messages

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -3462,6 +3462,27 @@ supportedConfigurations:
     documentation: |-
       Configuration key for enabling or disabling the diagnostic log at startup
       <seealso cref="Datadog.Trace.Configuration.MutableSettings.StartupDiagnosticLogEnabled"/>
+  DD_TRACE_STATS_ADDITIONAL_TAGS:
+  - implementation: A
+    scope: managed
+    type: array
+    default: null
+    const_name: StatsAdditionalTags
+    documentation: |-
+      Configuration key for a comma-separated list of span-tag keys to extract and
+      include as additional aggregation dimensions for client-side stats.
+      Requires <see cref="ConfigurationKeys.ExperimentalFeaturesEnabled"/> to include
+      "DD_TRACE_STATS_ADDITIONAL_TAGS". A maximum of 4 keys are allowed; any excess keys are dropped.
+  DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT:
+  - implementation: A
+    scope: managed
+    type: int
+    default: '100'
+    const_name: StatsAdditionalTagsCardinalityLimit
+    documentation: |-
+      Configuration key for the maximum number of distinct stat entries with additional
+      tags allowed per flush interval. New entries beyond the cap have their additional
+      tag values replaced with "blocked_by_tracer".
   DD_TRACE_STATS_COMPUTATION_ENABLED:
   - implementation: A
     scope: managed

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -3482,7 +3482,7 @@ supportedConfigurations:
     documentation: |-
       Configuration key for the maximum number of distinct stat entries with additional
       tags allowed per flush interval. New entries beyond the cap have their additional
-      tag values replaced with "blocked_by_tracer".
+      tag values replaced with "tracer_blocked_value".
   DD_TRACE_STATS_COMPUTATION_ENABLED:
   - implementation: A
     scope: managed

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -756,6 +756,21 @@ internal static partial class ConfigurationKeys
     public const string StartupDiagnosticLogEnabled = "DD_TRACE_STARTUP_LOGS";
 
     /// <summary>
+    /// Configuration key for a comma-separated list of span-tag keys to extract and
+    /// include as additional aggregation dimensions for client-side stats.
+    /// Requires <see cref="ConfigurationKeys.ExperimentalFeaturesEnabled"/> to include
+    /// "DD_TRACE_STATS_ADDITIONAL_TAGS". A maximum of 4 keys are allowed; any excess keys are dropped.
+    /// </summary>
+    public const string StatsAdditionalTags = "DD_TRACE_STATS_ADDITIONAL_TAGS";
+
+    /// <summary>
+    /// Configuration key for the maximum number of distinct stat entries with additional
+    /// tags allowed per flush interval. New entries beyond the cap have their additional
+    /// tag values replaced with "blocked_by_tracer".
+    /// </summary>
+    public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
+
+    /// <summary>
     /// Configuration key for enabling computation of stats (aka trace metrics) on the tracer side
     /// </summary>
     public const string StatsComputationEnabled = "DD_TRACE_STATS_COMPUTATION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -766,7 +766,7 @@ internal static partial class ConfigurationKeys
     /// <summary>
     /// Configuration key for the maximum number of distinct stat entries with additional
     /// tags allowed per flush interval. New entries beyond the cap have their additional
-    /// tag values replaced with "blocked_by_tracer".
+    /// tag values replaced with "tracer_blocked_value".
     /// </summary>
     public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -756,6 +756,21 @@ internal static partial class ConfigurationKeys
     public const string StartupDiagnosticLogEnabled = "DD_TRACE_STARTUP_LOGS";
 
     /// <summary>
+    /// Configuration key for a comma-separated list of span-tag keys to extract and
+    /// include as additional aggregation dimensions for client-side stats.
+    /// Requires <see cref="ConfigurationKeys.ExperimentalFeaturesEnabled"/> to include
+    /// "DD_TRACE_STATS_ADDITIONAL_TAGS". A maximum of 4 keys are allowed; any excess keys are dropped.
+    /// </summary>
+    public const string StatsAdditionalTags = "DD_TRACE_STATS_ADDITIONAL_TAGS";
+
+    /// <summary>
+    /// Configuration key for the maximum number of distinct stat entries with additional
+    /// tags allowed per flush interval. New entries beyond the cap have their additional
+    /// tag values replaced with "blocked_by_tracer".
+    /// </summary>
+    public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
+
+    /// <summary>
     /// Configuration key for enabling computation of stats (aka trace metrics) on the tracer side
     /// </summary>
     public const string StatsComputationEnabled = "DD_TRACE_STATS_COMPUTATION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -766,7 +766,7 @@ internal static partial class ConfigurationKeys
     /// <summary>
     /// Configuration key for the maximum number of distinct stat entries with additional
     /// tags allowed per flush interval. New entries beyond the cap have their additional
-    /// tag values replaced with "blocked_by_tracer".
+    /// tag values replaced with "tracer_blocked_value".
     /// </summary>
     public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -756,6 +756,21 @@ internal static partial class ConfigurationKeys
     public const string StartupDiagnosticLogEnabled = "DD_TRACE_STARTUP_LOGS";
 
     /// <summary>
+    /// Configuration key for a comma-separated list of span-tag keys to extract and
+    /// include as additional aggregation dimensions for client-side stats.
+    /// Requires <see cref="ConfigurationKeys.ExperimentalFeaturesEnabled"/> to include
+    /// "DD_TRACE_STATS_ADDITIONAL_TAGS". A maximum of 4 keys are allowed; any excess keys are dropped.
+    /// </summary>
+    public const string StatsAdditionalTags = "DD_TRACE_STATS_ADDITIONAL_TAGS";
+
+    /// <summary>
+    /// Configuration key for the maximum number of distinct stat entries with additional
+    /// tags allowed per flush interval. New entries beyond the cap have their additional
+    /// tag values replaced with "blocked_by_tracer".
+    /// </summary>
+    public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
+
+    /// <summary>
     /// Configuration key for enabling computation of stats (aka trace metrics) on the tracer side
     /// </summary>
     public const string StatsComputationEnabled = "DD_TRACE_STATS_COMPUTATION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -766,7 +766,7 @@ internal static partial class ConfigurationKeys
     /// <summary>
     /// Configuration key for the maximum number of distinct stat entries with additional
     /// tags allowed per flush interval. New entries beyond the cap have their additional
-    /// tag values replaced with "blocked_by_tracer".
+    /// tag values replaced with "tracer_blocked_value".
     /// </summary>
     public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -756,6 +756,21 @@ internal static partial class ConfigurationKeys
     public const string StartupDiagnosticLogEnabled = "DD_TRACE_STARTUP_LOGS";
 
     /// <summary>
+    /// Configuration key for a comma-separated list of span-tag keys to extract and
+    /// include as additional aggregation dimensions for client-side stats.
+    /// Requires <see cref="ConfigurationKeys.ExperimentalFeaturesEnabled"/> to include
+    /// "DD_TRACE_STATS_ADDITIONAL_TAGS". A maximum of 4 keys are allowed; any excess keys are dropped.
+    /// </summary>
+    public const string StatsAdditionalTags = "DD_TRACE_STATS_ADDITIONAL_TAGS";
+
+    /// <summary>
+    /// Configuration key for the maximum number of distinct stat entries with additional
+    /// tags allowed per flush interval. New entries beyond the cap have their additional
+    /// tag values replaced with "blocked_by_tracer".
+    /// </summary>
+    public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
+
+    /// <summary>
     /// Configuration key for enabling computation of stats (aka trace metrics) on the tracer side
     /// </summary>
     public const string StatsComputationEnabled = "DD_TRACE_STATS_COMPUTATION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -766,7 +766,7 @@ internal static partial class ConfigurationKeys
     /// <summary>
     /// Configuration key for the maximum number of distinct stat entries with additional
     /// tags allowed per flush interval. New entries beyond the cap have their additional
-    /// tag values replaced with "blocked_by_tracer".
+    /// tag values replaced with "tracer_blocked_value".
     /// </summary>
     public const string StatsAdditionalTagsCardinalityLimit = "DD_TRACE_STATS_ADDITIONAL_TAGS_CARDINALITY_LIMIT";
 

--- a/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientGroupedStats.cs
@@ -69,4 +69,7 @@ public class MockClientGroupedStats
 
     [Key("PeerTags")]
     public string[] PeerTags { get; set; }
+
+    [Key("AdditionalMetricTags")]
+    public string[] AdditionalMetricTags { get; set; }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1171,7 +1171,7 @@ namespace Datadog.Trace.Tests.Agent
             span.Tags.SetTag("peer.service", "remote-service");
 
             List<StatsAggregator.PeerTagKey> peerTagKeys = [new("peer.service")];
-            var key = aggregator.BuildKey(span, peerTagKeys, out _);
+            var key = aggregator.BuildKey(span, peerTagKeys, out _, out _);
 
             key.PeerTagsHash.Should().Be(3430395298086625290UL);
         }
@@ -1193,7 +1193,7 @@ namespace Datadog.Trace.Tests.Agent
 
             // Keys must be pre-sorted (matching agent behavior)
             List<StatsAggregator.PeerTagKey> peerTagKeys = [new("db.instance"), new("db.system"), new("peer.service")];
-            var key = aggregator.BuildKey(span, peerTagKeys, out _);
+            var key = aggregator.BuildKey(span, peerTagKeys, out _, out _);
 
             key.PeerTagsHash.Should().Be(9894752672193411515UL);
         }
@@ -1213,7 +1213,7 @@ namespace Datadog.Trace.Tests.Agent
             span.Tags.SetTag("messaging.system", "kafka");
 
             List<StatsAggregator.PeerTagKey> peerTagKeys = [new("db.instance"), new("db.system"), new("messaging.destination"), new("messaging.system")];
-            var key = aggregator.BuildKey(span, peerTagKeys, out _);
+            var key = aggregator.BuildKey(span, peerTagKeys, out _, out _);
 
             key.PeerTagsHash.Should().Be(0xf5eeb51fbe7929b4UL);
         }
@@ -1233,7 +1233,7 @@ namespace Datadog.Trace.Tests.Agent
             span.Tags.SetTag("db.system", string.Empty);
 
             List<StatsAggregator.PeerTagKey> peerTagKeys = [new("db.instance"), new("db.system"), new("peer.service")];
-            var key = aggregator.BuildKey(span, peerTagKeys, out _);
+            var key = aggregator.BuildKey(span, peerTagKeys, out _, out _);
 
             key.PeerTagsHash.Should().Be(3430395298086625290UL);
         }
@@ -1253,7 +1253,7 @@ namespace Datadog.Trace.Tests.Agent
             span.Tags.SetTag("db.system", "postgres");
 
             List<StatsAggregator.PeerTagKey> peerTagKeys = [new("db.instance"), new("db.system"), new("peer.service")];
-            var key = aggregator.BuildKey(span, peerTagKeys, out var peerTagResults);
+            var key = aggregator.BuildKey(span, peerTagKeys, out var peerTagResults, out _);
             var encodedTags = StatsAggregator.GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
 
             // Hash the encoded tags the same way the Go agent does:
@@ -1279,7 +1279,7 @@ namespace Datadog.Trace.Tests.Agent
             span.Tags.SetTag(Tags.BaseService, "my-base-service");
 
             List<StatsAggregator.PeerTagKey> peerTagKeys = [new("peer.service")];
-            var key = aggregator.BuildKey(span, peerTagKeys, out var peerTagResults);
+            var key = aggregator.BuildKey(span, peerTagKeys, out var peerTagResults, out _);
             var encodedTags = StatsAggregator.GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
 
             encodedTags.Should().HaveCount(1);
@@ -1299,10 +1299,170 @@ namespace Datadog.Trace.Tests.Agent
             // No peer tags set on the span
 
             List<StatsAggregator.PeerTagKey> peerTagKeys = [new("peer.service")];
-            var key = aggregator.BuildKey(span, peerTagKeys, out _);
+            var key = aggregator.BuildKey(span, peerTagKeys, out _, out _);
 
             key.PeerTagsHash.Should().Be(0UL);
         }
+
+        [Fact]
+        public async Task AdditionalTags_PresentValuesDistinguishBuckets()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region"), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            var span1 = CreateTopLevelSpan(start, "svc");
+            span1.SetTag("region", "us-east-1");
+
+            var span2 = CreateTopLevelSpan(start, "svc");
+            span2.SetTag("region", "eu-west-1");
+
+            aggregator.Add(span1, span2);
+
+            // Otherwise-identical spans aggregate separately because their region values differ
+            aggregator.CurrentBuffer.Buckets.Should().HaveCount(2);
+            aggregator.BuildKey(span1).AdditionalMetricTagsHash.Should().NotBe(aggregator.BuildKey(span2).AdditionalMetricTagsHash);
+        }
+
+        [Fact]
+        public async Task AdditionalTags_MissingTagBucketsSeparatelyFromPresent()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region"), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            var withRegion = CreateTopLevelSpan(start, "svc");
+            withRegion.SetTag("region", "us-east-1");
+
+            var withoutRegion = CreateTopLevelSpan(start, "svc");
+
+            aggregator.Add(withRegion, withoutRegion);
+
+            aggregator.CurrentBuffer.Buckets.Should().HaveCount(2);
+
+            // The span without the configured tag contributes no additional-tags dimension (hash 0, empty map)
+            var withoutKey = aggregator.BuildKey(withoutRegion);
+            withoutKey.AdditionalMetricTagsHash.Should().Be(0UL);
+            aggregator.CurrentBuffer.Buckets[withoutKey].AdditionalMetricTags.Should().BeEmpty();
+
+            var withKey = aggregator.BuildKey(withRegion);
+            withKey.AdditionalMetricTagsHash.Should().NotBe(0UL);
+            DecodeTags(aggregator.CurrentBuffer.Buckets[withKey].AdditionalMetricTags).Should().Equal("region:us-east-1");
+        }
+
+        [Fact]
+        public async Task AdditionalTags_HashIsConsistentAndOrderIndependent()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region,tenant"), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            // Same values, but set on the span in a different order: the hash must match because
+            // hashing iterates the configured (sorted) key order, not the span's tag insertion order.
+            var span1 = CreateTopLevelSpan(start, "svc");
+            span1.SetTag("region", "us-east-1");
+            span1.SetTag("tenant", "acme");
+
+            var span2 = CreateTopLevelSpan(start, "svc");
+            span2.SetTag("tenant", "acme");
+            span2.SetTag("region", "us-east-1");
+
+            aggregator.BuildKey(span1).AdditionalMetricTagsHash
+                      .Should().Be(aggregator.BuildKey(span2).AdditionalMetricTagsHash)
+                      .And.NotBe(0UL);
+        }
+
+        [Fact]
+        public async Task AdditionalTags_MultipleKeysAggregateIndependently()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region,tenant"), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            Span Make(string region, string tenant)
+            {
+                var span = CreateTopLevelSpan(start, "svc");
+                span.SetTag("region", region);
+                span.SetTag("tenant", tenant);
+                return span;
+            }
+
+            // Four distinct (region, tenant) combinations => four buckets
+            aggregator.Add(Make("us", "acme"), Make("us", "beta"), Make("eu", "acme"), Make("eu", "beta"));
+
+            aggregator.CurrentBuffer.Buckets.Should().HaveCount(4);
+        }
+
+        [Fact]
+        public async Task AdditionalTags_ValueExceedingLengthCap_SubstitutesBlockedByTracer()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region"), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            var span = CreateTopLevelSpan(start, "svc");
+            span.SetDuration(TimeSpan.FromMilliseconds(100));
+            span.SetTag("region", new string('x', 201)); // one over the 200-char cap
+
+            aggregator.Add(span);
+
+            var key = aggregator.BuildKey(span);
+            var bucket = aggregator.CurrentBuffer.Buckets[key];
+
+            // The oversized value is masked, but the dimension key and the span's base stats survive
+            DecodeTags(bucket.AdditionalMetricTags).Should().Equal("region:blocked_by_tracer");
+            bucket.Hits.Should().Be(1);
+            bucket.Duration.Should().Be(100 * 1_000_000);
+        }
+
+        [Fact]
+        public async Task AdditionalTags_ValueAtLengthCap_IsNotBlocked()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region"), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            var value = new string('x', 200); // exactly at the cap is allowed
+            var span = CreateTopLevelSpan(start, "svc");
+            span.SetTag("region", value);
+
+            aggregator.Add(span);
+
+            var bucket = aggregator.CurrentBuffer.Buckets[aggregator.BuildKey(span)];
+            DecodeTags(bucket.AdditionalMetricTags).Should().Equal($"region:{value}");
+        }
+
+        [Fact]
+        public async Task AdditionalTags_EncodedTagsAreSortedByConfiguredKeyOrder()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("tenant,region,az"), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            var span = CreateTopLevelSpan(start, "svc");
+            span.SetTag("region", "us-east-1");
+            span.SetTag("tenant", "acme");
+            span.SetTag("az", "az-1");
+
+            aggregator.Add(span);
+
+            var bucket = aggregator.CurrentBuffer.Buckets[aggregator.BuildKey(span)];
+            // Configured keys are deduped+sorted in settings, so encoding is alphabetical: az, region, tenant
+            DecodeTags(bucket.AdditionalMetricTags).Should().Equal("az:az-1", "region:us-east-1", "tenant:acme");
+        }
+
+        [Fact]
+        public async Task AdditionalTags_DisabledFeature_NoHashContribution()
+        {
+            var start = DateTimeOffset.UtcNow;
+            // No additional tags configured (feature off)
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            var span = CreateTopLevelSpan(start, "svc");
+            span.SetTag("region", "us-east-1");
+
+            aggregator.Add(span);
+
+            var key = aggregator.BuildKey(span);
+            key.AdditionalMetricTagsHash.Should().Be(0UL);
+            aggregator.CurrentBuffer.Buckets[key].AdditionalMetricTags.Should().BeEmpty();
+        }
+
+        private static List<string> DecodeTags(List<byte[]> encoded)
+            => encoded.Select(bytes => System.Text.Encoding.UTF8.GetString(bytes)).ToList();
 
         /// <summary>
         /// Creates a top-level span with a TraceContext.
@@ -1322,6 +1482,22 @@ namespace Datadog.Trace.Tests.Agent
                                : new TracerSettings();
 
             return settings;
+        }
+
+        private static TracerSettings GetSettingsWithAdditionalTags(string additionalTags, int? cardinalityLimit = null)
+        {
+            var config = new Dictionary<string, object>
+            {
+                { ConfigurationKeys.ExperimentalFeaturesEnabled, ConfigurationKeys.StatsAdditionalTags },
+                { ConfigurationKeys.StatsAdditionalTags, additionalTags },
+            };
+
+            if (cardinalityLimit.HasValue)
+            {
+                config[ConfigurationKeys.StatsAdditionalTagsCardinalityLimit] = cardinalityLimit.Value;
+            }
+
+            return TracerSettings.Create(config);
         }
 
         // Re-implement timestamp conversion to independently verify the operation

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1461,6 +1461,95 @@ namespace Datadog.Trace.Tests.Agent
             aggregator.CurrentBuffer.Buckets[key].AdditionalMetricTags.Should().BeEmpty();
         }
 
+        [Fact]
+        public async Task AdditionalTags_PerBucketCap_BlocksOverflowAndMergesAdmitted()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("tenant", cardinalityLimit: 3), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            Span MakeTenant(string tenant)
+            {
+                var span = CreateTopLevelSpan(start, "svc");
+                span.SetTag("tenant", tenant);
+                return span;
+            }
+
+            // First 3 distinct tenants are admitted; "d" and "e" overflow into one masked "blocked" bucket.
+            aggregator.Add(MakeTenant("a"), MakeTenant("b"), MakeTenant("c"), MakeTenant("d"), MakeTenant("e"));
+
+            // 3 admitted + 1 blocked sink
+            aggregator.CurrentBuffer.Buckets.Should().HaveCount(4);
+
+            var blockedBucket = aggregator.CurrentBuffer.Buckets.Values
+                                          .Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "tenant:blocked_by_tracer" }));
+            blockedBucket.Hits.Should().Be(2); // d + e merged into the blocked bucket
+
+            // A repeat of an already-admitted key still merges into its existing entry, regardless of the cap.
+            aggregator.Add(MakeTenant("a"));
+            aggregator.CurrentBuffer.Buckets.Should().HaveCount(4);
+            aggregator.CurrentBuffer.Buckets[aggregator.BuildKey(MakeTenant("a"))].Hits.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task AdditionalTags_PerBucketCap_DoesNotApplyToSpansWithoutAdditionalTags()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region", cardinalityLimit: 1), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            // Five distinct buckets (by resource) but none carry the configured tag, so the cap never triggers.
+            for (var i = 0; i < 5; i++)
+            {
+                var span = CreateTopLevelSpan(start, "svc");
+                span.ResourceName = $"resource-{i}";
+                aggregator.Add(span);
+            }
+
+            aggregator.CurrentBuffer.Buckets.Should().HaveCount(5);
+            aggregator.CurrentBuffer.Buckets.Values.Should().OnlyContain(b => b.AdditionalMetricTags.Count == 0);
+
+            // A span that does carry the tag is still admitted, since the budget was never consumed.
+            var withRegion = CreateTopLevelSpan(start, "svc");
+            withRegion.ResourceName = "resource-with-region";
+            withRegion.SetTag("region", "us-east-1");
+            aggregator.Add(withRegion);
+
+            DecodeTags(aggregator.CurrentBuffer.Buckets[aggregator.BuildKey(withRegion)].AdditionalMetricTags)
+                .Should().Equal("region:us-east-1");
+        }
+
+        [Fact]
+        public async Task AdditionalTags_FlushResetsCardinalityBudget()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region", cardinalityLimit: 1), new StubDiscoveryService(), isOtlp: false);
+
+            // Dispose so the background flush completes and explicit Flush() runs synchronously without delay.
+            await aggregator.DisposeAsync();
+
+            Span MakeRegion(string region)
+            {
+                var span = CreateTopLevelSpan(start, "svc");
+                span.SetTag("region", region);
+                return span;
+            }
+
+            aggregator.Add(MakeRegion("a")); // admitted (budget now full)
+            aggregator.Add(MakeRegion("b")); // blocked: budget of 1 exhausted
+
+            var bufferBeforeFlush = aggregator.CurrentBuffer;
+            bufferBeforeFlush.Buckets.Should().HaveCount(2); // region=a + blocked sink
+
+            // Flush swaps the buffer and resets the per-bucket cardinality budget.
+            await aggregator.Flush();
+
+            aggregator.Add(MakeRegion("c")); // fresh budget => admitted with its real value, not masked
+
+            var bufferAfterFlush = aggregator.CurrentBuffer;
+            bufferAfterFlush.Should().NotBeSameAs(bufferBeforeFlush);
+            DecodeTags(bufferAfterFlush.Buckets[aggregator.BuildKey(MakeRegion("c"))].AdditionalMetricTags)
+                .Should().Equal("region:c");
+        }
+
         private static List<string> DecodeTags(List<byte[]> encoded)
             => encoded.Select(bytes => System.Text.Encoding.UTF8.GetString(bytes)).ToList();
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1550,6 +1550,46 @@ namespace Datadog.Trace.Tests.Agent
                 .Should().Equal("region:c");
         }
 
+        [Fact]
+        public async Task AdditionalTags_RetainedBucketIsGatedByCapWhenReactivated()
+        {
+            var start = DateTimeOffset.UtcNow;
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region", cardinalityLimit: 1), new StubDiscoveryService(), isOtlp: false);
+
+            // Dispose so the background flush completes and explicit Flush() runs synchronously without delay.
+            await aggregator.DisposeAsync();
+
+            // Admit one real additional-tag bucket, then rotate two flushes back to the same buffer. region=a
+            // had hits, so it is retained (with Hits == 0) and the per-flush budget is reset to 0.
+            aggregator.Add(MakeRegion("a"));
+            var retainingBuffer = aggregator.CurrentBuffer;
+            await aggregator.Flush();
+            await aggregator.Flush();
+            aggregator.CurrentBuffer.Should().BeSameAs(retainingBuffer);
+
+            // In the new interval, activate two distinct additional-tag values. The first consumes the budget of
+            // 1; re-activating the retained region=a is over budget, so it is masked into the blocked sink rather
+            // than serializing its retained real bucket. This is the hard cap holding across the rotation.
+            aggregator.Add(MakeRegion("b")); // new, admitted real (budget now full)
+            aggregator.Add(MakeRegion("a")); // retained, first hit this interval, over budget => masked
+
+            var buckets = aggregator.CurrentBuffer.Buckets.Values.ToList();
+
+            // Exactly one real additional-tag bucket has hits this interval; region=a's retained real bucket got none.
+            buckets.Count(b => b.AdditionalMetricTags.Count > 0 && b.Hits > 0 && DecodeTags(b.AdditionalMetricTags)[0] != "region:blocked_by_tracer")
+                   .Should().Be(1);
+            buckets.Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "region:b" })).Hits.Should().Be(1);
+            buckets.Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "region:a" })).Hits.Should().Be(0);
+            buckets.Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "region:blocked_by_tracer" })).Hits.Should().Be(1);
+
+            Span MakeRegion(string region)
+            {
+                var span = CreateTopLevelSpan(start, "svc");
+                span.SetTag("region", region);
+                return span;
+            }
+        }
+
         private static List<string> DecodeTags(List<byte[]> encoded)
             => encoded.Select(bytes => System.Text.Encoding.UTF8.GetString(bytes)).ToList();
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1405,7 +1405,7 @@ namespace Datadog.Trace.Tests.Agent
             var bucket = aggregator.CurrentBuffer.Buckets[key];
 
             // The oversized value is masked, but the dimension key and the span's base stats survive
-            DecodeTags(bucket.AdditionalMetricTags).Should().Equal("region:blocked_by_tracer");
+            DecodeTags(bucket.AdditionalMetricTags).Should().Equal("region:tracer_blocked_value");
             bucket.Hits.Should().Be(1);
             bucket.Duration.Should().Be(100 * 1_000_000);
         }
@@ -1481,7 +1481,7 @@ namespace Datadog.Trace.Tests.Agent
             aggregator.CurrentBuffer.Buckets.Should().HaveCount(4);
 
             var blockedBucket = aggregator.CurrentBuffer.Buckets.Values
-                                          .Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "tenant:blocked_by_tracer" }));
+                                          .Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "tenant:tracer_blocked_value" }));
             blockedBucket.Hits.Should().Be(2); // d + e merged into the blocked bucket
 
             // A repeat of an already-admitted key still merges into its existing entry, regardless of the cap.
@@ -1576,11 +1576,11 @@ namespace Datadog.Trace.Tests.Agent
             var buckets = aggregator.CurrentBuffer.Buckets.Values.ToList();
 
             // Exactly one real additional-tag bucket has hits this interval; region=a's retained real bucket got none.
-            buckets.Count(b => b.AdditionalMetricTags.Count > 0 && b.Hits > 0 && DecodeTags(b.AdditionalMetricTags)[0] != "region:blocked_by_tracer")
+            buckets.Count(b => b.AdditionalMetricTags.Count > 0 && b.Hits > 0 && DecodeTags(b.AdditionalMetricTags)[0] != "region:tracer_blocked_value")
                    .Should().Be(1);
             buckets.Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "region:b" })).Hits.Should().Be(1);
             buckets.Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "region:a" })).Hits.Should().Be(0);
-            buckets.Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "region:blocked_by_tracer" })).Hits.Should().Be(1);
+            buckets.Single(b => DecodeTags(b.AdditionalMetricTags).SequenceEqual(new[] { "region:tracer_blocked_value" })).Hits.Should().Be(1);
 
             Span MakeRegion(string region)
             {

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -166,6 +166,41 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public void Serialization_EmitsEmptyAdditionalMetricTagsWhenEmpty()
+        {
+            var buffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
+            var key = CreateKey("resource", "service", "operation", "type", 200, false);
+            var bucket = new StatsBucket(key, EmptyTags, EmptyTags) { Duration = 1, Hits = 1, TopLevelHits = 1 };
+            buffer.Buckets.Add(key, bucket);
+
+            var stream = new MemoryStream();
+            buffer.Serialize(stream, 1);
+            var result = MessagePackSerializer.Deserialize<MockClientStatsPayload>(stream.ToArray());
+
+            result.Stats[0].Stats.Single().AdditionalMetricTags.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Serialization_PopulatesAdditionalMetricTags()
+        {
+            var buffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
+            var key = CreateKey("resource", "service", "operation", "type", 200, false, additionalMetricTagsHash: 12345);
+            var additionalTags = new List<byte[]>
+            {
+                System.Text.Encoding.UTF8.GetBytes("region:us-east-1"),
+                System.Text.Encoding.UTF8.GetBytes("tenant:acme"),
+            };
+            var bucket = new StatsBucket(key, EmptyTags, additionalTags) { Duration = 1, Hits = 1, TopLevelHits = 1 };
+            buffer.Buckets.Add(key, bucket);
+
+            var stream = new MemoryStream();
+            buffer.Serialize(stream, 1);
+            var result = MessagePackSerializer.Deserialize<MockClientStatsPayload>(stream.ToArray());
+
+            result.Stats[0].Stats.Single().AdditionalMetricTags.Should().Equal("region:us-east-1", "tenant:acme");
+        }
+
+        [Fact]
         public void KeyEquality_NewDimensions()
         {
             // Different SpanKind

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests.Agent
 {
     public class StatsBufferTests
     {
-        private static readonly List<byte[]> EmptyPeerTags = [];
+        private static readonly List<byte[]> EmptyTags = [];
 
         [Fact]
         public void KeyEquality()
@@ -62,9 +62,9 @@ namespace Datadog.Trace.Tests.Agent
             var key2 = CreateKey("resource2", "service2", "operation2", "type2", 2, false);
             var key3 = CreateKey("resource3", "service3", "operation3", "type3", 2, true);
 
-            var statsBucket1 = new StatsBucket(key1, EmptyPeerTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
-            var statsBucket2 = new StatsBucket(key2, EmptyPeerTags) { Duration = 2, Errors = 22, Hits = 222, TopLevelHits = 20 };
-            var statsBucket3 = new StatsBucket(key3, EmptyPeerTags) { Duration = 3, Errors = 0, Hits = 0, TopLevelHits = 0 };
+            var statsBucket1 = new StatsBucket(key1, EmptyTags, EmptyTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
+            var statsBucket2 = new StatsBucket(key2, EmptyTags, EmptyTags) { Duration = 2, Errors = 22, Hits = 222, TopLevelHits = 20 };
+            var statsBucket3 = new StatsBucket(key3, EmptyTags, EmptyTags) { Duration = 3, Errors = 0, Hits = 0, TopLevelHits = 0 };
 
             buffer.Buckets.Add(key1, statsBucket1);
             buffer.Buckets.Add(key2, statsBucket2);
@@ -114,8 +114,8 @@ namespace Datadog.Trace.Tests.Agent
             var key1 = CreateKey("resource1", "service1", "operation1", "type1", 1, false);
             var key2 = CreateKey("resource2", "service2", "operation2", "type2", 2, false);
 
-            var statsBucket1 = new StatsBucket(key1, EmptyPeerTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
-            var statsBucket2 = new StatsBucket(key2, EmptyPeerTags) { Duration = 2, Errors = 0, Hits = 0, TopLevelHits = 0 };
+            var statsBucket1 = new StatsBucket(key1, EmptyTags, EmptyTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
+            var statsBucket2 = new StatsBucket(key2, EmptyTags, EmptyTags) { Duration = 2, Errors = 0, Hits = 0, TopLevelHits = 0 };
 
             buffer.Buckets.Add(key1, statsBucket1);
             buffer.Buckets.Add(key2, statsBucket2);
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Tests.Agent
             var buffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
 
             var key = CreateKey("resource1", "service1", "operation1", "type1", 1, false);
-            var statsBucket = new StatsBucket(key, EmptyPeerTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
+            var statsBucket = new StatsBucket(key, EmptyTags, EmptyTags) { Duration = 1, Errors = 11, Hits = 111, TopLevelHits = 10 };
 
             buffer.Buckets.Add(key, statsBucket);
 
@@ -217,7 +217,8 @@ namespace Datadog.Trace.Tests.Agent
             string httpEndpoint = null,
             string grpcStatusCode = "",
             string serviceSource = null,
-            ulong peerTagsHash = 0)
+            ulong peerTagsHash = 0,
+            ulong additionalMetricTagsHash = 0)
         {
             return new StatsAggregationKey(
                 resource,
@@ -234,7 +235,8 @@ namespace Datadog.Trace.Tests.Agent
                 httpEndpoint ?? string.Empty,
                 grpcStatusCode,
                 serviceSource ?? string.Empty,
-                peerTagsHash);
+                peerTagsHash,
+                additionalMetricTagsHash);
         }
 
         private static void AssertStatsGroup(MockClientGroupedStats group, StatsAggregationKey expectedKey, StatsBucket expectedBucket)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -163,7 +163,18 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Fact]
-        public void StatsAdditionalTags_CapsToSixKeysKeepingAlphabeticallyFirst()
+        public void StatsAdditionalTags_EnabledByExperimentalFeaturesAll()
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.ExperimentalFeaturesEnabled, "all"),
+                (ConfigurationKeys.StatsAdditionalTags, "region"));
+            var settings = new TracerSettings(source);
+
+            settings.StatsAdditionalTags.Should().Equal("region");
+        }
+
+        [Fact]
+        public void StatsAdditionalTags_CapsToFourKeysKeepingAlphabeticallyFirst()
         {
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.ExperimentalFeaturesEnabled, ConfigurationKeys.StatsAdditionalTags),

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -142,6 +142,61 @@ namespace Datadog.Trace.Tests.Configuration
             settings.StatsComputationInterval.Should().Be(expected);
         }
 
+        [Fact]
+        public void StatsAdditionalTags_EmptyWhenExperimentalFeatureNotEnabled()
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.StatsAdditionalTags, "region,tenant_id"));
+            var settings = new TracerSettings(source);
+
+            settings.StatsAdditionalTags.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void StatsAdditionalTags_DeduplicatesAndSorts()
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.ExperimentalFeaturesEnabled, ConfigurationKeys.StatsAdditionalTags),
+                (ConfigurationKeys.StatsAdditionalTags, "tenant, region , tenant ,, region"));
+            var settings = new TracerSettings(source);
+
+            settings.StatsAdditionalTags.Should().Equal("region", "tenant");
+        }
+
+        [Fact]
+        public void StatsAdditionalTags_CapsToSixKeysKeepingAlphabeticallyFirst()
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.ExperimentalFeaturesEnabled, ConfigurationKeys.StatsAdditionalTags),
+                (ConfigurationKeys.StatsAdditionalTags, "h,g,f,e,d,c,b,a"));
+            var settings = new TracerSettings(source);
+
+            // dedup+sort then keep the first 4 alphabetically; "e" through "h" are dropped
+            settings.StatsAdditionalTags.Should().Equal("a", "b", "c", "d");
+        }
+
+        [Fact]
+        public void StatsAdditionalTagsCardinalityLimit_DefaultsTo100WhenNotSet()
+        {
+            var source = CreateConfigurationSource();
+            var settings = new TracerSettings(source);
+
+            settings.StatsAdditionalTagsCardinalityLimit.Should().Be(100);
+        }
+
+        [Theory]
+        [InlineData("50", 50)]
+        [InlineData("1", 1)]
+        [InlineData("0", 100)]
+        [InlineData("-5", 100)]
+        [InlineData("not-a-number", 100)]
+        public void StatsAdditionalTagsCardinalityLimit_ValidatesAndFallsBack(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.StatsAdditionalTagsCardinalityLimit, value));
+            var settings = new TracerSettings(source);
+
+            settings.StatsAdditionalTagsCardinalityLimit.Should().Be(expected);
+        }
+
         [Theory]
         [InlineData("true", "none", true)]
         [InlineData("true", "otlp", true)]


### PR DESCRIPTION
## Summary of changes

Implements span-derived primary tags (also called "Additional metric tags")

## Reason for change

This is a feature requested by customers, and defined in [the RFC](https://datadoghq.atlassian.net/wiki/spaces/APM/history/6482919540/PENDING+Span-Derived+Primary+Tags+-+V1)

## Implementation details

- Add `DD_TRACE_STATS_ADDITIONAL_TAGS` for controlling which span-tags to include as metric dimensions in client-side-stats
  - This is an experimental feature, so is gated on `DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED` currently
- Include the defined tags as additional dimensions in the metric key (similar to peer tags)
- Apply cardinality limits to avoid memory leaks
  - NOTE: the cardinality limits implemented here are somewhat superseded by [a subsequent RFC](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/6821151019/PENDING+Cardinality+Limits), and so are only partially implemented here.

## Test coverage

- Added unit tests for all the behaviour
- System tests TBC - once they're implemented, I'll enable them and confirm they're worked

## Other details

Some aspects of the RFC are missing/modified based on other discussions
- The telemetry metric in the span tags RFC is not defined, we will add the cardinality limit version instead.
- The required logging will be added as part of the cardinality RFC implementation
- Cardinality protection doesn't entirely match the RFC, as it follows the later RFC

Part of a stack

- https://github.com/DataDog/dd-trace-dotnet/pull/8822
- https://github.com/DataDog/dd-trace-dotnet/pull/8766 👈
- https://github.com/DataDog/dd-trace-dotnet/pull/8823
- https://github.com/DataDog/dd-trace-dotnet/pull/8824

https://datadoghq.atlassian.net/browse/APMLP-1446