### PR TITLE
fix(dsm): use TaskScheduler.Default for ProcessQueueLoop to avoid deadlock

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -103,7 +103,7 @@ internal sealed class DataStreamsWriter : IDataStreamsWriter
                 return;
             }
 
-            _processTask = Task.Factory.StartNew(ProcessQueueLoop, TaskCreationOptions.LongRunning);
+            _processTask = Task.Factory.StartNew(ProcessQueueLoop, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             _processTask.ContinueWith(t => Log.Error(t.Exception, "Error in processing task"), TaskContinuationOptions.OnlyOnFaulted);
 
             _flushTask = Task.Run(FlushTaskLoopAsync);


### PR DESCRIPTION
## Summary

Fixes a deadlock where DSM is initialized with the ambient `TaskScheduler`, which may not honor`TaskCreationOptions.LongRunning` or have capacity to run the task. Fix by supplying the default task scheduler.

The scenario to reproduce this was:
Calling `await IPublishEndpoint.Publish<T>()` hangs on classic ASP.NET/IIS with MassTransit 5.x + RabbitMQ + DSM enabled. Disabling DSM or disabling RabbitMQ removed the deadlock.

More detailed notes:
- `DataStreamsWriter.Initialize()` calls `Task.Factory.StartNew(ProcessQueueLoop, TaskCreationOptions.LongRunning)` without specifying a `TaskScheduler`.
- `Task.Factory.StartNew` inherits `TaskScheduler.Current` from the calling thread. When `Initialize()` is triggered from within a third-party task scheduler (i.e. MassTransit's `LimitedConcurrencyLevelTaskScheduler`), `ProcessQueueLoop` is posted to that scheduler instead of spawning a dedicated OS thread. If for example, the scheduler has zero concurrency, then `ProcessQueueLoop` takes it and blocks indefinitely.
- Fix is to pass `TaskScheduler.Default` explicitly.

Testing:
- Manual. I am not sure if we have a good way of verifying this behavior in automated tests
