### PR TITLE
[Debugger] Redact dictionary values by sensitive keys

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -67,19 +67,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             {
                 if (Redaction.Instance.ShouldRedact(variableName, type, out var redactionReason))
                 {
-                    if (variableName != null)
-                    {
-                        jsonWriter.WritePropertyName(variableName);
-                    }
-
-                    var notCapturedReason = redactionReason == RedactionReason.Identifier ? NotCapturedReason.redactedIdent : NotCapturedReason.redactedType;
-
-                    jsonWriter.WriteStartObject();
-                    jsonWriter.WritePropertyName("type");
-                    jsonWriter.WriteValue(type.Name);
-                    WriteNotCapturedReason(jsonWriter, notCapturedReason);
-                    jsonWriter.WriteEndObject();
-
+                    WriteRedactedValue(jsonWriter, type, variableName, redactionReason);
                     return true;
                 }
 
@@ -485,10 +473,35 @@ namespace Datadog.Trace.Debugger.Snapshots
             var valueType = value?.GetType() ?? descriptor.ValueType;
 
             bool serializedKey = SerializeInternal(key, keyType, jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
-            bool serializedValue = SerializeInternal(value, valueType, jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
+            bool serializedValue;
+            if (Redaction.Instance.ShouldRedact(key as string, valueType, out var redactionReason))
+            {
+                WriteRedactedValue(jsonWriter, valueType, variableName: null, redactionReason);
+                serializedValue = true;
+            }
+            else
+            {
+                serializedValue = SerializeInternal(value, valueType, jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
+            }
 
             jsonWriter.WriteEndArray();
             return serializedKey && serializedValue;
+        }
+
+        private static void WriteRedactedValue(JsonWriter jsonWriter, Type type, string variableName, RedactionReason redactionReason)
+        {
+            if (variableName != null)
+            {
+                jsonWriter.WritePropertyName(variableName);
+            }
+
+            var notCapturedReason = redactionReason == RedactionReason.Identifier ? NotCapturedReason.redactedIdent : NotCapturedReason.redactedType;
+
+            jsonWriter.WriteStartObject();
+            jsonWriter.WritePropertyName("type");
+            jsonWriter.WriteValue(type.Name);
+            WriteNotCapturedReason(jsonWriter, notCapturedReason);
+            jsonWriter.WriteEndObject();
         }
 
         private static void WriteNotCapturedReason(JsonWriter writer, NotCapturedReason notCapturedReason)

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -474,9 +474,9 @@ namespace Datadog.Trace.Debugger.Snapshots
 
             bool serializedKey = SerializeInternal(key, keyType, jsonWriter, cts, currentDepth, variableName: null, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
             bool serializedValue;
-            if (Redaction.Instance.ShouldRedact(key as string, valueType, out var redactionReason))
+            if (key is string keyName && Redaction.Instance.IsRedactedKeyword(keyName))
             {
-                WriteRedactedValue(jsonWriter, valueType, variableName: null, redactionReason: redactionReason);
+                WriteRedactedValue(jsonWriter, valueType, variableName: null, redactionReason: RedactionReason.Identifier);
                 serializedValue = true;
             }
             else

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -476,7 +476,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             bool serializedValue;
             if (Redaction.Instance.ShouldRedact(key as string, valueType, out var redactionReason))
             {
-                WriteRedactedValue(jsonWriter, valueType, variableName: null, redactionReason);
+                WriteRedactedValue(jsonWriter, valueType, variableName: null, redactionReason: redactionReason);
                 serializedValue = true;
             }
             else

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -252,6 +252,37 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ObjectStructure_DictionaryEntryValue_WithRedactedKey_IsRedacted()
+        {
+            object[] dictionaries =
+            [
+                new Dictionary<string, object> { { "password", "DD_SECRET_LEAK" }, { "name", "value" } },
+                new Dictionary<object, object> { { "password", "DD_SECRET_LEAK" }, { "name", "value" } }
+            ];
+
+            foreach (var dictionary in dictionaries)
+            {
+                var local = GetLocalToken(dictionary);
+
+                Assert.Equal("Dictionary`2", local["type"]?.Value<string>());
+                Assert.Equal(2, local["size"]?.Value<int>());
+                Assert.Null(local["elements"]);
+
+                var entries = local["entries"] as JArray;
+                Assert.NotNull(entries);
+                Assert.Equal(2, entries!.Count);
+                Assert.Contains(entries, entry =>
+                    entry[0]?["value"]?.Value<string>() == "password" &&
+                    entry[1]?["type"]?.Value<string>() == "String" &&
+                    entry[1]?["notCapturedReason"]?.Value<string>() == "redactedIdent" &&
+                    entry[1]?["value"] is null);
+                Assert.Contains(entries, entry =>
+                    entry[0]?["value"]?.Value<string>() == "name" &&
+                    entry[1]?["value"]?.Value<string>() == "value");
+            }
+        }
+
+        [Fact]
         public void ObjectStructure_SortedList_IsSerializedAsDictionary()
         {
             var local = GetLocalToken(new SortedList { { "one", 1 }, { "two", 2 } });

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -257,14 +257,16 @@ namespace Datadog.Trace.Tests.Debugger
             object[] dictionaries =
             [
                 new Dictionary<string, object> { { "password", "DD_SECRET_LEAK" }, { "name", "value" } },
-                new Dictionary<object, object> { { "password", "DD_SECRET_LEAK" }, { "name", "value" } }
+                new Dictionary<object, object> { { "password", "DD_SECRET_LEAK" }, { "name", "value" } },
+                new Hashtable { { "password", "DD_SECRET_LEAK" }, { "name", "value" } }
             ];
 
             foreach (var dictionary in dictionaries)
             {
                 var local = GetLocalToken(dictionary);
+                var expectedType = dictionary is Hashtable ? "Hashtable" : "Dictionary`2";
 
-                Assert.Equal("Dictionary`2", local["type"]?.Value<string>());
+                Assert.Equal(expectedType, local["type"]?.Value<string>());
                 Assert.Equal(2, local["size"]?.Value<int>());
                 Assert.Null(local["elements"]);
 


### PR DESCRIPTION
### Motivation

- A change started serializing runtime scalar values for object-typed dictionary entries without supplying the dictionary key as the variable name, which allowed sensitive entries (e.g., `"password"`) to bypass redaction and leak secrets in debugger snapshots.

### Description

- Add a shared helper `WriteRedactedValue` to emit the redacted JSON shape and use it from `SerializeInternal` when `Redaction.Instance.ShouldRedact(...)` returns true for variables. 
- During dictionary entry serialization, check string dictionary keys with `Redaction.Instance.IsRedactedKeyword(...)` and use `WriteRedactedValue` for redacted values instead of serializing the runtime value. 
- This change applies to supported dictionary serialization when the runtime key is a string redacted identifier. Standalone `KeyValuePair` objects and non-string dictionary keys remain out of scope.
- Add a unit test `ObjectStructure_DictionaryEntryValue_WithRedactedKey_IsRedacted` covering `Dictionary<string, object>`, `Dictionary<object, object>`, and `Hashtable` to ensure entries under a sensitive key are emitted with `notCapturedReason` and the secret value is not included.

### Testing

- Ran the focused unit tests with `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj -f net8.0 --filter "FullyQualifiedName~DebuggerSnapshotCreatorTests.ObjectStructure_DictionaryEntryValue_WithRedactedKey_IsRedacted|FullyQualifiedName~DebuggerSnapshotCreatorTests.ObjectStructure_ObjectTypedDictionaryEntries_UseRuntimeTypeAndNullFallback" -v minimal` and both tests passed. 
- Verified there are no `git diff --check` issues and added tests exercise the fixed behavior (redaction of dictionary values by key).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a27d290b0e883279db47146c5a6fefc)