### PR TITLE
[Debugger] Minor Dynamic Instrumentation cleanups

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
@@ -630,7 +630,7 @@ namespace Datadog.Trace.Debugger
 
         private bool ShouldSkipDiUpdate(bool requested, bool current, DebuggerSettings debuggerSettings)
         {
-            if (requested && !debuggerSettings.DynamicInstrumentationCanBeEnabled)
+            if (requested && debuggerSettings is { DynamicInstrumentationCanBeEnabled: false })
             {
                 Log.Debug("Dynamic Instrumentation can't be enabled because the local environment variable is set to false");
                 return true;
@@ -702,6 +702,7 @@ namespace Datadog.Trace.Debugger
             {
                 var tracerManager = TracerManager.Instance;
                 var discoveryService = tracerManager.DiscoveryService;
+
                 di = DebuggerFactory.CreateDynamicInstrumentation(
                     discoveryService,
                     RcmSubscriptionManager.Instance,

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
@@ -259,7 +259,6 @@ internal sealed class ProbeExpressionEvaluator
         }
 
         CompiledExpression<bool> compiledExpression = default;
-
         try
         {
             if (!cached.HasValue)
@@ -717,9 +716,9 @@ internal sealed class ProbeExpressionEvaluator
     internal CompiledProbeExpressions CompileAll(MethodScopeMembers scopeMembers)
     {
         return new CompiledProbeExpressions(
-            templates: Templates == null ? null : CompileTemplates(scopeMembers),
-            condition: Condition == null ? null : CompileCondition(scopeMembers),
-            metric: Metric == null ? null : CompileMetric(scopeMembers),
-            decorations: SpanDecorations == null ? null : CompileDecorations(scopeMembers));
+            CompileTemplates(scopeMembers),
+            CompileCondition(scopeMembers),
+            CompileMetric(scopeMembers),
+            CompileDecorations(scopeMembers));
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
@@ -643,7 +643,7 @@ internal sealed class ProbeExpressionEvaluator
             return null;
         }
 
-        return string.IsNullOrEmpty(expression.Value.Json);
+        return StringUtil.IsNullOrEmpty(expression.Value.Json);
     }
 
     private bool IsLiteral<T>(CompiledExpression<T> expression)
@@ -658,7 +658,7 @@ internal sealed class ProbeExpressionEvaluator
             return null;
         }
 
-        return !string.IsNullOrEmpty(expression.Value.Json) && string.IsNullOrEmpty(expression.Value.Str);
+        return !StringUtil.IsNullOrEmpty(expression.Value.Json) && StringUtil.IsNullOrEmpty(expression.Value.Str);
     }
 
     private bool IsExpression<T>(CompiledExpression<T> expression)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -53,6 +53,7 @@ namespace Datadog.Trace.Debugger.Expressions
             catch (Exception e)
             {
                 Log.Error(e, "Failed to create probe processor for probe: {Id}", probe.Id);
+                return;
             }
 
             if (Log.IsEnabled(LogEventLevel.Debug))

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -10,7 +10,6 @@ using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util.Json;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Debugger.Expressions

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using Datadog.Trace.Debugger.Configurations.Models;
-using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Serilog.Events;

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -353,6 +353,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void EndEntry()
         {
+            // Do not rely on "hasArgumentsOrLocals" heuristics here.
             // Some instrumentations intentionally skip capturing args/locals (e.g. methods with byref-like args),
             // and closing a non-open container corrupts the JsonWriter state ("No token to close").
             CloseLocalsOrArgsIfOpen();


### PR DESCRIPTION
## Summary of changes

- Simplify `ProbeExpressionEvaluator.CompileAll` by dropping the redundant `== null ? null :` ternaries; each `Compile*` helper already null-checks its source and returns `null`.
- Use the nullable-aware `StringUtil.IsNullOrEmpty` instead of `string.IsNullOrEmpty` in the `#nullable enable` `ProbeExpressionEvaluator`.
- Harden `DebuggerManager.ShouldSkipDiUpdate` with a property-pattern null check (`debuggerSettings is { DynamicInstrumentationCanBeEnabled: false }`).
- Remove unused usings in `ProbeExpressionsProcessor` (`Newtonsoft.Json` and `Debugger.Snapshots`).
- Add a clarifying comment in `DebuggerSnapshotCreator.EndEntry` about why arg/local capture must not rely on heuristics.
- Fix a logging bug in `ProbeExpressionsProcessor.AddProbeProcessor` so it no longer logs `"Successfully created probe processor"` after creation throws.

## Reason for change

- These are low-risk cleanups split out of #8572 to keep that PR focused on the snapshot-exploration feature.
- The `AddProbeProcessor` change fixes a real (debug-level) logging inconsistency: a probe whose processor creation throws would log both a failure and a success line.

## Implementation details

- `CompileAll` simplification is behavior-preserving: `CompileTemplates`/`CompileCondition`/`CompileMetric`/`CompileDecorations` each return `null` when their source is null. One benign difference: when `SpanDecorations` is null, `CompileDecorations` now emits its existing debug-level "is null" log.
- `StringUtil.IsNullOrEmpty` only adds value under `#nullable enable` (it carries the `[NotNullWhen(false)]` annotation), so the swap was limited to that file; other `string.IsNullOrEmpty` call sites in non-nullable files were intentionally left unchanged.
- The `ShouldSkipDiUpdate` property pattern is equivalent for the normal (non-null) case and additionally avoids a potential NRE if settings were ever null.

## Test coverage

- No new tests added; changes are cleanups plus one debug-only logging fix.

