### PR TITLE
[Debugger] Avoid evaluating expressionless snapshot probes

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -180,11 +180,14 @@ namespace Datadog.Trace.Debugger.Expressions
                         {
                             AddAsyncMethodArguments(snapshotCreator, ref info);
                             snapshotCreator.AddScopeMember(info.Name, info.Type, info.Value, info.MemberKind);
-                            evaluationResult = Evaluate(state, probeInfo, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
-                            if (shouldStopCapture)
+                            if (state.ShouldEvaluateExpressions)
                             {
-                                snapshotCreator.Stop();
-                                return false;
+                                evaluationResult = Evaluate(state, probeInfo, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
+                                if (shouldStopCapture)
+                                {
+                                    snapshotCreator.Stop();
+                                    return false;
+                                }
                             }
 
                             break;
@@ -246,11 +249,14 @@ namespace Datadog.Trace.Debugger.Expressions
                                         }
 
                                         snapshotCreator.AddScopeMember(info.Name, info.Type, info.Value, info.MemberKind);
-                                        evaluationResult = Evaluate(state, probeInfo, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
-                                        if (shouldStopCapture)
+                                        if (state.ShouldEvaluateExpressions)
                                         {
-                                            snapshotCreator.Stop();
-                                            return false;
+                                            evaluationResult = Evaluate(state, probeInfo, snapshotCreator, out var shouldStopCapture, probeData.Sampler);
+                                            if (shouldStopCapture)
+                                            {
+                                                snapshotCreator.Stop();
+                                                return false;
+                                            }
                                         }
 
                                         break;
@@ -748,6 +754,13 @@ namespace Datadog.Trace.Debugger.Expressions
                 HasCondition = condition.HasValue;
                 IsMetricCountWithoutExpression = probeInfo.ProbeType == ProbeType.Metric && (metric?.Json == null) && probeInfo.MetricKind == MetricKind.COUNT;
                 ShouldCaptureExpressions = !probeInfo.IsFullSnapshot && captureExpressions is { Length: > 0 };
+                ShouldEvaluateExpressions =
+                    HasCondition ||
+                    templates is { Length: > 0 } ||
+                    metric.HasValue ||
+                    spanDecorations is { Length: > 0 } ||
+                    IsMetricCountWithoutExpression ||
+                    ShouldCaptureExpressions;
             }
 
             internal ProbeInfo ProbeInfo { get; }
@@ -767,6 +780,8 @@ namespace Datadog.Trace.Debugger.Expressions
             internal bool IsMetricCountWithoutExpression { get; }
 
             internal bool ShouldCaptureExpressions { get; }
+
+            internal bool ShouldEvaluateExpressions { get; }
 
             internal static ProbeProcessorState Create(ProbeDefinition probe)
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeProcessorTests.cs
@@ -87,6 +87,23 @@ public class ProbeProcessorTests
     }
 
     [Fact]
+    public void UnconditionalFullSnapshotWithoutExpressionsDoesNotEvaluate()
+    {
+        var processor = new ProbeProcessor(CreateLogProbe("probe-id", captureSnapshot: true));
+        var sampler = new TestAdaptiveSampler(true);
+        var probeData = new ProbeData("probe-id", sampler, processor);
+        var method = typeof(SampleTarget).GetMethod(nameof(SampleTarget.Execute))!;
+        var snapshotCreator = CreateSnapshotCreator(processor, in probeData);
+
+        Assert.True(ProcessEntryStart(processor, snapshotCreator, in probeData, method));
+        Assert.True(ProcessEntryEnd(processor, snapshotCreator, in probeData, method));
+
+        var snapshot = JObject.Parse(FinalizeMethodSnapshot(snapshotCreator, "probe-id", method));
+
+        Assert.Null(snapshot.SelectToken("debugger.snapshot.evaluationErrors"));
+    }
+
+    [Fact]
     public void ConditionEvaluationExceptionsBypassSampler()
     {
         var processor = CreateConditionalProbeProcessor();


### PR DESCRIPTION
## Summary of changes

- Prevents `ProbeProcessor` from invoking expression evaluation for probes that do not have any expression payload.
- Adds `ShouldEvaluateExpressions` to distinguish “this capture point should finalize/process” from “this probe has expressions to evaluate.”
- Adds regression coverage for unconditional full snapshot probes without `when`, template, metric, span decoration, or capture expressions.

## Reason for change

- We discovered this regression while running the snapshot exploration test against Protobuf.
- Snapshot exploration generated full snapshot probes with `captureSnapshot: true` and no `when` expression. Those probes reached `Evaluate()`, produced a default `ExpressionEvaluationResult`, and were reported as `Evaluation result should not be null`.
- In production, expression evaluation should not run when there is no `when` or other expression payload to evaluate.

## Implementation details

- Keeps the existing guard that treats a null/default evaluation result as an error when evaluation was actually required.
- Gates calls to `Evaluate()` behind `ProbeProcessorState.ShouldEvaluateExpressions`.
- `ShouldEvaluateExpressions` is true for conditions, template segments, metric evaluation/count metrics, span decorations, and capture expressions.

## Test coverage

- Ran:
  - `ProbeProcessorTests`