### PR TITLE
[Debugger] Add agentless local probe support for Dynamic Instrumentation

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -821,6 +821,15 @@ supportedConfigurations:
     documentation: |-
       Configuration key for enabling or disabling Dynamic Instrumentation.
       Default value is false (disabled).
+  DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED:
+  - implementation: A
+    scope: managed
+    type: boolean
+    default: 'false'
+    product: Debugger
+    documentation: |-
+      Configuration key for enabling or disabling agentless Dynamic Instrumentation uploads.
+      Default value is false.
   DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE:
   - implementation: B
     scope: managed

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerFactory.cs
@@ -28,17 +28,22 @@ internal sealed class DebuggerFactory
 {
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebuggerFactory));
 
-    internal static DynamicInstrumentation CreateDynamicInstrumentation(IDiscoveryService discoveryService, IRcmSubscriptionManager remoteConfigurationManager, TracerSettings tracerSettings, Func<string> serviceNameProvider, DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider)
+    internal static DynamicInstrumentation? CreateDynamicInstrumentation(IDiscoveryService discoveryService, IRcmSubscriptionManager remoteConfigurationManager, TracerSettings tracerSettings, Func<string> serviceNameProvider, DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider)
     {
         var globalRateLimiter = DebuggerGlobalRateLimiter.Instance;
         var snapshotSlicer = SnapshotSlicer.Create(debuggerSettings);
         var snapshotSink = SnapshotSink.Create(debuggerSettings, snapshotSlicer);
         var logSink = SnapshotSink.Create(debuggerSettings, snapshotSlicer);
         var diagnosticsSink = DiagnosticsSink.Create(serviceNameProvider, debuggerSettings);
+        var transportInfo = DebuggerTransportFactory.CreateForDynamicInstrumentation(tracerSettings, debuggerSettings, discoveryService);
+        if (transportInfo is null)
+        {
+            return null;
+        }
 
-        var snapshotUploader = CreateSnapshotUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, true), snapshotSink);
-        var logUploader = CreateLogUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, false), logSink);
-        var diagnosticsUploader = CreateDiagnosticsUploader(discoveryService, debuggerSettings, gitMetadataTagsProvider, GetApiFactory(tracerSettings, true), diagnosticsSink);
+        var snapshotUploader = CreateSnapshotUploader(debuggerSettings, gitMetadataTagsProvider, transportInfo.Value, snapshotSink);
+        var logUploader = CreateLogUploader(debuggerSettings, gitMetadataTagsProvider, transportInfo.Value, logSink);
+        var diagnosticsUploader = CreateDiagnosticsUploader(debuggerSettings, gitMetadataTagsProvider, transportInfo.Value, diagnosticsSink);
         var lineProbeResolver = LineProbeResolver.Create(debuggerSettings.ThirdPartyDetectionExcludes, debuggerSettings.ThirdPartyDetectionIncludes);
         var probeStatusPoller = ProbeStatusPoller.Create(diagnosticsSink, debuggerSettings);
         var configurationUpdater = ConfigurationUpdater.Create(tracerSettings.Manager.InitialMutableSettings.Environment, tracerSettings.Manager.InitialMutableSettings.ServiceVersion, debuggerSettings.MaxProbesPerType, globalRateLimiter);
@@ -83,9 +88,9 @@ internal sealed class DebuggerFactory
         return statsd;
     }
 
-    private static SnapshotUploader CreateSnapshotUploader(IDiscoveryService discoveryService, DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider, IApiRequestFactory apiFactory, SnapshotSink snapshotSink)
+    private static SnapshotUploader CreateSnapshotUploader(DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider, DebuggerTransportInfo transportInfo, SnapshotSink snapshotSink)
     {
-        var snapshotBatchUploadApi = DebuggerUploadApiFactory.CreateSnapshotUploadApi(apiFactory, discoveryService, gitMetadataTagsProvider);
+        var snapshotBatchUploadApi = DebuggerUploadApiFactory.CreateSnapshotUploadApi(transportInfo.ApiRequestFactory, transportInfo.DiscoveryService, gitMetadataTagsProvider, transportInfo.StaticEndpoint);
         var snapshotBatchUploader = BatchUploader.Create(snapshotBatchUploadApi);
 
         var debuggerSink = SnapshotUploader.Create(snapshotSink, snapshotBatchUploader, debuggerSettings);
@@ -93,9 +98,9 @@ internal sealed class DebuggerFactory
         return debuggerSink;
     }
 
-    private static SnapshotUploader CreateLogUploader(IDiscoveryService discoveryService, DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider, IApiRequestFactory apiFactory, SnapshotSink snapshotSink)
+    private static SnapshotUploader CreateLogUploader(DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider, DebuggerTransportInfo transportInfo, SnapshotSink snapshotSink)
     {
-        var logUploaderApi = DebuggerUploadApiFactory.CreateLogUploadApi(apiFactory, discoveryService, gitMetadataTagsProvider);
+        var logUploaderApi = DebuggerUploadApiFactory.CreateLogUploadApi(transportInfo.ApiRequestFactory, transportInfo.DiscoveryService, gitMetadataTagsProvider, transportInfo.StaticEndpoint);
         var logBatchUploader = BatchUploader.Create(logUploaderApi);
 
         var debuggerSink = SnapshotUploader.Create(snapshotSink, logBatchUploader, debuggerSettings);
@@ -103,9 +108,9 @@ internal sealed class DebuggerFactory
         return debuggerSink;
     }
 
-    private static DiagnosticsUploader CreateDiagnosticsUploader(IDiscoveryService discoveryService, DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider, IApiRequestFactory apiFactory, DiagnosticsSink diagnosticsSink)
+    private static DiagnosticsUploader CreateDiagnosticsUploader(DebuggerSettings debuggerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider, DebuggerTransportInfo transportInfo, DiagnosticsSink diagnosticsSink)
     {
-        var diagnosticsBatchUploadApi = DebuggerUploadApiFactory.CreateDiagnosticsUploadApi(apiFactory, discoveryService, gitMetadataTagsProvider);
+        var diagnosticsBatchUploadApi = DebuggerUploadApiFactory.CreateDiagnosticsUploadApi(transportInfo.ApiRequestFactory, transportInfo.DiscoveryService, gitMetadataTagsProvider, transportInfo.StaticEndpoint);
         var diagnosticsBatchUploader = BatchUploader.Create(diagnosticsBatchUploadApi);
 
         var debuggerSink = DiagnosticsUploader.Create(diagnosticsSink, diagnosticsBatchUploader: diagnosticsBatchUploader, debuggerSettings);
@@ -115,12 +120,12 @@ internal sealed class DebuggerFactory
 
     internal static IDebuggerUploader CreateSymbolsUploader(IDiscoveryService discoveryService, Func<string> serviceNameProvider, TracerSettings tracerSettings, DebuggerSettings settings, IGitMetadataTagsProvider gitMetadataTagsProvider)
     {
-        var symbolBatchApi = DebuggerUploadApiFactory.CreateSymbolsUploadApi(GetApiFactory(tracerSettings, true), discoveryService, gitMetadataTagsProvider, settings.SymbolDatabaseCompressionEnabled);
+        var symbolBatchApi = DebuggerUploadApiFactory.CreateSymbolsUploadApi(GetApiFactory(tracerSettings), discoveryService, gitMetadataTagsProvider, settings.SymbolDatabaseCompressionEnabled);
         var symbolsUploader = SymbolsUploader.Create(symbolBatchApi, discoveryService, tracerSettings, settings, serviceNameProvider);
         return symbolsUploader;
     }
 
-    private static IApiRequestFactory GetApiFactory(TracerSettings tracerSettings, bool isMultipart)
+    private static IApiRequestFactory GetApiFactory(TracerSettings tracerSettings)
     {
         // TODO: we need to be able to update the tracer settings dynamically
         return AgentTransportStrategy.Get(

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerManager.cs
@@ -564,7 +564,7 @@ namespace Datadog.Trace.Debugger
                 return;
             }
 
-            if (!tracerSettings.IsRemoteConfigurationAvailable)
+            if (!tracerSettings.IsRemoteConfigurationAvailable && !debuggerSettings.IsDynamicInstrumentationAgentlessLocalMode)
             {
                 if (debuggerSettings.DynamicInstrumentationEnabled)
                 {
@@ -711,7 +711,13 @@ namespace Datadog.Trace.Debugger
                     DebuggerSettings,
                     tracerManager.GitMetadataTagsProvider);
 
-                if (!_isDebuggerEndpointAvailable)
+                if (di is null)
+                {
+                    Volatile.Write(ref _diState, 0);
+                    return;
+                }
+
+                if (!_isDebuggerEndpointAvailable && !DebuggerSettings.IsDynamicInstrumentationAgentlessLocalMode)
                 {
                     var isDiscoverySuccessful = await WaitForDebuggerEndpointAsync(discoveryService, _processExit.Task).ConfigureAwait(false);
                     if (!isDiscoverySuccessful)

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace.Debugger
         public const int DefaultMaxProbesPerType = 0;
 
         private const int DefaultUploadBatchSize = 100;
+        private const string DefaultSite = "datadoghq.com";
         public const int DefaultSymbolBatchSizeInBytes = 1 * 1024 * 1024; // 1 MB
         private const int DefaultDiagnosticsIntervalSeconds = 60 * 60; // 1 hour
         private const int DefaultUploadFlushIntervalMilliseconds = 0;
@@ -154,6 +155,9 @@ namespace Datadog.Trace.Debugger
             SymbolDatabaseCompressionEnabled = config.WithKeys(ConfigurationKeys.Debugger.SymbolDatabaseCompressionEnabled).AsBool(true);
 
             ProbeFile = config.WithKeys(ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile).AsString() ?? string.Empty;
+            DynamicInstrumentationAgentlessEnabled = config.WithKeys(ConfigurationKeys.Debugger.DynamicInstrumentationAgentlessEnabled).AsBool(false);
+            DynamicInstrumentationAgentlessApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
+            DynamicInstrumentationAgentlessSite = config.WithKeys(ConfigurationKeys.Site).AsString(DefaultSite, site => !string.IsNullOrEmpty(site)) ?? DefaultSite;
         }
 
         internal ImmutableDynamicDebuggerSettings DynamicSettings { get; init; } = new();
@@ -201,6 +205,15 @@ namespace Datadog.Trace.Debugger
         public int CodeOriginMaxUserFrames { get; }
 
         public string ProbeFile { get; }
+
+        public bool DynamicInstrumentationAgentlessEnabled { get; }
+
+        public string? DynamicInstrumentationAgentlessApiKey { get; }
+
+        public string DynamicInstrumentationAgentlessSite { get; }
+
+        public bool IsDynamicInstrumentationAgentlessLocalMode =>
+            DynamicInstrumentationAgentlessEnabled && !StringUtil.IsNullOrEmpty(ProbeFile);
 
         public static DebuggerSettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry)
         {

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -139,7 +139,9 @@ namespace Datadog.Trace.Debugger
             {
                 // Start loading probes from file and checking RCM availability in parallel
                 var fileProbesTask = ProbeConfigurationFileLoader.LoadAsync(_settings.ProbeFile);
-                var rcmAvailabilityTask = WaitForRcmAvailabilityAsync();
+                var rcmAvailabilityTask = _settings.IsDynamicInstrumentationAgentlessLocalMode
+                                              ? Task.FromResult(false)
+                                              : WaitForRcmAvailabilityAsync();
 
                 var hasFileProbes = false;
 
@@ -147,6 +149,11 @@ namespace Datadog.Trace.Debugger
                 var probeConfiguration = await fileProbesTask.ConfigureAwait(false);
                 if (probeConfiguration != null)
                 {
+                    if (_settings.IsDynamicInstrumentationAgentlessLocalMode)
+                    {
+                        probeConfiguration = FilterAgentlessLocalProbeConfiguration(probeConfiguration);
+                    }
+
                     hasFileProbes = _configurationUpdater.HasAnyEffectiveProbeForFile(probeConfiguration);
                     if (hasFileProbes)
                     {
@@ -186,6 +193,41 @@ namespace Datadog.Trace.Debugger
             {
                 Interlocked.CompareExchange(ref _initializationState, 0, 1);
             }
+        }
+
+        private ProbeConfiguration FilterAgentlessLocalProbeConfiguration(ProbeConfiguration probeConfiguration)
+        {
+            var logProbes = probeConfiguration.LogProbes.Where(IsSupportedAgentlessLocalProbe).ToArray();
+            var filteredCount =
+                (probeConfiguration.LogProbes.Length - logProbes.Length) +
+                probeConfiguration.MetricProbes.Length +
+                probeConfiguration.SpanProbes.Length +
+                probeConfiguration.SpanDecorationProbes.Length;
+
+            if (filteredCount != 0)
+            {
+                Log.Information<int>("Dynamic Instrumentation agentless local mode ignored {Count} unsupported probe definition(s). Only method log probes are supported.", filteredCount);
+            }
+
+            return new ProbeConfiguration
+            {
+                ServiceConfiguration = probeConfiguration.ServiceConfiguration,
+                LogProbes = logProbes,
+                MetricProbes = [],
+                SpanProbes = [],
+                SpanDecorationProbes = []
+            };
+        }
+
+        private bool IsSupportedAgentlessLocalProbe(LogProbe probe)
+        {
+            if (probe.Where?.MethodName is { Length: > 0 })
+            {
+                return true;
+            }
+
+            Log.Information("Dynamic Instrumentation agentless local mode ignored line probe {ProbeId}. Line probes require PDB/source resolution and are not supported in this mode yet.", probe.Id);
+            return false;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DynamicInstrumentation.cs
@@ -221,12 +221,12 @@ namespace Datadog.Trace.Debugger
 
         private bool IsSupportedAgentlessLocalProbe(LogProbe probe)
         {
-            if (probe.Where?.MethodName is { Length: > 0 })
+            if (probe.Where is { TypeName.Length: > 0, MethodName.Length: > 0 })
             {
                 return true;
             }
 
-            Log.Information("Dynamic Instrumentation agentless local mode ignored line probe {ProbeId}. Line probes require PDB/source resolution and are not supported in this mode yet.", probe.Id);
+            Log.Information("Dynamic Instrumentation agentless local mode ignored probe {ProbeId}. Only method log probes with type and method names are supported.", probe.Id);
             return false;
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerTransportFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerTransportFactory.cs
@@ -1,0 +1,60 @@
+// <copyright file="DebuggerTransportFactory.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Debugger.Upload;
+
+internal static class DebuggerTransportFactory
+{
+    internal const string DefaultAgentlessRelativePath = "/api/v2/debugger";
+
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebuggerTransportFactory));
+
+    internal static DebuggerTransportInfo? CreateForDynamicInstrumentation(TracerSettings tracerSettings, DebuggerSettings settings, IDiscoveryService discoveryService)
+    {
+        if (!settings.IsDynamicInstrumentationAgentlessLocalMode)
+        {
+            return CreateAgentTransport(tracerSettings, discoveryService);
+        }
+
+        if (StringUtil.IsNullOrWhiteSpace(settings.DynamicInstrumentationAgentlessApiKey))
+        {
+            Log.ErrorSkipTelemetry("Dynamic Instrumentation agentless uploads enabled but DD_API_KEY is not set. Disabling Dynamic Instrumentation.");
+            return null;
+        }
+
+        var baseUri = new Uri($"https://debugger-intake.{settings.DynamicInstrumentationAgentlessSite}");
+
+        var apiFactory = DebuggerTransportStrategy.Get(
+            baseUri,
+            [
+                ..AgentHttpHeaderNames.DefaultHeaders,
+                new KeyValuePair<string, string>("DD-API-KEY", settings.DynamicInstrumentationAgentlessApiKey),
+                new KeyValuePair<string, string>("DD-EVP-ORIGIN", "dd-trace-dotnet")
+            ]);
+
+        return new DebuggerTransportInfo(apiFactory, discoveryService: null, DefaultAgentlessRelativePath, isAgentless: true);
+    }
+
+    private static DebuggerTransportInfo CreateAgentTransport(TracerSettings tracerSettings, IDiscoveryService discoveryService)
+    {
+        var apiFactory = AgentTransportStrategy.Get(
+            tracerSettings.Manager.InitialExporterSettings,
+            productName: "debugger",
+            tcpTimeout: TimeSpan.FromSeconds(15),
+            httpHeaderHelper: MinimalAgentHeaderHelper.Instance);
+
+        return new DebuggerTransportInfo(apiFactory, discoveryService, staticEndpoint: null, isAgentless: false);
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerTransportInfo.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerTransportInfo.cs
@@ -1,0 +1,30 @@
+// <copyright file="DebuggerTransportInfo.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
+
+namespace Datadog.Trace.Debugger.Upload;
+
+internal readonly struct DebuggerTransportInfo
+{
+    public DebuggerTransportInfo(IApiRequestFactory apiRequestFactory, IDiscoveryService? discoveryService, string? staticEndpoint, bool isAgentless)
+    {
+        ApiRequestFactory = apiRequestFactory;
+        DiscoveryService = discoveryService;
+        StaticEndpoint = staticEndpoint;
+        IsAgentless = isAgentless;
+    }
+
+    public IApiRequestFactory ApiRequestFactory { get; }
+
+    public IDiscoveryService? DiscoveryService { get; }
+
+    public string? StaticEndpoint { get; }
+
+    public bool IsAgentless { get; }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DebuggerUploadApiFactory.cs
@@ -18,14 +18,14 @@ namespace Datadog.Trace.Debugger.Upload
             return SnapshotUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider, staticEndpoint);
         }
 
-        internal static IBatchUploadApi CreateLogUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider)
+        internal static IBatchUploadApi CreateLogUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService? discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider, string? staticEndpoint = null)
         {
-            return LogUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
+            return LogUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider, staticEndpoint);
         }
 
-        internal static IBatchUploadApi CreateDiagnosticsUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider)
+        internal static IBatchUploadApi CreateDiagnosticsUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService? discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider, string? staticEndpoint = null)
         {
-            return DiagnosticsUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
+            return DiagnosticsUploadApi.Create(apiRequestFactory, discoveryService, gitMetadataTagsProvider, staticEndpoint);
         }
 
         internal static ISymbolUploadApi CreateSymbolsUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider, bool enableCompression)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
@@ -19,23 +19,36 @@ namespace Datadog.Trace.Debugger.Upload
 
         private DiagnosticsUploadApi(
             IApiRequestFactory apiRequestFactory,
-            IDiscoveryService discoveryService,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
+            IDiscoveryService? discoveryService,
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            string? staticEndpoint)
             : base(apiRequestFactory, gitMetadataTagsProvider)
         {
-            discoveryService.SubscribeToChanges(c =>
+            if (!StringUtil.IsNullOrEmpty(staticEndpoint))
             {
-                Endpoint = c.DebuggerDiagnosticsUploadEndpoint;
-                Log.Debug("DiagnosticsUploadApi: Updated endpoint to {Endpoint}", Endpoint);
-            });
+                Endpoint = staticEndpoint;
+            }
+            else if (discoveryService is not null)
+            {
+                discoveryService.SubscribeToChanges(c =>
+                {
+                    Endpoint = c.DebuggerDiagnosticsUploadEndpoint;
+                    Log.Debug("DiagnosticsUploadApi: Updated endpoint to {Endpoint}", Endpoint);
+                });
+            }
+            else
+            {
+                Log.Warning("DiagnosticsUploadApi: No discovery service or static endpoint available. Diagnostics will not be uploaded until an endpoint is configured.");
+            }
         }
 
         public static DiagnosticsUploadApi Create(
             IApiRequestFactory apiRequestFactory,
-            IDiscoveryService discoveryService,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
+            IDiscoveryService? discoveryService,
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            string? staticEndpoint = null)
         {
-            return new DiagnosticsUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
+            return new DiagnosticsUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, staticEndpoint);
         }
 
         public async Task<bool> SendBatchAsync(ArraySegment<byte> data)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Debugger.Upload
             var uri = BuildUri();
             if (string.IsNullOrEmpty(uri))
             {
-                Log.Warning("Failed to upload diagnostics: debugger endpoint not yet retrieved from discovery service");
+                Log.Warning("Failed to upload diagnostics: debugger diagnostics upload endpoint is not configured");
                 return false;
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Debugger.Upload
             var uri = BuildUri();
             if (string.IsNullOrEmpty(uri))
             {
-                Log.Warning("Failed to upload log: debugger endpoint not yet retrieved from discovery service");
+                Log.Warning("Failed to upload log: debugger upload endpoint is not configured");
                 return false;
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/LogUploadApi.cs
@@ -19,23 +19,36 @@ namespace Datadog.Trace.Debugger.Upload
 
         private LogUploadApi(
             IApiRequestFactory apiRequestFactory,
-            IDiscoveryService discoveryService,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
+            IDiscoveryService? discoveryService,
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            string? staticEndpoint)
             : base(apiRequestFactory, gitMetadataTagsProvider)
         {
-            discoveryService.SubscribeToChanges(c =>
+            if (!StringUtil.IsNullOrEmpty(staticEndpoint))
             {
-                Endpoint = c.DebuggerUploadEndpoint;
-                Log.Debug("LogUploadApi: Updated endpoint to {Endpoint}", Endpoint);
-            });
+                Endpoint = staticEndpoint;
+            }
+            else if (discoveryService is not null)
+            {
+                discoveryService.SubscribeToChanges(c =>
+                {
+                    Endpoint = c.DebuggerUploadEndpoint;
+                    Log.Debug("LogUploadApi: Updated endpoint to {Endpoint}", Endpoint);
+                });
+            }
+            else
+            {
+                Log.Warning("LogUploadApi: No discovery service or static endpoint available. Logs will not be uploaded until an endpoint is configured.");
+            }
         }
 
         public static LogUploadApi Create(
             IApiRequestFactory apiRequestFactory,
-            IDiscoveryService discoveryService,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
+            IDiscoveryService? discoveryService,
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            string? staticEndpoint = null)
         {
-            return new LogUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
+            return new LogUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, staticEndpoint);
         }
 
         public async Task<bool> SendBatchAsync(ArraySegment<byte> data)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SnapshotUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SnapshotUploadApi.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Debugger.Upload
             var uri = BuildUri();
             if (StringUtil.IsNullOrEmpty(uri))
             {
-                Log.Warning("Failed to upload snapshot: debugger endpoint not yet retrieved from discovery service");
+                Log.Warning("Failed to upload snapshot: debugger upload endpoint is not configured");
                 return false;
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -30,6 +30,12 @@ internal static partial class ConfigurationKeys
         public const string CodeOriginMaxUserFrames = "DD_CODE_ORIGIN_FOR_SPANS_MAX_USER_FRAMES";
 
         /// <summary>
+        /// Configuration key for enabling or disabling agentless Dynamic Instrumentation uploads.
+        /// Default value is false.
+        /// </summary>
+        public const string DynamicInstrumentationAgentlessEnabled = "DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED";
+
+        /// <summary>
         /// Configuration key for the interval (in seconds) between sending probe statuses.
         /// Default value is 3600.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -30,6 +30,12 @@ internal static partial class ConfigurationKeys
         public const string CodeOriginMaxUserFrames = "DD_CODE_ORIGIN_FOR_SPANS_MAX_USER_FRAMES";
 
         /// <summary>
+        /// Configuration key for enabling or disabling agentless Dynamic Instrumentation uploads.
+        /// Default value is false.
+        /// </summary>
+        public const string DynamicInstrumentationAgentlessEnabled = "DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED";
+
+        /// <summary>
         /// Configuration key for the interval (in seconds) between sending probe statuses.
         /// Default value is 3600.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -30,6 +30,12 @@ internal static partial class ConfigurationKeys
         public const string CodeOriginMaxUserFrames = "DD_CODE_ORIGIN_FOR_SPANS_MAX_USER_FRAMES";
 
         /// <summary>
+        /// Configuration key for enabling or disabling agentless Dynamic Instrumentation uploads.
+        /// Default value is false.
+        /// </summary>
+        public const string DynamicInstrumentationAgentlessEnabled = "DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED";
+
+        /// <summary>
         /// Configuration key for the interval (in seconds) between sending probe statuses.
         /// Default value is 3600.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.Debugger.g.cs
@@ -30,6 +30,12 @@ internal static partial class ConfigurationKeys
         public const string CodeOriginMaxUserFrames = "DD_CODE_ORIGIN_FOR_SPANS_MAX_USER_FRAMES";
 
         /// <summary>
+        /// Configuration key for enabling or disabling agentless Dynamic Instrumentation uploads.
+        /// Default value is false.
+        /// </summary>
+        public const string DynamicInstrumentationAgentlessEnabled = "DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED";
+
+        /// <summary>
         /// Configuration key for the interval (in seconds) between sending probe statuses.
         /// Default value is 3600.
         /// </summary>

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -356,6 +356,38 @@ namespace Datadog.Trace.Tests.Debugger
             settings.ProbeFile.Should().BeEmpty();
         }
 
+        [Fact]
+        public void DynamicInstrumentationAgentless_ParsesCorrectly()
+        {
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationAgentlessEnabled, "true" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, "probes.json" },
+                    { ConfigurationKeys.ApiKey, "test-key" },
+                    { ConfigurationKeys.Site, "datadoghq.eu" }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            settings.DynamicInstrumentationAgentlessEnabled.Should().BeTrue();
+            settings.DynamicInstrumentationAgentlessApiKey.Should().Be("test-key");
+            settings.DynamicInstrumentationAgentlessSite.Should().Be("datadoghq.eu");
+            settings.IsDynamicInstrumentationAgentlessLocalMode.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DynamicInstrumentationAgentlessLocalMode_RequiresProbeFile()
+        {
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationAgentlessEnabled, "true" }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            settings.IsDynamicInstrumentationAgentlessLocalMode.Should().BeFalse();
+        }
+
         public class DebuggerSettingsCodeOriginTests
         {
             [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerTransportFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerTransportFactoryTests.cs
@@ -1,0 +1,80 @@
+// <copyright file="DebuggerTransportFactoryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Debugger;
+using Datadog.Trace.Debugger.Upload;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class DebuggerTransportFactoryTests
+{
+    [Fact]
+    public void ReturnsAgentlessTransport_WhenDynamicInstrumentationAgentlessConfigured()
+    {
+        var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()));
+        var debuggerSettings = new DebuggerSettings(
+            new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.Debugger.DynamicInstrumentationAgentlessEnabled, "true" },
+                { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, "probes.json" },
+                { ConfigurationKeys.ApiKey, "test-key" },
+                { ConfigurationKeys.Site, "datadoghq.eu" }
+            }),
+            NullConfigurationTelemetry.Instance);
+
+        var transport = DebuggerTransportFactory.CreateForDynamicInstrumentation(tracerSettings, debuggerSettings, NullDiscoveryService.Instance);
+
+        transport.Should().NotBeNull();
+        transport!.Value.IsAgentless.Should().BeTrue();
+        transport.Value.DiscoveryService.Should().BeNull();
+        transport.Value.StaticEndpoint.Should().Be(DebuggerTransportFactory.DefaultAgentlessRelativePath);
+        transport.Value.ApiRequestFactory.GetEndpoint(transport.Value.StaticEndpoint).ToString().Should().Be("https://debugger-intake.datadoghq.eu/api/v2/debugger");
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenDynamicInstrumentationAgentlessEnabledWithoutApiKey()
+    {
+        var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()));
+        var debuggerSettings = new DebuggerSettings(
+            new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.Debugger.DynamicInstrumentationAgentlessEnabled, "true" },
+                { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, "probes.json" }
+            }),
+            NullConfigurationTelemetry.Instance);
+
+        var transport = DebuggerTransportFactory.CreateForDynamicInstrumentation(tracerSettings, debuggerSettings, NullDiscoveryService.Instance);
+
+        transport.Should().BeNull();
+    }
+
+    private sealed class NullDiscoveryService : IDiscoveryService
+    {
+        public static NullDiscoveryService Instance { get; } = new();
+
+        public void SubscribeToChanges(Action<AgentConfiguration> callback)
+        {
+        }
+
+        public void RemoveSubscription(Action<AgentConfiguration> callback)
+        {
+        }
+
+        public void SetCurrentConfigStateHash(string configStateHash)
+        {
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -1002,6 +1002,66 @@ public class DynamicInstrumentationTests
             GetFileProbes(debugger).Should().NotBeNull();
         }
 
+        [Fact]
+        public async Task ProbeFile_AgentlessLocalMode_AppliesOnlyMethodLogProbes()
+        {
+            var probeJson = @"[
+                {
+                    ""id"": ""method-log-probe"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""typeName"": ""MyClass"", ""methodName"": ""MyMethod"" },
+                    ""template"": ""Hello"",
+                    ""captureSnapshot"": false
+                },
+                {
+                    ""id"": ""line-log-probe"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""sourceFile"": ""file-only.cs"", ""lines"": [""10""] },
+                    ""captureSnapshot"": true
+                },
+                {
+                    ""id"": ""metric-probe"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""METRIC_PROBE"",
+                    ""where"": { ""typeName"": ""MyClass"", ""methodName"": ""MyMethod"" },
+                    ""kind"": ""COUNT"",
+                    ""metricName"": ""my.metric""
+                },
+                {
+                    ""id"": ""span-probe"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""SPAN_PROBE"",
+                    ""where"": { ""typeName"": ""MyClass"", ""methodName"": ""MyMethod"" }
+                }
+            ]";
+
+            var tempFile = CreateTempProbeFile(probeJson);
+
+            var settings = DebuggerSettings.FromSource(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationAgentlessEnabled, "1" },
+                    { ConfigurationKeys.Debugger.DynamicInstrumentationProbeFile, tempFile },
+                    { ConfigurationKeys.ApiKey, "test-key" }
+                }),
+                NullConfigurationTelemetry.Instance);
+
+            var debugger = CreateDebugger(settings, new DiscoveryServiceWithoutRcmMock());
+            debugger.Initialize();
+            await WaitUntilAsync(() => GetFileProbes(debugger) is not null);
+
+            var fileProbes = GetFileProbes(debugger);
+            fileProbes.Should().NotBeNull();
+            fileProbes!.LogProbes.Should().ContainSingle(probe => probe.Id == "method-log-probe");
+            fileProbes.MetricProbes.Should().BeEmpty();
+            fileProbes.SpanProbes.Should().BeEmpty();
+            fileProbes.SpanDecorationProbes.Should().BeEmpty();
+            GetCurrentConfiguration(debugger).LogProbes.Should().ContainSingle(probe => probe.Id == "method-log-probe");
+        }
+
         private static LineProbeResolveErrorKey SourceMismatchKey(LineProbeFallbackFailureReason fallbackFailureReason = LineProbeFallbackFailureReason.NoQualifiedSuffixMatch)
         {
             return new LineProbeResolveErrorKey(

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DynamicInstrumentationTests.cs
@@ -1022,6 +1022,20 @@ public class DynamicInstrumentationTests
                     ""captureSnapshot"": true
                 },
                 {
+                    ""id"": ""method-log-probe-without-type-name"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""methodName"": ""MyMethod"" },
+                    ""captureSnapshot"": false
+                },
+                {
+                    ""id"": ""method-log-probe-without-method-name"",
+                    ""language"": ""dotnet"",
+                    ""type"": ""LOG_PROBE"",
+                    ""where"": { ""typeName"": ""MyClass"" },
+                    ""captureSnapshot"": false
+                },
+                {
                     ""id"": ""metric-probe"",
                     ""language"": ""dotnet"",
                     ""type"": ""METRIC_PROBE"",
@@ -1052,6 +1066,7 @@ public class DynamicInstrumentationTests
             var debugger = CreateDebugger(settings, new DiscoveryServiceWithoutRcmMock());
             debugger.Initialize();
             await WaitUntilAsync(() => GetFileProbes(debugger) is not null);
+            await WaitUntilAsync(() => GetCurrentConfiguration(debugger).LogProbes.Any(probe => probe.Id == "method-log-probe"));
 
             var fileProbes = GetFileProbes(debugger);
             fileProbes.Should().NotBeNull();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotUploadApiTests.cs
@@ -33,5 +33,39 @@ namespace Datadog.Trace.Tests.Debugger
             requestUri.GetLeftPart(UriPartial.Path).Should().Be("https://debugger-intake.example/api/v2/debugger");
             requestUri.Query.Should().Contain("ddtags=");
         }
+
+        [Fact]
+        public async Task LogUploadApiUsesStaticEndpointWhenProvided()
+        {
+            var factory = new TestRequestFactory(new Uri("https://debugger-intake.example/"));
+            var gitMetadataProvider = new NullGitMetadataProvider();
+            var logApi = LogUploadApi.Create(factory, discoveryService: null, gitMetadataProvider, staticEndpoint: "/api/v2/debugger");
+
+            var payload = new ArraySegment<byte>(new byte[] { 1, 2, 3 });
+            var success = await logApi.SendBatchAsync(payload);
+
+            success.Should().BeTrue();
+            factory.RequestsSent.Should().ContainSingle();
+            var requestUri = factory.RequestsSent[0].Endpoint;
+            requestUri.GetLeftPart(UriPartial.Path).Should().Be("https://debugger-intake.example/api/v2/debugger");
+            requestUri.Query.Should().Contain("ddtags=");
+        }
+
+        [Fact]
+        public async Task DiagnosticsUploadApiUsesStaticEndpointWhenProvided()
+        {
+            var factory = new TestRequestFactory(new Uri("https://debugger-intake.example/"));
+            var gitMetadataProvider = new NullGitMetadataProvider();
+            var diagnosticsApi = DiagnosticsUploadApi.Create(factory, discoveryService: null, gitMetadataProvider, staticEndpoint: "/api/v2/debugger");
+
+            var payload = new ArraySegment<byte>(new byte[] { 1, 2, 3 });
+            var success = await diagnosticsApi.SendBatchAsync(payload);
+
+            success.Should().BeTrue();
+            factory.RequestsSent.Should().ContainSingle();
+            var requestUri = factory.RequestsSent[0].Endpoint;
+            requestUri.GetLeftPart(UriPartial.Path).Should().Be("https://debugger-intake.example/api/v2/debugger");
+            requestUri.Query.Should().Contain("ddtags=");
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Adds an agentless mode for Dynamic Instrumentation so method log probes can run without a Datadog Agent or Remote Configuration Management (RCM).
- Adds `DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED` as the opt-in switch for agentless DI uploads.
- Reuses existing debugger intake conventions for agentless uploads: `DD_API_KEY` for authentication, `DD_SITE` for site selection, and `/api/v2/debugger` as the debugger intake path.
- Allows DI snapshot, log, and diagnostics upload APIs to use either Agent discovery endpoints or a static debugger intake endpoint.
- Adds a DI transport factory modeled after Exception Replay’s agentless transport path, so transport selection is centralized instead of duplicated across uploaders.
- Updates DI initialization so local probe-file mode can start without waiting for RCM availability or Agent debugger endpoint discovery.
- Filters agentless local probe files to the initially supported probe shape: method-based `LOG_PROBE`s only.

## Reason for change

Serverless environments cannot rely on a full Datadog Agent or Remote Configuration support. Existing Dynamic Instrumentation startup and upload paths assumed the Agent was available for debugger endpoint discovery and for probe delivery through RCM.

This change enables a narrower, explicit serverless-friendly path: customers can provide probes locally through `DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE`, enable agentless DI uploads, and send debugger payloads directly to Datadog intake using an API key.

The goal of this PR is intentionally limited to method probes - log or snapshot. Span probes, span decoration probes, metric probes, and line probes are deliberately excluded from this first version to keep the behavior predictable and avoid introducing source/PDB resolution and trace/span semantics into the initial serverless path.

## Implementation details

A new DI agentless local mode is active only when both of these are true:

- `DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED=true`
- `DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE` is set

`DD_DYNAMIC_INSTRUMENTATION_ENABLED` is still required to enable Dynamic Instrumentation itself. The new setting only changes how local probe-file DI uploads are transported and initialized.

The agentless upload endpoint is derived from existing shared configuration:

- `DD_API_KEY` is required for direct intake authentication.
- `DD_SITE` selects the Datadog site.
- The derived default endpoint is `https://debugger-intake.{DD_SITE}/api/v2/debugger`.
- If `DD_SITE` is not set, the default site is `datadoghq.com`.

This PR deliberately does not add `DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_URL`. Exception Replay has an override key, but DI does not need a new product-specific URL override for the initial serverless use case. Using `DD_SITE` keeps configuration smaller, matches normal Datadog site routing expectations, and avoids exposing a second intake URL knob unless we later find a concrete need for custom intake routing.

Transport selection is centralized in the new `DebuggerTransportFactory` and `DebuggerTransportInfo` types. In normal DI mode, the factory returns the existing Agent transport with the discovery service, preserving current RCM/Agent behavior. In agentless local mode, it returns a direct debugger-intake transport, no discovery service, and a static `/api/v2/debugger` endpoint. If agentless local mode is enabled but `DD_API_KEY` is missing, the factory returns `null` and DI initialization is skipped cleanly.

This mirrors the structure Exception Replay already uses with `ExceptionReplayTransportFactory` and `ExceptionReplayTransportInfo`, while keeping DI-specific settings, product naming, and activation rules separate.

The DI initialization flow now treats local agentless probe-file mode as independent from RCM availability. Probe-file loading still happens asynchronously, but in this mode DI does not wait for RCM availability and `DebuggerManager` does not wait for Agent debugger endpoint discovery before starting the DI runtime.

Probe filtering is intentionally conservative in agentless local mode:

- Supported: method-based `LOG_PROBE`s, including probes with `captureSnapshot`.
- Not supported yet: line probes, metric probes, span probes, and span decoration probes.
- Unsupported probes from the file are filtered out before applying the local probe configuration.

The upload APIs for snapshots, logs, and diagnostics now accept either:

- a discovery service, preserving existing Agent endpoint updates, or
- a static endpoint, used by agentless DI.

This keeps existing Agent-based behavior intact while allowing direct-intake uploads where no Agent endpoint discovery exists.

Generated configuration key files were refreshed from `supported-configurations.yaml`, and telemetry normalization was updated for the new config key.

## Test coverage


- `DebuggerSettingsTests|DebuggerTransportFactoryTests|SnapshotUploadApiTests|DynamicInstrumentationTests`

Coverage added/updated for:

- Parsing `DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED`, `DD_API_KEY`, `DD_SITE`, and local-mode activation.
- Requiring a probe file for DI agentless local mode.
- Building direct debugger-intake transport from `DD_SITE`.
- Returning no DI transport when `DD_API_KEY` is missing in agentless local mode.
- Static endpoint uploads for snapshot, log, and diagnostics APIs.
- Loading local probe files in agentless mode without RCM.
- Filtering local probe files to method-based log probes only.

## Other details

This PR does not enable remote probe delivery without an Agent. Agentless DI depends on a local probe file and does not introduce a Datadog backend polling path.

This PR does not add support for span probes, trace/span instrumentation probes, metric probes, or line probes in serverless mode. Those require additional design around trace semantics, source/PDB availability, diagnostics, and customer expectations in serverless deployments.

Existing Agent and RCM Dynamic Instrumentation behavior should remain unchanged when `DD_DYNAMIC_INSTRUMENTATION_AGENTLESS_ENABLED` is not enabled together with `DD_DYNAMIC_INSTRUMENTATION_PROBE_FILE`.