### PR TITLE
[Stats] Fix partial_version exclusion: use >= 0 instead of > 0

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -524,7 +524,7 @@ namespace Datadog.Trace.Agent
 
             if (!_isOtlp // If we are using OTLP, we include both top-level and non-top-level spans
                 && (!(span.IsTopLevel || isSpanKindEligible || span.GetMetric(Tags.Measured) == 1.0)
-                 || span.GetMetric(Tags.PartialSnapshot) > 0))
+                 || span.GetMetric(Tags.PartialSnapshot) >= 0))
             {
                 return;
             }

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -368,6 +368,43 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public async Task ExcludesSpanWithPartialVersionZero_TS014()
+        {
+            // A span with _dd.partial_version=0 must be excluded from stats (spec §7: partial_version >= 0 means excluded)
+            const int millisecondsToNanoseconds = 1_000_000;
+            const long expectedTotalDuration = 100 * millisecondsToNanoseconds;
+
+            var start = DateTimeOffset.UtcNow;
+
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
+
+            try
+            {
+                var normalSpan = CreateTopLevelSpan(start, "service");
+                normalSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // partialVersionZeroSpan should be excluded because _dd.partial_version=0 (>= 0)
+                var partialVersionZeroSpan = CreateTopLevelSpan(start, "service");
+                partialVersionZeroSpan.SetMetric(Tags.PartialSnapshot, 0.0);
+                partialVersionZeroSpan.SetDuration(TimeSpan.FromMilliseconds(200));
+
+                aggregator.Add(normalSpan, partialVersionZeroSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+
+                buffer.Buckets.Should().HaveCount(1);
+                var bucket = buffer.Buckets.Values.Single();
+
+                bucket.Hits.Should().Be(1);
+                bucket.Duration.Should().Be(expectedTotalDuration);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
         public async Task RecordsSuccessesAndErrorsSeparately_TS006()
         {
             const int millisecondsToNanoseconds = 1_000_000;

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -371,8 +371,7 @@ namespace Datadog.Trace.Tests.Agent
         public async Task ExcludesSpanWithPartialVersionZero_TS014()
         {
             // A span with _dd.partial_version=0 must be excluded from stats (spec §7: partial_version >= 0 means excluded)
-            const int millisecondsToNanoseconds = 1_000_000;
-            const long expectedTotalDuration = 100 * millisecondsToNanoseconds;
+            var expectedTotalDuration = TimeSpan.FromMilliseconds(100).ToNanoseconds();
 
             var start = DateTimeOffset.UtcNow;
 


### PR DESCRIPTION
CSS v1.2.0 spec §7 requires spans with `_dd.partial_version` >= 0 to be excluded from stats, but `StatsAggregator.cs` used `> 0`, silently including spans with value 0. This changes the check to `>= 0`. In C# with `double?`, `null >= 0` is false, so spans without the metric are correctly included. Adds a unit test (`TS014`) for the value=0 case. Tracked in [APMSP-3045](https://datadoghq.atlassian.net/browse/APMSP-3045); context in the [CSS v1.2.0 Implementation Status](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/6378587288/Implementation+Status).

[APMSP-3045]: https://datadoghq.atlassian.net/browse/APMSP-3045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ