### PR TITLE
[Profiler] Improve memory consumption `LibrariesInfoCache`

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DlPhdrInfoWrapper.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DlPhdrInfoWrapper.cpp
@@ -12,7 +12,7 @@
 // dlclose is happening when libunwind is calling our custom dl_iterate_phdr.
 // The pointers will be invalidated and a crash can happen.
 DlPhdrInfoWrapper::DlPhdrInfoWrapper(struct dl_phdr_info const* info, std::size_t size, shared::pmr::memory_resource* allocator) :
-    _info{0}, _phdr{nullptr}, _name{nullptr}, _size(size), _allocator{allocator}
+    _info{0}, _phdr{nullptr, {}}, _name{nullptr, {}}, _size(size), _allocator{allocator}
 {
     DeepCopy(_info, info);
 }
@@ -22,25 +22,25 @@ std::pair<struct dl_phdr_info*, std::size_t> DlPhdrInfoWrapper::Get()
     return {&_info, _size};
 }
 
-using custom_deleter = std::function<void(void*)>;
 template <class T, typename _Naked_T = std::remove_cv_t<T>>
-std::unique_ptr<_Naked_T, custom_deleter> Duplicate(shared::pmr::memory_resource* allocator, T* src, std::size_t count)
+std::unique_ptr<_Naked_T[], DlPhdrInfoWrapper::PmrDeleter> DuplicateWithPmr(
+    shared::pmr::memory_resource* allocator, T* src, std::size_t count)
 {
     // Static assertions to that T does not need special treatment (ex:. calling ctor or dtor)
     static_assert(std::is_trivially_copyable_v<T>, 
         "T must be trivially copyable");
-    static_assert(std::is_trivially_destructible_v<T>, 
+    static_assert(std::is_trivially_destructible_v<T>,
         "T must be trivially destructible");
 
     if (src == nullptr)
     {
-        return {nullptr};
+        return {nullptr, {}};
     }
 
     const std::size_t size = sizeof(T) * count;
     auto* newPtr = static_cast<_Naked_T*>(allocator->allocate(size, alignof(T)));
     memcpy(newPtr, src, size);
-    return {static_cast<_Naked_T*>(newPtr), [allocator, size](void* ptr) { allocator->deallocate(ptr, size, alignof(T)); }};
+    return {newPtr, {allocator, size, alignof(T)}};
 }
 
 void DlPhdrInfoWrapper::DeepCopy(struct dl_phdr_info& destination, struct dl_phdr_info const* source)
@@ -48,11 +48,11 @@ void DlPhdrInfoWrapper::DeepCopy(struct dl_phdr_info& destination, struct dl_phd
     // first copy all fields
     destination = *source;
     // then update the pointer-ones
-    _name = Duplicate(_allocator, source->dlpi_name, strlen(source->dlpi_name) + 1);
+    _name = DuplicateWithPmr(_allocator, source->dlpi_name, strlen(source->dlpi_name) + 1);
     destination.dlpi_name = _name.get();
 
     // copy header
-    _phdr = Duplicate(_allocator, source->dlpi_phdr, source->dlpi_phnum);
+    _phdr = DuplicateWithPmr(_allocator, source->dlpi_phdr, source->dlpi_phnum);
     destination.dlpi_phdr = _phdr.get();
 
     // Those fields appeared in glibc 2.4 (with two others).

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DlPhdrInfoWrapper.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DlPhdrInfoWrapper.cpp
@@ -23,7 +23,7 @@ std::pair<struct dl_phdr_info*, std::size_t> DlPhdrInfoWrapper::Get()
 }
 
 template <class T, typename _Naked_T = std::remove_cv_t<T>>
-std::unique_ptr<_Naked_T[], DlPhdrInfoWrapper::PmrDeleter> DuplicateWithPmr(
+std::unique_ptr<_Naked_T[], DlPhdrInfoWrapper::PmrDeleter> Duplicate(
     shared::pmr::memory_resource* allocator, T* src, std::size_t count)
 {
     // Static assertions to that T does not need special treatment (ex:. calling ctor or dtor)
@@ -48,11 +48,11 @@ void DlPhdrInfoWrapper::DeepCopy(struct dl_phdr_info& destination, struct dl_phd
     // first copy all fields
     destination = *source;
     // then update the pointer-ones
-    _name = DuplicateWithPmr(_allocator, source->dlpi_name, strlen(source->dlpi_name) + 1);
+    _name = Duplicate(_allocator, source->dlpi_name, strlen(source->dlpi_name) + 1);
     destination.dlpi_name = _name.get();
 
     // copy header
-    _phdr = DuplicateWithPmr(_allocator, source->dlpi_phdr, source->dlpi_phnum);
+    _phdr = Duplicate(_allocator, source->dlpi_phdr, source->dlpi_phnum);
     destination.dlpi_phdr = _phdr.get();
 
     // Those fields appeared in glibc 2.4 (with two others).

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DlPhdrInfoWrapper.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/DlPhdrInfoWrapper.h
@@ -7,7 +7,6 @@
 #include <memory>
 #include <stdlib.h>
 #include <string.h>
-#include <functional>
 
 #include "shared/src/native-src/dd_memory_resource.hpp"
 
@@ -26,13 +25,28 @@ public:
 
     bool IsSame(struct dl_phdr_info const * other) const;
 
+    struct PmrDeleter
+    {
+        shared::pmr::memory_resource* allocator = nullptr;
+        std::size_t size = 0;
+        std::size_t alignment = 1;
+
+        void operator()(void* ptr) const
+        {
+            if (ptr != nullptr && allocator != nullptr)
+            {
+                allocator->deallocate(ptr, size, alignment);
+            }
+        }
+    };
+
 private:
+
     struct dl_phdr_info _info;
     void DeepCopy(struct dl_phdr_info& destination, struct dl_phdr_info const * source);
 
-    using custom_deleter = std::function<void(void*)>;
-    std::unique_ptr<ElfW(Phdr), custom_deleter> _phdr;
-    std::unique_ptr<char, custom_deleter> _name;
+    std::unique_ptr<ElfW(Phdr)[], PmrDeleter> _phdr;
+    std::unique_ptr<char[], PmrDeleter> _name;
     std::size_t _size;
     shared::pmr::memory_resource* _allocator;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -476,7 +476,10 @@ void LibrariesInfoCache::BuildSymbolCache(
             !IsFileRangeValid(ehdr->e_shoff,
                               static_cast<std::uint64_t>(ehdr->e_shnum) * sizeof(ElfW(Shdr)),
                               fileSize))
+        {
+            LogOnce(Info, "LibrariesInfoCache: skipping invalid ELF header in ", modulePath);
             continue;
+        }
 
         auto* shdrs = reinterpret_cast<const ElfW(Shdr)*>(base + ehdr->e_shoff);
 
@@ -491,7 +494,10 @@ void LibrariesInfoCache::BuildSymbolCache(
                 continue;
 
             if (!IsFileRangeValid(shdrs[s].sh_offset, shdrs[s].sh_size, fileSize))
+            {
+                LogOnce(Info, "LibrariesInfoCache: skipping invalid section header in ", modulePath);
                 continue;
+            }
 
             auto symCount = shdrs[s].sh_size / sizeof(ElfW(Sym));
             auto* syms = reinterpret_cast<const ElfW(Sym)*>(base + shdrs[s].sh_offset);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <elf.h>
 #include <fcntl.h>
 #include <string.h>
@@ -43,6 +44,14 @@ struct ScopedMmap
 
     explicit operator bool() const { return data != MAP_FAILED; }
 };
+
+#ifdef ARM64
+bool IsFileRangeValid(std::uint64_t offset, std::uint64_t size, size_t fileSize)
+{
+    auto fileSize64 = static_cast<std::uint64_t>(fileSize);
+    return offset <= fileSize64 && size <= fileSize64 - offset;
+}
+#endif
 
 } // anonymous namespace
 
@@ -463,7 +472,10 @@ void LibrariesInfoCache::BuildSymbolCache(
         auto base = static_cast<const uint8_t*>(mapping.data);
 
         if (ehdr->e_shoff == 0 || ehdr->e_shnum == 0 ||
-            ehdr->e_shoff + static_cast<size_t>(ehdr->e_shnum) * sizeof(ElfW(Shdr)) > fileSize)
+            ehdr->e_shentsize != sizeof(ElfW(Shdr)) ||
+            !IsFileRangeValid(ehdr->e_shoff,
+                              static_cast<std::uint64_t>(ehdr->e_shnum) * sizeof(ElfW(Shdr)),
+                              fileSize))
             continue;
 
         auto* shdrs = reinterpret_cast<const ElfW(Shdr)*>(base + ehdr->e_shoff);
@@ -475,13 +487,13 @@ void LibrariesInfoCache::BuildSymbolCache(
             if (shdrs[s].sh_type != SHT_SYMTAB && shdrs[s].sh_type != SHT_DYNSYM)
                 continue;
 
-            if (shdrs[s].sh_entsize == 0)
+            if (shdrs[s].sh_entsize != sizeof(ElfW(Sym)))
                 continue;
 
-            if (shdrs[s].sh_offset + shdrs[s].sh_size > fileSize)
+            if (!IsFileRangeValid(shdrs[s].sh_offset, shdrs[s].sh_size, fileSize))
                 continue;
 
-            auto symCount = shdrs[s].sh_size / shdrs[s].sh_entsize;
+            auto symCount = shdrs[s].sh_size / sizeof(ElfW(Sym));
             auto* syms = reinterpret_cast<const ElfW(Sym)*>(base + shdrs[s].sh_offset);
 
             for (size_t j = 0; j < symCount; ++j)
@@ -514,15 +526,27 @@ void LibrariesInfoCache::BuildSymbolCache(
         moduleSymbols.erase(last, moduleSymbols.end());
 
         auto symOffset = static_cast<uint32_t>(outSymbols.size());
-        auto symCount = static_cast<uint32_t>(moduleSymbols.size());
-        outRegions.push_back({segLow, segHigh, symOffset, symCount});
+        outRegions.push_back({segLow, segHigh, symOffset, 0});
 
+        // FuncEntry uses uint32_t for offset and size to halve memory usage (8 vs 16 bytes
+        // per entry). This is safe because ARM64 shared libraries are constrained to < 4GiB
+        // by the ABI (ADRP instruction range is ±4GiB). Skip any symbol that would overflow
+        // as a defensive measure against hypothetical large code model binaries.
+        uint32_t inserted = 0;
         for (const auto& abs : moduleSymbols)
         {
-            outSymbols.push_back({
-                static_cast<uint32_t>(abs.start_ip - segLow),
-                static_cast<uint32_t>(abs.end_ip - abs.start_ip)});
+            auto offset = abs.start_ip - segLow;
+            auto funcSize = abs.end_ip - abs.start_ip;
+            if (offset > UINT32_MAX || funcSize > UINT32_MAX) [[unlikely]]
+            {
+                Log::Info("LibrariesInfoCache: skipping out-of-range symbol (offset=",
+                          offset, ", size=", funcSize, ") in ", modulePath);
+                continue;
+            }
+            outSymbols.push_back({static_cast<uint32_t>(offset), static_cast<uint32_t>(funcSize)});
+            inserted++;
         }
+        outRegions.back().sym_count = inserted;
     }
 
     std::sort(outRegions.begin(), outRegions.end(),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -400,7 +400,12 @@ void LibrariesInfoCache::BuildSymbolCache(
     std::vector<ModuleRegion, shared::pmr::polymorphic_allocator<ModuleRegion>>& outRegions,
     std::vector<FuncEntry, shared::pmr::polymorphic_allocator<FuncEntry>>& outSymbols)
 {
-    std::vector<FuncEntry> moduleSymbols;
+    struct AbsFuncEntry
+    {
+        unw_word_t start_ip;
+        unw_word_t end_ip;
+    };
+    std::vector<AbsFuncEntry> moduleSymbols;
 
     for (auto& wrapper : phdrCache)
     {
@@ -498,13 +503,12 @@ void LibrariesInfoCache::BuildSymbolCache(
             continue;
 
         std::sort(moduleSymbols.begin(), moduleSymbols.end(),
-                  [](const FuncEntry& a, const FuncEntry& b) {
+                  [](const AbsFuncEntry& a, const AbsFuncEntry& b) {
                       return a.start_ip < b.start_ip || (a.start_ip == b.start_ip && a.end_ip < b.end_ip);
                   });
 
-        // Remove duplicates
         auto last = std::unique(moduleSymbols.begin(), moduleSymbols.end(),
-                                [](const FuncEntry& a, const FuncEntry& b) {
+                                [](const AbsFuncEntry& a, const AbsFuncEntry& b) {
                                     return a.start_ip == b.start_ip && a.end_ip == b.end_ip;
                                 });
         moduleSymbols.erase(last, moduleSymbols.end());
@@ -512,7 +516,13 @@ void LibrariesInfoCache::BuildSymbolCache(
         auto symOffset = static_cast<uint32_t>(outSymbols.size());
         auto symCount = static_cast<uint32_t>(moduleSymbols.size());
         outRegions.push_back({segLow, segHigh, symOffset, symCount});
-        outSymbols.insert(outSymbols.end(), moduleSymbols.begin(), moduleSymbols.end());
+
+        for (const auto& abs : moduleSymbols)
+        {
+            outSymbols.push_back({
+                static_cast<uint32_t>(abs.start_ip - segLow),
+                static_cast<uint32_t>(abs.end_ip - abs.start_ip)});
+        }
     }
 
     std::sort(outRegions.begin(), outRegions.end(),
@@ -537,19 +547,23 @@ int LibrariesInfoCache::FindFunctionStart(unw_word_t ip, unw_word_t* func_start)
 
     const FuncEntry* symBegin = _symbols.data() + regionIt->sym_offset;
     const FuncEntry* symEnd = symBegin + regionIt->sym_count;
+    unw_word_t baseLow = regionIt->addr_low;
 
     auto symIt = std::upper_bound(
         symBegin, symEnd, ip,
-        [](unw_word_t addr, const FuncEntry& entry) { return addr < entry.start_ip; });
+        [baseLow](unw_word_t addr, const FuncEntry& entry) {
+            return addr < baseLow + entry.offset;
+        });
 
     if (symIt == symBegin)
         return -UNW_ENOINFO;
 
     --symIt;
-    if (ip >= symIt->end_ip)
+    unw_word_t startIp = baseLow + symIt->offset;
+    if (ip >= startIp + symIt->size)
         return -UNW_ENOINFO;
 
-    *func_start = symIt->start_ip;
+    *func_start = startIp;
     return 0;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -22,8 +22,8 @@
 #ifdef ARM64
 struct FuncEntry
 {
-    unw_word_t start_ip;
-    unw_word_t end_ip;
+    uint32_t offset; // relative to ModuleRegion::addr_low
+    uint32_t size;   // function size (end_ip - start_ip)
 };
 
 struct ModuleRegion

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
@@ -32,6 +32,7 @@ namespace Datadog.Profiler.SmokeTests
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
         }
     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
@@ -42,6 +42,7 @@ namespace Datadog.Profiler.SmokeTests
             {
                 runner.EnvironmentHelper.SetVariable(EnvironmentVariables.EtwEnabled, "0");
             }
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
 
             runner.RunAndCheck();
         }
@@ -54,6 +55,7 @@ namespace Datadog.Profiler.SmokeTests
             {
                 runner.EnvironmentHelper.SetVariable(EnvironmentVariables.EtwEnabled, "0");
             }
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
 
             runner.RunAndCheck();
         }
@@ -66,6 +68,7 @@ namespace Datadog.Profiler.SmokeTests
             {
                 runner.EnvironmentHelper.SetVariable(EnvironmentVariables.EtwEnabled, "0");
             }
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
 
             runner.RunAndCheck();
         }
@@ -78,6 +81,7 @@ namespace Datadog.Profiler.SmokeTests
             {
                 runner.EnvironmentHelper.SetVariable(EnvironmentVariables.EtwEnabled, "0");
             }
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
 
             runner.RunAndCheck();
         }
@@ -89,6 +93,7 @@ namespace Datadog.Profiler.SmokeTests
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
         }
 
@@ -99,6 +104,7 @@ namespace Datadog.Profiler.SmokeTests
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", output: _output);
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
         }
 
@@ -109,6 +115,7 @@ namespace Datadog.Profiler.SmokeTests
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", output: _output);
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
         }
 
@@ -119,6 +126,7 @@ namespace Datadog.Profiler.SmokeTests
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", output: _output);
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
         }
 
@@ -127,6 +135,7 @@ namespace Datadog.Profiler.SmokeTests
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 0", output: _output);
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.UseManagedCodeCache, "1");
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             if (framework == "net48")
             {
                 runner.EnvironmentHelper.SetVariable(EnvironmentVariables.EtwEnabled, "0");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/ExceptionGeneratorTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/ExceptionGeneratorTest.cs
@@ -30,6 +30,7 @@ namespace Datadog.Profiler.SmokeTests
             {
                 runner.EnvironmentHelper.SetVariable(EnvironmentVariables.EtwEnabled, "0");
             }
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
 
             runner.RunAndCheck();
         }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/WebsiteAspNetCore01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/WebsiteAspNetCore01Test.cs
@@ -22,6 +22,7 @@ namespace Datadog.Profiler.SmokeTests
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);
+            runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
         }
     }

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibrariesInfoCacheTest.cpp
@@ -268,13 +268,13 @@ TEST(LibrariesInfoCacheTests, BuildSymbolCacheProducesNoDuplicates)
         {
             auto idx = region.sym_offset + i;
             auto prev = region.sym_offset + i - 1;
-            bool isDuplicate = symbols[idx].start_ip == symbols[prev].start_ip &&
-                               symbols[idx].end_ip == symbols[prev].end_ip;
+            bool isDuplicate = symbols[idx].offset == symbols[prev].offset &&
+                               symbols[idx].size == symbols[prev].size;
             EXPECT_FALSE(isDuplicate)
                 << "Duplicate symbol entry in region " << r
                 << " at index " << i
-                << ": start_ip=0x" << std::hex << symbols[idx].start_ip
-                << " end_ip=0x" << symbols[idx].end_ip;
+                << ": offset=0x" << std::hex << symbols[idx].offset
+                << " size=0x" << symbols[idx].size;
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Improve memory overhead of the `LibrariesCacheInfo`.

## Reason for change

`LibrariesCacheInfo` component caches ELF symbols to improve stack walking. But this comes at a cost CPU + Memory.

Today (master)
```
[2026-06-11 10:58:49.687 | info | PId: 140997 | TId: 140997] LibrariesInfoCache stats:
[2026-06-11 10:58:49.687 | info | PId: 140997 | TId: 140997]   Cache reloads: 10
[2026-06-11 10:58:49.687 | info | PId: 140997 | TId: 140997]   Total CPU (worker): 42 ms
[2026-06-11 10:58:49.687 | info | PId: 140997 | TId: 140997]   Libraries in cache: 21
[2026-06-11 10:58:49.687 | info | PId: 140997 | TId: 140997]   Module regions: 18
[2026-06-11 10:58:49.687 | info | PId: 140997 | TId: 140997]   Symbol entries: 27179
[2026-06-11 10:58:49.687 | info | PId: 140997 | TId: 140997]   Memory current: 1410520 bytes
```

We can see a 42ms CPU usage and 1.4MB memory usage for 27179 symbols.  42ms of CPU over the lifetime of the application is totally negligible, but 1.4MB leaves a mark.

This PR does 2 improvements:
- Replace std::function Deleters
- Compact FuncEntry for ARM64

With this PR
```
[2026-06-11 07:53:01.910 | info | PId: 20347 | TId: 20347] LibrariesInfoCache stats:
[2026-06-11 07:53:01.910 | info | PId: 20347 | TId: 20347]   Cache reloads: 13
[2026-06-11 07:53:01.910 | info | PId: 20347 | TId: 20347]   Total CPU (worker): 57 ms
[2026-06-11 07:53:01.910 | info | PId: 20347 | TId: 20347]   Libraries in cache: 21
[2026-06-11 07:53:01.910 | info | PId: 20347 | TId: 20347]   Module regions: 18
[2026-06-11 07:53:01.910 | info | PId: 20347 | TId: 20347]   Symbol entries: 27179
[2026-06-11 07:53:01.910 | info | PId: 20347 | TId: 20347]   Memory current: 565528 bytes
```

## Implementation details
- Replace std::unique_ptr<T, std::function<void(void*)>> with a trivial deleter struct `PmrDeleter`
- Store function entries relative to their module base:
Works because: modules are always < 4GB (shared libraries mapped within 32-bit offset range from their base)


## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
