### PR TITLE
Use `TaskScheduler.Default` when calling `Task.Factory.StartNew`

### DIFF
--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -63,7 +63,7 @@ namespace UpdateVendors
                 version: "6.0.0",
                 downloadUrl: "https://github.com/DataDog/dogstatsd-csharp-client/archive/6.0.0.zip",
                 pathToSrc: new[] { "dogstatsd-csharp-client-6.0.0", "src", "StatsdClient" },
-                transform: filePath => RewriteCsFileWithStandardTransform(filePath, originalNamespace: "StatsdClient", AddAnonymousImpersonationToStatsdNamedPipe));
+                transform: filePath => RewriteCsFileWithStandardTransform(filePath, originalNamespace: "StatsdClient", ApplyStatsdClientTweaks));
 
             Add(
                 libraryName: "MessagePack",
@@ -529,18 +529,25 @@ namespace UpdateVendors
             return content;
         }
 
-        private static string AddAnonymousImpersonationToStatsdNamedPipe(string filePath, string content)
+        private static string ApplyStatsdClientTweaks(string filePath, string content)
         {
-            if (!filePath.Replace('\\', '/').EndsWith("Transport/NamedPipeTransport.cs", StringComparison.OrdinalIgnoreCase))
+            var normalizedPath = filePath.Replace('\\', '/');
+
+            if (normalizedPath.EndsWith("Transport/NamedPipeTransport.cs", StringComparison.OrdinalIgnoreCase))
             {
-                return content;
+                // The agent does not authenticate clients on the named pipe, so request Anonymous
+                // impersonation so the listener cannot identify or impersonate the calling process.
+                content = content.Replace(
+                    "_namedPipe = new NamedPipeClientStream(\".\", pipeName, PipeDirection.Out, PipeOptions.Asynchronous);",
+                    "_namedPipe = new NamedPipeClientStream(\".\", pipeName, PipeDirection.Out, PipeOptions.Asynchronous, System.Security.Principal.TokenImpersonationLevel.Anonymous);");
             }
 
-            // The agent does not authenticate clients on the named pipe, so request Anonymous
-            // impersonation so the listener cannot identify or impersonate the calling process.
-            content = content.Replace(
-                "_namedPipe = new NamedPipeClientStream(\".\", pipeName, PipeDirection.Out, PipeOptions.Asynchronous);",
-                "_namedPipe = new NamedPipeClientStream(\".\", pipeName, PipeDirection.Out, PipeOptions.Asynchronous, System.Security.Principal.TokenImpersonationLevel.Anonymous);");
+            if (normalizedPath.EndsWith("Worker/AsynchronousWorker.cs", StringComparison.OrdinalIgnoreCase))
+            {
+                content = content.Replace(
+                    "Task.Factory.StartNew(() => Dequeue(), TaskCreationOptions.LongRunning)",
+                    "Task.Factory.StartNew(() => Dequeue(), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)");
+            }
 
             return content;
         }

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -112,7 +112,9 @@ namespace Datadog.Trace.Agent
             _traceMetricsEnabled = initialTracerMetricsEnabled;
             _statsd.SetRequired(StatsdConsumer.AgentWriter, initialTracerMetricsEnabled);
 
-            _serializationTask = automaticFlush ? Task.Factory.StartNew(SerializeTracesLoop, TaskCreationOptions.LongRunning) : Task.CompletedTask;
+            _serializationTask = automaticFlush
+                                     ? Task.Factory.StartNew(SerializeTracesLoop, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)
+                                     : Task.CompletedTask;
             _serializationTask.ContinueWith(t => Log.Error(t.Exception, "Error in serialization task"), TaskContinuationOptions.OnlyOnFaulted);
 
             _flushTask = automaticFlush ? Task.Run(FlushBuffersTaskLoopAsync) : Task.CompletedTask;

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Util;
@@ -70,7 +71,9 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
                         _log.Error(t.Exception, "Error in flush task");
                         _disableSinkAction?.Invoke();
                     },
-                    TaskContinuationOptions.OnlyOnFaulted);
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted,
+                    TaskScheduler.Default);
             }
             else
             {

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -131,7 +131,7 @@ namespace Datadog.Trace.RuntimeMetrics
 #if NETFRAMEWORK
             // This delay is set to infinite in tests, so don't start the loop in that case
             _pushEventsTask = delay != Timeout.InfiniteTimeSpan
-                                  ? Task.Factory.StartNew(PushEventsLoop, TaskCreationOptions.LongRunning)
+                                  ? Task.Factory.StartNew(PushEventsLoop, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)
                                   : Task.CompletedTask;
 #else
             _timer = new Timer(_ => PushEvents(), null, delay, Timeout.InfiniteTimeSpan);

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/Worker/AsynchronousWorker.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/Worker/AsynchronousWorker.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Vendors.StatsdClient.Worker
             _waiter = waiter;
             for (int i = 0; i < workerThreadCount; ++i)
             {
-                _workers.Add(Task.Factory.StartNew(() => Dequeue(), TaskCreationOptions.LongRunning));
+                _workers.Add(Task.Factory.StartNew(() => Dequeue(), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));
             }
         }
 


### PR DESCRIPTION
## Summary of changes

Uses `TaskScheduler.Default` when calling `Task.Factory.StartNew`

## Reason for change

When calling `Task.Factory.StartNew`, if you don't explicitly provide a `TaskScheduler`, it inherits `TaskScheduler.Current` from the calling thread. If there's a custom scheduler, this can cause problems (e.g. same as #8767). That PR fixed the issue for DataStreamsMonitoring, this PR fixes it everywhere else.

## Implementation details

- Had 🤖 look for all the cases where we were missing this
- _Technically_ there are some `ContinueWith` that should have it too, but in all of the _other_ cases not covered by this PR, those are simply logging on faulted, so it didn't seem worth the hassle
- Updated the vendoring code to handle our changes to Statsdclient too
- Note that `Task.Run` ignores `TaskScheduler.Current` so it's not a problem

## Test coverage

Covered by existing tests, and not worth creating a regression for IMO