### PR TITLE
Remove debugging blocks leaking environment variables in tests

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -435,7 +435,7 @@ namespace Samples
 
         public static List<KeyValuePair<string, string>> GetDatadogEnvironmentVariables()
         {
-            var prefixes = new[] { "COR_", "CORECLR_", "DD_", "DATADOG_" };
+            var prefixes = new[] { "COR_", "CORECLR_" };
 
             var envVars = from envVar in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
                           from prefix in prefixes

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
@@ -70,12 +70,6 @@ namespace LogsInjection.NLog
             // Disabling the startup log at the process level should prevent this.
             Environment.SetEnvironmentVariable("DD_TRACE_STARTUP_LOGS", "0");
 
-            // var env = SampleHelpers.GetDatadogEnvironmentVariables();
-            // foreach(var kvp in env)
-            // {
-            //     Console.WriteLine($"{kvp.Key}: {kvp.Value}");
-            // }
-
             bool isAttached = SampleHelpers.IsProfilerAttached();
             Console.WriteLine(" * Checking if the profiler is attached: {0}", isAttached);
 

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
@@ -70,11 +70,11 @@ namespace LogsInjection.NLog
             // Disabling the startup log at the process level should prevent this.
             Environment.SetEnvironmentVariable("DD_TRACE_STARTUP_LOGS", "0");
 
-            var env = SampleHelpers.GetDatadogEnvironmentVariables();
-            foreach(var kvp in env)
-            {
-                Console.WriteLine($"{kvp.Key}: {kvp.Value}");
-            }
+            // var env = SampleHelpers.GetDatadogEnvironmentVariables();
+            // foreach(var kvp in env)
+            // {
+            //     Console.WriteLine($"{kvp.Key}: {kvp.Value}");
+            // }
 
             bool isAttached = SampleHelpers.IsProfilerAttached();
             Console.WriteLine(" * Checking if the profiler is attached: {0}", isAttached);
@@ -299,21 +299,6 @@ namespace LogsInjection.NLog
                     }
                 }
             }
-        }
-
-        public static IEnumerable<KeyValuePair<string,string>> GetDatadogEnvironmentVariables()
-        {
-            var prefixes = new[] { "COR_", "CORECLR_", "DD_", "DATADOG_" };
-
-            var envVars = from envVar in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
-                          from prefix in prefixes
-                          let key = (envVar.Key as string)?.ToUpperInvariant()
-                          let value = envVar.Value as string
-                          where key.StartsWith(prefix)
-                          orderby key
-                          select new KeyValuePair<string, string>(key, value);
-
-            return envVars.ToList();
         }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.MSTestTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.MSTestTests/TestSuite.cs
@@ -15,12 +15,6 @@ public class TestSuite
     public static void AssemblyInit(TestContext context)
     {
         context.WriteLine($"Pid: {Process.GetCurrentProcess().Id}");
-        context.WriteLine("Environment Variables:");
-        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
-        {
-            context.WriteLine($"  {entry.Key} = {entry.Value}");
-        }
-
         context.WriteLine(string.Empty);
     }
 

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -14,11 +14,6 @@ namespace Samples.NUnitTests
         {
             var writer = TestContext.Progress;
             writer.WriteLine($"Pid: {Process.GetCurrentProcess().Id}");
-            writer.WriteLine("Environment Variables:");
-            foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
-            {
-                writer.WriteLine($"  {entry.Key} = {entry.Value}");
-            }
             writer.WriteLine(string.Empty);
         }
 


### PR DESCRIPTION
## Summary of changes

This PR removes blocks that can leak environment variables.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
