### PR TITLE
[CI] Add commit-only fallback when resolving serverless/single-step Azure build artifacts

### DIFF
--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -29,19 +29,36 @@ artifactName="serverless-artifacts"
 
 echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
 
-# Artifacts are identified by the commit SHA, not the branch: the same SHA always produces
-# the same artifacts regardless of which ref the pipeline ran on. A branch-keyed lookup
-# breaks when the mirrored GitLab pipeline is attributed to a ref that merely *contains*
-# this commit (e.g. a feature branch rebased onto this master commit) — no Azure build
-# exists for that (branch, SHA) pair even though builds for the SHA exist on another branch.
-# So match on the commit SHA first, across all branches. A build "carries" the commit when
-# it is a PR build with pr.sourceSha == SHA, or any build with sourceVersion == SHA. Prefer
-# non-scheduled builds, but fall back to a scheduled build for the same SHA.
-allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
-buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
-  [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-  | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
-  | .[0].id // empty')
+# Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
+# builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
+# necessarily identical — so we match from most-specific to least-specific, and only broaden
+# when the precise build can't be found:
+#   1. the PR build for this branch + commit (most likely a "full" build)
+#   2. a standalone (manual/individualCI) build for this branch + commit
+#   3. as a last resort, ANY build carrying this commit on any branch. This rescues pipelines
+#      that the GitLab mirror attributed to a ref that merely *contains* the commit (e.g. a
+#      feature branch rebased onto this master commit), where no (branch, SHA) build exists.
+
+# 1. PR build for this branch + commit
+allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
+buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+
+# 2. Standalone (manual/individualCI) build for this branch + commit
+if [ -z "${buildId}" ]; then
+  echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
+  allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
+  buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
+fi
+
+# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled)
+if [ -z "${buildId}" ]; then
+  echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
+  allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
+  buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
+    [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
+    | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
+    | .[0].id // empty')
+fi
 
 if [ -z "${buildId}" ]; then
   echo "No build found carrying commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"

--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -27,15 +27,31 @@ fi
 branchName="refs/heads/$CI_COMMIT_BRANCH"
 artifactName="serverless-artifacts"
 
-echo "Looking for azure devops PR builds for branch '$branchName' for commit '$CI_COMMIT_SHA' to start"
+echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
 
-# We should _definitely_ have the build by now, so if not, there probably won't be one
-# Check for PR builds first (as more likely to be "full" builds)
-allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+# Artifacts are identified by the commit SHA, not the branch: the same SHA always produces
+# the same artifacts regardless of which ref the pipeline ran on. A branch-keyed lookup
+# breaks when the mirrored GitLab pipeline is attributed to a ref that merely *contains*
+# this commit (e.g. a feature branch rebased onto this master commit) — no Azure build
+# exists for that (branch, SHA) pair even though builds for the SHA exist on another branch.
+# So match on the commit SHA first, across all branches. A build "carries" the commit when
+# it is a PR build with pr.sourceSha == SHA, or any build with sourceVersion == SHA. Prefer
+# non-scheduled builds, but fall back to a scheduled build for the same SHA.
+allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
+buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
+  [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
+  | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
+  | .[0].id // empty')
+
+# Fallback: original branch-keyed lookup (PR builds first, then standalone branch builds).
+if [ -z "${buildId}" ]; then
+  echo "No build matched commit '$CI_COMMIT_SHA' directly; falling back to branch '$branchName' lookup..."
+  allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
+  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+fi
 
 if [ -z "${buildId}" ]; then
-  echo "No PR builds found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."  
+  echo "No PR builds found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
   allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
   buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
 fi
@@ -45,7 +61,7 @@ if [ -z "${buildId}" ]; then
   exit 1
 fi
 
-echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA' on branch '$branchName'"
+echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
 
 # Now try to download the artifacts from the build
 artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"

--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -43,21 +43,8 @@ buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
   | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
   | .[0].id // empty')
 
-# Fallback: original branch-keyed lookup (PR builds first, then standalone branch builds).
 if [ -z "${buildId}" ]; then
-  echo "No build matched commit '$CI_COMMIT_SHA' directly; falling back to branch '$branchName' lookup..."
-  allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
-fi
-
-if [ -z "${buildId}" ]; then
-  echo "No PR builds found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
-  allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
-  buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
-fi
-
-if [ -z "${buildId}" ]; then
-  echo "No build found for commit '$CI_COMMIT_SHA' on branch '$branchName' (including PRs)"
+  echo "No build found carrying commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
   exit 1
 fi
 

--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -50,13 +50,20 @@ if [ -z "${buildId}" ]; then
   buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
 fi
 
-# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled)
+# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
+# Unlike tiers 1-2 (which intentionally wait on an in-progress build for this exact branch),
+# tier 3's commit is already built elsewhere, so we prefer a completed-successful build to avoid
+# locking onto a queued/canceled/failed newer build and polling it for 40 minutes; we still fall
+# back to an in-progress build if no successful one is found.
 if [ -z "${buildId}" ]; then
   echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
   allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
   buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
     [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-    | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
+    | ( map(select(.reason != "schedule" and .result == "succeeded"))
+      + map(select(.reason == "schedule"  and .result == "succeeded"))
+      + map(select(.reason != "schedule"))
+      + map(select(.reason == "schedule")) )
     | .[0].id // empty')
 fi
 

--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -44,7 +44,7 @@ buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
   | .[0].id // empty')
 
 if [ -z "${buildId}" ]; then
-  echo "No build found carrying commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
+  echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
   exit 1
 fi
 

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -46,15 +46,31 @@ fi
 branchName="refs/heads/$CI_COMMIT_BRANCH"
 artifactName="ssi-artifacts"
 
-echo "Looking for azure devops PR builds for branch '$branchName' for commit '$CI_COMMIT_SHA' to start"
+echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
 
-# We should _definitely_ have the build by now, so if not, there probably won't be one
-# Check for PR builds first (as more likely to be "full" builds)
-allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+# Artifacts are identified by the commit SHA, not the branch: the same SHA always produces
+# the same artifacts regardless of which ref the pipeline ran on. A branch-keyed lookup
+# breaks when the mirrored GitLab pipeline is attributed to a ref that merely *contains*
+# this commit (e.g. a feature branch rebased onto this master commit) — no Azure build
+# exists for that (branch, SHA) pair even though builds for the SHA exist on another branch.
+# So match on the commit SHA first, across all branches. A build "carries" the commit when
+# it is a PR build with pr.sourceSha == SHA, or any build with sourceVersion == SHA. Prefer
+# non-scheduled builds, but fall back to a scheduled build for the same SHA.
+allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
+buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
+  [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
+  | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
+  | .[0].id // empty')
+
+# Fallback: original branch-keyed lookup (PR builds first, then standalone branch builds).
+if [ -z "${buildId}" ]; then
+  echo "No build matched commit '$CI_COMMIT_SHA' directly; falling back to branch '$branchName' lookup..."
+  allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
+  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+fi
 
 if [ -z "${buildId}" ]; then
-  echo "No PR builds found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."  
+  echo "No PR builds found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
   allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
   buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
 fi
@@ -64,7 +80,7 @@ if [ -z "${buildId}" ]; then
   exit 1
 fi
 
-echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA' on branch '$branchName'"
+echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
 
 # Now try to download the ssi artifacts from the build
 artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -48,19 +48,36 @@ artifactName="ssi-artifacts"
 
 echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
 
-# Artifacts are identified by the commit SHA, not the branch: the same SHA always produces
-# the same artifacts regardless of which ref the pipeline ran on. A branch-keyed lookup
-# breaks when the mirrored GitLab pipeline is attributed to a ref that merely *contains*
-# this commit (e.g. a feature branch rebased onto this master commit) — no Azure build
-# exists for that (branch, SHA) pair even though builds for the SHA exist on another branch.
-# So match on the commit SHA first, across all branches. A build "carries" the commit when
-# it is a PR build with pr.sourceSha == SHA, or any build with sourceVersion == SHA. Prefer
-# non-scheduled builds, but fall back to a scheduled build for the same SHA.
-allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
-buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
-  [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-  | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
-  | .[0].id // empty')
+# Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
+# builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
+# necessarily identical — and this job publishes the "real" artifacts, so we match from
+# most-specific to least-specific, and only broaden when the precise build can't be found:
+#   1. the PR build for this branch + commit (most likely a "full" build)
+#   2. a standalone (manual/individualCI) build for this branch + commit
+#   3. as a last resort, ANY build carrying this commit on any branch. This rescues pipelines
+#      that the GitLab mirror attributed to a ref that merely *contains* the commit (e.g. a
+#      feature branch rebased onto this master commit), where no (branch, SHA) build exists.
+
+# 1. PR build for this branch + commit
+allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
+buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+
+# 2. Standalone (manual/individualCI) build for this branch + commit
+if [ -z "${buildId}" ]; then
+  echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
+  allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
+  buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
+fi
+
+# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled)
+if [ -z "${buildId}" ]; then
+  echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
+  allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
+  buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
+    [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
+    | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
+    | .[0].id // empty')
+fi
 
 if [ -z "${buildId}" ]; then
   echo "No build found carrying commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -69,13 +69,20 @@ if [ -z "${buildId}" ]; then
   buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
 fi
 
-# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled)
+# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
+# Unlike tiers 1-2 (which intentionally wait on an in-progress build for this exact branch),
+# tier 3's commit is already built elsewhere, so we prefer a completed-successful build to avoid
+# locking onto a queued/canceled/failed newer build and polling it for 40 minutes; we still fall
+# back to an in-progress build if no successful one is found.
 if [ -z "${buildId}" ]; then
   echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
   allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
   buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
     [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-    | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
+    | ( map(select(.reason != "schedule" and .result == "succeeded"))
+      + map(select(.reason == "schedule"  and .result == "succeeded"))
+      + map(select(.reason != "schedule"))
+      + map(select(.reason == "schedule")) )
     | .[0].id // empty')
 fi
 

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -87,7 +87,7 @@ if [ -z "${buildId}" ]; then
 fi
 
 if [ -z "${buildId}" ]; then
-  echo "No build found carrying commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
+  echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
   exit 1
 fi
 

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -62,21 +62,8 @@ buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
   | ( map(select(.reason != "schedule")) + map(select(.reason == "schedule")) )
   | .[0].id // empty')
 
-# Fallback: original branch-keyed lookup (PR builds first, then standalone branch builds).
 if [ -z "${buildId}" ]; then
-  echo "No build matched commit '$CI_COMMIT_SHA' directly; falling back to branch '$branchName' lookup..."
-  allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
-fi
-
-if [ -z "${buildId}" ]; then
-  echo "No PR builds found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
-  allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
-  buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
-fi
-
-if [ -z "${buildId}" ]; then
-  echo "No build found for commit '$CI_COMMIT_SHA' on branch '$branchName' (including PRs)"
+  echo "No build found carrying commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

The serverless and single-step artifact download scripts (`.gitlab/download-serverless-artifacts.sh`, `.gitlab/download-single-step-artifacts.sh`) resolved the Azure DevOps build by matching **branch name + commit SHA**. This intermittently failed:

```
No build found for commit 'cf138c11...' on branch 'refs/heads/dudik/bounded-capture-filters' (including PRs)
ERROR: Job failed: command terminated with exit code 1
```

**Root cause:** `cf138c11` is a normal `master` commit whose artifacts live on the `master` Azure builds. But the GitLab pipeline ran with `CI_COMMIT_BRANCH=dudik/bounded-capture-filters` — a feature branch whose tip transiently parked on this commit during a rebase/force-push, firing a branch pipeline for a `(branch, SHA)` pair that has no Azure build. The branch-keyed lookups never checked `master`, where the artifacts actually exist → `exit 1`.

## Change

Resolve the build most-specific-first, stopping at the first hit:

1. **PR build** for this branch + commit — unchanged.
2. **Standalone (manual/individualCI) build** for this branch + commit — unchanged.
3. **New fallback:** any build carrying this commit on any branch, preferring **completed-successful, non-scheduled** builds:

```sh
buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
  [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
  | ( map(select(.reason != "schedule" and .result == "succeeded"))
    + map(select(.reason == "schedule"  and .result == "succeeded"))
    + map(select(.reason != "schedule"))
    + map(select(.reason == "schedule")) )
  | .[0].id // empty')
```

**Why most-specific-first:** Azure builds can be parameterized (e.g. debug mode), so when the branch is correct we still pick the exact `(branch, commit)` build, preserving today's behavior. Tier 3 only fires when the precise build genuinely can't be found.

**Why prefer completed-successful in tier 3:** when several runs carry the same SHA, this avoids locking onto a queued/canceled/failed build that never reaches the artifact-publish stage and polling it for 40 minutes before failing. Applied only to tier 3 — tiers 1–2 intentionally wait on an in-progress build for the exact branch. If no successful build exists, tier 3 still falls back to an in-progress one rather than failing.

## Test coverage

Validated against the live Azure DevOps API for the failing inputs (`branch=dudik/bounded-capture-filters`, `sha=cf138c11`):

- **Before:** branch-keyed searches return `0` matches → reproduces the failure.
- **After:** tier 3 resolves to build `203307`, with both `serverless-artifacts` and `ssi-artifacts` confirmed present.
- Tier-3 jq selection unit-checked: succeeded non-scheduled preferred over failed/scheduled; unknown SHA → empty; falls back to failed/in-progress when that's all that carries the SHA.
- A bogus SHA returns empty at every tier (correct `exit 1`); `bash -n` passes on both scripts.

## Notes

- "No Azure build exists for the SHA at all" still (correctly) exits 1.
- The benchmark `check-azure-pipeline` jobs do an equivalent lookup but delegate to an external `wait-for-pipeline.sh` (out of scope here); flagged separately for those owners.
