### PR TITLE
[Debugger] Resolve instanceof types at runtime

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -1,0 +1,580 @@
+// <copyright file="InstanceOfHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog.Events;
+
+namespace Datadog.Trace.Debugger.Expressions;
+
+internal static class InstanceOfHelper
+{
+    private const int MaxCachedTypes = 512;
+    private const int MaxTrackedMisses = 512;
+    private const int MaxResolutionRetries = 3;
+
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(InstanceOfHelper));
+    private static readonly string[] EmptyAssemblyNames = [];
+    private static readonly ConcurrentDictionary<string, ResolutionState> ResolutionStates = new(StringComparer.Ordinal);
+    private static readonly Dictionary<string, Type> BclTypeAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "Array", typeof(Array) },
+        { typeof(Array).FullName, typeof(Array) },
+        { "bool", typeof(bool) },
+        { typeof(bool).FullName, typeof(bool) },
+        { "byte", typeof(byte) },
+        { typeof(byte).FullName, typeof(byte) },
+        { "sbyte", typeof(sbyte) },
+        { typeof(sbyte).FullName, typeof(sbyte) },
+        { "char", typeof(char) },
+        { typeof(char).FullName, typeof(char) },
+        { "DateTime", typeof(DateTime) },
+        { typeof(DateTime).FullName, typeof(DateTime) },
+        { "DateTimeOffset", typeof(DateTimeOffset) },
+        { typeof(DateTimeOffset).FullName, typeof(DateTimeOffset) },
+        { "decimal", typeof(decimal) },
+        { typeof(decimal).FullName, typeof(decimal) },
+        { "Delegate", typeof(Delegate) },
+        { typeof(Delegate).FullName, typeof(Delegate) },
+        { "double", typeof(double) },
+        { typeof(double).FullName, typeof(double) },
+        { "Enum", typeof(Enum) },
+        { typeof(Enum).FullName, typeof(Enum) },
+        { "Exception", typeof(Exception) },
+        { typeof(Exception).FullName, typeof(Exception) },
+        { "float", typeof(float) },
+        { typeof(float).FullName, typeof(float) },
+        { "Guid", typeof(Guid) },
+        { typeof(Guid).FullName, typeof(Guid) },
+        { "int", typeof(int) },
+        { typeof(int).FullName, typeof(int) },
+        { "IntPtr", typeof(IntPtr) },
+        { typeof(IntPtr).FullName, typeof(IntPtr) },
+        { "uint", typeof(uint) },
+        { typeof(uint).FullName, typeof(uint) },
+        { "long", typeof(long) },
+        { typeof(long).FullName, typeof(long) },
+        { "nint", typeof(IntPtr) },
+        { "nuint", typeof(UIntPtr) },
+        { "ulong", typeof(ulong) },
+        { typeof(ulong).FullName, typeof(ulong) },
+        { "object", typeof(object) },
+        { typeof(object).FullName, typeof(object) },
+        { "short", typeof(short) },
+        { typeof(short).FullName, typeof(short) },
+        { "ushort", typeof(ushort) },
+        { typeof(ushort).FullName, typeof(ushort) },
+        { "string", typeof(string) },
+        { typeof(string).FullName, typeof(string) },
+        { "TimeSpan", typeof(TimeSpan) },
+        { typeof(TimeSpan).FullName, typeof(TimeSpan) },
+        { "Type", typeof(Type) },
+        { typeof(Type).FullName, typeof(Type) },
+        { "UIntPtr", typeof(UIntPtr) },
+        { typeof(UIntPtr).FullName, typeof(UIntPtr) },
+        { "ValueType", typeof(ValueType) },
+        { typeof(ValueType).FullName, typeof(ValueType) },
+    };
+
+    private static Func<Assembly[]> _getAssemblies = AppDomain.CurrentDomain.GetAssemblies;
+    private static int _assemblyLoadGeneration;
+
+    static InstanceOfHelper()
+    {
+        AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
+    }
+
+    internal static bool IsInstanceOf(object value, string typeName)
+    {
+        var type = ResolveType(typeName);
+        var result = type.IsInstanceOfType(value);
+        LogSuspiciousMismatch(type, value?.GetType(), typeName, result);
+        return result;
+    }
+
+    internal static bool IsInstanceOf<TValue>(TValue value, string typeName)
+    {
+        var type = ResolveType(typeName);
+        var valueType = typeof(TValue);
+        bool result;
+        if (valueType.IsValueType)
+        {
+            if (Nullable.GetUnderlyingType(valueType) is not null)
+            {
+                result = type.IsInstanceOfType(value);
+                LogSuspiciousMismatch(type, value?.GetType(), typeName, result);
+                return result;
+            }
+
+            result = type.IsAssignableFrom(valueType);
+            LogSuspiciousMismatch(type, valueType, typeName, result);
+            return result;
+        }
+
+        result = type.IsInstanceOfType(value);
+        LogSuspiciousMismatch(type, value?.GetType(), typeName, result);
+        return result;
+    }
+
+    internal static Type ResolveType(string typeName)
+    {
+        if (string.IsNullOrEmpty(typeName))
+        {
+            ThrowInvalidTypeName();
+        }
+
+        if (BclTypeAliases.TryGetValue(typeName, out var aliasType))
+        {
+            return aliasType;
+        }
+
+        var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
+        if (ResolutionStates.TryGetValue(typeName, out var cachedResolution))
+        {
+            if (cachedResolution.Type is not null || cachedResolution.IsAmbiguous)
+            {
+                return GetResolvedTypeOrThrow(typeName, cachedResolution, noNewAssemblies: false);
+            }
+
+            if (cachedResolution.ScannedGeneration == observedGeneration)
+            {
+                return GetResolvedTypeOrThrow(typeName, cachedResolution, noNewAssemblies: true);
+            }
+        }
+
+        var typeNameInfo = ParseTypeName(typeName);
+        var resolvedType = typeNameInfo.IsAssemblyQualified
+                               ? null
+                               : Type.GetType(typeName, throwOnError: false, ignoreCase: true);
+        if (resolvedType is not null)
+        {
+            AddResolvedType(typeName, resolvedType, Volatile.Read(ref _assemblyLoadGeneration));
+            return resolvedType;
+        }
+
+        if (!IsFullyQualifiedTypeName(typeNameInfo.SearchTypeName))
+        {
+            ThrowFullyQualifiedNameRequired(typeName);
+        }
+
+        return ResolveLoadedType(typeName, typeNameInfo);
+    }
+
+    private static Type ResolveLoadedType(string typeName, TypeNameInfo typeNameInfo)
+    {
+        ResolutionState lastResolution = null;
+        for (var i = 0; i < MaxResolutionRetries; i++)
+        {
+            var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
+            ResolutionStates.TryGetValue(typeName, out var currentResolution);
+            if (currentResolution is not null)
+            {
+                if (currentResolution.Type is not null || currentResolution.IsAmbiguous)
+                {
+                    return GetResolvedTypeOrThrow(typeName, currentResolution, noNewAssemblies: false);
+                }
+
+                if (currentResolution.ScannedGeneration == observedGeneration)
+                {
+                    return GetResolvedTypeOrThrow(typeName, currentResolution, noNewAssemblies: true);
+                }
+            }
+
+            var assemblies = Volatile.Read(ref _getAssemblies)();
+            var scanResult = ScanAssemblies(typeName, typeNameInfo, assemblies, currentResolution?.ScannedAssemblies, currentResolution?.Type);
+            lastResolution = AddScannedResolution(typeName, currentResolution, scanResult, observedGeneration);
+            if (lastResolution.IsAmbiguous)
+            {
+                ThrowAmbiguousType(typeName);
+            }
+
+            if (lastResolution.Type is not null)
+            {
+                return lastResolution.Type;
+            }
+
+            if (observedGeneration != Volatile.Read(ref _assemblyLoadGeneration))
+            {
+                continue;
+            }
+
+            ThrowUnknownType(typeName);
+        }
+
+        if (lastResolution is not null)
+        {
+            return GetResolvedTypeOrThrow(typeName, lastResolution, noNewAssemblies: false);
+        }
+
+        ThrowUnknownType(typeName);
+        return null;
+    }
+
+    private static ScanResult ScanAssemblies(string typeName, TypeNameInfo typeNameInfo, Assembly[] assemblies, string[] alreadyScannedAssemblies, Type currentResolvedType)
+    {
+        Type resolvedType = null;
+        var isAmbiguous = false;
+        var scannedAssemblies = new List<string>();
+        var alreadyScannedAssemblySet = alreadyScannedAssemblies is null || alreadyScannedAssemblies.Length == 0
+                                            ? null
+                                            : new HashSet<string>(alreadyScannedAssemblies, StringComparer.Ordinal);
+
+        for (var i = 0; i < assemblies.Length; i++)
+        {
+            var assembly = assemblies[i];
+            var assemblyIdentity = GetAssemblyIdentity(assembly);
+            if (alreadyScannedAssemblySet?.Contains(assemblyIdentity) == true)
+            {
+                continue;
+            }
+
+            scannedAssemblies.Add(assemblyIdentity);
+            var matchedType = TryResolveFromAssembly(typeName, typeNameInfo, assembly);
+            if (matchedType is null)
+            {
+                continue;
+            }
+
+            var previousMatch = currentResolvedType ?? resolvedType;
+            if (previousMatch is not null && previousMatch != matchedType)
+            {
+                isAmbiguous = true;
+                if (Log.IsEnabled(LogEventLevel.Debug))
+                {
+                    Log.Debug("Ambiguous case-insensitive type lookup for '{TypeName}'. Matched '{FirstType}' and '{SecondType}'. Use exact type casing or an assembly-qualified name.", typeName, previousMatch.AssemblyQualifiedName, matchedType.AssemblyQualifiedName);
+                }
+
+                continue;
+            }
+
+            resolvedType = matchedType;
+        }
+
+        return new ScanResult(resolvedType, isAmbiguous, scannedAssemblies.Count == 0 ? EmptyAssemblyNames : scannedAssemblies.ToArray());
+    }
+
+    private static Type TryResolveFromAssembly(string typeName, TypeNameInfo typeNameInfo, Assembly assembly)
+    {
+        if (typeNameInfo.IsAssemblyQualified && !IsMatchingAssembly(assembly, typeNameInfo.AssemblyName))
+        {
+            return null;
+        }
+
+        Type type;
+        try
+        {
+            type = assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
+        }
+        catch (AmbiguousMatchException ex)
+        {
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug(ex, "Ambiguous case-insensitive type lookup for '{TypeName}' in assembly '{AssemblyName}'. Use exact type casing or an assembly-qualified name.", typeName, assembly.FullName);
+            }
+
+            throw new InstanceOfEvaluationException($"Multiple types matching '{typeName}' were found using case-insensitive lookup. Use exact type casing or an assembly-qualified name.", ex);
+        }
+        catch (Exception ex)
+        {
+            throw new InstanceOfEvaluationException($"Failed to inspect assembly '{assembly.FullName}' while resolving type '{typeName}': {ex.Message}", ex);
+        }
+
+        return type;
+    }
+
+    private static bool IsFullyQualifiedTypeName(string typeName)
+    {
+        return typeName.IndexOf('.') >= 0;
+    }
+
+    private static void LogSuspiciousMismatch(Type resolvedType, Type valueType, string requestedTypeName, bool result)
+    {
+        if (result ||
+            valueType is null ||
+            !Log.IsEnabled(LogEventLevel.Debug))
+        {
+            return;
+        }
+
+        var typeNameInfo = ParseTypeName(requestedTypeName);
+        if (typeNameInfo.IsAssemblyQualified ||
+            !string.Equals(valueType.FullName, typeNameInfo.SearchTypeName, StringComparison.OrdinalIgnoreCase) ||
+            resolvedType == valueType)
+        {
+            return;
+        }
+
+        Log.Debug("Instanceof lookup for '{TypeName}' resolved to '{ResolvedType}', but the runtime value type is '{ValueType}'. The namespace-qualified name may exist in multiple assemblies; use an assembly-qualified name to disambiguate.", requestedTypeName, resolvedType.AssemblyQualifiedName, valueType.AssemblyQualifiedName);
+    }
+
+    private static TypeNameInfo ParseTypeName(string typeName)
+    {
+        var assemblySeparatorIndex = GetAssemblySeparatorIndex(typeName);
+        if (assemblySeparatorIndex < 0)
+        {
+            return new TypeNameInfo(typeName, null);
+        }
+
+        return new TypeNameInfo(
+            typeName.Substring(0, assemblySeparatorIndex).Trim(),
+            typeName.Substring(assemblySeparatorIndex + 1).Trim());
+    }
+
+    private static int GetAssemblySeparatorIndex(string typeName)
+    {
+        var bracketDepth = 0;
+        for (var i = 0; i < typeName.Length; i++)
+        {
+            switch (typeName[i])
+            {
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    bracketDepth--;
+                    break;
+                case ',' when bracketDepth == 0:
+                    return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsMatchingAssembly(Assembly assembly, string assemblyName)
+    {
+        if (string.IsNullOrEmpty(assemblyName))
+        {
+            return false;
+        }
+
+        return string.Equals(assembly.GetName().Name, assemblyName, StringComparison.Ordinal) ||
+               string.Equals(assembly.FullName, assemblyName, StringComparison.Ordinal);
+    }
+
+    private static string GetAssemblyIdentity(Assembly assembly)
+    {
+        return string.Concat(assembly.FullName, "|", RuntimeHelpers.GetHashCode(assembly).ToString());
+    }
+
+    private static Type GetResolvedTypeOrThrow(string typeName, ResolutionState resolution, bool noNewAssemblies)
+    {
+        if (resolution.IsAmbiguous)
+        {
+            ThrowAmbiguousType(typeName);
+        }
+
+        if (resolution.Type is not null)
+        {
+            return resolution.Type;
+        }
+
+        if (noNewAssemblies)
+        {
+            ThrowUnknownTypeNoNewAssemblies(typeName);
+        }
+
+        ThrowUnknownType(typeName);
+        return null;
+    }
+
+    private static void AddResolvedType(string typeName, Type type, int scannedGeneration)
+    {
+        ClearCacheIfNeeded();
+        var newResolution = new ResolutionState(type, isAmbiguous: false, scannedGeneration, EmptyAssemblyNames);
+        ResolutionStates.AddOrUpdate(
+            typeName,
+            newResolution,
+            (_, currentResolution) => MergeResolvedType(typeName, currentResolution, type, scannedGeneration));
+    }
+
+    private static ResolutionState AddScannedResolution(string typeName, ResolutionState currentResolution, ScanResult scanResult, int scannedGeneration)
+    {
+        ClearCacheIfNeeded();
+        var newResolution = currentResolution is null
+                                ? new ResolutionState(scanResult.Type, scanResult.IsAmbiguous, scannedGeneration, scanResult.ScannedAssemblies)
+                                : MergeScannedResolution(typeName, currentResolution, scanResult, scannedGeneration);
+
+        return ResolutionStates.AddOrUpdate(
+            typeName,
+            newResolution,
+            (_, currentResolution) => MergeScannedResolution(typeName, currentResolution, scanResult, scannedGeneration));
+    }
+
+    private static ResolutionState MergeResolvedType(string typeName, ResolutionState currentResolution, Type resolvedType, int scannedGeneration)
+    {
+        var isAmbiguous = currentResolution.IsAmbiguous;
+        var type = currentResolution.Type ?? resolvedType;
+        if (currentResolution.Type is not null && currentResolution.Type != resolvedType)
+        {
+            isAmbiguous = true;
+        }
+
+        return new ResolutionState(type, isAmbiguous, Math.Max(currentResolution.ScannedGeneration, scannedGeneration), currentResolution.ScannedAssemblies);
+    }
+
+    private static ResolutionState MergeScannedResolution(string typeName, ResolutionState currentResolution, ScanResult scanResult, int scannedGeneration)
+    {
+        var isAmbiguous = currentResolution.IsAmbiguous || scanResult.IsAmbiguous;
+        var type = currentResolution.Type ?? scanResult.Type;
+        if (currentResolution.Type is not null &&
+            scanResult.Type is not null &&
+            currentResolution.Type != scanResult.Type)
+        {
+            isAmbiguous = true;
+        }
+
+        return new ResolutionState(type, isAmbiguous, Math.Max(currentResolution.ScannedGeneration, scannedGeneration), MergeScannedAssemblies(currentResolution.ScannedAssemblies, scanResult.ScannedAssemblies));
+    }
+
+    private static string[] MergeScannedAssemblies(string[] currentAssemblies, string[] scannedAssemblies)
+    {
+        if (currentAssemblies is null || currentAssemblies.Length == 0)
+        {
+            return scannedAssemblies is null || scannedAssemblies.Length == 0 ? EmptyAssemblyNames : scannedAssemblies;
+        }
+
+        if (scannedAssemblies is null || scannedAssemblies.Length == 0)
+        {
+            return currentAssemblies;
+        }
+
+        var merged = new HashSet<string>(currentAssemblies, StringComparer.Ordinal);
+        for (var i = 0; i < scannedAssemblies.Length; i++)
+        {
+            merged.Add(scannedAssemblies[i]);
+        }
+
+        var result = new string[merged.Count];
+        merged.CopyTo(result);
+        return result;
+    }
+
+    private static void ClearCacheIfNeeded()
+    {
+        if (ResolutionStates.Count >= MaxCachedTypes ||
+            ResolutionStates.Count >= MaxTrackedMisses)
+        {
+            ResolutionStates.Clear();
+        }
+    }
+
+    private static void OnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
+    {
+        Interlocked.Increment(ref _assemblyLoadGeneration);
+    }
+
+    internal static void ResetForTests()
+    {
+        ResolutionStates.Clear();
+        Volatile.Write(ref _getAssemblies, AppDomain.CurrentDomain.GetAssemblies);
+        Interlocked.Exchange(ref _assemblyLoadGeneration, 0);
+    }
+
+    internal static void SetAssemblyProviderForTests(Func<Assembly[]> getAssemblies)
+    {
+        ResolutionStates.Clear();
+        Volatile.Write(ref _getAssemblies, getAssemblies ?? AppDomain.CurrentDomain.GetAssemblies);
+        Interlocked.Exchange(ref _assemblyLoadGeneration, 0);
+    }
+
+    internal static void IncrementAssemblyLoadGenerationForTests()
+    {
+        Interlocked.Increment(ref _assemblyLoadGeneration);
+    }
+
+    private static void ThrowInvalidTypeName()
+    {
+        throw new InstanceOfEvaluationException("failed to parse type name");
+    }
+
+    private static void ThrowFullyQualifiedNameRequired(string typeName)
+    {
+        throw new InstanceOfEvaluationException($"'{typeName}' must be a fully qualified type name");
+    }
+
+    private static void ThrowUnknownType(string typeName)
+    {
+        throw new InstanceOfEvaluationException($"'{typeName}' is unknown type");
+    }
+
+    private static void ThrowUnknownTypeNoNewAssemblies(string typeName)
+    {
+        throw new InstanceOfEvaluationException($"'{typeName}' is unknown type. No new assemblies were loaded since the last lookup.");
+    }
+
+    private static void ThrowAmbiguousType(string typeName)
+    {
+        throw new InstanceOfEvaluationException($"Multiple types matching '{typeName}' were found using case-insensitive lookup. Use exact type casing or an assembly-qualified name.");
+    }
+
+    private readonly struct ScanResult
+    {
+        internal ScanResult(Type type, bool isAmbiguous, string[] scannedAssemblies)
+        {
+            Type = type;
+            IsAmbiguous = isAmbiguous;
+            ScannedAssemblies = scannedAssemblies;
+        }
+
+        internal Type Type { get; }
+
+        internal bool IsAmbiguous { get; }
+
+        internal string[] ScannedAssemblies { get; }
+    }
+
+    private readonly struct TypeNameInfo
+    {
+        internal TypeNameInfo(string searchTypeName, string assemblyName)
+        {
+            SearchTypeName = searchTypeName;
+            AssemblyName = assemblyName;
+        }
+
+        internal string SearchTypeName { get; }
+
+        internal string AssemblyName { get; }
+
+        internal bool IsAssemblyQualified => AssemblyName is not null;
+    }
+
+    private sealed class ResolutionState
+    {
+        internal ResolutionState(Type type, bool isAmbiguous, int scannedGeneration, string[] scannedAssemblies)
+        {
+            Type = type;
+            IsAmbiguous = isAmbiguous;
+            ScannedGeneration = scannedGeneration;
+            ScannedAssemblies = scannedAssemblies ?? EmptyAssemblyNames;
+        }
+
+        internal Type Type { get; }
+
+        internal bool IsAmbiguous { get; }
+
+        internal int ScannedGeneration { get; }
+
+        internal string[] ScannedAssemblies { get; }
+    }
+
+    internal sealed class InstanceOfEvaluationException : Exception
+    {
+        internal InstanceOfEvaluationException(string message)
+            : base(message)
+        {
+        }
+
+        internal InstanceOfEvaluationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -3,9 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -23,65 +26,7 @@ internal static class InstanceOfHelper
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(InstanceOfHelper));
     private static readonly string[] EmptyAssemblyNames = [];
     private static readonly ConcurrentDictionary<string, ResolutionState> ResolutionStates = new(StringComparer.Ordinal);
-    private static readonly Dictionary<string, Type> BclTypeAliases = new(StringComparer.OrdinalIgnoreCase)
-    {
-        { "Array", typeof(Array) },
-        { typeof(Array).FullName, typeof(Array) },
-        { "bool", typeof(bool) },
-        { typeof(bool).FullName, typeof(bool) },
-        { "byte", typeof(byte) },
-        { typeof(byte).FullName, typeof(byte) },
-        { "sbyte", typeof(sbyte) },
-        { typeof(sbyte).FullName, typeof(sbyte) },
-        { "char", typeof(char) },
-        { typeof(char).FullName, typeof(char) },
-        { "DateTime", typeof(DateTime) },
-        { typeof(DateTime).FullName, typeof(DateTime) },
-        { "DateTimeOffset", typeof(DateTimeOffset) },
-        { typeof(DateTimeOffset).FullName, typeof(DateTimeOffset) },
-        { "decimal", typeof(decimal) },
-        { typeof(decimal).FullName, typeof(decimal) },
-        { "Delegate", typeof(Delegate) },
-        { typeof(Delegate).FullName, typeof(Delegate) },
-        { "double", typeof(double) },
-        { typeof(double).FullName, typeof(double) },
-        { "Enum", typeof(Enum) },
-        { typeof(Enum).FullName, typeof(Enum) },
-        { "Exception", typeof(Exception) },
-        { typeof(Exception).FullName, typeof(Exception) },
-        { "float", typeof(float) },
-        { typeof(float).FullName, typeof(float) },
-        { "Guid", typeof(Guid) },
-        { typeof(Guid).FullName, typeof(Guid) },
-        { "int", typeof(int) },
-        { typeof(int).FullName, typeof(int) },
-        { "IntPtr", typeof(IntPtr) },
-        { typeof(IntPtr).FullName, typeof(IntPtr) },
-        { "uint", typeof(uint) },
-        { typeof(uint).FullName, typeof(uint) },
-        { "long", typeof(long) },
-        { typeof(long).FullName, typeof(long) },
-        { "nint", typeof(IntPtr) },
-        { "nuint", typeof(UIntPtr) },
-        { "ulong", typeof(ulong) },
-        { typeof(ulong).FullName, typeof(ulong) },
-        { "object", typeof(object) },
-        { typeof(object).FullName, typeof(object) },
-        { "short", typeof(short) },
-        { typeof(short).FullName, typeof(short) },
-        { "ushort", typeof(ushort) },
-        { typeof(ushort).FullName, typeof(ushort) },
-        { "string", typeof(string) },
-        { typeof(string).FullName, typeof(string) },
-        { "TimeSpan", typeof(TimeSpan) },
-        { typeof(TimeSpan).FullName, typeof(TimeSpan) },
-        { "Type", typeof(Type) },
-        { typeof(Type).FullName, typeof(Type) },
-        { "UIntPtr", typeof(UIntPtr) },
-        { typeof(UIntPtr).FullName, typeof(UIntPtr) },
-        { "ValueType", typeof(ValueType) },
-        { typeof(ValueType).FullName, typeof(ValueType) },
-    };
+    private static readonly Dictionary<string, Type> BclTypeAliases = CreateBclTypeAliases();
 
     private static Func<Assembly[]> _getAssemblies = AppDomain.CurrentDomain.GetAssemblies;
     private static int _assemblyLoadGeneration;
@@ -91,7 +36,7 @@ internal static class InstanceOfHelper
         AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
     }
 
-    internal static bool IsInstanceOf(object value, string typeName)
+    internal static bool IsInstanceOf(object? value, string typeName)
     {
         var type = ResolveType(typeName);
         var result = type.IsInstanceOfType(value);
@@ -138,12 +83,21 @@ internal static class InstanceOfHelper
         var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
         if (ResolutionStates.TryGetValue(typeName, out var cachedResolution))
         {
-            if (cachedResolution.Type is not null || cachedResolution.IsAmbiguous)
+            if (cachedResolution.IsAmbiguous)
             {
                 return GetResolvedTypeOrThrow(typeName, cachedResolution, noNewAssemblies: false);
             }
 
-            if (cachedResolution.ScannedGeneration == observedGeneration)
+            if (cachedResolution.TryGetType(out var cachedType))
+            {
+                return cachedType;
+            }
+
+            if (cachedResolution.HasResolvedType)
+            {
+                TryRemoveResolution(typeName, cachedResolution);
+            }
+            else if (cachedResolution.ScannedGeneration == observedGeneration)
             {
                 return GetResolvedTypeOrThrow(typeName, cachedResolution, noNewAssemblies: true);
             }
@@ -169,35 +123,45 @@ internal static class InstanceOfHelper
 
     private static Type ResolveLoadedType(string typeName, TypeNameInfo typeNameInfo)
     {
-        ResolutionState lastResolution = null;
+        ResolutionState? lastResolution = null;
         for (var i = 0; i < MaxResolutionRetries; i++)
         {
             var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
             ResolutionStates.TryGetValue(typeName, out var currentResolution);
             if (currentResolution is not null)
             {
-                if (currentResolution.Type is not null || currentResolution.IsAmbiguous)
+                if (currentResolution.IsAmbiguous)
                 {
                     return GetResolvedTypeOrThrow(typeName, currentResolution, noNewAssemblies: false);
                 }
 
-                if (currentResolution.ScannedGeneration == observedGeneration)
+                if (currentResolution.TryGetType(out var currentType))
+                {
+                    return currentType;
+                }
+
+                if (currentResolution.HasResolvedType)
+                {
+                    TryRemoveResolution(typeName, currentResolution);
+                    currentResolution = null;
+                }
+                else if (currentResolution.ScannedGeneration == observedGeneration)
                 {
                     return GetResolvedTypeOrThrow(typeName, currentResolution, noNewAssemblies: true);
                 }
             }
 
             var assemblies = Volatile.Read(ref _getAssemblies)();
-            var scanResult = ScanAssemblies(typeName, typeNameInfo, assemblies, currentResolution?.ScannedAssemblies, currentResolution?.Type);
+            var scanResult = ScanAssemblies(typeName, typeNameInfo, assemblies, currentResolution?.ScannedAssemblies, currentResolution?.GetTypeOrDefault());
             lastResolution = AddScannedResolution(typeName, currentResolution, scanResult, observedGeneration);
             if (lastResolution.IsAmbiguous)
             {
                 ThrowAmbiguousType(typeName);
             }
 
-            if (lastResolution.Type is not null)
+            if (lastResolution.TryGetType(out var lastType))
             {
-                return lastResolution.Type;
+                return lastType;
             }
 
             if (observedGeneration != Volatile.Read(ref _assemblyLoadGeneration))
@@ -213,13 +177,12 @@ internal static class InstanceOfHelper
             return GetResolvedTypeOrThrow(typeName, lastResolution, noNewAssemblies: false);
         }
 
-        ThrowUnknownType(typeName);
-        return null;
+        throw UnknownType(typeName);
     }
 
-    private static ScanResult ScanAssemblies(string typeName, TypeNameInfo typeNameInfo, Assembly[] assemblies, string[] alreadyScannedAssemblies, Type currentResolvedType)
+    private static ScanResult ScanAssemblies(string typeName, TypeNameInfo typeNameInfo, Assembly[] assemblies, string[]? alreadyScannedAssemblies, Type? currentResolvedType)
     {
-        Type resolvedType = null;
+        Type? resolvedType = null;
         var isAmbiguous = false;
         var scannedAssemblies = new List<string>();
         var alreadyScannedAssemblySet = alreadyScannedAssemblies is null || alreadyScannedAssemblies.Length == 0
@@ -260,14 +223,14 @@ internal static class InstanceOfHelper
         return new ScanResult(resolvedType, isAmbiguous, scannedAssemblies.Count == 0 ? EmptyAssemblyNames : scannedAssemblies.ToArray());
     }
 
-    private static Type TryResolveFromAssembly(string typeName, TypeNameInfo typeNameInfo, Assembly assembly)
+    private static Type? TryResolveFromAssembly(string typeName, TypeNameInfo typeNameInfo, Assembly assembly)
     {
-        if (typeNameInfo.IsAssemblyQualified && !IsMatchingAssembly(assembly, typeNameInfo.AssemblyName))
+        if (typeNameInfo.IsAssemblyQualified && !IsMatchingAssembly(assembly, typeNameInfo.AssemblyName!))
         {
             return null;
         }
 
-        Type type;
+        Type? type;
         try
         {
             type = assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
@@ -294,7 +257,7 @@ internal static class InstanceOfHelper
         return typeName.IndexOf('.') >= 0;
     }
 
-    private static void LogSuspiciousMismatch(Type resolvedType, Type valueType, string requestedTypeName, bool result)
+    private static void LogSuspiciousMismatch(Type resolvedType, Type? valueType, string requestedTypeName, bool result)
     {
         if (result ||
             valueType is null ||
@@ -364,6 +327,52 @@ internal static class InstanceOfHelper
         return string.Concat(assembly.FullName, "|", RuntimeHelpers.GetHashCode(assembly).ToString());
     }
 
+    private static Dictionary<string, Type> CreateBclTypeAliases()
+    {
+        var aliases = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+        AddBclType(aliases, typeof(Array), "Array");
+        AddBclType(aliases, typeof(bool), "bool");
+        AddBclType(aliases, typeof(byte), "byte");
+        AddBclType(aliases, typeof(sbyte), "sbyte");
+        AddBclType(aliases, typeof(char), "char");
+        AddBclType(aliases, typeof(DateTime), "DateTime");
+        AddBclType(aliases, typeof(DateTimeOffset), "DateTimeOffset");
+        AddBclType(aliases, typeof(decimal), "decimal");
+        AddBclType(aliases, typeof(Delegate), "Delegate");
+        AddBclType(aliases, typeof(double), "double");
+        AddBclType(aliases, typeof(Enum), "Enum");
+        AddBclType(aliases, typeof(Exception), "Exception");
+        AddBclType(aliases, typeof(float), "float");
+        AddBclType(aliases, typeof(Guid), "Guid");
+        AddBclType(aliases, typeof(int), "int");
+        AddBclType(aliases, typeof(IntPtr), "IntPtr", "nint");
+        AddBclType(aliases, typeof(uint), "uint");
+        AddBclType(aliases, typeof(long), "long");
+        AddBclType(aliases, typeof(UIntPtr), "UIntPtr", "nuint");
+        AddBclType(aliases, typeof(ulong), "ulong");
+        AddBclType(aliases, typeof(object), "object");
+        AddBclType(aliases, typeof(short), "short");
+        AddBclType(aliases, typeof(ushort), "ushort");
+        AddBclType(aliases, typeof(string), "string");
+        AddBclType(aliases, typeof(TimeSpan), "TimeSpan");
+        AddBclType(aliases, typeof(Type), "Type");
+        AddBclType(aliases, typeof(ValueType), "ValueType");
+        return aliases;
+    }
+
+    private static void AddBclType(Dictionary<string, Type> aliases, Type type, params string[] names)
+    {
+        if (type.FullName is { } fullName)
+        {
+            aliases[fullName] = type;
+        }
+
+        for (var i = 0; i < names.Length; i++)
+        {
+            aliases[names[i]] = type;
+        }
+    }
+
     private static Type GetResolvedTypeOrThrow(string typeName, ResolutionState resolution, bool noNewAssemblies)
     {
         if (resolution.IsAmbiguous)
@@ -371,9 +380,9 @@ internal static class InstanceOfHelper
             ThrowAmbiguousType(typeName);
         }
 
-        if (resolution.Type is not null)
+        if (resolution.TryGetType(out var type))
         {
-            return resolution.Type;
+            return type;
         }
 
         if (noNewAssemblies)
@@ -381,8 +390,7 @@ internal static class InstanceOfHelper
             ThrowUnknownTypeNoNewAssemblies(typeName);
         }
 
-        ThrowUnknownType(typeName);
-        return null;
+        throw UnknownType(typeName);
     }
 
     private static void AddResolvedType(string typeName, Type type, int scannedGeneration)
@@ -395,7 +403,7 @@ internal static class InstanceOfHelper
             (_, currentResolution) => MergeResolvedType(typeName, currentResolution, type, scannedGeneration));
     }
 
-    private static ResolutionState AddScannedResolution(string typeName, ResolutionState currentResolution, ScanResult scanResult, int scannedGeneration)
+    private static ResolutionState AddScannedResolution(string typeName, ResolutionState? currentResolution, ScanResult scanResult, int scannedGeneration)
     {
         ClearCacheIfNeeded();
         var newResolution = currentResolution is null
@@ -411,8 +419,14 @@ internal static class InstanceOfHelper
     private static ResolutionState MergeResolvedType(string typeName, ResolutionState currentResolution, Type resolvedType, int scannedGeneration)
     {
         var isAmbiguous = currentResolution.IsAmbiguous;
-        var type = currentResolution.Type ?? resolvedType;
-        if (currentResolution.Type is not null && currentResolution.Type != resolvedType)
+        var hasCurrentType = currentResolution.TryGetType(out var currentType);
+        if (currentResolution.HasResolvedType && !hasCurrentType)
+        {
+            return new ResolutionState(resolvedType, isAmbiguous, scannedGeneration, EmptyAssemblyNames);
+        }
+
+        var type = currentType ?? resolvedType;
+        if (currentType is not null && currentType != resolvedType)
         {
             isAmbiguous = true;
         }
@@ -423,15 +437,26 @@ internal static class InstanceOfHelper
     private static ResolutionState MergeScannedResolution(string typeName, ResolutionState currentResolution, ScanResult scanResult, int scannedGeneration)
     {
         var isAmbiguous = currentResolution.IsAmbiguous || scanResult.IsAmbiguous;
-        var type = currentResolution.Type ?? scanResult.Type;
-        if (currentResolution.Type is not null &&
+        var hasCurrentType = currentResolution.TryGetType(out var currentType);
+        if (currentResolution.HasResolvedType && !hasCurrentType)
+        {
+            return new ResolutionState(scanResult.Type, scanResult.IsAmbiguous, scannedGeneration, scanResult.ScannedAssemblies);
+        }
+
+        var type = currentType ?? scanResult.Type;
+        if (currentType is not null &&
             scanResult.Type is not null &&
-            currentResolution.Type != scanResult.Type)
+            currentType != scanResult.Type)
         {
             isAmbiguous = true;
         }
 
         return new ResolutionState(type, isAmbiguous, Math.Max(currentResolution.ScannedGeneration, scannedGeneration), MergeScannedAssemblies(currentResolution.ScannedAssemblies, scanResult.ScannedAssemblies));
+    }
+
+    private static void TryRemoveResolution(string typeName, ResolutionState resolution)
+    {
+        ((ICollection<KeyValuePair<string, ResolutionState>>)ResolutionStates).Remove(new KeyValuePair<string, ResolutionState>(typeName, resolution));
     }
 
     private static string[] MergeScannedAssemblies(string[] currentAssemblies, string[] scannedAssemblies)
@@ -466,7 +491,7 @@ internal static class InstanceOfHelper
         }
     }
 
-    private static void OnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
+    private static void OnAssemblyLoad(object? sender, AssemblyLoadEventArgs args)
     {
         Interlocked.Increment(ref _assemblyLoadGeneration);
     }
@@ -502,7 +527,12 @@ internal static class InstanceOfHelper
 
     private static void ThrowUnknownType(string typeName)
     {
-        throw new InstanceOfEvaluationException($"'{typeName}' is unknown type");
+        throw UnknownType(typeName);
+    }
+
+    private static InstanceOfEvaluationException UnknownType(string typeName)
+    {
+        return new InstanceOfEvaluationException($"'{typeName}' is unknown type");
     }
 
     private static void ThrowUnknownTypeNoNewAssemblies(string typeName)
@@ -517,14 +547,14 @@ internal static class InstanceOfHelper
 
     private readonly struct ScanResult
     {
-        internal ScanResult(Type type, bool isAmbiguous, string[] scannedAssemblies)
+        internal ScanResult(Type? type, bool isAmbiguous, string[] scannedAssemblies)
         {
             Type = type;
             IsAmbiguous = isAmbiguous;
             ScannedAssemblies = scannedAssemblies;
         }
 
-        internal Type Type { get; }
+        internal Type? Type { get; }
 
         internal bool IsAmbiguous { get; }
 
@@ -533,7 +563,7 @@ internal static class InstanceOfHelper
 
     private readonly struct TypeNameInfo
     {
-        internal TypeNameInfo(string searchTypeName, string assemblyName)
+        internal TypeNameInfo(string searchTypeName, string? assemblyName)
         {
             SearchTypeName = searchTypeName;
             AssemblyName = assemblyName;
@@ -541,28 +571,46 @@ internal static class InstanceOfHelper
 
         internal string SearchTypeName { get; }
 
-        internal string AssemblyName { get; }
+        internal string? AssemblyName { get; }
 
         internal bool IsAssemblyQualified => AssemblyName is not null;
     }
 
     private sealed class ResolutionState
     {
-        internal ResolutionState(Type type, bool isAmbiguous, int scannedGeneration, string[] scannedAssemblies)
+        private readonly WeakReference<Type>? _type;
+
+        internal ResolutionState(Type? type, bool isAmbiguous, int scannedGeneration, string[] scannedAssemblies)
         {
-            Type = type;
+            _type = type is null ? null : new WeakReference<Type>(type);
             IsAmbiguous = isAmbiguous;
             ScannedGeneration = scannedGeneration;
             ScannedAssemblies = scannedAssemblies ?? EmptyAssemblyNames;
         }
 
-        internal Type Type { get; }
+        internal bool HasResolvedType => _type is not null;
 
         internal bool IsAmbiguous { get; }
 
         internal int ScannedGeneration { get; }
 
         internal string[] ScannedAssemblies { get; }
+
+        internal Type? GetTypeOrDefault()
+        {
+            return TryGetType(out var type) ? type : null;
+        }
+
+        internal bool TryGetType([NotNullWhen(true)] out Type? type)
+        {
+            if (_type is null)
+            {
+                type = null;
+                return false;
+            }
+
+            return _type.TryGetTarget(out type);
+        }
     }
 
     internal sealed class InstanceOfEvaluationException : Exception

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -81,26 +81,10 @@ internal static class InstanceOfHelper
         }
 
         var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
-        if (ResolutionStates.TryGetValue(typeName, out var cachedResolution))
+        ResolutionStates.TryGetValue(typeName, out var cachedResolution);
+        if (TryGetCachedResolution(typeName, observedGeneration, ref cachedResolution, out var cachedType))
         {
-            if (cachedResolution.IsAmbiguous)
-            {
-                return GetResolvedTypeOrThrow(typeName, cachedResolution, noNewAssemblies: false);
-            }
-
-            if (cachedResolution.TryGetType(out var cachedType))
-            {
-                return cachedType;
-            }
-
-            if (cachedResolution.HasResolvedType)
-            {
-                TryRemoveResolution(typeName, cachedResolution);
-            }
-            else if (cachedResolution.ScannedGeneration == observedGeneration)
-            {
-                return GetResolvedTypeOrThrow(typeName, cachedResolution, noNewAssemblies: true);
-            }
+            return cachedType;
         }
 
         var typeNameInfo = ParseTypeName(typeName);
@@ -135,27 +119,9 @@ internal static class InstanceOfHelper
         {
             var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
             ResolutionStates.TryGetValue(typeName, out var currentResolution);
-            if (currentResolution is not null)
+            if (TryGetCachedResolution(typeName, observedGeneration, ref currentResolution, out var cachedType))
             {
-                if (currentResolution.IsAmbiguous)
-                {
-                    return GetResolvedTypeOrThrow(typeName, currentResolution, noNewAssemblies: false);
-                }
-
-                if (currentResolution.TryGetType(out var currentType))
-                {
-                    return currentType;
-                }
-
-                if (currentResolution.HasResolvedType)
-                {
-                    TryRemoveResolution(typeName, currentResolution);
-                    currentResolution = null;
-                }
-                else if (currentResolution.ScannedGeneration == observedGeneration)
-                {
-                    return GetResolvedTypeOrThrow(typeName, currentResolution, noNewAssemblies: true);
-                }
+                return cachedType;
             }
 
             var assemblies = Volatile.Read(ref _getAssemblies)();
@@ -506,6 +472,37 @@ internal static class InstanceOfHelper
         }
     }
 
+    private static bool TryGetCachedResolution(string typeName, int observedGeneration, ref ResolutionState? resolution, [NotNullWhen(true)] out Type? type)
+    {
+        type = null;
+        if (resolution is null)
+        {
+            return false;
+        }
+
+        if (resolution.IsAmbiguous)
+        {
+            ThrowAmbiguousType(typeName);
+        }
+
+        if (resolution.TryGetType(out type))
+        {
+            return true;
+        }
+
+        if (resolution.HasResolvedType)
+        {
+            RemoveResolutionIfCurrent(typeName, resolution);
+            resolution = null;
+        }
+        else if (resolution.ScannedGeneration == observedGeneration)
+        {
+            ThrowUnknownTypeNoNewAssemblies(typeName);
+        }
+
+        return false;
+    }
+
     private static Type GetResolvedTypeOrThrow(string typeName, ResolutionState resolution, bool noNewAssemblies)
     {
         if (resolution.IsAmbiguous)
@@ -615,7 +612,7 @@ internal static class InstanceOfHelper
         return new ResolutionState(type, isAmbiguous, Math.Max(currentResolution.ScannedGeneration, scannedGeneration), MergeScannedAssemblies(currentResolution.ScannedAssemblies, scanResult.ScannedAssemblies));
     }
 
-    private static void TryRemoveResolution(string typeName, ResolutionState resolution)
+    private static void RemoveResolutionIfCurrent(string typeName, ResolutionState resolution)
     {
         ((ICollection<KeyValuePair<string, ResolutionState>>)ResolutionStates).Remove(new KeyValuePair<string, ResolutionState>(typeName, resolution));
     }
@@ -632,11 +629,17 @@ internal static class InstanceOfHelper
             return currentAssemblies;
         }
 
+        var maxCapacity = currentAssemblies.Length + scannedAssemblies.Length;
+        if (maxCapacity > LinearAssemblyIdentityScanThreshold)
+        {
+            return MergeScannedAssembliesWithSet(currentAssemblies, scannedAssemblies, maxCapacity);
+        }
+
         AssemblyIdentity[]? merged = null;
         var count = 0;
         for (var i = 0; i < currentAssemblies.Length; i++)
         {
-            AddAssemblyIdentity(ref merged, ref count, currentAssemblies.Length + scannedAssemblies.Length, currentAssemblies[i]);
+            AddAssemblyIdentity(ref merged, ref count, maxCapacity, currentAssemblies[i]);
         }
 
         for (var i = 0; i < scannedAssemblies.Length; i++)
@@ -644,7 +647,27 @@ internal static class InstanceOfHelper
             var scannedAssembly = scannedAssemblies[i];
             if (!ContainsAssemblyIdentity(merged!, count, scannedAssembly))
             {
-                AddAssemblyIdentity(ref merged, ref count, currentAssemblies.Length + scannedAssemblies.Length, scannedAssembly);
+                AddAssemblyIdentity(ref merged, ref count, maxCapacity, scannedAssembly);
+            }
+        }
+
+        return ToExactAssemblyIdentityArray(merged, count);
+    }
+
+    private static AssemblyIdentity[] MergeScannedAssembliesWithSet(AssemblyIdentity[] currentAssemblies, AssemblyIdentity[] scannedAssemblies, int maxCapacity)
+    {
+        var mergedSet = new HashSet<AssemblyIdentity>(currentAssemblies);
+        var merged = new AssemblyIdentity[maxCapacity];
+        Array.Copy(currentAssemblies, merged, currentAssemblies.Length);
+        var count = currentAssemblies.Length;
+
+        for (var i = 0; i < scannedAssemblies.Length; i++)
+        {
+            var scannedAssembly = scannedAssemblies[i];
+            if (mergedSet.Add(scannedAssembly))
+            {
+                merged[count] = scannedAssembly;
+                count++;
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -76,11 +76,6 @@ internal static class InstanceOfHelper
             ThrowInvalidTypeName();
         }
 
-        if (BclTypeAliases.TryGetValue(typeName, out var aliasType))
-        {
-            return aliasType;
-        }
-
         var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
         if (ResolutionStates.TryGetValue(typeName, out var cachedResolution))
         {
@@ -104,17 +99,25 @@ internal static class InstanceOfHelper
             }
         }
 
+        if (TryResolveBclTypeAlias(typeName, out var aliasType))
+        {
+            return aliasType;
+        }
+
         var typeNameInfo = ParseTypeName(typeName);
         if (typeNameInfo.IsAssemblyQualified)
         {
             return AssemblyQualifiedTypeResolver.Resolve(typeName, typeNameInfo);
         }
 
-        var resolvedType = Type.GetType(typeName, throwOnError: false, ignoreCase: true);
-        if (resolvedType is not null)
+        if (MayResolveWithoutAssemblyScan(typeNameInfo.SearchTypeName))
         {
-            AddResolvedType(typeName, resolvedType, Volatile.Read(ref _assemblyLoadGeneration));
-            return resolvedType;
+            var resolvedType = Type.GetType(typeName, throwOnError: false, ignoreCase: true);
+            if (resolvedType is not null)
+            {
+                AddResolvedType(typeName, resolvedType, Volatile.Read(ref _assemblyLoadGeneration));
+                return resolvedType;
+            }
         }
 
         if (!IsFullyQualifiedTypeName(typeNameInfo.SearchTypeName))
@@ -287,6 +290,11 @@ internal static class InstanceOfHelper
 
     private static TypeNameInfo ParseTypeName(string typeName)
     {
+        if (typeName.IndexOf(',') < 0)
+        {
+            return new TypeNameInfo(typeName, null);
+        }
+
         var assemblySeparatorIndex = GetAssemblySeparatorIndex(typeName);
         if (assemblySeparatorIndex < 0)
         {
@@ -423,6 +431,28 @@ internal static class InstanceOfHelper
         return aliases;
     }
 
+    private static bool TryResolveBclTypeAlias(string typeName, [NotNullWhen(true)] out Type? type)
+    {
+        type = null;
+        if (!MayBeBclTypeAlias(typeName))
+        {
+            return false;
+        }
+
+        return BclTypeAliases.TryGetValue(typeName, out type);
+    }
+
+    private static bool MayBeBclTypeAlias(string typeName)
+    {
+        return typeName.IndexOf('.') < 0 ||
+               typeName.StartsWith("System.", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool MayResolveWithoutAssemblyScan(string typeName)
+    {
+        return typeName.StartsWith("System.", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static void AddBclType(Dictionary<string, Type> aliases, Type type, params string[] names)
     {
         if (type.FullName is { } fullName)
@@ -460,10 +490,24 @@ internal static class InstanceOfHelper
     {
         ClearCacheIfNeeded();
         var newResolution = new ResolutionState(type, isAmbiguous: false, scannedGeneration, EmptyAssemblyIdentities);
-        ResolutionStates.AddOrUpdate(
-            typeName,
-            newResolution,
-            (_, currentResolution) => MergeResolvedType(typeName, currentResolution, type, scannedGeneration));
+        while (true)
+        {
+            if (!ResolutionStates.TryGetValue(typeName, out var currentResolution))
+            {
+                if (ResolutionStates.TryAdd(typeName, newResolution))
+                {
+                    return;
+                }
+
+                continue;
+            }
+
+            var mergedResolution = MergeResolvedType(typeName, currentResolution, type, scannedGeneration);
+            if (ResolutionStates.TryUpdate(typeName, mergedResolution, currentResolution))
+            {
+                return;
+            }
+        }
     }
 
     private static ResolutionState AddScannedResolution(string typeName, ResolutionState? currentResolution, ScanResult scanResult, int scannedGeneration)
@@ -473,10 +517,24 @@ internal static class InstanceOfHelper
                                 ? new ResolutionState(scanResult.Type, scanResult.IsAmbiguous, scannedGeneration, scanResult.ScannedAssemblies)
                                 : MergeScannedResolution(typeName, currentResolution, scanResult, scannedGeneration);
 
-        return ResolutionStates.AddOrUpdate(
-            typeName,
-            newResolution,
-            (_, currentResolution) => MergeScannedResolution(typeName, currentResolution, scanResult, scannedGeneration));
+        while (true)
+        {
+            if (!ResolutionStates.TryGetValue(typeName, out var latestResolution))
+            {
+                if (ResolutionStates.TryAdd(typeName, newResolution))
+                {
+                    return newResolution;
+                }
+
+                continue;
+            }
+
+            var mergedResolution = MergeScannedResolution(typeName, latestResolution, scanResult, scannedGeneration);
+            if (ResolutionStates.TryUpdate(typeName, mergedResolution, latestResolution))
+            {
+                return mergedResolution;
+            }
+        }
     }
 
     private static ResolutionState MergeResolvedType(string typeName, ResolutionState currentResolution, Type resolvedType, int scannedGeneration)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -861,7 +861,7 @@ internal static class InstanceOfHelper
             }
 
             var requestedName = assemblyName.Name;
-            if (requestedName is null)
+            if (requestedName is null || AssemblyNameHasMetadata(requestedFullName))
             {
                 return null;
             }
@@ -876,6 +876,11 @@ internal static class InstanceOfHelper
             }
 
             return null;
+        }
+
+        private static bool AssemblyNameHasMetadata(string assemblyName)
+        {
+            return assemblyName.IndexOf(',') >= 0;
         }
 
         private static bool IsKnownFrameworkAssemblyName(string assemblyName)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -22,9 +22,10 @@ internal static class InstanceOfHelper
     private const int MaxCachedTypes = 512;
     private const int MaxTrackedMisses = 512;
     private const int MaxResolutionRetries = 3;
+    private const int LinearAssemblyIdentityScanThreshold = 8;
 
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(InstanceOfHelper));
-    private static readonly string[] EmptyAssemblyNames = [];
+    private static readonly AssemblyIdentity[] EmptyAssemblyIdentities = [];
     private static readonly ConcurrentDictionary<string, ResolutionState> ResolutionStates = new(StringComparer.Ordinal);
     private static readonly Dictionary<string, Type> BclTypeAliases = CreateBclTypeAliases();
 
@@ -104,11 +105,12 @@ internal static class InstanceOfHelper
         }
 
         var typeNameInfo = ParseTypeName(typeName);
-        var resolvedType = TryResolveKnownFrameworkType(typeName, typeNameInfo, out var knownFrameworkType)
-                               ? knownFrameworkType
-                               : typeNameInfo.IsAssemblyQualified
-                                   ? null
-                                   : Type.GetType(typeName, throwOnError: false, ignoreCase: true);
+        if (typeNameInfo.IsAssemblyQualified)
+        {
+            return AssemblyQualifiedTypeResolver.Resolve(typeName, typeNameInfo);
+        }
+
+        var resolvedType = Type.GetType(typeName, throwOnError: false, ignoreCase: true);
         if (resolvedType is not null)
         {
             AddResolvedType(typeName, resolvedType, Volatile.Read(ref _assemblyLoadGeneration));
@@ -182,25 +184,28 @@ internal static class InstanceOfHelper
         throw UnknownType(typeName);
     }
 
-    private static ScanResult ScanAssemblies(string typeName, TypeNameInfo typeNameInfo, Assembly[] assemblies, string[]? alreadyScannedAssemblies, Type? currentResolvedType)
+    private static ScanResult ScanAssemblies(string typeName, TypeNameInfo typeNameInfo, Assembly[] assemblies, AssemblyIdentity[]? alreadyScannedAssemblies, Type? currentResolvedType)
     {
         Type? resolvedType = null;
         var isAmbiguous = false;
-        var scannedAssemblies = new List<string>();
+        AssemblyIdentity[]? scannedAssemblies = null;
+        var scannedAssemblyCount = 0;
         var alreadyScannedAssemblySet = alreadyScannedAssemblies is null || alreadyScannedAssemblies.Length == 0
                                             ? null
-                                            : new HashSet<string>(alreadyScannedAssemblies, StringComparer.Ordinal);
+                                            : alreadyScannedAssemblies.Length > LinearAssemblyIdentityScanThreshold
+                                                ? new HashSet<AssemblyIdentity>(alreadyScannedAssemblies)
+                                                : null;
 
         for (var i = 0; i < assemblies.Length; i++)
         {
             var assembly = assemblies[i];
-            var assemblyIdentity = GetAssemblyIdentity(assembly);
-            if (alreadyScannedAssemblySet?.Contains(assemblyIdentity) == true)
+            var assemblyIdentity = new AssemblyIdentity(assembly);
+            if (ContainsAssemblyIdentity(alreadyScannedAssemblies, alreadyScannedAssemblySet, assemblyIdentity))
             {
                 continue;
             }
 
-            scannedAssemblies.Add(assemblyIdentity);
+            AddAssemblyIdentity(ref scannedAssemblies, ref scannedAssemblyCount, assemblies.Length, assemblyIdentity);
             var matchedType = TryResolveFromAssembly(typeName, typeNameInfo, assembly);
             if (matchedType is null)
             {
@@ -222,12 +227,13 @@ internal static class InstanceOfHelper
             resolvedType = matchedType;
         }
 
-        return new ScanResult(resolvedType, isAmbiguous, scannedAssemblies.Count == 0 ? EmptyAssemblyNames : scannedAssemblies.ToArray());
+        return new ScanResult(resolvedType, isAmbiguous, ToExactAssemblyIdentityArray(scannedAssemblies, scannedAssemblyCount));
     }
 
     private static Type? TryResolveFromAssembly(string typeName, TypeNameInfo typeNameInfo, Assembly assembly)
     {
-        if (typeNameInfo.IsAssemblyQualified && !IsMatchingAssembly(assembly, typeNameInfo.AssemblyName!))
+        if (typeNameInfo.IsAssemblyQualified &&
+            !AssemblyQualifiedTypeResolver.IsMatchingAssembly(assembly, typeNameInfo.AssemblyName!))
         {
             return null;
         }
@@ -257,30 +263,6 @@ internal static class InstanceOfHelper
     private static bool IsFullyQualifiedTypeName(string typeName)
     {
         return typeName.IndexOf('.') >= 0;
-    }
-
-    private static bool TryResolveKnownFrameworkType(string typeName, TypeNameInfo typeNameInfo, [NotNullWhen(true)] out Type? type)
-    {
-        type = null;
-        if (!typeNameInfo.IsAssemblyQualified ||
-            !IsKnownFrameworkAssemblyName(typeNameInfo.AssemblyName!))
-        {
-            return false;
-        }
-
-        if (BclTypeAliases.TryGetValue(typeNameInfo.SearchTypeName, out type))
-        {
-            return true;
-        }
-
-        type = typeof(object).Assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
-        if (type is not null)
-        {
-            return true;
-        }
-
-        type = Type.GetType(typeName, ResolveLoadedAssembly, typeResolver: null, throwOnError: false, ignoreCase: true);
-        return type is not null;
     }
 
     private static void LogSuspiciousMismatch(Type resolvedType, Type? valueType, string requestedTypeName, bool result)
@@ -337,73 +319,75 @@ internal static class InstanceOfHelper
         return -1;
     }
 
-    private static bool IsMatchingAssembly(Assembly assembly, string assemblyName)
+    private static bool ContainsAssemblyIdentity(AssemblyIdentity[]? identities, HashSet<AssemblyIdentity>? identitySet, AssemblyIdentity identity)
     {
-        if (string.IsNullOrEmpty(assemblyName))
+        if (identitySet is not null)
+        {
+            return identitySet.Contains(identity);
+        }
+
+        if (identities is null)
         {
             return false;
         }
 
-        return string.Equals(assembly.GetName().Name, assemblyName, StringComparison.Ordinal) ||
-               string.Equals(assembly.FullName, assemblyName, StringComparison.Ordinal);
-    }
-
-    private static Assembly? ResolveLoadedAssembly(AssemblyName assemblyName)
-    {
-        var requestedFullName = assemblyName.FullName;
-        var assemblies = Volatile.Read(ref _getAssemblies)();
-
-        for (var i = 0; i < assemblies.Length; i++)
+        for (var i = 0; i < identities.Length; i++)
         {
-            var assembly = assemblies[i];
-            if (string.Equals(assembly.FullName, requestedFullName, StringComparison.Ordinal))
+            if (identities[i].Equals(identity))
             {
-                return assembly;
+                return true;
             }
         }
 
-        var requestedName = assemblyName.Name;
-        if (requestedName is null)
-        {
-            return null;
-        }
+        return false;
+    }
 
-        for (var i = 0; i < assemblies.Length; i++)
+    private static bool ContainsAssemblyIdentity(AssemblyIdentity[] identities, int count, AssemblyIdentity identity)
+    {
+        for (var i = 0; i < count; i++)
         {
-            var assembly = assemblies[i];
-            if (string.Equals(assembly.GetName().Name, requestedName, StringComparison.Ordinal))
+            if (identities[i].Equals(identity))
             {
-                return assembly;
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 
-    private static bool IsKnownFrameworkAssemblyName(string assemblyName)
+    private static void AddAssemblyIdentity(ref AssemblyIdentity[]? identities, ref int count, int maxCapacity, AssemblyIdentity identity)
     {
-        var simpleNameLength = assemblyName.IndexOf(',');
-        if (simpleNameLength < 0)
+        if (identities is null)
         {
-            simpleNameLength = assemblyName.Length;
+            identities = new AssemblyIdentity[Math.Min(maxCapacity, LinearAssemblyIdentityScanThreshold)];
+        }
+        else if (count == identities.Length)
+        {
+            var newLength = Math.Min(maxCapacity, identities.Length * 2);
+            var resizedIdentities = new AssemblyIdentity[newLength];
+            Array.Copy(identities, resizedIdentities, identities.Length);
+            identities = resizedIdentities;
         }
 
-        return AssemblyNameEquals(assemblyName, simpleNameLength, "mscorlib") ||
-               AssemblyNameEquals(assemblyName, simpleNameLength, "netstandard") ||
-               AssemblyNameEquals(assemblyName, simpleNameLength, "System") ||
-               AssemblyNameEquals(assemblyName, simpleNameLength, "System.Private.CoreLib") ||
-               AssemblyNameEquals(assemblyName, simpleNameLength, "System.Runtime");
+        identities[count] = identity;
+        count++;
     }
 
-    private static bool AssemblyNameEquals(string assemblyName, int simpleNameLength, string expectedName)
+    private static AssemblyIdentity[] ToExactAssemblyIdentityArray(AssemblyIdentity[]? identities, int count)
     {
-        return simpleNameLength == expectedName.Length &&
-               string.Compare(assemblyName, 0, expectedName, 0, expectedName.Length, StringComparison.Ordinal) == 0;
-    }
+        if (identities is null || count == 0)
+        {
+            return EmptyAssemblyIdentities;
+        }
 
-    private static string GetAssemblyIdentity(Assembly assembly)
-    {
-        return string.Concat(assembly.FullName, "|", RuntimeHelpers.GetHashCode(assembly).ToString());
+        if (count == identities.Length)
+        {
+            return identities;
+        }
+
+        var result = new AssemblyIdentity[count];
+        Array.Copy(identities, result, count);
+        return result;
     }
 
     private static Dictionary<string, Type> CreateBclTypeAliases()
@@ -475,7 +459,7 @@ internal static class InstanceOfHelper
     private static void AddResolvedType(string typeName, Type type, int scannedGeneration)
     {
         ClearCacheIfNeeded();
-        var newResolution = new ResolutionState(type, isAmbiguous: false, scannedGeneration, EmptyAssemblyNames);
+        var newResolution = new ResolutionState(type, isAmbiguous: false, scannedGeneration, EmptyAssemblyIdentities);
         ResolutionStates.AddOrUpdate(
             typeName,
             newResolution,
@@ -501,7 +485,7 @@ internal static class InstanceOfHelper
         var hasCurrentType = currentResolution.TryGetType(out var currentType);
         if (currentResolution.HasResolvedType && !hasCurrentType)
         {
-            return new ResolutionState(resolvedType, isAmbiguous, scannedGeneration, EmptyAssemblyNames);
+            return new ResolutionState(resolvedType, isAmbiguous, scannedGeneration, EmptyAssemblyIdentities);
         }
 
         var type = currentType ?? resolvedType;
@@ -538,11 +522,11 @@ internal static class InstanceOfHelper
         ((ICollection<KeyValuePair<string, ResolutionState>>)ResolutionStates).Remove(new KeyValuePair<string, ResolutionState>(typeName, resolution));
     }
 
-    private static string[] MergeScannedAssemblies(string[] currentAssemblies, string[] scannedAssemblies)
+    private static AssemblyIdentity[] MergeScannedAssemblies(AssemblyIdentity[] currentAssemblies, AssemblyIdentity[] scannedAssemblies)
     {
         if (currentAssemblies is null || currentAssemblies.Length == 0)
         {
-            return scannedAssemblies is null || scannedAssemblies.Length == 0 ? EmptyAssemblyNames : scannedAssemblies;
+            return scannedAssemblies is null || scannedAssemblies.Length == 0 ? EmptyAssemblyIdentities : scannedAssemblies;
         }
 
         if (scannedAssemblies is null || scannedAssemblies.Length == 0)
@@ -550,15 +534,23 @@ internal static class InstanceOfHelper
             return currentAssemblies;
         }
 
-        var merged = new HashSet<string>(currentAssemblies, StringComparer.Ordinal);
-        for (var i = 0; i < scannedAssemblies.Length; i++)
+        AssemblyIdentity[]? merged = null;
+        var count = 0;
+        for (var i = 0; i < currentAssemblies.Length; i++)
         {
-            merged.Add(scannedAssemblies[i]);
+            AddAssemblyIdentity(ref merged, ref count, currentAssemblies.Length + scannedAssemblies.Length, currentAssemblies[i]);
         }
 
-        var result = new string[merged.Count];
-        merged.CopyTo(result);
-        return result;
+        for (var i = 0; i < scannedAssemblies.Length; i++)
+        {
+            var scannedAssembly = scannedAssemblies[i];
+            if (!ContainsAssemblyIdentity(merged!, count, scannedAssembly))
+            {
+                AddAssemblyIdentity(ref merged, ref count, currentAssemblies.Length + scannedAssemblies.Length, scannedAssembly);
+            }
+        }
+
+        return ToExactAssemblyIdentityArray(merged, count);
     }
 
     private static void ClearCacheIfNeeded()
@@ -626,7 +618,7 @@ internal static class InstanceOfHelper
 
     private readonly struct ScanResult
     {
-        internal ScanResult(Type? type, bool isAmbiguous, string[] scannedAssemblies)
+        internal ScanResult(Type? type, bool isAmbiguous, AssemblyIdentity[] scannedAssemblies)
         {
             Type = type;
             IsAmbiguous = isAmbiguous;
@@ -637,7 +629,35 @@ internal static class InstanceOfHelper
 
         internal bool IsAmbiguous { get; }
 
-        internal string[] ScannedAssemblies { get; }
+        internal AssemblyIdentity[] ScannedAssemblies { get; }
+    }
+
+    private readonly struct AssemblyIdentity : IEquatable<AssemblyIdentity>
+    {
+        private readonly string? _fullName;
+        private readonly int _runtimeHashCode;
+
+        internal AssemblyIdentity(Assembly assembly)
+        {
+            _fullName = assembly.FullName;
+            _runtimeHashCode = RuntimeHelpers.GetHashCode(assembly);
+        }
+
+        public bool Equals(AssemblyIdentity other)
+        {
+            return _runtimeHashCode == other._runtimeHashCode &&
+                   string.Equals(_fullName, other._fullName, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is AssemblyIdentity other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return _runtimeHashCode;
+        }
     }
 
     private readonly struct TypeNameInfo
@@ -655,16 +675,140 @@ internal static class InstanceOfHelper
         internal bool IsAssemblyQualified => AssemblyName is not null;
     }
 
+    private sealed class AssemblyQualifiedTypeResolver
+    {
+        internal static Type Resolve(string typeName, TypeNameInfo typeNameInfo)
+        {
+            if (TryResolveKnownFrameworkType(typeName, typeNameInfo, out var frameworkType))
+            {
+                AddResolvedType(typeName, frameworkType, Volatile.Read(ref _assemblyLoadGeneration));
+                return frameworkType;
+            }
+
+            if (!IsFullyQualifiedTypeName(typeNameInfo.SearchTypeName))
+            {
+                ThrowFullyQualifiedNameRequired(typeName);
+            }
+
+            return ResolveLoadedType(typeName, typeNameInfo);
+        }
+
+        internal static bool IsMatchingAssembly(Assembly assembly, string assemblyName)
+        {
+            if (string.IsNullOrEmpty(assemblyName))
+            {
+                return false;
+            }
+
+            var fullName = assembly.FullName;
+            return fullName is not null &&
+                   (string.Equals(fullName, assemblyName, StringComparison.Ordinal) ||
+                    AssemblySimpleNameEquals(fullName, assemblyName));
+        }
+
+        private static bool TryResolveKnownFrameworkType(string typeName, TypeNameInfo typeNameInfo, [NotNullWhen(true)] out Type? type)
+        {
+            type = null;
+            if (!IsKnownFrameworkAssemblyName(typeNameInfo.AssemblyName!))
+            {
+                return false;
+            }
+
+            if (BclTypeAliases.TryGetValue(typeNameInfo.SearchTypeName, out type))
+            {
+                return true;
+            }
+
+            type = typeof(object).Assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
+            if (type is not null)
+            {
+                return true;
+            }
+
+            type = Type.GetType(typeName, ResolveLoadedAssembly, typeResolver: null, throwOnError: false, ignoreCase: true);
+            return type is not null;
+        }
+
+        private static Assembly? ResolveLoadedAssembly(AssemblyName assemblyName)
+        {
+            var requestedFullName = assemblyName.FullName;
+            var assemblies = Volatile.Read(ref _getAssemblies)();
+
+            for (var i = 0; i < assemblies.Length; i++)
+            {
+                var assembly = assemblies[i];
+                if (string.Equals(assembly.FullName, requestedFullName, StringComparison.Ordinal))
+                {
+                    return assembly;
+                }
+            }
+
+            var requestedName = assemblyName.Name;
+            if (requestedName is null)
+            {
+                return null;
+            }
+
+            for (var i = 0; i < assemblies.Length; i++)
+            {
+                var assembly = assemblies[i];
+                if (AssemblySimpleNameEquals(assembly.FullName, requestedName))
+                {
+                    return assembly;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool IsKnownFrameworkAssemblyName(string assemblyName)
+        {
+            var simpleNameLength = assemblyName.IndexOf(',');
+            if (simpleNameLength < 0)
+            {
+                simpleNameLength = assemblyName.Length;
+            }
+
+            return AssemblyNameEquals(assemblyName, simpleNameLength, "mscorlib") ||
+                   AssemblyNameEquals(assemblyName, simpleNameLength, "netstandard") ||
+                   AssemblyNameEquals(assemblyName, simpleNameLength, "System") ||
+                   AssemblyNameEquals(assemblyName, simpleNameLength, "System.Private.CoreLib") ||
+                   AssemblyNameEquals(assemblyName, simpleNameLength, "System.Runtime");
+        }
+
+        private static bool AssemblyNameEquals(string assemblyName, int simpleNameLength, string expectedName)
+        {
+            return simpleNameLength == expectedName.Length &&
+                   string.Compare(assemblyName, 0, expectedName, 0, expectedName.Length, StringComparison.Ordinal) == 0;
+        }
+
+        private static bool AssemblySimpleNameEquals(string? assemblyFullName, string expectedName)
+        {
+            if (assemblyFullName is null)
+            {
+                return false;
+            }
+
+            var simpleNameLength = assemblyFullName.IndexOf(',');
+            if (simpleNameLength < 0)
+            {
+                simpleNameLength = assemblyFullName.Length;
+            }
+
+            return AssemblyNameEquals(assemblyFullName, simpleNameLength, expectedName);
+        }
+    }
+
     private sealed class ResolutionState
     {
         private readonly WeakReference<Type>? _type;
 
-        internal ResolutionState(Type? type, bool isAmbiguous, int scannedGeneration, string[] scannedAssemblies)
+        internal ResolutionState(Type? type, bool isAmbiguous, int scannedGeneration, AssemblyIdentity[] scannedAssemblies)
         {
             _type = type is null ? null : new WeakReference<Type>(type);
             IsAmbiguous = isAmbiguous;
             ScannedGeneration = scannedGeneration;
-            ScannedAssemblies = scannedAssemblies ?? EmptyAssemblyNames;
+            ScannedAssemblies = scannedAssemblies ?? EmptyAssemblyIdentities;
         }
 
         internal bool HasResolvedType => _type is not null;
@@ -673,7 +817,7 @@ internal static class InstanceOfHelper
 
         internal int ScannedGeneration { get; }
 
-        internal string[] ScannedAssemblies { get; }
+        internal AssemblyIdentity[] ScannedAssemblies { get; }
 
         internal Type? GetTypeOrDefault()
         {

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -246,7 +246,7 @@ internal static class InstanceOfHelper
 
     private static bool IsAssemblyInspectionException(Exception exception)
     {
-        return exception is TypeLoadException or FileNotFoundException or FileLoadException or BadImageFormatException or ReflectionTypeLoadException;
+        return exception is TypeLoadException or FileNotFoundException or BadImageFormatException;
     }
 
     private static Type? ResolveConstructedGenericFromLoadedAssemblies(string searchTypeName, Assembly assembly)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -20,7 +20,6 @@ namespace Datadog.Trace.Debugger.Expressions;
 internal static class InstanceOfHelper
 {
     private const int MaxCachedTypes = 512;
-    private const int MaxTrackedMisses = 512;
     private const int MaxResolutionRetries = 3;
     private const int LinearAssemblyIdentityScanThreshold = 8;
 
@@ -76,6 +75,11 @@ internal static class InstanceOfHelper
             ThrowInvalidTypeName();
         }
 
+        if (TryResolveBclTypeAlias(typeName, out var aliasType))
+        {
+            return aliasType;
+        }
+
         var observedGeneration = Volatile.Read(ref _assemblyLoadGeneration);
         if (ResolutionStates.TryGetValue(typeName, out var cachedResolution))
         {
@@ -97,11 +101,6 @@ internal static class InstanceOfHelper
             {
                 return GetResolvedTypeOrThrow(typeName, cachedResolution, noNewAssemblies: true);
             }
-        }
-
-        if (TryResolveBclTypeAlias(typeName, out var aliasType))
-        {
-            return aliasType;
         }
 
         var typeNameInfo = ParseTypeName(typeName);
@@ -613,8 +612,7 @@ internal static class InstanceOfHelper
 
     private static void ClearCacheIfNeeded()
     {
-        if (ResolutionStates.Count >= MaxCachedTypes ||
-            ResolutionStates.Count >= MaxTrackedMisses)
+        if (ResolutionStates.Count >= MaxCachedTypes)
         {
             ResolutionStates.Clear();
         }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -96,7 +96,7 @@ internal static class InstanceOfHelper
         if (MayResolveWithoutAssemblyScan(typeNameInfo.SearchTypeName) &&
             !typeNameInfo.MayContainAssemblyQualifiedGenericArguments)
         {
-            var resolvedType = Type.GetType(typeName, throwOnError: false, ignoreCase: true);
+            var resolvedType = Type.GetType(typeName, throwOnError: false, ignoreCase: false);
             if (resolvedType is not null)
             {
                 AddResolvedType(typeName, resolvedType, Volatile.Read(ref _assemblyLoadGeneration));
@@ -125,7 +125,10 @@ internal static class InstanceOfHelper
             }
 
             var assemblies = Volatile.Read(ref _getAssemblies)();
-            var scanResult = ScanAssemblies(typeName, typeNameInfo, assemblies, currentResolution?.ScannedAssemblies, currentResolution?.GetTypeOrDefault());
+            var alreadyScannedAssemblies = typeNameInfo.MayContainAssemblyQualifiedGenericArguments
+                                               ? null
+                                               : currentResolution?.ScannedAssemblies;
+            var scanResult = ScanAssemblies(typeName, typeNameInfo, assemblies, alreadyScannedAssemblies, currentResolution?.GetTypeOrDefault());
             lastResolution = AddScannedResolution(typeName, currentResolution, scanResult, observedGeneration);
             if (lastResolution.IsAmbiguous)
             {
@@ -187,7 +190,7 @@ internal static class InstanceOfHelper
                 isAmbiguous = true;
                 if (Log.IsEnabled(LogEventLevel.Debug))
                 {
-                    Log.Debug("Ambiguous case-insensitive type lookup for '{TypeName}'. Matched '{FirstType}' and '{SecondType}'. Use exact type casing or an assembly-qualified name.", typeName, previousMatch.AssemblyQualifiedName, matchedType.AssemblyQualifiedName);
+                    Log.Debug("Ambiguous type lookup for '{TypeName}'. Matched '{FirstType}' and '{SecondType}'. Use an assembly-qualified name.", typeName, previousMatch.AssemblyQualifiedName, matchedType.AssemblyQualifiedName);
                 }
 
                 continue;
@@ -210,34 +213,21 @@ internal static class InstanceOfHelper
         try
         {
             var searchTypeName = typeNameInfo.SearchTypeName;
-            Type? type;
             if (!typeNameInfo.MayContainAssemblyQualifiedGenericArguments)
             {
-                type = assembly.GetType(searchTypeName, throwOnError: false, ignoreCase: false);
-                if (type is not null)
-                {
-                    return type;
-                }
-
-                return assembly.GetType(searchTypeName, throwOnError: false, ignoreCase: true);
+                return assembly.GetType(searchTypeName, throwOnError: false, ignoreCase: false);
             }
 
-            type = ResolveConstructedGenericFromLoadedAssemblies(searchTypeName, assembly, ignoreCase: false);
-            if (type is not null)
-            {
-                return type;
-            }
-
-            return ResolveConstructedGenericFromLoadedAssemblies(searchTypeName, assembly, ignoreCase: true);
+            return ResolveConstructedGenericFromLoadedAssemblies(searchTypeName, assembly);
         }
         catch (AmbiguousMatchException ex)
         {
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug(ex, "Ambiguous case-insensitive type lookup for '{TypeName}' in assembly '{AssemblyName}'. Use exact type casing or an assembly-qualified name.", typeName, assembly.FullName);
+                Log.Debug(ex, "Ambiguous type lookup for '{TypeName}' in assembly '{AssemblyName}'. Use an assembly-qualified name.", typeName, assembly.FullName);
             }
 
-            throw new InstanceOfEvaluationException($"Multiple types matching '{typeName}' were found using case-insensitive lookup. Use exact type casing or an assembly-qualified name.", ex);
+            throw new InstanceOfEvaluationException($"Multiple types matching '{typeName}' were found. Use an assembly-qualified name.", ex);
         }
         catch (Exception ex)
         {
@@ -245,20 +235,20 @@ internal static class InstanceOfHelper
         }
     }
 
-    private static Type? ResolveConstructedGenericFromLoadedAssemblies(string searchTypeName, Assembly assembly, bool ignoreCase)
+    private static Type? ResolveConstructedGenericFromLoadedAssemblies(string searchTypeName, Assembly assembly)
     {
         return Type.GetType(
             searchTypeName,
-            AssemblyQualifiedTypeResolver.ResolveLoadedAssembly,
+            AssemblyQualifiedTypeResolver.ResolveGenericArgumentAssembly,
             (resolvedAssembly, nestedTypeName, nestedIgnoreCase) => ResolveTypePartFromLoadedAssembly(resolvedAssembly ?? assembly, nestedTypeName, nestedIgnoreCase),
             throwOnError: false,
-            ignoreCase);
+            ignoreCase: false);
     }
 
     private static Type? ResolveTypePartFromLoadedAssembly(Assembly assembly, string typeName, bool ignoreCase)
     {
         return MayContainAssemblyQualifiedGenericArguments(typeName)
-                   ? ResolveConstructedGenericFromLoadedAssemblies(typeName, assembly, ignoreCase)
+                   ? ResolveConstructedGenericFromLoadedAssemblies(typeName, assembly)
                    : assembly.GetType(typeName, throwOnError: false, ignoreCase: ignoreCase);
     }
 
@@ -406,7 +396,7 @@ internal static class InstanceOfHelper
 
     private static Dictionary<string, Type> CreateBclTypeAliases()
     {
-        var aliases = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+        var aliases = new Dictionary<string, Type>(StringComparer.Ordinal);
         AddBclType(aliases, typeof(Array), "Array");
         AddBclType(aliases, typeof(bool), "bool");
         AddBclType(aliases, typeof(byte), "byte");
@@ -451,12 +441,12 @@ internal static class InstanceOfHelper
     private static bool MayBeBclTypeAlias(string typeName)
     {
         return typeName.IndexOf('.') < 0 ||
-               typeName.StartsWith("System.", StringComparison.OrdinalIgnoreCase);
+               typeName.StartsWith("System.", StringComparison.Ordinal);
     }
 
     private static bool MayResolveWithoutAssemblyScan(string typeName)
     {
-        return typeName.StartsWith("System.", StringComparison.OrdinalIgnoreCase);
+        return typeName.StartsWith("System.", StringComparison.Ordinal);
     }
 
     private static void AddBclType(Dictionary<string, Type> aliases, Type type, params string[] names)
@@ -733,7 +723,7 @@ internal static class InstanceOfHelper
 
     private static void ThrowAmbiguousType(string typeName)
     {
-        throw new InstanceOfEvaluationException($"Multiple types matching '{typeName}' were found using case-insensitive lookup. Use exact type casing or an assembly-qualified name.");
+        throw new InstanceOfEvaluationException($"Multiple types matching '{typeName}' were found. Use an assembly-qualified name.");
     }
 
     private readonly struct ScanResult
@@ -837,20 +827,20 @@ internal static class InstanceOfHelper
                 return false;
             }
 
-            if (BclTypeAliases.TryGetValue(typeNameInfo.SearchTypeName, out type))
-            {
-                return true;
-            }
-
             type = typeNameInfo.MayContainAssemblyQualifiedGenericArguments
-                       ? ResolveConstructedGenericFromKnownFrameworkAssemblies(typeNameInfo.SearchTypeName, ignoreCase: true)
-                       : typeof(object).Assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
+                       ? ResolveConstructedGenericFromKnownFrameworkAssemblies(typeNameInfo.SearchTypeName, ignoreCase: false)
+                       : typeof(object).Assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: false);
             if (type is not null)
             {
                 return true;
             }
 
-            type = Type.GetType(typeName, ResolveLoadedAssembly, typeResolver: null, throwOnError: false, ignoreCase: true);
+            if (!IsFullyQualifiedTypeName(typeNameInfo.SearchTypeName))
+            {
+                return false;
+            }
+
+            type = Type.GetType(typeName, ResolveLoadedAssembly, typeResolver: null, throwOnError: false, ignoreCase: false);
             return type is not null;
         }
 
@@ -858,10 +848,22 @@ internal static class InstanceOfHelper
         {
             return Type.GetType(
                 searchTypeName,
-                ResolveKnownFrameworkAssembly,
-                (resolvedAssembly, nestedTypeName, nestedIgnoreCase) => (resolvedAssembly ?? typeof(object).Assembly).GetType(nestedTypeName, throwOnError: false, ignoreCase: nestedIgnoreCase),
+                ResolveGenericArgumentAssembly,
+                ResolveKnownFrameworkGenericTypePart,
                 throwOnError: false,
                 ignoreCase);
+        }
+
+        private static Type? ResolveKnownFrameworkGenericTypePart(Assembly? resolvedAssembly, string nestedTypeName, bool ignoreCase)
+        {
+            if (resolvedAssembly is not null)
+            {
+                return resolvedAssembly.GetType(nestedTypeName, throwOnError: false, ignoreCase: ignoreCase);
+            }
+
+            return IsKnownFrameworkTypeName(nestedTypeName)
+                       ? typeof(object).Assembly.GetType(nestedTypeName, throwOnError: false, ignoreCase: ignoreCase)
+                       : null;
         }
 
         private static Assembly? ResolveKnownFrameworkAssembly(AssemblyName assemblyName)
@@ -901,6 +903,11 @@ internal static class InstanceOfHelper
             return null;
         }
 
+        internal static Assembly? ResolveGenericArgumentAssembly(AssemblyName assemblyName)
+        {
+            return ResolveKnownFrameworkAssembly(assemblyName) ?? ResolveLoadedAssembly(assemblyName);
+        }
+
         private static bool AssemblyNameHasMetadata(string assemblyName)
         {
             return assemblyName.IndexOf(',') >= 0;
@@ -919,6 +926,11 @@ internal static class InstanceOfHelper
                    AssemblyNameEquals(assemblyName, simpleNameLength, "System") ||
                    AssemblyNameEquals(assemblyName, simpleNameLength, "System.Private.CoreLib") ||
                    AssemblyNameEquals(assemblyName, simpleNameLength, "System.Runtime");
+        }
+
+        private static bool IsKnownFrameworkTypeName(string typeName)
+        {
+            return typeName.StartsWith("System.", StringComparison.Ordinal);
         }
 
         private static bool AssemblyNameEquals(string assemblyName, int simpleNameLength, string expectedName)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -133,7 +133,7 @@ internal static class InstanceOfHelper
             var alreadyScannedAssemblies = typeNameInfo.MayContainAssemblyQualifiedGenericArguments
                                                ? null
                                                : currentResolution?.ScannedAssemblies;
-            var scanResult = ScanAssemblies(typeName, typeNameInfo, assemblies, alreadyScannedAssemblies, currentResolution?.GetTypeOrDefault());
+            var scanResult = ScanAssemblies(typeName, typeNameInfo, assemblies, alreadyScannedAssemblies);
             lastResolution = AddScannedResolution(typeName, currentResolution, scanResult, observedGeneration);
             if (lastResolution.IsAmbiguous)
             {
@@ -161,7 +161,7 @@ internal static class InstanceOfHelper
         throw UnknownType(typeName);
     }
 
-    private static ScanResult ScanAssemblies(string typeName, TypeNameInfo typeNameInfo, Assembly[] assemblies, AssemblyIdentity[]? alreadyScannedAssemblies, Type? currentResolvedType)
+    private static ScanResult ScanAssemblies(string typeName, TypeNameInfo typeNameInfo, Assembly[] assemblies, AssemblyIdentity[]? alreadyScannedAssemblies)
     {
         Type? resolvedType = null;
         var isAmbiguous = false;
@@ -189,13 +189,12 @@ internal static class InstanceOfHelper
                 continue;
             }
 
-            var previousMatch = currentResolvedType ?? resolvedType;
-            if (previousMatch is not null && previousMatch != matchedType)
+            if (resolvedType is not null && resolvedType != matchedType)
             {
                 isAmbiguous = true;
                 if (Log.IsEnabled(LogEventLevel.Debug))
                 {
-                    Log.Debug("Ambiguous type lookup for '{TypeName}'. Matched '{FirstType}' and '{SecondType}'. Use an assembly-qualified name.", typeName, previousMatch.AssemblyQualifiedName, matchedType.AssemblyQualifiedName);
+                    Log.Debug("Ambiguous type lookup for '{TypeName}'. Matched '{FirstType}' and '{SecondType}'. Use an assembly-qualified name.", typeName, resolvedType.AssemblyQualifiedName, matchedType.AssemblyQualifiedName);
                 }
 
                 continue;
@@ -993,11 +992,6 @@ internal static class InstanceOfHelper
         internal int ScannedGeneration { get; }
 
         internal AssemblyIdentity[] ScannedAssemblies { get; }
-
-        internal Type? GetTypeOrDefault()
-        {
-            return TryGetType(out var type) ? type : null;
-        }
 
         internal bool TryGetType([NotNullWhen(true)] out Type? type)
         {

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -54,7 +55,11 @@ internal static class InstanceOfHelper
             if (Nullable.GetUnderlyingType(valueType) is not null)
             {
                 result = type.IsInstanceOfType(value);
-                LogSuspiciousMismatch(type, value?.GetType(), typeName, result);
+                if (!result && Log.IsEnabled(LogEventLevel.Debug))
+                {
+                    LogSuspiciousMismatch(type, value?.GetType(), typeName, result);
+                }
+
                 return result;
             }
 
@@ -70,7 +75,7 @@ internal static class InstanceOfHelper
 
     internal static Type ResolveType(string typeName)
     {
-        if (string.IsNullOrEmpty(typeName))
+        if (StringUtil.IsNullOrEmpty(typeName))
         {
             ThrowInvalidTypeName();
         }
@@ -204,8 +209,8 @@ internal static class InstanceOfHelper
 
     private static Type? TryResolveFromAssembly(string typeName, TypeNameInfo typeNameInfo, Assembly assembly)
     {
-        if (typeNameInfo.IsAssemblyQualified &&
-            !AssemblyQualifiedTypeResolver.IsMatchingAssembly(assembly, typeNameInfo.AssemblyName!))
+        if (typeNameInfo.AssemblyName is { } assemblyName &&
+            !AssemblyQualifiedTypeResolver.IsMatchingAssembly(assembly, assemblyName))
         {
             return null;
         }
@@ -229,10 +234,20 @@ internal static class InstanceOfHelper
 
             throw new InstanceOfEvaluationException($"Multiple types matching '{typeName}' were found. Use an assembly-qualified name.", ex);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (IsAssemblyInspectionException(ex))
         {
-            throw new InstanceOfEvaluationException($"Failed to inspect assembly '{assembly.FullName}' while resolving type '{typeName}': {ex.Message}", ex);
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug(ex, "Failed to inspect assembly '{AssemblyName}' while resolving type '{TypeName}'. Continuing assembly scan.", assembly.FullName, typeName);
+            }
+
+            return null;
         }
+    }
+
+    private static bool IsAssemblyInspectionException(Exception exception)
+    {
+        return exception is TypeLoadException or FileNotFoundException or FileLoadException or BadImageFormatException or ReflectionTypeLoadException;
     }
 
     private static Type? ResolveConstructedGenericFromLoadedAssemblies(string searchTypeName, Assembly assembly)
@@ -625,19 +640,21 @@ internal static class InstanceOfHelper
             return MergeScannedAssembliesWithSet(currentAssemblies, scannedAssemblies, maxCapacity);
         }
 
-        AssemblyIdentity[]? merged = null;
+        var merged = new AssemblyIdentity[maxCapacity];
         var count = 0;
         for (var i = 0; i < currentAssemblies.Length; i++)
         {
-            AddAssemblyIdentity(ref merged, ref count, maxCapacity, currentAssemblies[i]);
+            merged[count] = currentAssemblies[i];
+            count++;
         }
 
         for (var i = 0; i < scannedAssemblies.Length; i++)
         {
             var scannedAssembly = scannedAssemblies[i];
-            if (!ContainsAssemblyIdentity(merged!, count, scannedAssembly))
+            if (!ContainsAssemblyIdentity(merged, count, scannedAssembly))
             {
-                AddAssemblyIdentity(ref merged, ref count, maxCapacity, scannedAssembly);
+                merged[count] = scannedAssembly;
+                count++;
             }
         }
 
@@ -808,7 +825,7 @@ internal static class InstanceOfHelper
 
         internal static bool IsMatchingAssembly(Assembly assembly, string assemblyName)
         {
-            if (string.IsNullOrEmpty(assemblyName))
+            if (StringUtil.IsNullOrEmpty(assemblyName))
             {
                 return false;
             }
@@ -822,7 +839,8 @@ internal static class InstanceOfHelper
         private static bool TryResolveKnownFrameworkType(string typeName, TypeNameInfo typeNameInfo, [NotNullWhen(true)] out Type? type)
         {
             type = null;
-            if (!IsKnownFrameworkAssemblyName(typeNameInfo.AssemblyName!))
+            if (typeNameInfo.AssemblyName is not { } assemblyName ||
+                !IsKnownFrameworkAssemblyName(assemblyName))
             {
                 return false;
             }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -109,7 +109,8 @@ internal static class InstanceOfHelper
             return AssemblyQualifiedTypeResolver.Resolve(typeName, typeNameInfo);
         }
 
-        if (MayResolveWithoutAssemblyScan(typeNameInfo.SearchTypeName))
+        if (MayResolveWithoutAssemblyScan(typeNameInfo.SearchTypeName) &&
+            !typeNameInfo.MayContainAssemblyQualifiedGenericArguments)
         {
             var resolvedType = Type.GetType(typeName, throwOnError: false, ignoreCase: true);
             if (resolvedType is not null)
@@ -240,10 +241,28 @@ internal static class InstanceOfHelper
             return null;
         }
 
-        Type? type;
         try
         {
-            type = assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
+            var searchTypeName = typeNameInfo.SearchTypeName;
+            Type? type;
+            if (!typeNameInfo.MayContainAssemblyQualifiedGenericArguments)
+            {
+                type = assembly.GetType(searchTypeName, throwOnError: false, ignoreCase: false);
+                if (type is not null)
+                {
+                    return type;
+                }
+
+                return assembly.GetType(searchTypeName, throwOnError: false, ignoreCase: true);
+            }
+
+            type = ResolveConstructedGenericFromLoadedAssemblies(searchTypeName, assembly, ignoreCase: false);
+            if (type is not null)
+            {
+                return type;
+            }
+
+            return ResolveConstructedGenericFromLoadedAssemblies(searchTypeName, assembly, ignoreCase: true);
         }
         catch (AmbiguousMatchException ex)
         {
@@ -258,8 +277,28 @@ internal static class InstanceOfHelper
         {
             throw new InstanceOfEvaluationException($"Failed to inspect assembly '{assembly.FullName}' while resolving type '{typeName}': {ex.Message}", ex);
         }
+    }
 
-        return type;
+    private static Type? ResolveConstructedGenericFromLoadedAssemblies(string searchTypeName, Assembly assembly, bool ignoreCase)
+    {
+        return Type.GetType(
+            searchTypeName,
+            AssemblyQualifiedTypeResolver.ResolveLoadedAssembly,
+            (resolvedAssembly, nestedTypeName, nestedIgnoreCase) => ResolveTypePartFromLoadedAssembly(resolvedAssembly ?? assembly, nestedTypeName, nestedIgnoreCase),
+            throwOnError: false,
+            ignoreCase);
+    }
+
+    private static Type? ResolveTypePartFromLoadedAssembly(Assembly assembly, string typeName, bool ignoreCase)
+    {
+        return MayContainAssemblyQualifiedGenericArguments(typeName)
+                   ? ResolveConstructedGenericFromLoadedAssemblies(typeName, assembly, ignoreCase)
+                   : assembly.GetType(typeName, throwOnError: false, ignoreCase: ignoreCase);
+    }
+
+    private static bool MayContainAssemblyQualifiedGenericArguments(string typeName)
+    {
+        return typeName.IndexOf("[[", StringComparison.Ordinal) >= 0;
     }
 
     private static bool IsFullyQualifiedTypeName(string typeName)
@@ -291,18 +330,20 @@ internal static class InstanceOfHelper
     {
         if (typeName.IndexOf(',') < 0)
         {
-            return new TypeNameInfo(typeName, null);
+            return new TypeNameInfo(typeName, null, mayContainAssemblyQualifiedGenericArguments: false);
         }
 
         var assemblySeparatorIndex = GetAssemblySeparatorIndex(typeName);
         if (assemblySeparatorIndex < 0)
         {
-            return new TypeNameInfo(typeName, null);
+            return new TypeNameInfo(typeName, null, MayContainAssemblyQualifiedGenericArguments(typeName));
         }
 
+        var searchTypeName = typeName.Substring(0, assemblySeparatorIndex).Trim();
         return new TypeNameInfo(
-            typeName.Substring(0, assemblySeparatorIndex).Trim(),
-            typeName.Substring(assemblySeparatorIndex + 1).Trim());
+            searchTypeName,
+            typeName.Substring(assemblySeparatorIndex + 1).Trim(),
+            MayContainAssemblyQualifiedGenericArguments(searchTypeName));
     }
 
     private static int GetAssemblySeparatorIndex(string typeName)
@@ -718,15 +759,18 @@ internal static class InstanceOfHelper
 
     private readonly struct TypeNameInfo
     {
-        internal TypeNameInfo(string searchTypeName, string? assemblyName)
+        internal TypeNameInfo(string searchTypeName, string? assemblyName, bool mayContainAssemblyQualifiedGenericArguments)
         {
             SearchTypeName = searchTypeName;
             AssemblyName = assemblyName;
+            MayContainAssemblyQualifiedGenericArguments = mayContainAssemblyQualifiedGenericArguments;
         }
 
         internal string SearchTypeName { get; }
 
         internal string? AssemblyName { get; }
+
+        internal bool MayContainAssemblyQualifiedGenericArguments { get; }
 
         internal bool IsAssemblyQualified => AssemblyName is not null;
     }
@@ -775,7 +819,9 @@ internal static class InstanceOfHelper
                 return true;
             }
 
-            type = typeof(object).Assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
+            type = typeNameInfo.MayContainAssemblyQualifiedGenericArguments
+                       ? ResolveConstructedGenericFromKnownFrameworkAssemblies(typeNameInfo.SearchTypeName, ignoreCase: true)
+                       : typeof(object).Assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
             if (type is not null)
             {
                 return true;
@@ -785,7 +831,22 @@ internal static class InstanceOfHelper
             return type is not null;
         }
 
-        private static Assembly? ResolveLoadedAssembly(AssemblyName assemblyName)
+        private static Type? ResolveConstructedGenericFromKnownFrameworkAssemblies(string searchTypeName, bool ignoreCase)
+        {
+            return Type.GetType(
+                searchTypeName,
+                ResolveKnownFrameworkAssembly,
+                (resolvedAssembly, nestedTypeName, nestedIgnoreCase) => (resolvedAssembly ?? typeof(object).Assembly).GetType(nestedTypeName, throwOnError: false, ignoreCase: nestedIgnoreCase),
+                throwOnError: false,
+                ignoreCase);
+        }
+
+        private static Assembly? ResolveKnownFrameworkAssembly(AssemblyName assemblyName)
+        {
+            return IsKnownFrameworkAssemblyName(assemblyName.FullName) ? typeof(object).Assembly : null;
+        }
+
+        internal static Assembly? ResolveLoadedAssembly(AssemblyName assemblyName)
         {
             var requestedFullName = assemblyName.FullName;
             var assemblies = Volatile.Read(ref _getAssemblies)();

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/InstanceOfHelper.cs
@@ -104,9 +104,11 @@ internal static class InstanceOfHelper
         }
 
         var typeNameInfo = ParseTypeName(typeName);
-        var resolvedType = typeNameInfo.IsAssemblyQualified
-                               ? null
-                               : Type.GetType(typeName, throwOnError: false, ignoreCase: true);
+        var resolvedType = TryResolveKnownFrameworkType(typeName, typeNameInfo, out var knownFrameworkType)
+                               ? knownFrameworkType
+                               : typeNameInfo.IsAssemblyQualified
+                                   ? null
+                                   : Type.GetType(typeName, throwOnError: false, ignoreCase: true);
         if (resolvedType is not null)
         {
             AddResolvedType(typeName, resolvedType, Volatile.Read(ref _assemblyLoadGeneration));
@@ -257,6 +259,30 @@ internal static class InstanceOfHelper
         return typeName.IndexOf('.') >= 0;
     }
 
+    private static bool TryResolveKnownFrameworkType(string typeName, TypeNameInfo typeNameInfo, [NotNullWhen(true)] out Type? type)
+    {
+        type = null;
+        if (!typeNameInfo.IsAssemblyQualified ||
+            !IsKnownFrameworkAssemblyName(typeNameInfo.AssemblyName!))
+        {
+            return false;
+        }
+
+        if (BclTypeAliases.TryGetValue(typeNameInfo.SearchTypeName, out type))
+        {
+            return true;
+        }
+
+        type = typeof(object).Assembly.GetType(typeNameInfo.SearchTypeName, throwOnError: false, ignoreCase: true);
+        if (type is not null)
+        {
+            return true;
+        }
+
+        type = Type.GetType(typeName, ResolveLoadedAssembly, typeResolver: null, throwOnError: false, ignoreCase: true);
+        return type is not null;
+    }
+
     private static void LogSuspiciousMismatch(Type resolvedType, Type? valueType, string requestedTypeName, bool result)
     {
         if (result ||
@@ -320,6 +346,59 @@ internal static class InstanceOfHelper
 
         return string.Equals(assembly.GetName().Name, assemblyName, StringComparison.Ordinal) ||
                string.Equals(assembly.FullName, assemblyName, StringComparison.Ordinal);
+    }
+
+    private static Assembly? ResolveLoadedAssembly(AssemblyName assemblyName)
+    {
+        var requestedFullName = assemblyName.FullName;
+        var assemblies = Volatile.Read(ref _getAssemblies)();
+
+        for (var i = 0; i < assemblies.Length; i++)
+        {
+            var assembly = assemblies[i];
+            if (string.Equals(assembly.FullName, requestedFullName, StringComparison.Ordinal))
+            {
+                return assembly;
+            }
+        }
+
+        var requestedName = assemblyName.Name;
+        if (requestedName is null)
+        {
+            return null;
+        }
+
+        for (var i = 0; i < assemblies.Length; i++)
+        {
+            var assembly = assemblies[i];
+            if (string.Equals(assembly.GetName().Name, requestedName, StringComparison.Ordinal))
+            {
+                return assembly;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsKnownFrameworkAssemblyName(string assemblyName)
+    {
+        var simpleNameLength = assemblyName.IndexOf(',');
+        if (simpleNameLength < 0)
+        {
+            simpleNameLength = assemblyName.Length;
+        }
+
+        return AssemblyNameEquals(assemblyName, simpleNameLength, "mscorlib") ||
+               AssemblyNameEquals(assemblyName, simpleNameLength, "netstandard") ||
+               AssemblyNameEquals(assemblyName, simpleNameLength, "System") ||
+               AssemblyNameEquals(assemblyName, simpleNameLength, "System.Private.CoreLib") ||
+               AssemblyNameEquals(assemblyName, simpleNameLength, "System.Runtime");
+    }
+
+    private static bool AssemblyNameEquals(string assemblyName, int simpleNameLength, string expectedName)
+    {
+        return simpleNameLength == expectedName.Length &&
+               string.Compare(assemblyName, 0, expectedName, 0, expectedName.Length, StringComparison.Ordinal) == 0;
     }
 
     private static string GetAssemblyIdentity(Assembly assembly)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -253,24 +253,18 @@ internal partial class ProbeExpressionParser<T>
             return Expression.Constant(false);
         }
 
-        Type type = null;
-        try
-        {
-            type = Type.GetType(typeName);
-        }
-        catch (Exception e)
-        {
-            AddError($"{value} is {typeName}", e.Message);
-            return Expression.Constant(false);
-        }
+        var instanceOfMethod = ProbeExpressionParserHelper.GetMethodByReflection(
+            typeof(InstanceOfHelper),
+            nameof(InstanceOfHelper.IsInstanceOf),
+            [value.Type, typeof(string)],
+            [value.Type]);
+        var isInstanceOfExpression = Expression.Call(
+            null,
+            instanceOfMethod,
+            value,
+            Expression.Constant(typeName));
 
-        if (type == null)
-        {
-            AddError($"{value} is {typeName}", $"'{typeName}' is unknown type");
-            return Expression.Constant(false);
-        }
-
-        return RedactDictionaryOperation(value, Expression.TypeIs(value, type));
+        return RedactDictionaryOperation(value, isInstanceOfExpression);
     }
 
     private Expression GetTypeName(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParserHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParserHelper.cs
@@ -74,13 +74,25 @@ internal static class ProbeExpressionParserHelper
                 continue;
             }
 
-            if (parameterType.Name != parameters[i].Name)
+            if (!ParameterTypeMatches(parameterType, parameters[i]))
             {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static bool ParameterTypeMatches(Type methodParameterType, Type requestedParameterType)
+    {
+        if (methodParameterType == requestedParameterType)
+        {
+            return true;
+        }
+
+        return methodParameterType.IsGenericType &&
+               requestedParameterType.IsGenericTypeDefinition &&
+               methodParameterType.GetGenericTypeDefinition() == requestedParameterType;
     }
 
     internal readonly struct ReflectionMethodIdentifier : IEquatable<ReflectionMethodIdentifier>

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParserHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParserHelper.cs
@@ -36,7 +36,7 @@ internal static class ProbeExpressionParserHelper
                                                     m.GetParameters().Length == methodIdentifier.Parameters.Length &&
                                                     m.ContainsGenericParameters &&
                                                     m.GetGenericArguments().Length == methodIdentifier.GenericArguments.Length).
-                                          SingleOrDefault(m => m.GetParameters().Select(pi => pi.ParameterType.Name).SequenceEqual(methodIdentifier.Parameters.Select(p => p.Name)));
+                                          SingleOrDefault(m => ParameterTypesMatch(m, methodIdentifier.Parameters, methodIdentifier.GenericArguments));
 
                 method = method?.MakeGenericMethod(methodIdentifier.GenericArguments);
             }
@@ -54,6 +54,33 @@ internal static class ProbeExpressionParserHelper
 
             return method;
         }
+    }
+
+    private static bool ParameterTypesMatch(MethodInfo method, Type[] parameters, Type[] genericArguments)
+    {
+        var methodParameters = method.GetParameters();
+        var methodGenericArguments = method.GetGenericArguments();
+        for (var i = 0; i < methodParameters.Length; i++)
+        {
+            var parameterType = methodParameters[i].ParameterType;
+            if (parameterType.IsGenericParameter)
+            {
+                var genericArgumentIndex = Array.IndexOf(methodGenericArguments, parameterType);
+                if (genericArgumentIndex < 0 || genericArguments[genericArgumentIndex] != parameters[i])
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (parameterType.Name != parameters[i].Name)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     internal readonly struct ReflectionMethodIdentifier : IEquatable<ReflectionMethodIdentifier>

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -991,6 +991,30 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_InstanceOf_GenericArgumentAssemblyRequiresExactIdentity()
+        {
+            var assembly = CreateDynamicAssembly(
+                "InstanceOfGenericArgumentVersionAssembly",
+                "GenericArgumentVersion.GenericType`1",
+                "GenericArgumentVersion.GenericArgument");
+            var argumentAssemblyName = assembly.GetName().Name;
+            var typeName = $"GenericArgumentVersion.GenericType`1[[GenericArgumentVersion.GenericArgument, {argumentAssemblyName}, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null]]";
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
+
+                Action lookup = () => InstanceOfHelper.ResolveType(typeName);
+
+                lookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
         public void ProbeExpressionParser_InstanceOf_CustomerSimpleName_ReportsRuntimeError()
         {
             try

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -906,6 +906,41 @@ namespace Datadog.Trace.Tests.Debugger
             }
         }
 
+        [Theory]
+        [InlineData("System.String, mscorlib")]
+        [InlineData("System.String, System.Runtime")]
+        [InlineData("System.String, System.Private.CoreLib")]
+        [InlineData("System.String, netstandard")]
+        public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedBclType_DoesNotScanAssemblies(string typeName)
+        {
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => throw new InvalidOperationException("Assembly scanning should not run for BCL aliases."));
+
+                InstanceOfHelper.IsInstanceOf("hello", typeName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Theory]
+        [InlineData("System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib")]
+        public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedFrameworkType_DoesNotScanAssemblies(string typeName)
+        {
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => throw new InvalidOperationException("Assembly scanning should not run for framework aliases."));
+
+                InstanceOfHelper.IsInstanceOf(new List<string>(), typeName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
         [Fact]
         public void ProbeExpressionParser_InstanceOf_CustomerSimpleName_ReportsRuntimeError()
         {
@@ -943,6 +978,23 @@ namespace Datadog.Trace.Tests.Debugger
 
                 InstanceOfHelper.IsInstanceOf(TestObject.Nested, $"{type.FullName}, {type.Assembly.GetName().Name}").Should().BeTrue();
                 InstanceOfHelper.IsInstanceOf(TestObject.Nested, type.AssemblyQualifiedName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedCustomerType_ScansLoadedAssembliesOnly()
+        {
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => []);
+
+                Action lookup = () => InstanceOfHelper.ResolveType("Unknown.CustomerType, UnknownCustomerAssembly");
+
+                lookup.Should().Throw<Exception>().WithMessage("*unknown type*");
             }
             finally
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -1366,6 +1366,44 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_InstanceOf_LargeMissCacheScansOnlyNewAssemblies()
+        {
+            var initialAssemblies = new Assembly[9];
+            for (var i = 0; i < initialAssemblies.Length; i++)
+            {
+                initialAssemblies[i] = CreateDynamicAssembly(
+                    $"InstanceOfLargeMissCacheAssembly{i}",
+                    $"LargeMissCache.IgnoredType{i}");
+            }
+
+            var resolvedAssembly = CreateDynamicAssembly(
+                "InstanceOfLargeMissCacheResolvedAssembly",
+                "LargeMissCache.ResolvedType");
+            var calls = 0;
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() =>
+                {
+                    calls++;
+                    return calls == 1 ? initialAssemblies : [.. initialAssemblies, resolvedAssembly];
+                });
+
+                Action firstLookup = () => InstanceOfHelper.ResolveType("LargeMissCache.ResolvedType");
+                firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+
+                InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
+                InstanceOfHelper.ResolveType("LargeMissCache.ResolvedType").Should().Be(resolvedAssembly.GetType("LargeMissCache.ResolvedType"));
+
+                calls.Should().Be(2);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
         public void ProbeExpressionParser_InstanceOf_CacheClearDuringMerge_PreservesScannedSnapshot()
         {
             var assembly = CreateDynamicAssembly(

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -773,7 +773,7 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
-        public void ProbeExpressionParser_InstanceOf_CustomerTypeName_EvaluatesCaseInsensitive()
+        public void ProbeExpressionParser_InstanceOf_CustomerTypeName_RequiresExactCasing()
         {
             try
             {
@@ -790,7 +790,9 @@ namespace Datadog.Trace.Tests.Debugger
                 var result = evaluator.Evaluate(scopeMembers);
 
                 result.Condition.Should().BeTrue();
-                result.Errors.Should().BeNullOrEmpty();
+                result.HasConditionError.Should().BeTrue();
+                result.Errors.Should().ContainSingle();
+                result.Errors[0].Message.Should().Contain("unknown type");
             }
             finally
             {
@@ -825,12 +827,9 @@ namespace Datadog.Trace.Tests.Debugger
 
         [Theory]
         [InlineData("string")]
-        [InlineData("STRING")]
         [InlineData("int")]
-        [InlineData("INT")]
         [InlineData("double")]
-        [InlineData("DOUBLE")]
-        public void ProbeExpressionParser_InstanceOf_BclAlias_EvaluatesConditionCaseInsensitive(string typeName)
+        public void ProbeExpressionParser_InstanceOf_BclAlias_EvaluatesCondition(string typeName)
         {
             try
             {
@@ -862,7 +861,7 @@ namespace Datadog.Trace.Tests.Debugger
         [Theory]
         [InlineData("string")]
         [InlineData("System.String")]
-        [InlineData("INT")]
+        [InlineData("int")]
         [InlineData("System.Int32")]
         [InlineData("Guid")]
         [InlineData("System.Guid")]
@@ -925,6 +924,23 @@ namespace Datadog.Trace.Tests.Debugger
             }
         }
 
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedBclAlias_RequiresFullyQualifiedClrTypeName()
+        {
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => throw new InvalidOperationException("Assembly scanning should not run for framework aliases."));
+
+                Action lookup = () => InstanceOfHelper.ResolveType("string, mscorlib");
+
+                lookup.Should().Throw<Exception>().WithMessage("*must be a fully qualified type name*");
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
         [Theory]
         [InlineData("System.Collections.Generic.List`1[[System.String, mscorlib]], mscorlib")]
         public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedFrameworkType_DoesNotScanAssemblies(string typeName)
@@ -934,6 +950,29 @@ namespace Datadog.Trace.Tests.Debugger
                 InstanceOfHelper.SetAssemblyProviderForTests(() => throw new InvalidOperationException("Assembly scanning should not run for framework aliases."));
 
                 InstanceOfHelper.IsInstanceOf(new List<string>(), typeName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedFrameworkGenericTypeWithLoadedArgument_EvaluatesCondition()
+        {
+            var argumentAssembly = CreateDynamicAssembly(
+                "InstanceOfFrameworkGenericArgumentAssembly",
+                "FrameworkGenericArgument.Argument");
+
+            try
+            {
+                var argumentType = argumentAssembly.GetType("FrameworkGenericArgument.Argument");
+                var listType = typeof(List<>).MakeGenericType(argumentType);
+                var instance = Activator.CreateInstance(listType);
+                var typeName = "System.Collections.Generic.List`1[[FrameworkGenericArgument.Argument, InstanceOfFrameworkGenericArgumentAssembly]], mscorlib";
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [argumentAssembly]);
+
+                InstanceOfHelper.IsInstanceOf(instance, typeName).Should().BeTrue();
             }
             finally
             {
@@ -957,6 +996,28 @@ namespace Datadog.Trace.Tests.Debugger
                 InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
 
                 InstanceOfHelper.IsInstanceOf(instance, genericType.FullName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_LoadedGenericTypeWithKnownFrameworkArgument_EvaluatesCondition()
+        {
+            var assembly = CreateDynamicAssembly(
+                "InstanceOfLoadedGenericFrameworkArgumentAssembly",
+                "LoadedGenericFrameworkArgument.GenericType`1");
+            var genericType = assembly.GetType("LoadedGenericFrameworkArgument.GenericType`1").MakeGenericType(typeof(string));
+            var instance = Activator.CreateInstance(genericType);
+            var typeName = "LoadedGenericFrameworkArgument.GenericType`1[[System.String, mscorlib]]";
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
+
+                InstanceOfHelper.IsInstanceOf(instance, typeName).Should().BeTrue();
             }
             finally
             {
@@ -1247,6 +1308,57 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_InstanceOf_ExactCaseMatchAcrossAssemblies_ResolvesExactMatch()
+        {
+            var firstAssembly = CreateDynamicAssembly(
+                "InstanceOfExactCaseAcrossAssembliesVariantAssembly",
+                "ExactCaseAcrossAssemblies.typeforinstanceof");
+            var secondAssembly = CreateDynamicAssembly(
+                "InstanceOfExactCaseAcrossAssembliesExactAssembly",
+                "ExactCaseAcrossAssemblies.TypeForInstanceOf");
+
+            try
+            {
+                var casingVariantType = firstAssembly.GetType("ExactCaseAcrossAssemblies.typeforinstanceof");
+                var exactType = secondAssembly.GetType("ExactCaseAcrossAssemblies.TypeForInstanceOf");
+                casingVariantType.Should().NotBe(exactType);
+
+                var instance = Activator.CreateInstance(exactType);
+                var casingVariantInstance = Activator.CreateInstance(casingVariantType);
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [firstAssembly, secondAssembly]);
+
+                InstanceOfHelper.IsInstanceOf(instance, "ExactCaseAcrossAssemblies.TypeForInstanceOf").Should().BeTrue();
+                InstanceOfHelper.IsInstanceOf(casingVariantInstance, "ExactCaseAcrossAssemblies.TypeForInstanceOf").Should().BeFalse();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedTypeNameRequiresExactCasing()
+        {
+            var assembly = CreateDynamicAssembly(
+                "InstanceOfAssemblyQualifiedExactCaseAssembly",
+                "AssemblyQualifiedExactCase.TypeForInstanceOf");
+            var typeName = "AssemblyQualifiedExactCase.typeforinstanceof, InstanceOfAssemblyQualifiedExactCaseAssembly";
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
+
+                Action lookup = () => InstanceOfHelper.ResolveType(typeName);
+
+                lookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
         public void ProbeExpressionParser_InstanceOf_AmbiguousTypeAfterCacheHit_KeepsCachedResolution()
         {
             var firstAssembly = CreateDynamicAssembly(
@@ -1302,6 +1414,45 @@ namespace Datadog.Trace.Tests.Debugger
                 InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
                 InstanceOfHelper.IsInstanceOf(instance, "LazyLoaded.TypeForInstanceOf").Should().BeTrue();
                 calls.Should().Be(2);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_LazyLoadedGenericArgument_CanSucceedWithoutRecompile()
+        {
+            var outerAssembly = CreateDynamicAssembly(
+                "InstanceOfLazyGenericOuterAssembly",
+                "LazyGeneric.Outer`1");
+            var argumentAssembly = CreateDynamicAssembly(
+                "InstanceOfLazyGenericArgumentAssembly",
+                "LazyGeneric.Argument");
+            var includeArgumentAssembly = false;
+            var calls = 0;
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() =>
+                {
+                    calls++;
+                    return includeArgumentAssembly ? [outerAssembly, argumentAssembly] : [outerAssembly];
+                });
+
+                var typeName = "LazyGeneric.Outer`1[[LazyGeneric.Argument, InstanceOfLazyGenericArgumentAssembly]]";
+
+                Action firstLookup = () => InstanceOfHelper.ResolveType(typeName);
+                firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+
+                InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
+                includeArgumentAssembly = true;
+                var argumentType = argumentAssembly.GetType("LazyGeneric.Argument");
+                var genericType = outerAssembly.GetType("LazyGeneric.Outer`1").MakeGenericType(argumentType);
+                var instance = Activator.CreateInstance(genericType);
+                InstanceOfHelper.IsInstanceOf(instance, typeName).Should().BeTrue();
+                calls.Should().BeGreaterThan(1);
             }
             finally
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -19,6 +20,8 @@ using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using VerifyTests;
 using VerifyXunit;
 using Xunit;
@@ -741,6 +744,528 @@ namespace Datadog.Trace.Tests.Debugger
             result.CaptureExpressionCount.Should().Be(0);
             result.CaptureExpressions.Should().BeNull();
             result.Errors.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_ResolvedCustomerType_EvaluatesCondition()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var typeName = typeof(TestStruct.NestedObject).FullName;
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: new DebuggerExpression(string.Empty, CreateInstanceOfJson(@"{""ref"":""NestedObjectLocal""}", typeName), null),
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Condition.Should().BeTrue();
+                result.Errors.Should().BeNullOrEmpty();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_CustomerTypeName_EvaluatesCaseInsensitive()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var typeName = typeof(TestStruct.NestedObject).FullName.ToUpperInvariant();
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: new DebuggerExpression(string.Empty, CreateInstanceOfJson(@"{""ref"":""NestedObjectLocal""}", typeName), null),
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Condition.Should().BeTrue();
+                result.Errors.Should().BeNullOrEmpty();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_ValueType_EvaluatesCondition()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: new DebuggerExpression(string.Empty, CreateInstanceOfJson(@"{""ref"":""IntLocal""}", typeof(int).FullName), null),
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Condition.Should().BeTrue();
+                result.Errors.Should().BeNullOrEmpty();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Theory]
+        [InlineData("string")]
+        [InlineData("STRING")]
+        [InlineData("int")]
+        [InlineData("INT")]
+        [InlineData("double")]
+        [InlineData("DOUBLE")]
+        public void ProbeExpressionParser_InstanceOf_BclAlias_EvaluatesConditionCaseInsensitive(string typeName)
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var source = typeName.Equals("string", StringComparison.OrdinalIgnoreCase)
+                                 ? @"{""ref"":""StringLocal""}"
+                                 : typeName.Equals("int", StringComparison.OrdinalIgnoreCase)
+                                     ? @"{""ref"":""IntLocal""}"
+                                     : @"{""ref"":""DoubleLocal""}";
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: new DebuggerExpression(string.Empty, CreateInstanceOfJson(source, typeName), null),
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Condition.Should().BeTrue();
+                result.Errors.Should().BeNullOrEmpty();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Theory]
+        [InlineData("string")]
+        [InlineData("System.String")]
+        [InlineData("INT")]
+        [InlineData("System.Int32")]
+        [InlineData("Guid")]
+        [InlineData("System.Guid")]
+        [InlineData("DateTime")]
+        [InlineData("System.DateTimeOffset")]
+        [InlineData("TimeSpan")]
+        [InlineData("Type")]
+        [InlineData("Exception")]
+        [InlineData("Enum")]
+        [InlineData("ValueType")]
+        [InlineData("Array")]
+        [InlineData("IntPtr")]
+        public void ProbeExpressionParser_InstanceOf_KnownBclType_DoesNotScanAssemblies(string typeName)
+        {
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => throw new InvalidOperationException("Assembly scanning should not run for BCL aliases."));
+
+                object value = typeName switch
+                {
+                    { } name when name.IndexOf("String", StringComparison.OrdinalIgnoreCase) >= 0 => "hello",
+                    { } name when name.IndexOf("Int32", StringComparison.OrdinalIgnoreCase) >= 0 || name.Equals("int", StringComparison.OrdinalIgnoreCase) => 42,
+                    { } name when name.IndexOf("Guid", StringComparison.OrdinalIgnoreCase) >= 0 => Guid.NewGuid(),
+                    { } name when name.IndexOf("DateTimeOffset", StringComparison.OrdinalIgnoreCase) >= 0 => DateTimeOffset.UtcNow,
+                    { } name when name.IndexOf("DateTime", StringComparison.OrdinalIgnoreCase) >= 0 => DateTime.UtcNow,
+                    { } name when name.IndexOf("TimeSpan", StringComparison.OrdinalIgnoreCase) >= 0 => TimeSpan.FromSeconds(1),
+                    { } name when name.IndexOf("Exception", StringComparison.OrdinalIgnoreCase) >= 0 => new Exception(),
+                    { } name when name.IndexOf("Enum", StringComparison.OrdinalIgnoreCase) >= 0 => DayOfWeek.Friday,
+                    { } name when name.IndexOf("ValueType", StringComparison.OrdinalIgnoreCase) >= 0 => 42,
+                    { } name when name.IndexOf("Array", StringComparison.OrdinalIgnoreCase) >= 0 => Array.Empty<string>(),
+                    { } name when name.IndexOf("Type", StringComparison.OrdinalIgnoreCase) >= 0 => typeof(string),
+                    { } name when name.IndexOf("IntPtr", StringComparison.OrdinalIgnoreCase) >= 0 => new IntPtr(42),
+                    _ => throw new InvalidOperationException($"Unexpected test case: {typeName}")
+                };
+
+                InstanceOfHelper.IsInstanceOf((object)value, typeName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_CustomerSimpleName_ReportsRuntimeError()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: new DebuggerExpression(string.Empty, CreateInstanceOfJson(@"{""ref"":""NestedObjectLocal""}", "NestedObject"), null),
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Condition.Should().BeTrue();
+                result.HasConditionError.Should().BeTrue();
+                result.Errors.Should().ContainSingle();
+                result.Errors[0].Message.Should().Contain("must be a fully qualified type name");
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_AssemblyQualifiedTypeName_EvaluatesCondition()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var type = typeof(TestStruct.NestedObject);
+
+                InstanceOfHelper.IsInstanceOf(TestObject.Nested, $"{type.FullName}, {type.Assembly.GetName().Name}").Should().BeTrue();
+                InstanceOfHelper.IsInstanceOf(TestObject.Nested, type.AssemblyQualifiedName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_ResolvedCustomerType_EvaluatesTemplate()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var typeName = typeof(TestStruct.NestedObject).FullName;
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: [new(null, null, "instanceof: "), new(string.Empty, CreateInstanceOfJson(@"{""ref"":""NestedObjectLocal""}", typeName), null)],
+                    condition: null,
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Template.Should().Be("instanceof: True");
+                result.Errors.Should().BeNullOrEmpty();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_ResolvedCustomerType_EvaluatesCaptureExpression()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var typeName = typeof(TestStruct.NestedObject).FullName;
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: null,
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions:
+                    [
+                        new CaptureExpressionDefinition("is_nested", new DebuggerExpression(string.Empty, CreateInstanceOfJson(@"{""ref"":""NestedObjectLocal""}", typeName), null), default)
+                    ]);
+
+                ExpressionEvaluationResult result = default;
+                evaluator.EvaluateCaptureExpressions(ref result, scopeMembers);
+
+                result.CaptureExpressionCount.Should().Be(1);
+                result.CaptureExpressions[0].Name.Should().Be("is_nested");
+                result.CaptureExpressions[0].Value.Should().Be(true);
+                result.CaptureExpressions[0].Type.Should().Be(typeof(bool));
+                result.Errors.Should().BeNullOrEmpty();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_ResolvedCustomerType_EvaluatesSpanDecoration()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var typeName = typeof(TestStruct.NestedObject).FullName;
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: null,
+                    metric: null,
+                    spanDecorations:
+                    [
+                        new KeyValuePair<DebuggerExpression?, KeyValuePair<string, DebuggerExpression?[]>[]>(
+                            new DebuggerExpression(string.Empty, CreateInstanceOfJson(@"{""ref"":""NestedObjectLocal""}", typeName), null),
+                            [new KeyValuePair<string, DebuggerExpression?[]>("tag", [new DebuggerExpression(null, null, "decorated")])])
+                    ],
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Decorations.Should().ContainSingle();
+                result.Decorations[0].TagName.Should().Be("tag");
+                result.Decorations[0].Value.Should().Be("decorated");
+                result.Decorations[0].Errors.Should().BeNullOrEmpty();
+                result.Errors.Should().BeNullOrEmpty();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_UnknownType_ReportsRuntimeError()
+        {
+            try
+            {
+                InstanceOfHelper.ResetForTests();
+                var scopeMembers = CreateScopeMembers();
+                var evaluator = new ProbeExpressionEvaluator(
+                    templates: null,
+                    condition: new DebuggerExpression(string.Empty, CreateInstanceOfJson(@"{""ref"":""NestedObjectLocal""}", "DebuggerExpressionLanguageTests"), null),
+                    metric: null,
+                    spanDecorations: null,
+                    captureExpressions: null);
+
+                var result = evaluator.Evaluate(scopeMembers);
+
+                result.Condition.Should().BeTrue();
+                result.HasConditionError.Should().BeTrue();
+                result.Errors.Should().ContainSingle();
+                result.Errors[0].Message.Should().Contain("must be a fully qualified type name");
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_AmbiguousType_ReportsRuntimeError()
+        {
+            var firstAssembly = CreateDynamicAssembly(
+                "InstanceOfAmbiguousAssemblyOne",
+                "Ambiguous.TypeForInstanceOf");
+            var secondAssembly = CreateDynamicAssembly(
+                "InstanceOfAmbiguousAssemblyTwo",
+                "Ambiguous.TypeForInstanceOf");
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [firstAssembly, secondAssembly]);
+
+                Action lookup = () => InstanceOfHelper.ResolveType("Ambiguous.TypeForInstanceOf");
+
+                lookup.Should().Throw<Exception>().WithMessage("*Multiple types matching*");
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_AmbiguousTypeAfterCacheHit_KeepsCachedResolution()
+        {
+            var firstAssembly = CreateDynamicAssembly(
+                "InstanceOfAmbiguousCachedAssemblyOne",
+                "AmbiguousCached.TypeForInstanceOf");
+            var secondAssembly = CreateDynamicAssembly(
+                "InstanceOfAmbiguousCachedAssemblyTwo",
+                "AmbiguousCached.TypeForInstanceOf");
+            var calls = 0;
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() =>
+                {
+                    calls++;
+                    return calls == 1 ? [firstAssembly] : [firstAssembly, secondAssembly];
+                });
+
+                InstanceOfHelper.ResolveType("AmbiguousCached.TypeForInstanceOf").Should().Be(firstAssembly.GetType("AmbiguousCached.TypeForInstanceOf"));
+                InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
+
+                InstanceOfHelper.ResolveType("AmbiguousCached.TypeForInstanceOf").Should().Be(firstAssembly.GetType("AmbiguousCached.TypeForInstanceOf"));
+                calls.Should().Be(1);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_LazyLoadedType_CanSucceedWithoutRecompile()
+        {
+            var firstAssembly = typeof(string).Assembly;
+            var secondAssembly = CreateDynamicAssembly(
+                "InstanceOfLazyAssembly",
+                "LazyLoaded.TypeForInstanceOf");
+            var calls = 0;
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() =>
+                {
+                    calls++;
+                    return calls == 1 ? [firstAssembly] : [firstAssembly, secondAssembly];
+                });
+
+                var instance = Activator.CreateInstance(secondAssembly.GetType("LazyLoaded.TypeForInstanceOf"));
+
+                Action firstLookup = () => InstanceOfHelper.ResolveType("LazyLoaded.TypeForInstanceOf");
+                firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+
+                InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
+                InstanceOfHelper.IsInstanceOf(instance, "LazyLoaded.TypeForInstanceOf").Should().BeTrue();
+                calls.Should().Be(2);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_CacheHit_DoesNotScanAssembliesAgain()
+        {
+            var assembly = typeof(TestStruct.NestedObject).Assembly;
+            var calls = 0;
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() =>
+                {
+                    calls++;
+                    return [assembly];
+                });
+
+                var typeName = typeof(TestStruct.NestedObject).FullName;
+                InstanceOfHelper.IsInstanceOf(TestObject.Nested, typeName).Should().BeTrue();
+                InstanceOfHelper.IsInstanceOf(TestObject.Nested, typeName).Should().BeTrue();
+
+                calls.Should().Be(1);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_MissScansOnlyNewAssemblies()
+        {
+            var firstAssembly = typeof(string).Assembly;
+            var secondAssembly = typeof(TestStruct.NestedObject).Assembly;
+            var calls = 0;
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() =>
+                {
+                    calls++;
+                    return calls == 1 ? [firstAssembly] : [firstAssembly, secondAssembly];
+                });
+
+                Action firstLookup = () => InstanceOfHelper.ResolveType("Missing.TypeForInstanceOf");
+                firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+
+                InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
+                Action secondLookup = () => InstanceOfHelper.ResolveType("Missing.TypeForInstanceOf");
+                secondLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+
+                calls.Should().Be(2);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_CacheClearDuringMerge_PreservesScannedSnapshot()
+        {
+            var assembly = CreateDynamicAssembly(
+                "InstanceOfCacheClearAssembly",
+                "CacheClear.TypeForInstanceOf");
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
+
+                InstanceOfHelper.ResolveType("CacheClear.TypeForInstanceOf").Should().Be(assembly.GetType("CacheClear.TypeForInstanceOf"));
+
+                for (var i = 0; i < 511; i++)
+                {
+                    Action fillCache = () => InstanceOfHelper.ResolveType($"Missing.CacheFill{i}");
+                    fillCache.Should().Throw<Exception>().WithMessage("*unknown type*");
+                }
+
+                InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
+
+                InstanceOfHelper.ResolveType("CacheClear.TypeForInstanceOf").Should().Be(assembly.GetType("CacheClear.TypeForInstanceOf"));
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_ContinuousAssemblyLoadChurn_StopsAfterBoundedRetries()
+        {
+            var calls = 0;
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() =>
+                {
+                    calls++;
+                    InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
+                    return [typeof(string).Assembly];
+                });
+
+                Action lookup = () => InstanceOfHelper.ResolveType("Missing.ChurningTypeForInstanceOf");
+
+                lookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+                calls.Should().Be(3);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
         }
 
         [Theory]
@@ -1571,6 +2096,33 @@ namespace Datadog.Trace.Tests.Debugger
 
             Assert.Equal("{[hello, ], }", result);
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        private static string CreateInstanceOfJson(string valueJson, string typeName)
+        {
+            return $$"""
+                    {
+                      "instanceof": [
+                        {{valueJson}},
+                        "{{typeName}}"
+                      ]
+                    }
+                    """;
+        }
+
+        private static Assembly CreateDynamicAssembly(string assemblyName, string typeName)
+        {
+            var lastDotIndex = typeName.LastIndexOf('.');
+            var compilation = CSharpCompilation.Create(
+                assemblyName,
+                syntaxTrees: [CSharpSyntaxTree.ParseText($"namespace {typeName.Substring(0, lastDotIndex)} {{ public class {typeName.Substring(lastDotIndex + 1)} {{ }} }}")],
+                references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            using var stream = new MemoryStream();
+            var result = compilation.Emit(stream);
+            result.Success.Should().BeTrue(string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString())));
+            return Assembly.Load(stream.ToArray());
         }
 
         private async Task Test(string expressionTestFilePath)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -1281,6 +1281,26 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_InstanceOf_AssemblyInspectionFailure_ContinuesScanning()
+        {
+            var throwingAssembly = new ThrowingGetTypeAssembly("InstanceOfThrowingAssembly");
+            var resolvedAssembly = CreateDynamicAssembly(
+                "InstanceOfInspectionFailureResolvedAssembly",
+                "InspectionFailure.TypeForInstanceOf");
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [throwingAssembly, resolvedAssembly]);
+
+                InstanceOfHelper.ResolveType("InspectionFailure.TypeForInstanceOf").Should().Be(resolvedAssembly.GetType("InspectionFailure.TypeForInstanceOf"));
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
         public void ProbeExpressionParser_InstanceOf_ExactCaseMatch_ResolvesCasingAmbiguousType()
         {
             var assembly = CreateDynamicAssembly(
@@ -2895,6 +2915,23 @@ namespace Datadog.Trace.Tests.Debugger
             {
                 { "hello", null },
             };
+        }
+
+        private sealed class ThrowingGetTypeAssembly : Assembly
+        {
+            private readonly string _fullName;
+
+            public ThrowingGetTypeAssembly(string name)
+            {
+                _fullName = $"{name}, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null";
+            }
+
+            public override string FullName => _fullName;
+
+            public override Type GetType(string name, bool throwOnError, bool ignoreCase)
+            {
+                throw new FileLoadException("Test assembly cannot inspect types.");
+            }
         }
 
         private sealed class ThrowsOnToStringKey

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -171,6 +171,34 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_MethodReflectionCache_UsesStructuralParameterKeys()
+        {
+            var first = new ProbeExpressionParserHelper.ReflectionMethodIdentifier(typeof(string), nameof(string.Contains), [typeof(string)], null);
+            var second = new ProbeExpressionParserHelper.ReflectionMethodIdentifier(typeof(string), nameof(string.Contains), [typeof(string)], null);
+
+            second.Should().Be(first);
+            second.GetHashCode().Should().Be(first.GetHashCode());
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_GenericMethodReflectionCache_UsesStructuralGenericArgumentKeys()
+        {
+            var first = new ProbeExpressionParserHelper.ReflectionMethodIdentifier(
+                typeof(InstanceOfHelper),
+                nameof(InstanceOfHelper.IsInstanceOf),
+                [typeof(int), typeof(string)],
+                [typeof(int)]);
+            var second = new ProbeExpressionParserHelper.ReflectionMethodIdentifier(
+                typeof(InstanceOfHelper),
+                nameof(InstanceOfHelper.IsInstanceOf),
+                [typeof(int), typeof(string)],
+                [typeof(int)]);
+
+            second.Should().Be(first);
+            second.GetHashCode().Should().Be(first.GetHashCode());
+        }
+
+        [Fact]
         public void ProbeExpressionParser_ObjectReturnType_AllowsValueTypeResults()
         {
             // Arrange

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -939,7 +939,6 @@ namespace Datadog.Trace.Tests.Debugger
             try
             {
                 InstanceOfHelper.ResetForTests();
-                var scopeMembers = CreateScopeMembers();
                 var type = typeof(TestStruct.NestedObject);
 
                 InstanceOfHelper.IsInstanceOf(TestObject.Nested, $"{type.FullName}, {type.Assembly.GetName().Name}").Should().BeTrue();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -199,6 +199,30 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_GenericMethodReflection_UsesExactNonGenericParameterTypes()
+        {
+            var method = ProbeExpressionParserHelper.GetMethodByReflection(
+                typeof(SameParameterNameOverloads),
+                nameof(SameParameterNameOverloads.Match),
+                [typeof(string), typeof(string)],
+                [typeof(string)]);
+
+            method.Invoke(null, ["value", "generic"]).Should().Be("system");
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_GenericMethodReflection_MatchesOpenGenericParameterDefinitions()
+        {
+            var method = ProbeExpressionParserHelper.GetMethodByReflection(
+                typeof(Enumerable),
+                nameof(Enumerable.Where),
+                [typeof(IEnumerable<>), typeof(Func<,>)],
+                [typeof(string)]);
+
+            method.GetParameters()[0].ParameterType.GetGenericTypeDefinition().Should().Be(typeof(IEnumerable<>));
+        }
+
+        [Fact]
         public void ProbeExpressionParser_ObjectReturnType_AllowsValueTypeResults()
         {
             // Arrange
@@ -2934,6 +2958,23 @@ namespace Datadog.Trace.Tests.Debugger
 
         internal class RecursiveGenericConstraintTarget<T>
             where T : IComparable<T>
+        {
+        }
+
+        internal class SameParameterNameOverloads
+        {
+            public static string Match<T>(String value, T genericValue)
+            {
+                return "custom";
+            }
+
+            public static string Match<T>(string value, T genericValue)
+            {
+                return "system";
+            }
+        }
+
+        internal sealed class String
         {
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -2999,7 +2999,7 @@ namespace Datadog.Trace.Tests.Debugger
 
             public override Type GetType(string name, bool throwOnError, bool ignoreCase)
             {
-                throw new FileLoadException("Test assembly cannot inspect types.");
+                throw new TypeLoadException("Test assembly cannot inspect types.");
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -942,6 +942,55 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionParser_InstanceOf_LoadedGenericTypeWithLoadedArgument_EvaluatesCondition()
+        {
+            var assembly = CreateDynamicAssembly(
+                "InstanceOfLoadedGenericAssembly",
+                "LoadedGeneric.GenericType`1",
+                "LoadedGeneric.GenericArgument");
+
+            try
+            {
+                var genericArgument = assembly.GetType("LoadedGeneric.GenericArgument");
+                var genericType = assembly.GetType("LoadedGeneric.GenericType`1").MakeGenericType(genericArgument);
+                var instance = Activator.CreateInstance(genericType);
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
+
+                InstanceOfHelper.IsInstanceOf(instance, genericType.FullName).Should().BeTrue();
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_LoadedGenericTypeWithUnloadedArgument_DoesNotLoadArgumentAssembly()
+        {
+            var assembly = CreateDynamicAssembly(
+                "InstanceOfGenericDefinitionAssembly",
+                "GenericDefinition.GenericType`1");
+            var unloadedArgumentAssemblyName = $"InstanceOfUnloadedGenericArgumentAssembly_{Guid.NewGuid():N}";
+            var typeName = $"GenericDefinition.GenericType`1[[Unloaded.Argument, {unloadedArgumentAssemblyName}]]";
+
+            try
+            {
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
+
+                Action lookup = () => InstanceOfHelper.ResolveType(typeName);
+
+                lookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+                AppDomain.CurrentDomain.GetAssemblies()
+                         .Should()
+                         .NotContain(a => a.GetName().Name == unloadedArgumentAssemblyName);
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
         public void ProbeExpressionParser_InstanceOf_CustomerSimpleName_ReportsRuntimeError()
         {
             try
@@ -1139,6 +1188,33 @@ namespace Datadog.Trace.Tests.Debugger
                 Action lookup = () => InstanceOfHelper.ResolveType("Ambiguous.TypeForInstanceOf");
 
                 lookup.Should().Throw<Exception>().WithMessage("*Multiple types matching*");
+            }
+            finally
+            {
+                InstanceOfHelper.ResetForTests();
+            }
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_InstanceOf_ExactCaseMatch_ResolvesCasingAmbiguousType()
+        {
+            var assembly = CreateDynamicAssembly(
+                "InstanceOfExactCaseAmbiguousAssembly",
+                "ExactCase.TypeForInstanceOf",
+                "ExactCase.typeforinstanceof");
+
+            try
+            {
+                var exactType = assembly.GetType("ExactCase.TypeForInstanceOf");
+                var casingVariantType = assembly.GetType("ExactCase.typeforinstanceof");
+                casingVariantType.Should().NotBe(exactType);
+
+                var instance = Activator.CreateInstance(exactType);
+                var casingVariantInstance = Activator.CreateInstance(casingVariantType);
+                InstanceOfHelper.SetAssemblyProviderForTests(() => [assembly]);
+
+                InstanceOfHelper.IsInstanceOf(instance, "ExactCase.TypeForInstanceOf").Should().BeTrue();
+                InstanceOfHelper.IsInstanceOf(casingVariantInstance, "ExactCase.TypeForInstanceOf").Should().BeFalse();
             }
             finally
             {
@@ -2161,12 +2237,23 @@ namespace Datadog.Trace.Tests.Debugger
                     """;
         }
 
-        private static Assembly CreateDynamicAssembly(string assemblyName, string typeName)
+        private static Assembly CreateDynamicAssembly(string assemblyName, params string[] typeNames)
         {
-            var lastDotIndex = typeName.LastIndexOf('.');
+            var source = new StringBuilder();
+            for (var i = 0; i < typeNames.Length; i++)
+            {
+                var typeName = typeNames[i];
+                var lastDotIndex = typeName.LastIndexOf('.');
+                source.Append("namespace ")
+                      .Append(typeName.Substring(0, lastDotIndex))
+                      .Append(" { public class ")
+                      .Append(CreateDynamicTypeDeclaration(typeName.Substring(lastDotIndex + 1)))
+                      .Append(" { } }");
+            }
+
             var compilation = CSharpCompilation.Create(
                 assemblyName,
-                syntaxTrees: [CSharpSyntaxTree.ParseText($"namespace {typeName.Substring(0, lastDotIndex)} {{ public class {typeName.Substring(lastDotIndex + 1)} {{ }} }}")],
+                syntaxTrees: [CSharpSyntaxTree.ParseText(source.ToString())],
                 references: [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
@@ -2174,6 +2261,31 @@ namespace Datadog.Trace.Tests.Debugger
             var result = compilation.Emit(stream);
             result.Success.Should().BeTrue(string.Join(Environment.NewLine, result.Diagnostics.Select(d => d.ToString())));
             return Assembly.Load(stream.ToArray());
+        }
+
+        private static string CreateDynamicTypeDeclaration(string typeName)
+        {
+            var arityIndex = typeName.IndexOf('`');
+            if (arityIndex < 0)
+            {
+                return typeName;
+            }
+
+            var arity = int.Parse(typeName.Substring(arityIndex + 1));
+            var builder = new StringBuilder(typeName.Substring(0, arityIndex));
+            builder.Append('<');
+            for (var i = 0; i < arity; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append('T').Append(i);
+            }
+
+            builder.Append('>');
+            return builder.ToString();
         }
 
         private async Task Test(string expressionTestFilePath)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
@@ -47,7 +47,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = this.String is int;
+    var $dd_el_result = InstanceOfHelper.IsInstanceOf(this.String, "System.Int32");
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
@@ -47,7 +47,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = this.String is string;
+    var $dd_el_result = InstanceOfHelper.IsInstanceOf(this.String, "System.String");
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
@@ -10,7 +10,7 @@ Json:
         "String"
       ]
     },
-    "string"
+    "Missing.Type"
   ]
 }
 Expression: (
@@ -47,8 +47,10 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = InstanceOfHelper.IsInstanceOf(this.String, "string");
+    var $dd_el_result = InstanceOfHelper.IsInstanceOf(this.String, "Missing.Type");
 
     return $dd_el_result;
 }
 Result: True
+Errors:
+EvaluationError { Expression = IsInstanceOf(this.String, "Missing.Type")), Message = 'Missing.Type' is unknown type }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
@@ -47,10 +47,8 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = false;
+    var $dd_el_result = InstanceOfHelper.IsInstanceOf(this.String, "string");
 
     return $dd_el_result;
 }
-Result: False
-Errors:
-EvaluationError { Expression = this.String is string, Message = 'string' is unknown type }
+Result: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfUnknownType.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfUnknownType.json
@@ -1,5 +1,5 @@
 {
-  "dsl": "{instanceof(this.String, string)}",
+  "dsl": "{instanceof(this.String, Missing.Type)}",
   "instanceof": [
     {
       "getmember": [
@@ -9,6 +9,6 @@
         "String"
       ]
     },
-    "string"
+    "Missing.Type"
   ]
 }


### PR DESCRIPTION
## Summary of changes

- Changes debugger expression `instanceof` evaluation to resolve target types at runtime instead of parse/compile time.
- Adds `InstanceOfHelper` to resolve known framework types and customer types without intentionally loading additional customer assemblies.
- Adds no-scan fast paths for known BCL/core runtime types such as `int`, `string`, `Guid`, `DateTime`, `TimeSpan`, `Type`, `Exception`, `Array`, and related `System.*` names.
- Resolves scanned customer type names with exact, case-sensitive matching, and requires fully qualified type names unless the target is a known BCL/core alias.
- Caches customer type resolution with immutable entries, weak references for resolved customer types, scanned assembly identities, and atomic assembly-load generation tracking.
- Updates expression snapshots and adds regression coverage for condition, template, capture expression, span decoration, lazy assembly loading, ambiguity, cache behavior, generic argument resolution, no-load behavior, exact matching, and bounded retry behavior.

## Reason for change

- `instanceof` previously resolved target types too early, which meant expressions could fail when customer types were loaded after probe parsing.
- Dynamic instrumentation expressions need to work against customer application types that may only become available later in process lifetime.
- Runtime type resolution must avoid loading assemblies as a side effect in instrumented customer processes.
- Customer type lookup should be deterministic: ambiguous names fail with a controlled expression error, and callers can use assembly-qualified names to disambiguate.

## Implementation details

- `instanceof` now compiles to a runtime helper call: `InstanceOfHelper.IsInstanceOf<TValue>(value, typeName)`.
- Known BCL/core aliases are resolved before cache lookup, generation checks, or loaded assembly scans. These names do not depend on loaded customer assemblies.
- Known framework assembly-qualified names are resolved through framework fast paths where possible, preserving the no-scan behavior for BCL/framework types.
- Customer type names are resolved lazily from `AppDomain.CurrentDomain.GetAssemblies()` only when an expression is evaluated.
- Namespace-qualified customer type names are treated as best effort:
  - If no matching loaded type is found, the miss is cached for the observed assembly-load generation and retried after new assemblies load.
  - If one matching loaded type is found, that result is cached and kept stable while the weak `Type` reference remains alive.
  - If multiple different matching loaded types are found, evaluation fails with a controlled expression error.
- For simple scanned type names, the resolver uses exact case-sensitive `Assembly.GetType`; there is no case-insensitive fallback for customer types.
- For constructed generic names that contain assembly-qualified generic arguments, the resolver uses callback-based `Type.GetType` resolution where assembly callbacks return only known framework assemblies or already-loaded assemblies. Missing generic argument assemblies stay unresolved instead of being loaded.
- Generic argument assembly resolution requires exact full identity matches when metadata is supplied. Simple-name fallback is only used for simple-name assembly requests.
- Assembly-qualified names are parsed and supported by the resolver, but this PR does not make them the required customer-facing format.
- Scanned assembly identities are cached using assembly full name plus runtime identity, without holding `Assembly` references.
- Resolved customer `Type` values are cached through `WeakReference<Type>` so the cache does not keep collectible AssemblyLoadContexts alive. If a weak type target is collected, that cache entry is discarded and the next lookup resolves from the currently loaded assemblies again.
- Debug logging was added for suspicious best-effort mismatches where a namespace-qualified lookup resolves to one type but the runtime value has the same full name from another assembly.

## Test coverage

- Added/updated `DebuggerExpressionLanguageTests` coverage for runtime `instanceof` resolution across conditions, templates, capture expressions, span decorations, known BCL/framework names, customer names, assembly-qualified names, generic arguments, ambiguity, cache behavior, lazy assembly loading, no-load behavior, exact matching, and bounded retry behavior.
- Updated Verify snapshots for `instanceof` expression output and unknown-type error behavior.

## Other details
<!-- Fixes #{issue} -->