### PR TITLE
Trim experimental features flags

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -70,7 +70,11 @@ namespace Datadog.Trace.Configuration
                     {
                         null or "none" => new HashSet<string>(),
                         "all" => DefaultExperimentalFeatures,
-                        string s => new HashSet<string>(s.Split([','], StringSplitOptions.RemoveEmptyEntries)),
+#if NET6_0_OR_GREATER
+                        string s => new HashSet<string>(s.Split(commaSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)),
+#else
+                        string s => new HashSet<string>(s.Split(commaSeparator, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim())),
+#endif
                     };
 
             PropagateProcessTags = config

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1171,5 +1171,21 @@ namespace Datadog.Trace.Tests.Configuration
 
             settings.PropagateProcessTags.Should().Be(expected);
         }
+
+        [Theory]
+        [InlineData(null, new string[0])]
+        [InlineData("none", new string[0])]
+        [InlineData("DD_TAGS", new[] { "DD_TAGS" })]
+        [InlineData("DD_TAGS,OTHER_FEATURE", new[] { "DD_TAGS", "OTHER_FEATURE" })]
+        [InlineData(" DD_TAGS , OTHER_FEATURE ", new[] { "DD_TAGS", "OTHER_FEATURE" })]
+        [InlineData("DD_TAGS, OTHER_FEATURE", new[] { "DD_TAGS", "OTHER_FEATURE" })]
+        [InlineData("DD_TAGS ,OTHER_FEATURE", new[] { "DD_TAGS", "OTHER_FEATURE" })]
+        public void ExperimentalFeaturesEnabled_ParsesAndTrimsEntries(string value, string[] expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ExperimentalFeaturesEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.ExperimentalFeaturesEnabled.Should().BeEquivalentTo(expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

Trims the "experimental features" entries, to ensure later comparisons aren't impacted

## Reason for change

If we have multiple entries and they have whitespace, e.g. `DD_TAGS , DD_SOME_FEATURE`, then the individual tags aren't trimmed:

- `DD_TAGS `
- ` DD_SOME_FEATURE`

And the `Contains()` calls will fail, and it won't be obvious why, so just trim.

## Implementation details

Add a `Trim()` when parsing the entries in `TraceSettings`

## Test coverage

Unit test for coverage
