### PR TITLE
Bump System.DirectoryServices.Protocols to 5.0.1 in debugger sample

### DIFF
--- a/tracer/test/test-applications/debugger/Samples.Debugger.AspNetCore5/Samples.Debugger.AspNetCore5.csproj
+++ b/tracer/test/test-applications/debugger/Samples.Debugger.AspNetCore5/Samples.Debugger.AspNetCore5.csproj
@@ -131,7 +131,7 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
     <PackageReference Include="System.DirectoryServices" Version="5.0.0" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="5.0.1" />
     <PackageReference Include="System.DirectoryServices.AccountManagement" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Addresses GHSA-9cxh-gqpx-qc5m (CVE-2021-41355).

## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
