### PR TITLE
WIP feat(otel): Update tracing integrations to emit span attributes in alignment with the OpenTelemetry HTTP span specification

### DIFF
--- a/docs/superpowers/plans/2026-06-15-otel-semantics.md
+++ b/docs/superpowers/plans/2026-06-15-otel-semantics.md
@@ -1,0 +1,911 @@
+# OTel Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` opt-in flag that replaces Datadog HTTP span attribute names with OpenTelemetry semantic convention names (e.g. `http.request.method` instead of `http.method`).
+
+**Architecture:** A new bool setting `OtelSemanticsEnabled` gates two code paths — HTTP client tags (set in `ScopeFactory.CreateInactiveOutboundHttpSpan`) and HTTP server tags (set in `SpanExtensions.DecorateWebServerSpan` and `SpanExtensions.SetHttpStatusCode`). A shared `HttpOtelHelper` class centralizes all OTel `SetTag` calls. When OTel mode is on, Datadog typed-tag properties are skipped and OTel attributes are set via `span.SetTag()` directly.
+
+**Tech Stack:** C# / .NET; xUnit integration tests; `./tracer/build.sh` Nuke build; YAML-driven config source generators.
+
+---
+
+## File Map
+
+**Created:**
+- `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelper.cs` — all OTel `SetTag` helpers
+
+**Modified:**
+- `tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml` — add `DD_TRACE_OTEL_SEMANTICS_ENABLED` entry
+- `tracer/src/Datadog.Trace/Configuration/TracerSettings.cs` — add `OtelSemanticsEnabled` property
+- `tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs` — OTel branch for HTTP client tags
+- `tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs` — OTel branch in `DecorateWebServerSpan` and `SetHttpStatusCode`
+- `tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs` — OTel branch after `AddIpToTags`
+- `tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs` — add `"otel"` dispatch cases for HTTP integrations
+- `tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs` — add `SubmitsTracesOTel` test
+- `tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs` — add `SubmitsTracesOTel` test
+- `tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs` — add `"otel"` dispatch to `ValidateIntegrationSpan` and add `SubmitsTracesOTel` test
+
+---
+
+## Task 1: Add Config Key to YAML and Regenerate
+
+**Files:**
+- Modify: `tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml`
+
+- [ ] **Step 1: Open the YAML file and locate the `DD_APM_TRACING_ENABLED` entry (around line 146) as a formatting reference.**
+
+```bash
+grep -n "DD_APM_TRACING_ENABLED" tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+```
+
+Expected output: a line number around 146.
+
+- [ ] **Step 2: Add the new config key entry immediately before `DD_TRACE_OTEL_SEMANTICS_ENABLED`'s alphabetical neighbor in the file (or any convenient location near other `DD_TRACE_*` boolean keys). Search for a good insertion point:**
+
+```bash
+grep -n "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA" tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+```
+
+- [ ] **Step 3: Insert the new YAML entry after `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA` (or an appropriate alphabetical location). The entry must be:**
+
+```yaml
+  DD_TRACE_OTEL_SEMANTICS_ENABLED:
+  - implementation: A
+    scope: managed
+    type: boolean
+    default: 'false'
+    const_name: OtelSemanticsEnabled
+    documentation: |-
+      Configuration key for enabling OpenTelemetry semantic convention attribute names on HTTP spans.
+      When true, HTTP span attributes use OTel naming (e.g. <c>http.request.method</c>)
+      instead of Datadog naming (e.g. <c>http.method</c>). Supersedes <c>DD_TRACE_SPAN_ATTRIBUTE_SCHEMA</c>.
+      Default value is <c>false</c> (disabled).
+      <seealso cref="Datadog.Trace.Configuration.TracerSettings.OtelSemanticsEnabled"/>
+```
+
+- [ ] **Step 4: Build `Datadog.Trace` to trigger the source generator:**
+
+```bash
+dotnet build tracer/src/Datadog.Trace/Datadog.Trace.csproj
+```
+
+Expected: build succeeds. The generator produces/updates files under `tracer/src/Datadog.Trace/Generated/`.
+
+- [ ] **Step 5: Verify the constant was generated:**
+
+```bash
+grep -r "OtelSemanticsEnabled" tracer/src/Datadog.Trace/Generated/
+```
+
+Expected output: a line like `public const string OtelSemanticsEnabled = "DD_TRACE_OTEL_SEMANTICS_ENABLED";` in `ConfigurationKeys.g.cs`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+git add tracer/src/Datadog.Trace/Generated/
+git commit -m "[Config] Add DD_TRACE_OTEL_SEMANTICS_ENABLED configuration key"
+```
+
+---
+
+## Task 2: Add OtelSemanticsEnabled Property to TracerSettings
+
+**Files:**
+- Modify: `tracer/src/Datadog.Trace/Configuration/TracerSettings.cs`
+
+The pattern to follow is the existing `ApmTracingEnabled` bool property (lines 99–101 for the constructor read, line 786 for the property declaration).
+
+- [ ] **Step 1: Add the config read in the constructor. Find the `ApmTracingEnabled` read:**
+
+```bash
+grep -n "ApmTracingEnabled" tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+```
+
+- [ ] **Step 2: Add the `OtelSemanticsEnabled` read immediately after the `ApmTracingEnabled` read (around line 102). Insert:**
+
+```csharp
+            OtelSemanticsEnabled = config
+                                         .WithKeys(ConfigurationKeys.OtelSemanticsEnabled)
+                                         .AsBool(defaultValue: false);
+```
+
+- [ ] **Step 3: Add the property declaration. Find where `ApmTracingEnabled` property is declared:**
+
+```bash
+grep -n "internal bool ApmTracingEnabled" tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+```
+
+- [ ] **Step 4: Add `OtelSemanticsEnabled` property immediately after `ApmTracingEnabled` (around line 787):**
+
+```csharp
+        /// <summary>
+        /// Gets a value indicating whether OTel semantic convention attribute names are used for HTTP spans.
+        /// Default is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.OtelSemanticsEnabled"/>
+        internal bool OtelSemanticsEnabled { get; }
+```
+
+- [ ] **Step 5: Build to confirm no errors:**
+
+```bash
+dotnet build tracer/src/Datadog.Trace/Datadog.Trace.csproj
+```
+
+Expected: build succeeds, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+git commit -m "[Config] Add OtelSemanticsEnabled TracerSettings property"
+```
+
+---
+
+## Task 3: Create HttpOtelHelper
+
+**Files:**
+- Create: `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelper.cs`
+
+This helper centralizes all OTel `SetTag` calls. Note: the `url.query` attribute is omitted when the query string is empty, and `server.port` is derived from the parsed URI.
+
+- [ ] **Step 1: Create the file:**
+
+```csharp
+// <copyright file="HttpOtelHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http
+{
+    internal static class HttpOtelHelper
+    {
+        internal static void SetRequestMethod(ISpan span, string method)
+            => span.SetTag("http.request.method", method);
+
+        internal static void SetResponseStatusCode(ISpan span, int statusCode)
+            => span.SetTag("http.response.status_code", statusCode.ToString());
+
+        internal static void SetClientUrl(ISpan span, string rawUrl)
+        {
+            if (StringUtil.IsNullOrEmpty(rawUrl))
+            {
+                return;
+            }
+
+            span.SetTag("url.full", rawUrl);
+
+            if (Uri.TryParse(rawUrl, out var uri))
+            {
+                span.SetTag("url.scheme", uri.Scheme);
+                span.SetTag("url.path", uri.AbsolutePath);
+                if (!StringUtil.IsNullOrEmpty(uri.Query))
+                {
+                    span.SetTag("url.query", uri.Query);
+                }
+
+                if (uri.Port > 0)
+                {
+                    span.SetTag("server.port", uri.Port.ToString());
+                }
+            }
+        }
+
+        internal static void SetServerUrl(ISpan span, string rawUrl)
+        {
+            if (StringUtil.IsNullOrEmpty(rawUrl))
+            {
+                return;
+            }
+
+            span.SetTag("url.full", rawUrl);
+
+            if (Uri.TryParse(rawUrl, out var uri))
+            {
+                span.SetTag("url.scheme", uri.Scheme);
+                span.SetTag("url.path", uri.AbsolutePath);
+                if (!StringUtil.IsNullOrEmpty(uri.Query))
+                {
+                    span.SetTag("url.query", uri.Query);
+                }
+
+                if (uri.Port > 0)
+                {
+                    span.SetTag("server.port", uri.Port.ToString());
+                }
+            }
+        }
+
+        internal static void SetServerAddress(ISpan span, string host)
+            => span.SetTag("server.address", host);
+
+        internal static void SetUserAgent(ISpan span, string ua)
+            => span.SetTag("user_agent.original", ua);
+
+        internal static void SetClientAddress(ISpan span, string ip)
+            => span.SetTag("client.address", ip);
+
+        internal static void SetNetworkPeerAddress(ISpan span, string ip)
+            => span.SetTag("network.peer.address", ip);
+    }
+}
+```
+
+- [ ] **Step 2: Build to confirm no errors:**
+
+```bash
+dotnet build tracer/src/Datadog.Trace/Datadog.Trace.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelper.cs
+git commit -m "[HTTP] Add HttpOtelHelper for OTel semantic convention tag helpers"
+```
+
+---
+
+## Task 4: Modify ScopeFactory for HTTP Client OTel Tags
+
+**Files:**
+- Modify: `tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs`
+
+In `CreateInactiveOutboundHttpSpan` (line 79), the HTTP client tags are set at lines 123–128:
+```csharp
+tags.HttpMethod = httpMethod?.ToUpperInvariant();
+if (requestUri is not null)
+{
+    tags.HttpUrl = HttpRequestUtils.GetUrl(requestUri, tracer.TracerManager.QueryStringManager);
+    tags.Host = HttpRequestUtils.GetNormalizedHost(requestUri.Host);
+}
+```
+
+In OTel mode, these typed-tag properties must NOT be set (they would emit Datadog attribute names). Instead, we call `HttpOtelHelper` methods on the span directly.
+
+- [ ] **Step 1: Add the `using` directive for `HttpOtelHelper`. Find the existing usings at the top of `ScopeFactory.cs` and add:**
+
+```csharp
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
+```
+
+- [ ] **Step 2: Replace the tag-setting block (lines 123–128) with an OTel branch. The new code:**
+
+```csharp
+                if (tracer.Settings.OtelSemanticsEnabled)
+                {
+                    HttpOtelHelper.SetRequestMethod(span, httpMethod?.ToUpperInvariant());
+                    if (requestUri is not null)
+                    {
+                        HttpOtelHelper.SetClientUrl(span, HttpRequestUtils.GetUrl(requestUri, tracer.TracerManager.QueryStringManager));
+                        HttpOtelHelper.SetServerAddress(span, HttpRequestUtils.GetNormalizedHost(requestUri.Host));
+                    }
+                }
+                else
+                {
+                    tags.HttpMethod = httpMethod?.ToUpperInvariant();
+                    if (requestUri is not null)
+                    {
+                        tags.HttpUrl = HttpRequestUtils.GetUrl(requestUri, tracer.TracerManager.QueryStringManager);
+                        tags.Host = HttpRequestUtils.GetNormalizedHost(requestUri.Host);
+                    }
+                }
+```
+
+- [ ] **Step 3: Build to confirm no errors:**
+
+```bash
+dotnet build tracer/src/Datadog.Trace/Datadog.Trace.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+git commit -m "[HTTP] Switch HTTP client span tags to OTel attributes when OtelSemanticsEnabled"
+```
+
+---
+
+## Task 5: Modify SpanExtensions for HTTP Server OTel Tags
+
+**Files:**
+- Modify: `tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs`
+
+`DecorateWebServerSpan` (line 47) currently sets `tags.HttpMethod`, `tags.HttpRequestHeadersHost`, `tags.HttpUrl`, `tags.HttpUserAgent`. In OTel mode these must be replaced with OTel attributes.
+
+`DecorateWebServerSpan` does not currently accept a settings/bool parameter. The caller `AspNetCoreHttpRequestHandler.StartAspNetCorePipelineScope` has `tracer`, so we add `bool otelSemanticsEnabled = false` to the signature.
+
+`SetHttpStatusCode` (line 96) already takes `MutableSettings tracerSettings`, so it can read `OtelSemanticsEnabled` from that object.
+
+- [ ] **Step 1: Add the `using` directive for `HttpOtelHelper`:**
+
+```csharp
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
+```
+
+- [ ] **Step 2: Replace `DecorateWebServerSpan` signature and body. The current signature is:**
+
+```csharp
+internal static void DecorateWebServerSpan(
+    this ISpan span,
+    string resourceName,
+    string method,
+    string host,
+    string httpUrl,
+    string userAgent,
+    WebTags tags)
+```
+
+Replace with:
+
+```csharp
+internal static void DecorateWebServerSpan(
+    this ISpan span,
+    string resourceName,
+    string method,
+    string host,
+    string httpUrl,
+    string userAgent,
+    WebTags tags,
+    bool otelSemanticsEnabled = false)
+{
+    span.Type = SpanTypes.Web;
+    span.ResourceName = resourceName?.Trim();
+
+    if (otelSemanticsEnabled)
+    {
+        HttpOtelHelper.SetRequestMethod(span, method);
+        HttpOtelHelper.SetServerUrl(span, httpUrl);
+        HttpOtelHelper.SetServerAddress(span, host);
+        HttpOtelHelper.SetUserAgent(span, userAgent);
+    }
+    else if (tags is not null)
+    {
+        tags.HttpMethod = method;
+        tags.HttpRequestHeadersHost = host;
+        tags.HttpUrl = httpUrl;
+        tags.HttpUserAgent = userAgent;
+    }
+}
+```
+
+- [ ] **Step 3: Modify `SetHttpStatusCode` to use the OTel attribute name when OTel mode is on. The current block at line 104 is:**
+
+```csharp
+string statusCodeString = ConvertStatusCodeToString(statusCode);
+
+if (span.Tags is IHasStatusCode statusCodeTags)
+{
+    statusCodeTags.HttpStatusCode = statusCodeString;
+}
+else
+{
+    span.SetTag(Tags.HttpStatusCode, statusCodeString);
+}
+```
+
+Replace with:
+
+```csharp
+string statusCodeString = ConvertStatusCodeToString(statusCode);
+
+if (tracerSettings.OtelSemanticsEnabled)
+{
+    span.SetTag("http.response.status_code", statusCodeString);
+}
+else if (span.Tags is IHasStatusCode statusCodeTags)
+{
+    statusCodeTags.HttpStatusCode = statusCodeString;
+}
+else
+{
+    span.SetTag(Tags.HttpStatusCode, statusCodeString);
+}
+```
+
+- [ ] **Step 4: Build to confirm no errors:**
+
+```bash
+dotnet build tracer/src/Datadog.Trace/Datadog.Trace.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Check that `MutableSettings` (the type of `tracerSettings`) exposes `OtelSemanticsEnabled`. `MutableSettings` is a read-only view of `TracerSettings`:**
+
+```bash
+grep -n "OtelSemanticsEnabled\|class MutableSettings" tracer/src/Datadog.Trace/Configuration/TracerSettings.cs | head -20
+```
+
+If `OtelSemanticsEnabled` is only on `TracerSettings` (not on an interface), verify that `MutableSettings` provides access to it. If not, add it to the appropriate interface or read it via `tracerSettings` directly (the exact type at the call site may be `ImmutableTracerSettings` or `MutableSettings`). Fix accordingly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+git commit -m "[HTTP] Switch HTTP server span tags and status code to OTel attributes when OtelSemanticsEnabled"
+```
+
+---
+
+## Task 6: Wire OtelSemanticsEnabled to DecorateWebServerSpan Callers
+
+**Files:**
+- Modify: `tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs`
+
+The call site for `DecorateWebServerSpan` is line 138 in `StartAspNetCorePipelineScope`. The `tracer` variable is in scope there. Add `otelSemanticsEnabled: tracer.Settings.OtelSemanticsEnabled` to the call.
+
+Also: after `AddIpToTags` (line 205), remap the IP tags to OTel attributes when OTel mode is on — by reading the values that were just set on `tags` and calling `HttpOtelHelper`, then nulling the Datadog typed-tag properties so they are not double-emitted.
+
+- [ ] **Step 1: Update the `DecorateWebServerSpan` call at line 138. Change:**
+
+```csharp
+scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, userAgent, tags);
+```
+
+to:
+
+```csharp
+scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, userAgent, tags, otelSemanticsEnabled: tracer.Settings.OtelSemanticsEnabled);
+```
+
+- [ ] **Step 2: Update the IP tag handling. The `AddIpToTags` call is at line 205. After it, add the OTel remap block:**
+
+```csharp
+                Headers.Ip.RequestIpExtractor.AddIpToTags(peerIp, request.IsHttps, GetRequestHeaderFromKey, tracer.Settings.IpHeader, tags);
+
+                if (tracer.Settings.OtelSemanticsEnabled)
+                {
+                    if (tags.NetworkClientIp is not null)
+                    {
+                        HttpOtelHelper.SetNetworkPeerAddress(scope.Span, tags.NetworkClientIp);
+                        tags.NetworkClientIp = null;
+                    }
+
+                    if (tags.HttpClientIp is not null)
+                    {
+                        HttpOtelHelper.SetClientAddress(scope.Span, tags.HttpClientIp);
+                        tags.HttpClientIp = null;
+                    }
+                }
+```
+
+- [ ] **Step 3: Add the `using` directive if not already present:**
+
+```csharp
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
+```
+
+- [ ] **Step 4: Build to confirm no errors:**
+
+```bash
+dotnet build tracer/src/Datadog.Trace/Datadog.Trace.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+git commit -m "[HTTP] Pass OtelSemanticsEnabled to DecorateWebServerSpan and remap IP tags"
+```
+
+---
+
+## Task 7: Add "otel" Dispatch Cases to SpanMetadataAPI
+
+**Files:**
+- Modify: `tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs`
+
+The test framework dispatches schema version strings to the right validation rule method. We need `"otel"` cases for the four HTTP integrations.
+
+- [ ] **Step 1: Find the `IsHttpMessageHandler` method (around line 212):**
+
+```bash
+grep -n "IsHttpMessageHandler\|IsWebRequest\|IsAspNetCore\b\|IsAspNetCoreMvc\b" tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
+```
+
+- [ ] **Step 2: Add `"otel"` dispatch to `IsHttpMessageHandler`:**
+
+```csharp
+public static Result IsHttpMessageHandler(this MockSpan span, string metadataSchemaVersion) =>
+    metadataSchemaVersion switch
+    {
+        "otel" => span.IsHttpClientRequestOTel(),
+        "v1" => span.IsHttpMessageHandlerV1(),
+        _ => span.IsHttpMessageHandlerV0(),
+    };
+```
+
+- [ ] **Step 3: Add `"otel"` dispatch to `IsWebRequest`:**
+
+```csharp
+public static Result IsWebRequest(this MockSpan span, string metadataSchemaVersion) =>
+    metadataSchemaVersion switch
+    {
+        "otel" => span.IsHttpClientRequestOTel(),
+        "v1" => span.IsWebRequestV1(),
+        _ => span.IsWebRequestV0(),
+    };
+```
+
+- [ ] **Step 4: Add `"otel"` dispatch to `IsAspNetCore`:**
+
+```csharp
+public static Result IsAspNetCore(this MockSpan span, string metadataSchemaVersion, ISet<string> excludeTags = null) =>
+    metadataSchemaVersion switch
+    {
+        "otel" => span.IsAspNetCoreOTel(excludeTags),
+        "v1" => span.IsAspNetCoreV1(excludeTags),
+        _ => span.IsAspNetCoreV0(excludeTags),
+    };
+```
+
+- [ ] **Step 5: Add `"otel"` dispatch to `IsAspNetCoreMvc`:**
+
+```csharp
+public static Result IsAspNetCoreMvc(this MockSpan span, string metadataSchemaVersion) =>
+    metadataSchemaVersion switch
+    {
+        "otel" => span.IsAspNetCoreMvcOTel(),
+        "v1" => span.IsAspNetCoreMvcV1(),
+        _ => span.IsAspNetCoreMvcV0(),
+    };
+```
+
+- [ ] **Step 6: Build to confirm no errors:**
+
+```bash
+dotnet build tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
+git commit -m "[Test] Add 'otel' dispatch cases to SpanMetadataAPI for HTTP integrations"
+```
+
+---
+
+## Task 8: Add OTel Integration Test to HttpMessageHandlerTests
+
+**Files:**
+- Modify: `tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs`
+
+The existing `HttpClient_SubmitsTraces` test uses `[MetadataSchemaVersionData]` which only generates `"v0"` and `"v1"` combinations. Add a dedicated `[SkippableTheory]` test that sets `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` and passes `"otel"` as schema version.
+
+Looking at the existing test body (lines 56–145), the OTel test can reuse the same structure but simplify: we don't need the combinatorial `InstrumentationOptions` explosion for the OTel validation pass. A single instrumentation config is sufficient to verify the OTel tag names.
+
+- [ ] **Step 1: Add the test method after `HttpClient_SubmitsTraces`. Insert before the end of the class:**
+
+```csharp
+[SkippableTheory]
+[Trait("Category", "EndToEnd")]
+[Trait("RunOnWindows", "True")]
+[CombinatorialOrPairwiseData]
+public async Task HttpClient_SubmitsTracesOTel(
+    [CombinatorialMemberData(nameof(GetInstrumentationOptions))] InstrumentationOptions instrumentation,
+    bool socketsHandlerEnabled)
+{
+    SetInstrumentationVerification();
+    ConfigureInstrumentation(instrumentation, socketsHandlerEnabled);
+    SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+
+    const string metadataSchemaVersion = "otel";
+    var expectedAsyncCount = CalculateExpectedAsyncSpans(instrumentation);
+    var expectedSyncCount = CalculateExpectedSyncSpans(instrumentation);
+    var expectedSpanCount = expectedAsyncCount + expectedSyncCount;
+
+    int httpPort = TcpPortProvider.GetOpenPort();
+    Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
+    using var telemetry = this.ConfigureTelemetry();
+    using var agent = EnvironmentHelper.GetMockAgent();
+    using var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}");
+
+    agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
+    var spans = await agent.WaitForSpansAsync(expectedSpanCount);
+    spans.Should().HaveCount(expectedSpanCount);
+
+    // OTel mode: external span service naming still follows v0 convention
+    var clientSpanServiceName = $"{EnvironmentHelper.FullSampleName}-http-client";
+    ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
+    VerifyInstrumentation(processResult.Process);
+}
+```
+
+- [ ] **Step 2: Build the integration test project to confirm no errors:**
+
+```bash
+dotnet build tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+git commit -m "[Test] Add HttpClient_SubmitsTracesOTel integration test"
+```
+
+---
+
+## Task 9: Add OTel Integration Test to WebRequestTests
+
+**Files:**
+- Modify: `tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs`
+
+The existing pattern uses `RunTest("v0")` / `RunTest("v1")`. Add a `SubmitsTracesOTel` test that calls a `RunTest("otel")` path. The `RunTest` private method already handles the schema version plumbing.
+
+- [ ] **Step 1: Add the public test method after `SubmitsTracesV1`:**
+
+```csharp
+[SkippableFact]
+[Trait("Category", "EndToEnd")]
+[Trait("RunOnWindows", "True")]
+[Trait("SupportsInstrumentationVerification", "True")]
+public Task SubmitsTracesOTel() => RunTestOTel();
+```
+
+- [ ] **Step 2: Add a `RunTestOTel` private method. Review the existing `RunTest(string metadataSchemaVersion)` method for exact structure. The OTel version sets `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` instead of `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA`:**
+
+```csharp
+private async Task RunTestOTel()
+{
+    SetInstrumentationVerification();
+
+    var expectedAllSpansCount = 134;
+
+    int httpPort = TcpPortProvider.GetOpenPort();
+    Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
+    SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+    // OTel mode: service name follows v0 external span convention
+    var clientSpanServiceName = $"{EnvironmentHelper.FullSampleName}-http-client";
+
+    using var telemetry = this.ConfigureTelemetry();
+    using var agent = EnvironmentHelper.GetMockAgent();
+    using ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}");
+
+    var allSpans = (await agent.WaitForSpansAsync(expectedAllSpansCount, assertExpectedCount: false)).OrderBy(s => s.Start).ToList();
+
+    allSpans.Should().OnlyHaveUniqueItems(s => new { s.SpanId, s.TraceId });
+    var httpSpans = allSpans.Where(s => s.Type == SpanTypes.Http).ToList();
+    ValidateIntegrationSpans(httpSpans, "otel", expectedServiceName: clientSpanServiceName, isExternalSpan: true);
+    VerifyInstrumentation(processResult.Process);
+}
+```
+
+- [ ] **Step 3: Build the integration test project:**
+
+```bash
+dotnet build tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+git commit -m "[Test] Add SubmitsTracesOTel integration test for WebRequest"
+```
+
+---
+
+## Task 10: Add OTel Integration Test to AspNetCore Tests
+
+**Files:**
+- Modify: `tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs`
+
+`ValidateIntegrationSpan` (line 92) switches on `span.Name` and dispatches to `IsAspNetCore` / `IsAspNetCoreMvc`. These methods already have `"otel"` dispatch after Task 7, so `ValidateIntegrationSpan` already handles `"otel"` without modification.
+
+The task here is to add a `SubmitsTracesOTel` test method in `AspNetCoreMvcTestBase`. First, find a concrete subclass that runs these tests for `Samples.AspNetCoreMvc31` to understand where to add the actual test.
+
+- [ ] **Step 1: Find the concrete test class for AspNetCoreMvc31:**
+
+```bash
+grep -rn "AspNetCoreMvc31\|Mvc31" tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/ --include="*.cs" | head -20
+```
+
+- [ ] **Step 2: Identify the class that constructs with `"AspNetCoreMvc31"` sample. It should look like:**
+
+```csharp
+public class AspNetCoreMvc31Tests : AspNetCoreMvcTestBase
+{
+    public AspNetCoreMvc31Tests(...)
+        : base("AspNetCoreMvc31", ...)
+    { }
+    
+    [SkippableTheory]
+    ...
+    public async Task SubmitsTraces(...) { ... }
+}
+```
+
+- [ ] **Step 3: Add a `SubmitsTracesOTel` method to `AspNetCoreMvcTestBase`. This method calls the test infrastructure with `metadataSchemaVersion = "otel"` and `DD_TRACE_OTEL_SEMANTICS_ENABLED=true`. Add this method to `AspNetCoreMvcTestBase.cs` (inside the `#if NETCOREAPP` guard):**
+
+```csharp
+protected async Task SubmitsTracesOTel()
+{
+    SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+    const string metadataSchemaVersion = "otel";
+
+    var testName = GetTestName(nameof(SubmitsTracesOTel));
+    using var fixture = Fixture;
+
+    await fixture.TryStartApp(this, enableSecurity: false);
+    var spans = await fixture.WaitForSpansAsync();
+
+    ValidateIntegrationSpans(spans.Where(s => s.Type == SpanTypes.Web || s.Name is "aspnet_core.request" or "aspnet_core_mvc.request").ToList(), metadataSchemaVersion);
+}
+```
+
+> **Note:** Look at an existing `SubmitsTraces` method in the concrete subclass for the exact invocation pattern (fixture startup, span collection, validation call) and adapt accordingly. The key differences are: set `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` and pass `"otel"` as schema version to `ValidateIntegrationSpans`.
+
+- [ ] **Step 4: In the concrete `AspNetCoreMvc31Tests` class (and the RazorPages class), override or add a test that calls `await SubmitsTracesOTel()`:**
+
+```csharp
+[SkippableFact]
+[Trait("Category", "EndToEnd")]
+[Trait("RunOnWindows", "True")]
+public async Task SubmitsTracesOTel_Test() => await SubmitsTracesOTel();
+```
+
+- [ ] **Step 5: Find and repeat for `AspNetCoreRazorPages` test class:**
+
+```bash
+grep -rn "RazorPages\|Samples.AspNetCoreRazorPages" tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/ --include="*.cs" | head -10
+```
+
+Add the same `SubmitsTracesOTel_Test` method to the RazorPages test class.
+
+- [ ] **Step 6: Build:**
+
+```bash
+dotnet build tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/
+git commit -m "[Test] Add SubmitsTracesOTel integration tests for AspNetCore MVC and RazorPages"
+```
+
+---
+
+## Task 11: Full Build
+
+Before running integration tests, rebuild the tracer home to pick up all the changes.
+
+- [ ] **Step 1: Build the full tracer:**
+
+```bash
+./tracer/build.sh
+```
+
+Expected: build completes without errors. This produces the tracer home artifacts.
+
+- [ ] **Step 2: If the build fails with a warning treated as error, investigate and fix before proceeding. Common issues:**
+  - Missing `using` directive
+  - Property not visible on `MutableSettings` — check if `OtelSemanticsEnabled` is on the right class
+
+---
+
+## Task 12: E2E Verification Loop
+
+Run each HTTP integration test suite against `net10.0` to verify the full OTel path.
+
+- [ ] **Step 1: HttpMessageHandler tests:**
+
+```bash
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "HttpMessageHandlerTests" \
+  --SampleName "Samples.HttpMessageHandler"
+```
+
+Expected: all tests pass, including `HttpClient_SubmitsTracesOTel`.
+
+- [ ] **Step 2: If a test fails, check the span output. The most common cause is a required tag missing (e.g., `http.request.method` not present). To debug:**
+  - Set a breakpoint or add logging in `ScopeFactory.CreateInactiveOutboundHttpSpan`
+  - Verify `tracer.Settings.OtelSemanticsEnabled` is true when the `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` env var is set
+  - Check that `HttpOtelHelper.SetRequestMethod` is actually being called
+
+- [ ] **Step 3: WebRequest tests:**
+
+```bash
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "WebRequestTests" \
+  --SampleName "Samples.WebRequest"
+```
+
+Expected: all tests pass, including `SubmitsTracesOTel`.
+
+- [ ] **Step 4: AspNetCore MVC tests:**
+
+```bash
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "AspNetCoreTests" \
+  --SampleName "Samples.AspNetCoreMvc31"
+```
+
+Expected: all tests pass, including `SubmitsTracesOTel_Test`.
+
+- [ ] **Step 5: AspNetCore RazorPages tests:**
+
+```bash
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "AspNetCoreTests" \
+  --SampleName "Samples.AspNetCoreRazorPages"
+```
+
+Expected: all tests pass, including `SubmitsTracesOTel_Test`.
+
+- [ ] **Step 6: Verify no regressions in v0/v1 tests. Run a quick smoke check on HttpMessageHandler v0:**
+
+```bash
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "HttpMessageHandlerTests.HttpClient_SubmitsTraces" \
+  --SampleName "Samples.HttpMessageHandler"
+```
+
+Expected: v0/v1 tests still pass (OTel mode is off by default).
+
+---
+
+## Reference: OTel Attribute Mapping
+
+### HTTP Client spans (`http.out` type):
+
+| Set when OTel=false (Datadog) | Set when OTel=true (OTel) | Source |
+|---|---|---|
+| `http.method` (via `tags.HttpMethod`) | `http.request.method` | `ScopeFactory` |
+| `http.url` (via `tags.HttpUrl`) | `url.full`, `url.scheme`, `url.path`, `url.query`* | `ScopeFactory` / `HttpOtelHelper.SetClientUrl` |
+| `out.host` (via `tags.Host`) | `server.address` | `ScopeFactory` / `HttpOtelHelper.SetServerAddress` |
+| *(from url)* | `server.port` | `HttpOtelHelper.SetClientUrl` |
+| `http.status_code` | `http.response.status_code` | `SpanExtensions.SetHttpStatusCode` |
+| `http-client-handler-type` | `http-client-handler-type` | unchanged |
+| `peer.service` | `peer.service` | unchanged |
+| `_dd.peer.service.source` | `_dd.peer.service.source` | unchanged |
+| `peer.service.remapped_from` | `peer.service.remapped_from` | unchanged |
+
+### HTTP Server spans (`web` type):
+
+| Set when OTel=false (Datadog) | Set when OTel=true (OTel) | Source |
+|---|---|---|
+| `http.method` | `http.request.method` | `SpanExtensions.DecorateWebServerSpan` |
+| `http.url` | `url.full`, `url.scheme`, `url.path`, `url.query`* | `SpanExtensions.DecorateWebServerSpan` |
+| `http.request.headers.host` | `server.address` | `SpanExtensions.DecorateWebServerSpan` |
+| *(from url)* | `server.port` | `SpanExtensions.DecorateWebServerSpan` / `HttpOtelHelper.SetServerUrl` |
+| `http.useragent` | `user_agent.original` | `SpanExtensions.DecorateWebServerSpan` |
+| `http.status_code` | `http.response.status_code` | `SpanExtensions.SetHttpStatusCode` |
+| `network.client.ip` | `network.peer.address` | `AspNetCoreHttpRequestHandler` (post-`AddIpToTags`) |
+| `http.client_ip` | `client.address` | `AspNetCoreHttpRequestHandler` (post-`AddIpToTags`) |
+| `http.route` | `http.route` | unchanged |
+
+*`url.query` omitted if the query string is empty.

--- a/docs/superpowers/specs/2026-06-15-otel-semantics-design.md
+++ b/docs/superpowers/specs/2026-06-15-otel-semantics-design.md
@@ -1,0 +1,180 @@
+# OTel Semantics Feature Design
+
+**Date:** 2026-06-15
+**Scope:** HTTP integrations only
+**Status:** Approved
+
+## Overview
+
+A new opt-in feature controlled by `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` that causes HTTP span tags to be emitted using OpenTelemetry semantic convention attribute names instead of Datadog convention names. When enabled, OTel mode supersedes `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA` (v0/v1) for tag naming. Only tags change — span name and type are unaffected.
+
+## Configuration
+
+- **Environment variable:** `DD_TRACE_OTEL_SEMANTICS_ENABLED`
+- **Default:** `false`
+- **C# constant:** `ConfigurationKeys.OtelSemanticsEnabled`
+- **TracerSettings property:** `bool OtelSemanticsEnabled { get; }`
+- **Registration:** Added to `supported-configurations.yaml` and read via `config.WithKeys(ConfigurationKeys.OtelSemanticsEnabled).AsBool(defaultValue: false)`
+- **Schema version interaction:** When `OtelSemanticsEnabled=true`, schema version is ignored for tag naming decisions.
+
+## Attribute Mapping
+
+### HTTP Client (`HttpMessageHandler`, `WebRequest`)
+
+| Datadog attribute | OTel attribute | Notes |
+|---|---|---|
+| `http.method` | `http.request.method` | |
+| `http.status_code` | `http.response.status_code` | |
+| `http.url` | `url.full` | Full URL string |
+| `http.url` | `url.scheme` | Decomposed from URL |
+| `http.url` | `url.path` | Decomposed from URL |
+| `http.url` | `url.query` | Decomposed from URL, omitted if empty |
+| `out.host` | `server.address` | |
+| `out.port` | `server.port` | Decomposed from URL port |
+| `peer.service` | `peer.service` | Unchanged |
+| `http-client-handler-type` | `http-client-handler-type` | Unchanged |
+| `_dd.peer.service.source` | `_dd.peer.service.source` | Unchanged |
+| `peer.service.remapped_from` | `peer.service.remapped_from` | Unchanged |
+
+### HTTP Server (`AspNetCore`, `AspNet`, `AspNetWebApi2`)
+
+| Datadog attribute | OTel attribute | Notes |
+|---|---|---|
+| `http.method` | `http.request.method` | |
+| `http.status_code` | `http.response.status_code` | |
+| `http.url` | `url.full` | Full URL string |
+| `http.url` | `url.scheme` | Decomposed from URL |
+| `http.url` | `url.path` | Decomposed from URL |
+| `http.url` | `url.query` | Decomposed from URL, omitted if empty |
+| `http.useragent` | `user_agent.original` | |
+| `http.request.headers.host` | `server.address` | |
+| *(URL port)* | `server.port` | Decomposed from URL port |
+| `http.client_ip` | `client.address` | |
+| `network.client.ip` | `network.peer.address` | |
+| `http.route` | `http.route` | Unchanged — same in both conventions |
+
+## Shared Helper
+
+`HttpOtelHelper` (new static class in `Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/`) centralizes all OTel tag-setting:
+
+```csharp
+internal static class HttpOtelHelper
+{
+    public static void SetRequestMethod(ISpan span, string method)
+        => span.SetTag("http.request.method", method);
+
+    public static void SetResponseStatusCode(ISpan span, int statusCode)
+        => span.SetTag("http.response.status_code", statusCode.ToString());
+
+    public static void SetUrl(ISpan span, string rawUrl)
+    {
+        span.SetTag("url.full", rawUrl);
+        if (Uri.TryParse(rawUrl, out var uri))
+        {
+            span.SetTag("url.scheme", uri.Scheme);
+            span.SetTag("url.path", uri.AbsolutePath);
+            if (!string.IsNullOrEmpty(uri.Query))
+                span.SetTag("url.query", uri.Query);
+            if (uri.Port > 0)
+                span.SetTag("server.port", uri.Port.ToString());
+        }
+    }
+
+    public static void SetServerAddress(ISpan span, string host)
+        => span.SetTag("server.address", host);
+
+    public static void SetServerPort(ISpan span, int port)
+        => span.SetTag("server.port", port.ToString());
+
+    public static void SetUserAgent(ISpan span, string ua)
+        => span.SetTag("user_agent.original", ua);
+
+    public static void SetClientAddress(ISpan span, string ip)
+        => span.SetTag("client.address", ip);
+
+    public static void SetNetworkPeerAddress(ISpan span, string ip)
+        => span.SetTag("network.peer.address", ip);
+}
+```
+
+## Integration Touch Points
+
+Each integration checks `tracer.Settings.OtelSemanticsEnabled` and branches:
+
+```csharp
+if (tracer.Settings.OtelSemanticsEnabled)
+    HttpOtelHelper.SetRequestMethod(span, method);
+else
+    span.SetTag(Tags.HttpMethod, method);
+```
+
+**Files modified:**
+- `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs`
+- `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestIntegration.cs`
+- `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/AspNetCoreHttpRequestHandler.cs`
+- `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetIntegration.cs`
+- `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetWebApi2/AspNetWebApi2Integration.cs`
+- `tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs`
+- `tracer/src/Datadog.Trace/Configuration/TracerSettings.cs`
+- `tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml`
+
+**Files created:**
+- `tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelper.cs`
+
+## Test Strategy
+
+### Test Infrastructure
+
+`SpanMetadataAPI.cs` gets an `"otel"` dispatch case for each HTTP integration:
+
+```csharp
+public static Result IsHttpMessageHandler(this MockSpan span, string metadataSchemaVersion) =>
+    metadataSchemaVersion switch
+    {
+        "otel" => span.IsHttpClientRequestOTel(),
+        "v1"   => span.IsHttpMessageHandlerV1(),
+        _      => span.IsHttpMessageHandlerV0(),
+    };
+```
+
+Applied to: `IsHttpMessageHandler`, `IsWebRequest`, `IsAspNetCore`, `IsAspNetCoreMvc`, `IsAspNet`, `IsAspNetWebApi2`.
+
+### Integration Tests
+
+Each HTTP integration test class gets a new `[Theory]` method that:
+1. Sets `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` in the environment
+2. Passes `"otel"` as `metadataSchemaVersion` to `ValidateIntegrationSpan`
+3. Validates spans against `SpanMetadataOTelRules` via the dispatch above
+
+> **Note:** `AspNet` and `AspNetWebApi2` are .NET Framework-only integrations. Their tag-switching code will be implemented, but their integration tests require a Windows/.NET Framework environment and are **out of scope** for the `net10.0` E2E verification loop below.
+
+### E2E Verification Loop
+
+```bash
+# 1. Build tracer home
+./tracer/build.sh
+
+# 2. HTTP client — HttpMessageHandler
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "HttpMessageHandlerTests" \
+  --SampleName "Samples.HttpMessageHandler"
+
+# 3. HTTP client — WebRequest
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "WebRequestTests" \
+  --SampleName "Samples.WebRequest"
+
+# 4. HTTP server — AspNetCore MVC
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "AspNetCoreTests" \
+  --SampleName "Samples.AspNetCoreMvc31"
+
+# 5. HTTP server — AspNetCore Razor Pages
+./tracer/build.sh BuildAndRunIntegrationTests \
+  --framework net10.0 \
+  --filter "AspNetCoreTests" \
+  --SampleName "Samples.AspNetCoreRazorPages"
+```

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -415,6 +415,7 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/ErrorLocationStruct.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommonBase.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLTags.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/OperationTypeProxy.cs
+src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelper.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/CachedMessageHeadersHelper.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IConsumeException.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IConsumeResult.cs

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -36,6 +36,15 @@ namespace Datadog.Trace.Agent
                 httpStatusCode = 0;
             }
 
+            if (httpStatusCode == 0)
+            {
+                var tagStatusCode = span.GetTag("http.response.status_code");
+                if (tagStatusCode is not null && int.TryParse(tagStatusCode, out var httpStatusCodeValue))
+                {
+                    httpStatusCode = httpStatusCodeValue;
+                }
+            }
+
             return new StatsAggregationKey(
                 span.ResourceName,
                 span.ServiceName,

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -368,6 +368,15 @@ namespace Datadog.Trace.Agent
                 httpStatusCode = 0;
             }
 
+            if (httpStatusCode == 0)
+            {
+                var tagStatusCode = span.GetTag("http.response.status_code");
+                if (tagStatusCode is not null && int.TryParse(tagStatusCode, out var httpStatusCodeValue))
+                {
+                    httpStatusCode = httpStatusCodeValue;
+                }
+            }
+
             // Check gRPC status code tags in priority order per CSS v1.2.0 spec.
             // Stored as string to match the Go agent's wire format (GRPCStatusCode is a string field).
             // This preserves the distinction between "0" (gRPC OK) and "" (no gRPC status).

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
@@ -255,7 +255,7 @@ internal sealed partial class SecurityReporter
 
             if (status is not null)
             {
-                _span.SetHttpStatusCode(status.Value, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings);
+                _span.SetHttpStatusCode(status.Value, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
             }
         }
 
@@ -350,7 +350,7 @@ internal sealed partial class SecurityReporter
 
     internal void AddResponseHeaderTags()
     {
-        var route = _span.GetTag(Tags.AspNetCoreRoute) ?? _span.GetTag(Tags.AspNetRoute);
+        var route = _span.GetTag(Tags.HttpRoute) ?? _span.GetTag(Tags.AspNetCoreRoute) ?? _span.GetTag(Tags.AspNetRoute);
         if (route != null)
         {
             _span.SetTag(Tags.HttpEndpoint, route);

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -194,7 +194,7 @@ namespace Datadog.Trace.AspNet
                 var resourceName = tracer.CurrentTraceSettings.HasResourceBasedSamplingRule
                                        ? BuildResourceName(tracer, httpRequest)
                                        : null;
-                scope.Span.DecorateWebServerSpan(resourceName: resourceName, httpMethod, host, url, userAgent, tags);
+                scope.Span.DecorateWebServerSpan(resourceName: resourceName, httpMethod, host, url, userAgent, tags, otelSemanticsEnabled: tracer.Settings.OtelSemanticsEnabled);
                 tracer.TracerManager.SpanContextPropagator.AddHeadersToSpanAsTags(scope.Span, headers, tracer.CurrentTraceSettings.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpRequestHeadersTagPrefix);
                 tracer.TracerManager.SpanContextPropagator.AddSecurityTestingHeadersAsTags(scope.Span, headers);
                 if (inferredProxyScope?.Span is { } proxySpan)
@@ -409,21 +409,21 @@ namespace Datadog.Trace.AspNet
                         // add "http.status_code" tag to the root span
                         if (!rootSpan.HasHttpStatusCode())
                         {
-                            rootSpan.SetHttpStatusCode(status, isServer: true, settings);
+                            rootSpan.SetHttpStatusCode(status, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
                             AddHeaderTagsFromHttpResponse(app.Context, rootScope);
                         }
 
                         // also add "http.status_code" tag to the current span if it's not the root
                         if (currentSpan != rootSpan && !currentSpan.HasHttpStatusCode())
                         {
-                            currentSpan.SetHttpStatusCode(status, isServer: true, settings);
+                            currentSpan.SetHttpStatusCode(status, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
                             AddHeaderTagsFromHttpResponse(app.Context, scope);
                         }
 
                         // also add "http.status_code" tag to the inferred proxy span
                         if (proxyScope?.Span is { } proxySpan && proxySpan != rootSpan && !proxySpan.HasHttpStatusCode())
                         {
-                            proxySpan.SetHttpStatusCode(status, isServer: true, settings);
+                            proxySpan.SetHttpStatusCode(status, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
                             AddHeaderTagsFromHttpResponse(app.Context, proxyScope);
                         }
 
@@ -502,8 +502,8 @@ namespace Datadog.Trace.AspNet
                         {
                             // in classic mode, the exception won't cause the correct status code to be set
                             // even though a 500 response will be sent ultimately, so set it manually
-                            scope.Span.SetHttpStatusCode(500, isServer: true, settings);
-                            proxyScope?.Span.SetHttpStatusCode(500, isServer: true, settings);
+                            scope.Span.SetHttpStatusCode(500, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
+                            proxyScope?.Span.SetHttpStatusCode(500, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
                         }
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                 if (response.Instance is not null)
                 {
                     tags.RequestId = response.ResponseMetadata?.RequestId;
-                    state.Scope.Span.SetHttpStatusCode((int)response.HttpStatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)response.HttpStatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeSyncIntegration.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                 if (responseContext.Instance is not null && responseContext.Response is { } response)
                 {
                     tags.RequestId = response.ResponseMetadata?.RequestId;
-                    state.Scope.Span.SetHttpStatusCode((int)response.HttpStatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)response.HttpStatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
             else
             {
                 HttpContextHelper.AddHeaderTagsFromHttpResponse(HttpContext.Current, scope);
-                scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings);
+                scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                 scope.Dispose();
             }
 
@@ -136,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         private static void OnRequestCompletedAfterException(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
             HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
-            scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings);
+            scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
             scope.Span.Finish(finishTime);
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -177,7 +177,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         host: host,
                         httpUrl: url,
                         userAgent: userAgent,
-                        tags);
+                        tags,
+                        otelSemanticsEnabled: tracer.Settings.OtelSemanticsEnabled);
 
                     if (headers is not null)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -200,7 +200,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     host: host,
                     httpUrl: url,
                     userAgent: userAgent,
-                    tags);
+                    tags,
+                    otelSemanticsEnabled: tracer.Settings.OtelSemanticsEnabled);
 
                 if (tags is not null)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
@@ -94,12 +94,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 else
                 {
                     HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
-                    scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings);
+                    scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
 
                     if (proxyScope?.Span != null)
                     {
                         HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, proxyScope);
-                        proxyScope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings);
+                        proxyScope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                     }
 
                     scope.Dispose();
@@ -129,12 +129,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 if (proxyScope?.Span != null)
                 {
                     HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, proxyScope);
-                    proxyScope.Span.SetHttpStatusCode(statusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings);
+                    proxyScope.Span.SetHttpStatusCode(statusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                     proxyScope.Span.Finish(finishTime);
                 }
 
                 HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
-                scope.Span.SetHttpStatusCode(statusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings);
+                scope.Span.SetHttpStatusCode(statusCode, isServer: true, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                 scope.Span.Finish(finishTime);
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -457,7 +457,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 
                 if (!span.HasHttpStatusCode())
                 {
-                    span.SetHttpStatusCode(statusCode: 500, isServer: true, settings);
+                    span.SetHttpStatusCode(statusCode: 500, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
                 }
 
                 span.SetException(exception);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -128,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
                 {
                     var statusCode = responseMessage.StatusCode;
 #endif
-                    scope.Span.SetHttpStatusCode(statusCode, false, Tracer.Instance.CurrentTraceSettings.Settings);
+                    scope.Span.SetHttpStatusCode(statusCode, false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                 }
 
                 if (exception != null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelper.cs
@@ -1,0 +1,136 @@
+// <copyright file="HttpOtelHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http
+{
+    internal static class HttpOtelHelper
+    {
+        private static readonly System.Collections.Generic.HashSet<string> KnownMethods = new(System.StringComparer.OrdinalIgnoreCase)
+        {
+            "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "PATCH", "CONNECT", "QUERY"
+        };
+
+        internal static string GetResourceNameMethod(string method)
+        {
+            if (StringUtil.IsNullOrEmpty(method))
+            {
+                return "HTTP";
+            }
+
+            var upper = method.ToUpperInvariant();
+            return KnownMethods.Contains(upper) ? upper : "HTTP";
+        }
+
+        internal static void SetRequestMethod(ISpan span, string method)
+        {
+            if (StringUtil.IsNullOrEmpty(method))
+            {
+                return;
+            }
+
+            var upper = method.ToUpperInvariant();
+            if (KnownMethods.Contains(upper))
+            {
+                span.SetTag("http.request.method", upper);
+            }
+            else
+            {
+                span.SetTag("http.request.method", "_OTHER");
+                span.SetTag("http.request.method_original", method);
+            }
+        }
+
+        internal static void SetClientUrl(ISpan span, string rawUrl)
+        {
+            if (StringUtil.IsNullOrEmpty(rawUrl))
+            {
+                return;
+            }
+
+            if (Uri.TryCreate(rawUrl, UriKind.Absolute, out var uri))
+            {
+                span.SetTag("url.scheme", uri.Scheme);
+
+                // Redact credentials (username:password@host) before setting url.full
+                if (!StringUtil.IsNullOrEmpty(uri.UserInfo))
+                {
+                    var builder = new UriBuilder(uri) { UserName = string.Empty, Password = string.Empty };
+                    span.SetTag("url.full", builder.Uri.ToString());
+                }
+                else
+                {
+                    span.SetTag("url.full", rawUrl);
+                }
+
+                if (span is Span internalSpan && uri.Port > 0 && !uri.IsDefaultPort)
+                {
+                    internalSpan.SetMetric("server.port", uri.Port);
+                }
+            }
+            else
+            {
+                span.SetTag("url.full", rawUrl);
+            }
+        }
+
+        internal static void SetServerUrl(ISpan span, string rawUrl)
+        {
+            if (StringUtil.IsNullOrEmpty(rawUrl))
+            {
+                return;
+            }
+
+            if (Uri.TryCreate(rawUrl, UriKind.Absolute, out var uri))
+            {
+                span.SetTag("url.scheme", uri.Scheme);
+                span.SetTag("url.path", uri.AbsolutePath);
+                if (!StringUtil.IsNullOrEmpty(uri.Query) && uri.Query.Length > 1)
+                {
+                    span.SetTag("url.query", uri.Query.Substring(1));
+                }
+
+                if (span is Span internalSpan && uri.Port > 0 && !uri.IsDefaultPort)
+                {
+                    internalSpan.SetMetric("server.port", uri.Port);
+                }
+            }
+        }
+
+        internal static void SetServerAddress(ISpan span, string host)
+        {
+            if (!StringUtil.IsNullOrEmpty(host))
+            {
+                span.SetTag("server.address", host);
+            }
+        }
+
+        internal static void SetUserAgent(ISpan span, string ua)
+        {
+            if (!StringUtil.IsNullOrEmpty(ua))
+            {
+                span.SetTag("user_agent.original", ua);
+            }
+        }
+
+        internal static void SetClientAddress(ISpan span, string ip)
+        {
+            if (!StringUtil.IsNullOrEmpty(ip))
+            {
+                span.SetTag("client.address", ip);
+            }
+        }
+
+        internal static void SetNetworkPeerAddress(ISpan span, string ip)
+        {
+            if (!StringUtil.IsNullOrEmpty(ip))
+            {
+                span.SetTag("network.peer.address", ip);
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponseV9_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponseV9_Integration.cs
@@ -94,7 +94,7 @@ public sealed class HttpWebRequest_EndGetResponseV9_Integration
 
                     if (returnValue is HttpWebResponse response)
                     {
-                        scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings);
+                        scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                         scope.Dispose();
                     }
                     else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
@@ -103,7 +103,7 @@ public sealed class HttpWebRequest_EndGetResponseV9_Integration
                         // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
                         scope.Span.SetException(exception, markAsError: false);
 
-                        scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings);
+                        scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                         scope.Dispose();
                     }
                     else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                         if (returnValue is HttpWebResponse response)
                         {
-                            scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings);
+                            scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                             scope.Dispose();
                         }
                         else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                             // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
                             scope.Span.SetException(exception, markAsError: false);
 
-                            scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings);
+                            scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                             scope.Dispose();
                         }
                         else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
             {
                 if (returnValue is HttpWebResponse response)
                 {
-                    state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                     state.Scope.Dispose();
                 }
                 else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
                     state.Scope.Span.SetException(exception, markAsError: false);
 
-                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
                     state.Scope.Dispose();
                 }
                 else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 Tracer tracer = Tracer.Instance;
                 if (returnValue is HttpWebResponse response)
                 {
-                    state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, tracer.CurrentTraceSettings.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, tracer.CurrentTraceSettings.Settings, tracer.Settings.OtelSemanticsEnabled);
                     state.Scope.Dispose();
                 }
                 else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
@@ -75,7 +75,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
                     state.Scope.Span.SetException(exception, markAsError: false);
 
-                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, tracer.CurrentTraceSettings.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, tracer.CurrentTraceSettings.Settings, tracer.Settings.OtelSemanticsEnabled);
 
                     state.Scope.Dispose();
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpReceiveAndProcessIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpReceiveAndProcessIntegration.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
         {
             if (state.Scope is not null && state.State is HttpWebResponse response)
             {
-                state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings);
+                state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.Instance.CurrentTraceSettings.Settings, Tracer.Instance.Settings.OtelSemanticsEnabled);
             }
 
             return CallTargetReturn.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
@@ -190,7 +190,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                     host,
                     httpUrl: requestHeadersTo?.AbsoluteUri,
                     userAgent,
-                    tags);
+                    tags,
+                    otelSemanticsEnabled: tracer.Settings.OtelSemanticsEnabled);
 
                 if (headers is not null)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
 using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Schema;
@@ -120,11 +121,23 @@ namespace Datadog.Trace.ClrProfiler
                 span.Type = SpanTypes.Http;
                 span.ResourceName = $"{httpMethod} {resourceUrl}";
 
-                tags.HttpMethod = httpMethod?.ToUpperInvariant();
-                if (requestUri is not null)
+                if (tracer.Settings.OtelSemanticsEnabled)
                 {
-                    tags.HttpUrl = HttpRequestUtils.GetUrl(requestUri, tracer.TracerManager.QueryStringManager);
-                    tags.Host = HttpRequestUtils.GetNormalizedHost(requestUri.Host);
+                    HttpOtelHelper.SetRequestMethod(span, httpMethod?.ToUpperInvariant());
+                    if (requestUri is not null)
+                    {
+                        HttpOtelHelper.SetClientUrl(span, HttpRequestUtils.GetUrl(requestUri, tracer.TracerManager.QueryStringManager));
+                        HttpOtelHelper.SetServerAddress(span, HttpRequestUtils.GetNormalizedHost(requestUri.Host));
+                    }
+                }
+                else
+                {
+                    tags.HttpMethod = httpMethod?.ToUpperInvariant();
+                    if (requestUri is not null)
+                    {
+                        tags.HttpUrl = HttpRequestUtils.GetUrl(requestUri, tracer.TracerManager.QueryStringManager);
+                        tags.Host = HttpRequestUtils.GetNormalizedHost(requestUri.Host);
+                    }
                 }
 
                 tags.InstrumentationName = IntegrationRegistry.GetName(integrationId);

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.SpanCodeOrigin;
@@ -303,13 +304,6 @@ namespace Datadog.Trace.DiagnosticListeners
             HttpContext httpContext,
             HttpRequest request)
         {
-            // Create a child span for the MVC action
-            var mvcSpanTags = new AspNetCoreMvcTags();
-            var mvcScope = tracer.StartActiveInternal(MvcOperationName, tags: mvcSpanTags);
-            tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
-            var span = mvcScope.Span;
-            span.Type = SpanTypes.Web;
-
             // StartMvcCoreSpan is only called with new route names, so parent tags are always AspNetCoreEndpointTags
             var rootSpan = trackingFeature.RootScope.Span;
             var rootSpanTags = (AspNetCoreEndpointTags)rootSpan.Tags;
@@ -381,7 +375,12 @@ namespace Datadog.Trace.DiagnosticListeners
                         actionName: actionName,
                         expandRouteParameters: tracer.Settings.ExpandRouteTemplatesEnabled);
 
-                    resourceName = $"{rootSpanTags.HttpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
+                    // HttpMethod is null in OTel mode (stored as "http.request.method" raw tag instead)
+                    // In OTel mode, use "HTTP" for unknown methods per OTel semantic conventions
+                    var httpMethod = tracer.Settings.OtelSemanticsEnabled
+                        ? HttpOtelHelper.GetResourceNameMethod(request.Method)
+                        : (rootSpanTags.HttpMethod ?? request.Method?.ToUpperInvariant() ?? "UNKNOWN");
+                    resourceName = $"{httpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
 
                     aspNetRoute = routeTemplate?.TemplateText.ToLowerInvariant();
                 }
@@ -389,24 +388,47 @@ namespace Datadog.Trace.DiagnosticListeners
 
             // mirror the parent if we couldn't extract a route for some reason
             // (and the parent is not using the placeholder resource name)
-            span.ResourceName = resourceName
-                             ?? (string.IsNullOrEmpty(rootSpan.ResourceName)
-                                     ? AspNetCoreRequestHandler.GetDefaultResourceName(httpContext.Request)
-                                     : rootSpan.ResourceName);
+            var effectiveResourceName = resourceName
+                                     ?? (string.IsNullOrEmpty(rootSpan.ResourceName)
+                                             ? AspNetCoreRequestHandler.GetDefaultResourceName(httpContext.Request, tracer.Settings.OtelSemanticsEnabled)
+                                             : rootSpan.ResourceName);
+
+            if (!isUsingEndpointRouting && isFirstExecution)
+            {
+                // If we're using endpoint routing or this is a pipeline re-execution,
+                // these will already be set correctly
+                if (tracer.Settings.OtelSemanticsEnabled)
+                {
+                    rootSpanTags.HttpRoute = aspNetRoute;
+                }
+                else
+                {
+                    rootSpanTags.AspNetCoreRoute = aspNetRoute;
+                }
+
+                rootSpan.ResourceName = effectiveResourceName;
+            }
+
+            // In OTel semantics mode, a single server span is used: skip child span creation
+            if (tracer.Settings.OtelSemanticsEnabled)
+            {
+                return null;
+            }
+
+            // Create a child span for the MVC action
+            var mvcSpanTags = new AspNetCoreMvcTags();
+            var mvcScope = tracer.StartActiveInternal(MvcOperationName, tags: mvcSpanTags);
+            tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
+            var span = mvcScope.Span;
+            span.Type = SpanTypes.Web;
+
+            span.ResourceName = effectiveResourceName;
 
             mvcSpanTags.AspNetCoreAction = actionName;
             mvcSpanTags.AspNetCoreController = controllerName;
             mvcSpanTags.AspNetCoreArea = areaName;
             mvcSpanTags.AspNetCorePage = pagePath;
             mvcSpanTags.AspNetCoreRoute = aspNetRoute;
-
-            if (!isUsingEndpointRouting && isFirstExecution)
-            {
-                // If we're using endpoint routing or this is a pipeline re-execution,
-                // these will already be set correctly
-                rootSpanTags.AspNetCoreRoute = aspNetRoute;
-                rootSpan.ResourceName = span.ResourceName;
-            }
 
             return span;
         }
@@ -454,9 +476,10 @@ namespace Datadog.Trace.DiagnosticListeners
              && httpContext.Items[AspNetCoreHttpRequestHandler.HttpContextTrackingKey] is AspNetCoreHttpRequestHandler.RequestTrackingFeature { RootScope.Span: { } rootSpan } trackingFeature)
             {
                 var routeTemplateResourceNamesEnabled = _tracer.Settings.RouteTemplateResourceNamesEnabled;
+                var otelSemanticsEnabled = _tracer.Settings.OtelSemanticsEnabled;
                 var isFirstExecution = trackingFeature.IsFirstPipelineExecution;
                 // Only modify tracking feature if _not_ using legacy feature names
-                if (isFirstExecution && routeTemplateResourceNamesEnabled)
+                if (isFirstExecution && (routeTemplateResourceNamesEnabled || otelSemanticsEnabled))
                 {
                     trackingFeature.IsUsingEndpointRouting = true;
                     trackingFeature.IsFirstPipelineExecution = false;
@@ -520,7 +543,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     Log.Debug("Could not extract type and method for endpoint code origin. Endpoint: {EndpointDisplayName}", routeEndpoint.Value.DisplayName);
                 }
 
-                if (!routeTemplateResourceNamesEnabled)
+                if (!routeTemplateResourceNamesEnabled && !otelSemanticsEnabled)
                 {
                     return;
                 }
@@ -531,7 +554,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     return;
                 }
 
-                if (isFirstExecution)
+                if (isFirstExecution && !_tracer.Settings.OtelSemanticsEnabled)
                 {
                     tags.AspNetCoreEndpoint = routeEndpoint.Value.DisplayName;
                 }
@@ -557,15 +580,24 @@ namespace Datadog.Trace.DiagnosticListeners
                                       ? raw as string
                                       : null;
 
-                var resourcePathName = AspNetCoreResourceNameHelper.SimplifyRoutePattern(
-                    routePattern,
-                    routeValues,
-                    areaName: areaName,
-                    controllerName: controllerName,
-                    actionName: actionName,
-                    _tracer.Settings.ExpandRouteTemplatesEnabled);
+                // In OTel semantics mode, use the raw route text so the resource name matches http.route
+                // (preserving type constraints like {id:int}). Fall back to SimplifyRoutePattern otherwise.
+                var resourcePathName = otelSemanticsEnabled && normalizedRoute is not null
+                    ? normalizedRoute
+                    : AspNetCoreResourceNameHelper.SimplifyRoutePattern(
+                        routePattern,
+                        routeValues,
+                        areaName: areaName,
+                        controllerName: controllerName,
+                        actionName: actionName,
+                        _tracer.Settings.ExpandRouteTemplatesEnabled);
 
-                var resourceName = $"{tags.HttpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
+                // HttpMethod is null in OTel mode (stored as "http.request.method" raw tag instead)
+                // In OTel mode, use "HTTP" for unknown methods per OTel semantic conventions
+                var httpMethod = otelSemanticsEnabled
+                    ? HttpOtelHelper.GetResourceNameMethod(request.Method)
+                    : (tags.HttpMethod ?? request.Method?.ToUpperInvariant() ?? "UNKNOWN");
+                var resourceName = $"{httpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
 
                 // NOTE: We could set the controller/action/area tags on the parent span
                 // But instead we re-extract them in the MVC endpoint as these are MVC
@@ -576,7 +608,14 @@ namespace Datadog.Trace.DiagnosticListeners
                 {
                     // Overwrite the route in the parent span
                     rootSpan.ResourceName = resourceName;
-                    tags.AspNetCoreRoute = normalizedRoute;
+                    if (_tracer.Settings.OtelSemanticsEnabled)
+                    {
+                        tags.HttpRoute = normalizedRoute;
+                    }
+                    else
+                    {
+                        tags.AspNetCoreRoute = normalizedRoute;
+                    }
                 }
 
                 _security.CheckPathParamsAndSessionId(httpContext, rootSpan, routeValues);

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/SingleSpanAspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/SingleSpanAspNetCoreDiagnosticObserver.cs
@@ -10,6 +10,7 @@ using System;
 using System.Reflection;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.SpanCodeOrigin;
@@ -256,19 +257,38 @@ namespace Datadog.Trace.DiagnosticListeners
                     // No need to ToLowerInvariant() these strings, as we lower case
                     // the whole route later
 
-                    var resourcePathName = AspNetCoreResourceNameHelper.SimplifyRoutePattern(
-                        routePattern,
-                        routeValues,
-                        _tracer.Settings.ExpandRouteTemplatesEnabled);
+                    var normalizedRoute = routePattern.RawText?.ToLowerInvariant();
+
+                    // In OTel semantics mode, use the raw route text so the resource name matches http.route
+                    // (preserving type constraints like {id:int}). Fall back to SimplifyRoutePattern otherwise.
+                    var resourcePathName = _tracer.Settings.OtelSemanticsEnabled && normalizedRoute is not null
+                        ? normalizedRoute
+                        : AspNetCoreResourceNameHelper.SimplifyRoutePattern(
+                            routePattern,
+                            routeValues,
+                            _tracer.Settings.ExpandRouteTemplatesEnabled);
+
+                    // In OTel mode, HttpMethod is null (stored as "http.request.method" raw tag instead).
+                    // Use "HTTP" for unknown methods per OTel semantic conventions.
+                    var httpMethod = _tracer.Settings.OtelSemanticsEnabled
+                        ? HttpOtelHelper.GetResourceNameMethod(request.Method)
+                        : (tags.HttpMethod ?? "UNKNOWN");
 
                     // If we have a PathBase, then we need to do a bunch of encoding etc which requires allocating buffers
                     // and various other things. We could look at optimizing that later by inlining ToUriComponent and using a ValueStringBuilder,
                     // but for now, we just fast-path the no-path base case
-                    rootSpan.ResourceName = !request.PathBase.HasValue && tags.HttpMethod.Length + 1 + resourcePathName.Length <= 1024
-                                                ? string.Create(null, stackalloc char[1024], $"{tags.HttpMethod} {resourcePathName}")
-                                                : $"{tags.HttpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
+                    rootSpan.ResourceName = !request.PathBase.HasValue && httpMethod.Length + 1 + resourcePathName.Length <= 1024
+                                                ? string.Create(null, stackalloc char[1024], $"{httpMethod} {resourcePathName}")
+                                                : $"{httpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
 
-                    tags.AspNetCoreRoute = routePattern.RawText?.ToLowerInvariant();
+                    if (_tracer.Settings.OtelSemanticsEnabled)
+                    {
+                        tags.HttpRoute = normalizedRoute;
+                    }
+                    else
+                    {
+                        tags.AspNetCoreRoute = normalizedRoute;
+                    }
                 }
 
                 // We check appsec enabled in here, but this avoids the method call if it's not needed

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
@@ -51,12 +52,20 @@ namespace Datadog.Trace.ExtensionMethods
             string host,
             string httpUrl,
             string userAgent,
-            WebTags tags)
+            WebTags tags,
+            bool otelSemanticsEnabled = false)
         {
             span.Type = SpanTypes.Web;
             span.ResourceName = resourceName?.Trim();
 
-            if (tags is not null)
+            if (otelSemanticsEnabled)
+            {
+                HttpOtelHelper.SetRequestMethod(span, method);
+                HttpOtelHelper.SetServerUrl(span, httpUrl);
+                HttpOtelHelper.SetServerAddress(span, host);
+                HttpOtelHelper.SetUserAgent(span, userAgent);
+            }
+            else if (tags is not null)
             {
                 tags.HttpMethod = method;
                 tags.HttpRequestHeadersHost = host;
@@ -93,7 +102,7 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        internal static void SetHttpStatusCode(this Span span, int statusCode, bool isServer, MutableSettings tracerSettings)
+        internal static void SetHttpStatusCode(this Span span, int statusCode, bool isServer, MutableSettings tracerSettings, bool otelSemanticsEnabled = false)
         {
             if (statusCode < 100 || statusCode >= 600)
             {
@@ -103,7 +112,11 @@ namespace Datadog.Trace.ExtensionMethods
 
             string statusCodeString = ConvertStatusCodeToString(statusCode);
 
-            if (span.Tags is IHasStatusCode statusCodeTags)
+            if (otelSemanticsEnabled)
+            {
+                span.SetTag("http.response.status_code", statusCodeString);
+            }
+            else if (span.Tags is IHasStatusCode statusCodeTags)
             {
                 statusCodeTags.HttpStatusCode = statusCodeString;
             }
@@ -117,9 +130,17 @@ namespace Datadog.Trace.ExtensionMethods
             {
                 span.Error = true;
 
-                // if an error message already exists (e.g. from a previous exception), don't replace it
-                if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorMsg)))
+                if (otelSemanticsEnabled)
                 {
+                    // Don't clobber an error.type already set by an exception handler
+                    if (span.GetTag("error.type") is null)
+                    {
+                        span.SetTag("error.type", statusCodeString);
+                    }
+                }
+                else if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorMsg)))
+                {
+                    // if an error message already exists (e.g. from a previous exception), don't replace it
                     span.SetTag(Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");
                 }
             }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -76,6 +76,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.endpoint": 
                     AspNetCoreEndpoint = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -98,7 +101,6 @@ namespace Datadog.Trace.Tagging
                     CodeOriginFrameColumn = value;
                     break;
                 case "component": 
-                case "http.route": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreSingleSpanTags));
                     break;
                 default: 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -72,6 +72,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -92,9 +95,6 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "_dd.code_origin.frames.0.column": 
                     CodeOriginFrameColumn = value;
-                    break;
-                case "http.route": 
-                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
                     break;
                 default: 
                     base.SetTag(key, value);

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -76,6 +76,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.endpoint": 
                     AspNetCoreEndpoint = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -98,7 +101,6 @@ namespace Datadog.Trace.Tagging
                     CodeOriginFrameColumn = value;
                     break;
                 case "component": 
-                case "http.route": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreSingleSpanTags));
                     break;
                 default: 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -72,6 +72,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -92,9 +95,6 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "_dd.code_origin.frames.0.column": 
                     CodeOriginFrameColumn = value;
-                    break;
-                case "http.route": 
-                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
                     break;
                 default: 
                     base.SetTag(key, value);

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -76,6 +76,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.endpoint": 
                     AspNetCoreEndpoint = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -98,7 +101,6 @@ namespace Datadog.Trace.Tagging
                     CodeOriginFrameColumn = value;
                     break;
                 case "component": 
-                case "http.route": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreSingleSpanTags));
                     break;
                 default: 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -72,6 +72,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -92,9 +95,6 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "_dd.code_origin.frames.0.column": 
                     CodeOriginFrameColumn = value;
-                    break;
-                case "http.route": 
-                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
                     break;
                 default: 
                     base.SetTag(key, value);

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreSingleSpanTags.g.cs
@@ -76,6 +76,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.endpoint": 
                     AspNetCoreEndpoint = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -98,7 +101,6 @@ namespace Datadog.Trace.Tagging
                     CodeOriginFrameColumn = value;
                     break;
                 case "component": 
-                case "http.route": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreSingleSpanTags));
                     break;
                 default: 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/AspNetCoreTags.g.cs
@@ -72,6 +72,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "http.route": 
+                    HttpRoute = value;
+                    break;
                 case "_dd.code_origin.type": 
                     CodeOriginType = value;
                     break;
@@ -92,9 +95,6 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "_dd.code_origin.frames.0.column": 
                     CodeOriginFrameColumn = value;
-                    break;
-                case "http.route": 
-                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
                     break;
                 default: 
                     base.SetTag(key, value);

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Activity.Helpers;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Proxy;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring;
@@ -49,9 +50,15 @@ namespace Datadog.Trace.PlatformHelpers
             _requestInOperationName = requestInOperationName;
         }
 
-        public string GetDefaultResourceName(HttpRequest request)
+        public string GetDefaultResourceName(HttpRequest request, bool otelSemanticsEnabled = false)
         {
             string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
+
+            if (otelSemanticsEnabled)
+            {
+                // OTel spec: no http.route → span name is just the method (or "HTTP" for unknown methods)
+                return HttpOtelHelper.GetResourceNameMethod(httpMethod);
+            }
 
             string absolutePath = request.PathBase.HasValue
                                       ? request.PathBase.ToUriComponent() + request.Path.ToUriComponent()
@@ -104,7 +111,7 @@ namespace Datadog.Trace.PlatformHelpers
         public Scope StartAspNetCorePipelineScope(Tracer tracer, Security security, Iast.Iast iast, HttpContext httpContext, string resourceName)
         {
             var routeTemplateResourceNames = tracer.Settings.RouteTemplateResourceNamesEnabled;
-            var tags = routeTemplateResourceNames ? new AspNetCoreEndpointTags() : new AspNetCoreTags();
+            var tags = (routeTemplateResourceNames || tracer.Settings.OtelSemanticsEnabled) ? new AspNetCoreEndpointTags() : new AspNetCoreTags();
             return StartAspNetCorePipelineScope(tracer, security, iast, httpContext, resourceName, tags, useSingleSpanRequestTracking: false);
         }
 
@@ -121,7 +128,7 @@ namespace Datadog.Trace.PlatformHelpers
             string url = request.GetUrlForSpan(tracer.TracerManager.QueryStringManager);
             var userAgent = request.Headers[HttpHeaderNames.UserAgent];
 
-            resourceName ??= GetDefaultResourceName(request);
+            resourceName ??= GetDefaultResourceName(request, tracer.Settings.OtelSemanticsEnabled);
             var extractedContext = ExtractPropagatedContext(tracer, request).MergeBaggageInto(Baggage.Current);
             InferredProxyScopePropagationContext? proxyContext = null;
 
@@ -135,7 +142,7 @@ namespace Datadog.Trace.PlatformHelpers
             }
 
             var scope = tracer.StartActiveInternal(_requestInOperationName, extractedContext.SpanContext, tags: tags, links: extractedContext.Links);
-            scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, userAgent, tags);
+            scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, userAgent, tags, otelSemanticsEnabled: tracer.Settings.OtelSemanticsEnabled);
 
             var dataStreamsManager = tracer.TracerManager.DataStreamsManager;
             if (dataStreamsManager.IsTransactionTrackingEnabled)
@@ -203,6 +210,21 @@ namespace Datadog.Trace.PlatformHelpers
                 var peerIp = new Headers.Ip.IpInfo(httpContext.Connection.RemoteIpAddress?.ToString(), httpContext.Connection.RemotePort);
                 string GetRequestHeaderFromKey(string key) => request.Headers.TryGetValue(key, out var value) ? value : string.Empty;
                 Headers.Ip.RequestIpExtractor.AddIpToTags(peerIp, request.IsHttps, GetRequestHeaderFromKey, tracer.Settings.IpHeader, tags);
+
+                if (tracer.Settings.OtelSemanticsEnabled)
+                {
+                    if (tags.NetworkClientIp is not null)
+                    {
+                        HttpOtelHelper.SetNetworkPeerAddress(scope.Span, tags.NetworkClientIp);
+                        tags.NetworkClientIp = null;
+                    }
+
+                    if (tags.HttpClientIp is not null)
+                    {
+                        HttpOtelHelper.SetClientAddress(scope.Span, tags.HttpClientIp);
+                        tags.HttpClientIp = null;
+                    }
+                }
             }
 
             if (iast.Settings.Enabled && iast.OverheadController.AcquireRequest())
@@ -241,12 +263,12 @@ namespace Datadog.Trace.PlatformHelpers
                 {
                     if (string.IsNullOrEmpty(span.ResourceName))
                     {
-                        span.ResourceName = GetDefaultResourceName(httpContext.Request);
+                        span.ResourceName = GetDefaultResourceName(httpContext.Request, tracer.Settings.OtelSemanticsEnabled);
                     }
 
                     if (isMissingHttpStatusCode)
                     {
-                        span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, settings);
+                        span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
                     }
                 }
 
@@ -254,7 +276,7 @@ namespace Datadog.Trace.PlatformHelpers
 
                 if (proxyScope?.Span != null)
                 {
-                    proxyScope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, settings);
+                    proxyScope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, settings, tracer.Settings.OtelSemanticsEnabled);
                     proxyScope.Span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 }
 
@@ -290,11 +312,11 @@ namespace Datadog.Trace.PlatformHelpers
                 }
 
                 // Generic unhandled exceptions are converted to 500 errors by Kestrel
-                rootSpan.SetHttpStatusCode(statusCode: statusCode, isServer: true, tracer.CurrentTraceSettings.Settings);
+                rootSpan.SetHttpStatusCode(statusCode: statusCode, isServer: true, tracer.CurrentTraceSettings.Settings, tracer.Settings.OtelSemanticsEnabled);
 
                 if (proxyScope?.Span != null)
                 {
-                    proxyScope.Span.SetHttpStatusCode(statusCode, isServer: true, tracer.CurrentTraceSettings.Settings);
+                    proxyScope.Span.SetHttpStatusCode(statusCode, isServer: true, tracer.CurrentTraceSettings.Settings, tracer.Settings.OtelSemanticsEnabled);
                 }
 
                 if (BlockException.GetBlockException(exception) is null)

--- a/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
@@ -130,7 +130,7 @@ namespace Datadog.Trace.Processors
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L136-L142
             if (span.Tags is IHasStatusCode statusCodeTags)
             {
-                if (!TraceUtil.IsValidStatusCode(statusCodeTags.HttpStatusCode))
+                if (!string.IsNullOrEmpty(statusCodeTags.HttpStatusCode) && !TraceUtil.IsValidStatusCode(statusCodeTags.HttpStatusCode))
                 {
                     Log.Debug("Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code={InvalidStatusCode}: {Span}", statusCodeTags.HttpStatusCode, span);
                     statusCodeTags.HttpStatusCode = string.Empty;

--- a/tracer/src/Datadog.Trace/Tagging/AspNetCoreSingleSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AspNetCoreSingleSpanTags.cs
@@ -12,6 +12,7 @@ namespace Datadog.Trace.Tagging;
 internal sealed partial class AspNetCoreSingleSpanTags : WebTags
 {
     private const string ComponentName = "aspnet_core";
+    private string? _httpRoute;
 
     // Read/write instead of readonly as AzureFunctions updates the component name
     [Tag(Trace.Tags.InstrumentationName)]
@@ -24,7 +25,11 @@ internal sealed partial class AspNetCoreSingleSpanTags : WebTags
     public string? AspNetCoreEndpoint { get; set; }
 
     [Tag(Tags.HttpRoute)]
-    public string? HttpRoute => AspNetCoreRoute;
+    public string? HttpRoute
+    {
+        get => _httpRoute ?? AspNetCoreRoute;
+        set => _httpRoute = value;
+    }
 
     [Tag(Tags.CodeOriginType)]
     public string? CodeOriginType { get; set; }

--- a/tracer/src/Datadog.Trace/Tagging/AspNetCoreTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AspNetCoreTags.cs
@@ -10,6 +10,7 @@ namespace Datadog.Trace.Tagging
     internal partial class AspNetCoreTags : WebTags
     {
         private const string ComponentName = "aspnet_core";
+        private string _httpRoute;
 
         // Read/write instead of readonly as AzureFunctions updates the component name
         [Tag(Trace.Tags.InstrumentationName)]
@@ -19,7 +20,11 @@ namespace Datadog.Trace.Tagging
         public string AspNetCoreRoute { get; set; }
 
         [Tag(Tags.HttpRoute)]
-        public string HttpRoute => AspNetCoreRoute;
+        public string HttpRoute
+        {
+            get => _httpRoute ?? AspNetCoreRoute;
+            set => _httpRoute = value;
+        }
 
         [Tag(Tags.CodeOriginType)]
         public string CodeOriginType { get; set; }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
@@ -6,11 +6,16 @@
 #if NET6_0_OR_GREATER
 #pragma warning disable SA1402 // File may only contain a single class
 #pragma warning disable SA1649 // File name must match first type name
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -154,6 +159,253 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                           .UseTypeName(_testName);
 
             VerifyInstrumentation(Fixture.Process);
+        }
+    }
+
+    public class AspNetCoreMinimalApisOTelTests : AspNetCoreMvcTestBase
+    {
+        private readonly string _testName;
+
+        public AspNetCoreMinimalApisOTelTests(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base("AspNetCoreMinimalApis", fixture, output, AspNetCoreFeatureFlags.None)
+        {
+            SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+            _testName = GetTestName(nameof(AspNetCoreMinimalApisOTelTests));
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task SubmitsTracesOTel(string path, int statusCode)
+        {
+            await Fixture.TryStartApp(this);
+
+            var spans = await Fixture.WaitForSpans("/");
+            ValidateIntegrationSpans(spans, metadataSchemaVersion: "otel", expectedServiceName: "Samples.AspNetCoreMinimalApis", isExternalSpan: false);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+    }
+
+    [Trait("RequiresDockerDependency", "true")]
+    [Trait("DockerGroup", "1")]
+    public class AspNetCoreMinimalApisOTelTestsWithOtlp : AspNetCoreMvcTestBase
+    {
+        private readonly string _testName;
+        private readonly string _testAgentHost;
+
+        public AspNetCoreMinimalApisOTelTestsWithOtlp(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base("AspNetCoreMinimalApis", fixture, output, AspNetCoreFeatureFlags.None)
+        {
+            _testAgentHost = Environment.GetEnvironmentVariable("TEST_AGENT_HOST") ?? "localhost";
+
+            SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+            SetEnvironmentVariable("OTEL_TRACES_EXPORTER", "otlp");
+            SetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json");
+            SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", $"http://{_testAgentHost}:4318");
+
+            _testName = GetTestName(nameof(AspNetCoreMinimalApisOTelTestsWithOtlp));
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [MemberData(nameof(Data))]
+        public async Task SubmitsOtlpTraces(string path, int statusCode)
+        {
+            await ClearTestAgentSession(_testAgentHost);
+
+            // Start the long-running ASP.NET Core app via the shared fixture (sendHealthCheck: false
+            // because OTLP mode routes spans to the test agent, not the mock agent, which would cause
+            // WaitForSpansAsync to timeout waiting for spans that will never arrive).
+            await Fixture.TryStartApp(this, sendHealthCheck: false);
+
+            // Send the request to the target path to generate a trace
+            var request = Fixture.CreateRequest(HttpMethod.Get, path);
+            await Fixture.SendHttpRequest(request);
+
+            // Poll the test agent for OTLP traces (DD SDK always uses http/json per constructor setup)
+            var tracesRequests = await WaitForTestAgentData($"http://{_testAgentHost}:4318/test/session/traces");
+            tracesRequests.Should().NotBeNullOrEmpty();
+
+            // All keys are camelCase because the DD SDK exports http/json
+            const string resourceSpansKey = "resourceSpans";
+            const string scopeSpansKey = "scopeSpans";
+            const string stringValueKey = "stringValue";
+            const string intValueKey = "intValue";
+            const string traceIdKey = "traceId";
+            const string spanIdKey = "spanId";
+            const string parentSpanIdKey = "parentSpanId";
+            const string startTimeUnixNanoKey = "startTimeUnixNano";
+            const string endTimeUnixNanoKey = "endTimeUnixNano";
+            const string timeUnixNanoKey = "timeUnixNano";
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..resource.attributes[?(@.key == 'telemetry.sdk.version')]"))
+            {
+                attribute["value"]![stringValueKey] = "sdk-version";
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..resource.attributes[?(@.key == 'telemetry.sdk.name')]"))
+            {
+                attribute["value"]![stringValueKey] = "sdk-name";
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..resource.attributes[?(@.key == 'git.commit.sha')]"))
+            {
+                attribute["value"]![stringValueKey] = "normalized-git-commit-sha";
+            }
+
+            foreach (var span in tracesRequests.SelectTokens("$..spans[*]"))
+            {
+                span[startTimeUnixNanoKey] = "0";
+                span[endTimeUnixNanoKey] = "0";
+                span[traceIdKey] = "normalized-trace-id";
+                span[spanIdKey] = "normalized-span-id";
+                if (span[parentSpanIdKey] != null)
+                {
+                    span[parentSpanIdKey] = "normalized-parent-span-id";
+                }
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..spans[*].attributes[?(@.key == 'otel.trace_id')]"))
+            {
+                attribute["value"]![stringValueKey] = "normalized-otel-trace-id";
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..spans[*].attributes[?(@.key == 'server.port')]"))
+            {
+                if (attribute["value"]![intValueKey] is not null)
+                {
+                    attribute["value"]![intValueKey] = "normalized-server-port";
+                }
+            }
+
+            foreach (var @event in tracesRequests.SelectTokens("$..events[*]"))
+            {
+                ((JObject)@event).Remove(timeUnixNanoKey);
+                ((JObject)@event).AddFirst(new JProperty(timeUnixNanoKey, "0"));
+            }
+
+            // DD SDK: assert resource attributes are consistent across all batches, consolidate
+            // all span batches into a single request, and sort spans by name for stability.
+            JToken previousResourceAttributes = null;
+            foreach (var tracesRequest in tracesRequests)
+            {
+                tracesRequest[resourceSpansKey].Should().HaveCount(1);
+                var resourceAttributes = tracesRequest[resourceSpansKey][0]["resource"]["attributes"];
+
+                if (previousResourceAttributes == null)
+                {
+                    previousResourceAttributes = resourceAttributes;
+                }
+                else
+                {
+                    JToken.DeepEquals(previousResourceAttributes, resourceAttributes).Should().BeTrue();
+                    previousResourceAttributes = resourceAttributes;
+                }
+            }
+
+            JArray firstSpans = null;
+            foreach (var tracesRequest in tracesRequests)
+            {
+                tracesRequest[resourceSpansKey][0][scopeSpansKey].Should().HaveCount(1);
+                var spans = tracesRequest[resourceSpansKey][0][scopeSpansKey][0]["spans"] as JArray;
+
+                if (firstSpans == null)
+                {
+                    firstSpans = spans;
+                }
+                else
+                {
+                    foreach (var span in spans)
+                    {
+                        firstSpans.Add(span);
+                    }
+                }
+            }
+
+            var sortedSpans = new JArray(firstSpans.OrderBy(s => s["name"]!.ToString()));
+            tracesRequests[0][resourceSpansKey][0][scopeSpansKey][0]["spans"] = sortedSpans;
+            var finalJson = tracesRequests[0].ToString(Formatting.Indented);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(finalJson, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+
+        /// <summary>
+        /// Clears the test-agent session, retrying if the agent is not yet ready.
+        /// Ensures the OTLP HTTP endpoint is accepting connections before tests proceed.
+        /// </summary>
+        private static async Task ClearTestAgentSession(string testAgentHost, int maxRetries = 5, int delayMs = 1000)
+        {
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            var url = $"http://{testAgentHost}:4318/test/session/clear";
+
+            for (var attempt = 1; attempt <= maxRetries; attempt++)
+            {
+                try
+                {
+                    var response = await httpClient.GetAsync(url);
+                    response.EnsureSuccessStatusCode();
+                    return;
+                }
+                catch (Exception) when (attempt < maxRetries)
+                {
+                    await Task.Delay(delayMs);
+                }
+            }
+
+            // Final attempt -- let it throw if it fails
+            var finalResponse = await httpClient.GetAsync(url);
+            finalResponse.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Polls the test-agent for data until non-empty results are returned or timeout is reached.
+        /// The sample app exports data during shutdown, so there can be a brief delay
+        /// between process exit and data appearing in the test-agent. The timeout is generous
+        /// because first-time gRPC connections (TCP+HTTP/2+TLS handshake) plus tracer shutdown
+        /// flushing can stack up on slower CI runners.
+        /// </summary>
+        private static async Task<JToken> WaitForTestAgentData(string url, int timeoutSeconds = 60, int pollIntervalMs = 500)
+        {
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                var response = await httpClient.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                var data = JToken.Parse(json);
+
+                if (data.HasValues)
+                {
+                    return data;
+                }
+
+                await Task.Delay(pollIntervalMs);
+            }
+
+            // Final attempt -- return whatever we get so the caller's assertion shows the actual value
+            var finalResponse = await httpClient.GetAsync(url);
+            finalResponse.EnsureSuccessStatusCode();
+            var finalJson = await finalResponse.Content.ReadAsStringAsync();
+            return JToken.Parse(finalJson);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -6,11 +6,17 @@
 #if NETCOREAPP3_1_OR_GREATER
 #pragma warning disable SA1402 // File may only contain a single class
 #pragma warning disable SA1649 // File name must match first type name
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -73,6 +79,253 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Verifier.Verify(spans, settings)
                           .UseMethodName("_")
                           .UseTypeName(_testName);
+        }
+    }
+
+    public class AspNetCoreMvc31OTelTests : AspNetCoreMvcTestBase
+    {
+        private readonly string _testName;
+
+        public AspNetCoreMvc31OTelTests(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base("AspNetCoreMvc31", fixture, output, AspNetCoreFeatureFlags.RouteTemplateResourceNames)
+        {
+            SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+            _testName = GetTestName(nameof(AspNetCoreMvc31OTelTests));
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task SubmitsTracesOTel(string path, int statusCode)
+        {
+            await Fixture.TryStartApp(this);
+
+            var spans = await Fixture.WaitForSpans("/");
+            ValidateIntegrationSpans(spans, metadataSchemaVersion: "otel", expectedServiceName: "Samples.AspNetCoreMvc31", isExternalSpan: false);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+    }
+
+    [Trait("RequiresDockerDependency", "true")]
+    [Trait("DockerGroup", "1")]
+    public class AspNetCoreMvc31OTelTestsWithOtlp : AspNetCoreMvcTestBase
+    {
+        private readonly string _testName;
+        private readonly string _testAgentHost;
+
+        public AspNetCoreMvc31OTelTestsWithOtlp(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base("AspNetCoreMvc31", fixture, output, AspNetCoreFeatureFlags.RouteTemplateResourceNames)
+        {
+            _testAgentHost = Environment.GetEnvironmentVariable("TEST_AGENT_HOST") ?? "localhost";
+
+            SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+            SetEnvironmentVariable("OTEL_TRACES_EXPORTER", "otlp");
+            SetEnvironmentVariable("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json");
+            SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", $"http://{_testAgentHost}:4318");
+
+            _testName = GetTestName(nameof(AspNetCoreMvc31OTelTestsWithOtlp));
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [MemberData(nameof(Data))]
+        public async Task SubmitsOtlpTraces(string path, int statusCode)
+        {
+            await ClearTestAgentSession(_testAgentHost);
+
+            // Start the long-running ASP.NET Core app via the shared fixture (sendHealthCheck: false
+            // because OTLP mode routes spans to the test agent, not the mock agent, which would cause
+            // WaitForSpansAsync to timeout waiting for spans that will never arrive).
+            await Fixture.TryStartApp(this, sendHealthCheck: false);
+
+            // Send the request to the target path to generate a trace
+            var request = Fixture.CreateRequest(HttpMethod.Get, path);
+            await Fixture.SendHttpRequest(request);
+
+            // Poll the test agent for OTLP traces (DD SDK always uses http/json per constructor setup)
+            var tracesRequests = await WaitForTestAgentData($"http://{_testAgentHost}:4318/test/session/traces");
+            tracesRequests.Should().NotBeNullOrEmpty();
+
+            // All keys are camelCase because the DD SDK exports http/json
+            const string resourceSpansKey = "resourceSpans";
+            const string scopeSpansKey = "scopeSpans";
+            const string stringValueKey = "stringValue";
+            const string intValueKey = "intValue";
+            const string traceIdKey = "traceId";
+            const string spanIdKey = "spanId";
+            const string parentSpanIdKey = "parentSpanId";
+            const string startTimeUnixNanoKey = "startTimeUnixNano";
+            const string endTimeUnixNanoKey = "endTimeUnixNano";
+            const string timeUnixNanoKey = "timeUnixNano";
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..resource.attributes[?(@.key == 'telemetry.sdk.version')]"))
+            {
+                attribute["value"]![stringValueKey] = "sdk-version";
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..resource.attributes[?(@.key == 'telemetry.sdk.name')]"))
+            {
+                attribute["value"]![stringValueKey] = "sdk-name";
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..resource.attributes[?(@.key == 'git.commit.sha')]"))
+            {
+                attribute["value"]![stringValueKey] = "normalized-git-commit-sha";
+            }
+
+            foreach (var span in tracesRequests.SelectTokens("$..spans[*]"))
+            {
+                span[startTimeUnixNanoKey] = "0";
+                span[endTimeUnixNanoKey] = "0";
+                span[traceIdKey] = "normalized-trace-id";
+                span[spanIdKey] = "normalized-span-id";
+                if (span[parentSpanIdKey] != null)
+                {
+                    span[parentSpanIdKey] = "normalized-parent-span-id";
+                }
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..spans[*].attributes[?(@.key == 'otel.trace_id')]"))
+            {
+                attribute["value"]![stringValueKey] = "normalized-otel-trace-id";
+            }
+
+            foreach (var attribute in tracesRequests.SelectTokens("$..spans[*].attributes[?(@.key == 'server.port')]"))
+            {
+                if (attribute["value"]![intValueKey] is not null)
+                {
+                    attribute["value"]![intValueKey] = "normalized-server-port";
+                }
+            }
+
+            foreach (var @event in tracesRequests.SelectTokens("$..events[*]"))
+            {
+                ((JObject)@event).Remove(timeUnixNanoKey);
+                ((JObject)@event).AddFirst(new JProperty(timeUnixNanoKey, "0"));
+            }
+
+            // DD SDK: assert resource attributes are consistent across all batches, consolidate
+            // all span batches into a single request, and sort spans by name for stability.
+            JToken previousResourceAttributes = null;
+            foreach (var tracesRequest in tracesRequests)
+            {
+                tracesRequest[resourceSpansKey].Should().HaveCount(1);
+                var resourceAttributes = tracesRequest[resourceSpansKey][0]["resource"]["attributes"];
+
+                if (previousResourceAttributes == null)
+                {
+                    previousResourceAttributes = resourceAttributes;
+                }
+                else
+                {
+                    JToken.DeepEquals(previousResourceAttributes, resourceAttributes).Should().BeTrue();
+                    previousResourceAttributes = resourceAttributes;
+                }
+            }
+
+            JArray firstSpans = null;
+            foreach (var tracesRequest in tracesRequests)
+            {
+                tracesRequest[resourceSpansKey][0][scopeSpansKey].Should().HaveCount(1);
+                var spans = tracesRequest[resourceSpansKey][0][scopeSpansKey][0]["spans"] as JArray;
+
+                if (firstSpans == null)
+                {
+                    firstSpans = spans;
+                }
+                else
+                {
+                    foreach (var span in spans)
+                    {
+                        firstSpans.Add(span);
+                    }
+                }
+            }
+
+            var sortedSpans = new JArray(firstSpans.OrderBy(s => s["name"]!.ToString()));
+            tracesRequests[0][resourceSpansKey][0][scopeSpansKey][0]["spans"] = sortedSpans;
+            var finalJson = tracesRequests[0].ToString(Formatting.Indented);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(finalJson, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+
+        /// <summary>
+        /// Clears the test-agent session, retrying if the agent is not yet ready.
+        /// Ensures the OTLP HTTP endpoint is accepting connections before tests proceed.
+        /// </summary>
+        private static async Task ClearTestAgentSession(string testAgentHost, int maxRetries = 5, int delayMs = 1000)
+        {
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            var url = $"http://{testAgentHost}:4318/test/session/clear";
+
+            for (var attempt = 1; attempt <= maxRetries; attempt++)
+            {
+                try
+                {
+                    var response = await httpClient.GetAsync(url);
+                    response.EnsureSuccessStatusCode();
+                    return;
+                }
+                catch (Exception) when (attempt < maxRetries)
+                {
+                    await Task.Delay(delayMs);
+                }
+            }
+
+            // Final attempt -- let it throw if it fails
+            var finalResponse = await httpClient.GetAsync(url);
+            finalResponse.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Polls the test-agent for data until non-empty results are returned or timeout is reached.
+        /// The sample app exports data during shutdown, so there can be a brief delay
+        /// between process exit and data appearing in the test-agent. The timeout is generous
+        /// because first-time gRPC connections (TCP+HTTP/2+TLS handshake) plus tracer shutdown
+        /// flushing can stack up on slower CI runners.
+        /// </summary>
+        private static async Task<JToken> WaitForTestAgentData(string url, int timeoutSeconds = 60, int pollIntervalMs = 500)
+        {
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                var response = await httpClient.GetAsync(url);
+                response.EnsureSuccessStatusCode();
+
+                var json = await response.Content.ReadAsStringAsync();
+                var data = JToken.Parse(json);
+
+                if (data.HasValues)
+                {
+                    return data;
+                }
+
+                await Task.Delay(pollIntervalMs);
+            }
+
+            // Final attempt -- return whatever we get so the caller's assertion shows the actual value
+            var finalResponse = await httpClient.GetAsync(url);
+            finalResponse.EnsureSuccessStatusCode();
+            var finalJson = await finalResponse.Content.ReadAsStringAsync();
+            return JToken.Parse(finalJson);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -70,6 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         public static TheoryData<string, int> Data() => new()
         {
             { "/", 200 },
+            { "/?query=test", 200 },
             { "/delay/0", 200 },
             { "/api/delay/0", 200 },
             { "/not-found", 404 },

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -180,6 +180,41 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
         [CombinatorialOrPairwiseData]
+        public async Task HttpClient_SubmitsTracesOTel(
+            [CombinatorialMemberData(nameof(GetInstrumentationOptions))] InstrumentationOptions instrumentation,
+            bool socketsHandlerEnabled)
+        {
+            SetInstrumentationVerification();
+            ConfigureInstrumentation(instrumentation, socketsHandlerEnabled);
+            SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+
+            const string metadataSchemaVersion = "otel";
+            var expectedAsyncCount = CalculateExpectedAsyncSpans(instrumentation);
+            var expectedSyncCount = CalculateExpectedSyncSpans(instrumentation);
+            var expectedSpanCount = expectedAsyncCount + expectedSyncCount;
+
+            int httpPort = TcpPortProvider.GetOpenPort();
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
+            using var telemetry = this.ConfigureTelemetry();
+            using var agent = EnvironmentHelper.GetMockAgent();
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}");
+
+            agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
+            var spans = await agent.WaitForSpansAsync(expectedSpanCount);
+            spans.Should().HaveCount(expectedSpanCount);
+
+            // OTel mode: service name still follows v0 external span convention
+            var clientSpanServiceName = $"{EnvironmentHelper.FullSampleName}-http-client";
+            ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
+            VerifyInstrumentation(processResult.Process);
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [Trait("SupportsInstrumentationVerification", "True")]
+        [CombinatorialOrPairwiseData]
         public async Task TracingDisabled_DoesNotSubmitsTraces(
             [CombinatorialMemberData(nameof(GetInstrumentationOptions))] InstrumentationOptions instrumentation,
             bool enableSocketsHandler)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -46,6 +46,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
+        public Task SubmitsTracesOTel() => RunTestOTel();
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [Trait("SupportsInstrumentationVerification", "True")]
         public async Task TracingDisabled_DoesNotSubmitsTraces()
         {
             SetInstrumentationVerification();
@@ -69,6 +75,30 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 await telemetry.AssertIntegrationDisabledAsync(IntegrationId.WebRequest);
                 VerifyInstrumentation(processResult.Process);
             }
+        }
+
+        private async Task RunTestOTel()
+        {
+            SetInstrumentationVerification();
+
+            var expectedAllSpansCount = 134;
+
+            int httpPort = TcpPortProvider.GetOpenPort();
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
+            SetEnvironmentVariable("DD_TRACE_OTEL_SEMANTICS_ENABLED", "true");
+            var clientSpanServiceName = $"{EnvironmentHelper.FullSampleName}-http-client";
+
+            using var telemetry = this.ConfigureTelemetry();
+            using var agent = EnvironmentHelper.GetMockAgent();
+            using ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}");
+
+            var allSpans = (await agent.WaitForSpansAsync(expectedAllSpansCount, assertExpectedCount: false)).OrderBy(s => s.Start).ToList();
+
+            allSpans.Should().OnlyHaveUniqueItems(s => new { s.SpanId, s.TraceId });
+            var httpSpans = allSpans.Where(s => s.Type == SpanTypes.Http).ToList();
+            ValidateIntegrationSpans(httpSpans, "otel", expectedServiceName: clientSpanServiceName, isExternalSpan: true);
+            VerifyInstrumentation(processResult.Process);
         }
 
         private async Task RunTest(string metadataSchemaVersion)

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -40,7 +40,9 @@ namespace Datadog.Trace.TestHelpers
             (new(@"_dd\.p\.tid: [0-9a-f]{16}", RegOptions), "_dd.p.tid: 1234567890abcdef"),
             (new(@"(_dd\.code_origin\.frames\.\d+\.line:\s*)\d+", RegOptions), "${1}0"),
             (new(@"(_dd\.code_origin\.frames\.\d+\.column:\s*)\d+", RegOptions), "${1}0"),
-            (new("x-datadog-trace-id\":\\[\\[\\[8,({\"category\":\"pii\",\"type\":\"vin\"})\\]\\]", RegOptions), "x-datadog-trace-id\":[[[8]]") // api security, sometimes we can get "x-datadog-trace-id":[[[8,{"category":"pii","type":"vin"}]], and not everytime depending on the number, should be removed with waf 1.15.1, bug is fixed
+            (new("x-datadog-trace-id\":\\[\\[\\[8,({\"category\":\"pii\",\"type\":\"vin\"})\\]\\]", RegOptions), "x-datadog-trace-id\":[[[8]]"), // api security, sometimes we can get "x-datadog-trace-id":[[[8,{"category":"pii","type":"vin"}]], and not everytime depending on the number, should be removed with waf 1.15.1, bug is fixed
+            // OpenTelemetry span attributes
+            (new(@"server.port: [0-9]+", RegOptions), "server.port: 00000"),
         };
 
         private static readonly Regex CodeOriginFilePathRegex = new(@"(?<prefix>_dd\.code_origin\.frames\.\d+\.file:\s*)(?<path>[^,\r\n]+)", RegOptions);

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
@@ -49,6 +49,7 @@ namespace Datadog.Trace.TestHelpers
         public static Result IsAspNetCore(this MockSpan span, string metadataSchemaVersion, ISet<string> excludeTags = null) =>
             metadataSchemaVersion switch
             {
+                "otel" => span.IsAspNetCoreOTel(excludeTags),
                 "v1" => span.IsAspNetCoreV1(excludeTags),
                 _ => span.IsAspNetCoreV0(excludeTags),
             };
@@ -56,6 +57,7 @@ namespace Datadog.Trace.TestHelpers
         public static Result IsAspNetCoreMvc(this MockSpan span, string metadataSchemaVersion) =>
             metadataSchemaVersion switch
             {
+                "otel" => span.IsAspNetCoreMvcOTel(),
                 "v1" => span.IsAspNetCoreMvcV1(),
                 _ => span.IsAspNetCoreMvcV0(),
             };
@@ -212,6 +214,7 @@ namespace Datadog.Trace.TestHelpers
         public static Result IsHttpMessageHandler(this MockSpan span, string metadataSchemaVersion) =>
             metadataSchemaVersion switch
             {
+                "otel" => span.IsHttpClientRequestOTel(),
                 "v1" => span.IsHttpMessageHandlerV1(),
                 _ => span.IsHttpMessageHandlerV0(),
             };
@@ -389,6 +392,7 @@ namespace Datadog.Trace.TestHelpers
         public static Result IsWebRequest(this MockSpan span, string metadataSchemaVersion) =>
             metadataSchemaVersion switch
             {
+                "otel" => span.IsHttpClientRequestOTel(),
                 "v1" => span.IsWebRequestV1(),
                 _ => span.IsWebRequestV0(),
             };

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataOTelRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataOTelRules.cs
@@ -1,0 +1,689 @@
+// <copyright file="SpanMetadataOTelRules.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using static Datadog.Trace.TestHelpers.SpanMetadataRulesHelpers;
+
+namespace Datadog.Trace.TestHelpers
+{
+#pragma warning disable SA1601 // Partial elements should be documented
+    internal static class SpanMetadataOTelRules
+    {
+        // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+        public static Result IsHttpClientRequestOTel(this MockSpan span) => Result.FromSpan(span)
+            .Tags(s => s
+                // Required
+                .IsPresent("http.request.method")
+                .IsPresent("server.address")
+                .IsPresent("url.full")
+                // Conditionally required
+                .IsOptional("error.type")
+                .IsOptional("http.request.method_original")
+                .IsOptional("http.response.status_code")
+                .IsOptional("network.protocol.name")
+                .IsOptional("server.port")
+                // Recommended
+                .IsOptional("http.request.resend_count")
+                .IsOptional("network.peer.address")
+                .IsOptional("network.peer.port")
+                .IsOptional("network.protocol.version")
+                // DD Only
+                .IsOptional("span.kind")
+                .IsOptional("component")
+                .IsOptional("http-client-handler-type")
+                .IsOptional("_dd.base_service")
+                .IsOptional("_dd.tags.process")
+                .IsOptional("_dd.svc_src"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+        public static Result IsHttpServerRequestOTel(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
+            .Tags(s => s
+                // Required
+                .IsPresent("http.request.method")
+                .IsPresent("url.path")
+                .IsPresent("url.scheme")
+                // Conditionally required
+                .IsOptional("error.type")
+                .IsOptional("http.request.method_original")
+                .IsOptional("http.response.status_code")
+                .IsOptional("http.route")
+                .IsOptional("network.protocol.name")
+                .IsOptional("server.port")
+                .IsOptional("url.query")
+                // Recommended
+                .IsOptional("client.address")
+                .IsOptional("network.peer.address")
+                .IsOptional("network.peer.port")
+                .IsOptional("network.protocol.version")
+                .IsOptional("server.address")
+                .IsOptional("user_agent.original")
+                // DD Only
+                .IsOptional("span.kind")
+                .IsOptional("component")
+                .IsOptional("_dd.base_service")
+                .IsOptional("_dd.tags.process"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+        public static Result IsAspNetCoreOTel(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
+            .Tags(s => s
+                // Required
+                .IsPresent("http.request.method")
+                .IsPresent("url.path")
+                .IsPresent("url.scheme")
+                // Conditionally required
+                .IsOptional("error.type")
+                .IsOptional("http.request.method_original")
+                .IsOptional("http.response.status_code")
+                .IsOptional("http.route")
+                .IsOptional("network.protocol.name")
+                .IsOptional("server.port")
+                .IsOptional("url.query")
+                // Recommended
+                .IsOptional("client.address")
+                .IsOptional("network.peer.address")
+                .IsOptional("network.peer.port")
+                .IsOptional("network.protocol.version")
+                .IsOptional("server.address")
+                .IsOptional("user_agent.original")
+                // DD Only
+                .IsOptional("span.kind")
+                .IsOptional("component")
+                .IsOptional("_dd.base_service")
+                .IsOptional("_dd.tags.process")
+                .IsOptional("_dd.code_origin.type")
+                .IsOptional("_dd.code_origin.frames.0.index")
+                .IsOptional("_dd.code_origin.frames.0.method")
+                .IsOptional("_dd.code_origin.frames.0.type")
+                .IsOptional("_dd.code_origin.frames.0.file")
+                .IsOptional("_dd.code_origin.frames.0.line")
+                .IsOptional("_dd.code_origin.frames.0.column"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+        public static Result IsAspNetCoreMvcOTel(this MockSpan span) => Result.FromSpan(span)
+            .WithIntegrationName("AspNetCore")
+            .Properties(s => s
+                .Matches(Type, "web"))
+            .Tags(s => s
+                // Required
+                .IsPresent("http.request.method")
+                .IsPresent("url.path")
+                .IsPresent("url.scheme")
+                // Conditionally required
+                .IsOptional("error.type")
+                .IsOptional("http.request.method_original")
+                .IsOptional("http.response.status_code")
+                .IsOptional("http.route")
+                .IsOptional("network.protocol.name")
+                .IsOptional("server.port")
+                .IsOptional("url.query")
+                // Recommended
+                .IsOptional("client.address")
+                .IsOptional("network.peer.address")
+                .IsOptional("network.peer.port")
+                .IsOptional("network.protocol.version")
+                .IsOptional("server.address")
+                .IsOptional("user_agent.original")
+                // DD Only
+                .IsOptional("span.kind")
+                .IsOptional("component")
+                .IsOptional("_dd.base_service")
+                .IsOptional("_dd.tags.process")
+                .IsOptional("_dd.code_origin.type")
+                .IsOptional("_dd.code_origin.frames.0.index")
+                .IsOptional("_dd.code_origin.frames.0.method")
+                .IsOptional("_dd.code_origin.frames.0.type")
+                .IsOptional("_dd.code_origin.frames.0.file")
+                .IsOptional("_dd.code_origin.frames.0.line")
+                .IsOptional("_dd.code_origin.frames.0.column"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsDatabaseClientOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "sql"))
+            .Tags(s => s
+                // Required
+                .IsPresent("db.system")
+                // Conditionally required
+                .IsOptional("db.collection.name")
+                .IsOptional("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("db.response.status_code")
+                .IsOptional("error.type")
+                .IsOptional("server.port")
+                // Recommended
+                .IsOptional("db.query.summary")
+                .IsOptional("db.query.text")
+                .IsOptional("network.peer.address")
+                .IsOptional("network.peer.port")
+                .IsOptional("server.address")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsSqlClientOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "sql"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "mssql")
+                // Conditionally required
+                .IsOptional("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("db.collection.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("db.user")
+                .IsOptional("network.peer.address")
+                .IsOptional("dd.instrumentation.time_ms")
+                .Matches("component", "SqlClient")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsMySqlOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "sql"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "mysql")
+                // Conditionally required
+                .IsPresent("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("db.collection.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("db.user")
+                .IsOptional("network.peer.address")
+                .Matches("component", "MySql")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsNpgsqlOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "sql"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "postgresql")
+                // Conditionally required
+                .IsPresent("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("db.collection.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("db.user")
+                .IsOptional("network.peer.address")
+                .Matches("component", "Npgsql")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsSqliteOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "sql"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "sqlite")
+                // Conditionally required
+                .IsOptional("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("db.collection.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("server.address")
+                .IsOptional("server.port")
+                .IsOptional("db.query.text")
+                .Matches("component", "Sqlite")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsOracleOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "sql"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "oracle")
+                // Conditionally required
+                .IsPresent("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("db.collection.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("network.peer.address")
+                .Matches("component", "Oracle")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsMongoDbOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "mongodb"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "mongodb")
+                // Conditionally required
+                .IsOptional("db.namespace")
+                .IsOptional("db.collection.name")
+                .IsOptional("db.operation.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsPresent("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("network.peer.address")
+                .Matches("component", "MongoDb")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsServiceStackRedisOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "redis"))
+            .Metrics(s => s
+                .IsPresent("db.redis.database_index"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "redis")
+                // Conditionally required
+                .IsOptional("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsPresent("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("network.peer.address")
+                .Matches("component", "ServiceStackRedis")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsStackExchangeRedisOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "redis"))
+            .Metrics(s => s
+                .IsOptional("db.redis.database_index"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "redis")
+                // Conditionally required
+                .IsOptional("db.namespace")
+                .IsOptional("db.operation.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsPresent("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("network.peer.address")
+                .Matches("component", "StackExchangeRedis")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsElasticsearchOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "elasticsearch"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "elasticsearch")
+                // Conditionally required
+                .IsOptional("db.operation.name")
+                .IsOptional("db.collection.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("db.query.text")
+                .IsOptional("network.peer.address")
+                // Elasticsearch-specific
+                .IsPresent("elasticsearch.action")
+                .IsPresent("elasticsearch.method")
+                .IsPresent("elasticsearch.url")
+                .Matches("component", "elasticsearch-net")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/database/database-spans/
+        public static Result IsCosmosDbOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "sql"))
+            .Tags(s => s
+                // Required
+                .Matches("db.system", "cosmosdb")
+                // Conditionally required
+                .IsOptional("db.namespace")
+                .IsOptional("db.collection.name")
+                .IsOptional("db.operation.name")
+                .IsOptional("db.response.status_code")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("network.peer.address")
+                // CosmosDB-specific
+                .IsOptional("db.cosmosdb.connection_mode")
+                .IsOptional("db.cosmosdb.response.sub_status_code")
+                .IsOptional("user_agent.original")
+                .Matches("component", "CosmosDb")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsKafkaInboundOTel(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Kafka - Inbound")
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Metrics(s => s
+                .IsOptional("message.queue_time_ms"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "kafka")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsPresent("messaging.destination.name")
+                .IsOptional("messaging.consumer.group.name")
+                .IsOptional("messaging.destination.partition.id")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("network.peer.address")
+                .IsOptional("server.address")
+                .IsOptional("server.port")
+                // Kafka-specific
+                .IsOptional("messaging.kafka.message.offset")
+                .IsOptional("messaging.kafka.message.tombstone")
+                .Matches("component", "kafka")
+                .Matches("span.kind", "consumer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsKafkaOutboundOTel(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Kafka - Outbound")
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Metrics(s => s
+                .IsOptional("message.queue_time_ms"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "kafka")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsPresent("messaging.destination.name")
+                .IsOptional("messaging.destination.partition.id")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("network.peer.address")
+                .IsOptional("server.address")
+                .IsOptional("server.port")
+                // Kafka-specific
+                .IsOptional("messaging.kafka.message.offset")
+                .IsOptional("messaging.kafka.message.tombstone")
+                .Matches("component", "kafka")
+                .Matches("span.kind", "producer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsRabbitMQInboundOTel(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("RabbitMQ - Inbound")
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "rabbitmq")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsOptional("messaging.destination.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("network.peer.address")
+                .IsOptional("server.address")
+                .IsOptional("server.port")
+                // RabbitMQ-specific
+                .IsOptional("messaging.rabbitmq.destination.routing_key")
+                .IsOptional("messaging.rabbitmq.message.delivery_tag")
+                .Matches("component", "RabbitMQ")
+                .Matches("span.kind", "consumer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsRabbitMQOutboundOTel(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("RabbitMQ - Outbound")
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "rabbitmq")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsOptional("messaging.destination.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("network.peer.address")
+                .IsOptional("server.address")
+                .IsOptional("server.port")
+                // RabbitMQ-specific
+                .IsOptional("messaging.rabbitmq.destination.routing_key")
+                .Matches("component", "RabbitMQ")
+                .Matches("span.kind", "producer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsAwsSqsInboundOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "http"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "aws_sqs")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsPresent("messaging.destination.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("messaging.message.id")
+                .IsOptional("server.address")
+                .IsOptional("server.port")
+                // AWS-specific
+                .IsOptional("aws.request_id")
+                .IsOptional("aws.region")
+                .Matches("component", "aws-sdk")
+                .Matches("span.kind", "consumer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsAwsSqsOutboundOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Type, "http"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "aws_sqs")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsPresent("messaging.destination.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("messaging.message.id")
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                // AWS-specific
+                .IsOptional("aws.request_id")
+                .IsOptional("aws.region")
+                .Matches("component", "aws-sdk")
+                .MatchesOneOf("span.kind", "producer", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsAzureServiceBusInboundOTel(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "servicebus")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsOptional("messaging.destination.name")
+                .IsOptional("messaging.consumer.group.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("messaging.batch.message_count")
+                .Matches("component", "AzureServiceBus")
+                .Matches("span.kind", "consumer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsAzureServiceBusOutboundOTel(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "servicebus")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsPresent("messaging.destination.name")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("messaging.batch.message_count")
+                .Matches("component", "AzureServiceBus")
+                .Matches("span.kind", "producer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsAzureEventHubsInboundOTel(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "eventhubs")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsOptional("messaging.destination.name")
+                .IsOptional("messaging.destination.partition.id")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("messaging.batch.message_count")
+                .Matches("component", "AzureEventHubs")
+                .Matches("span.kind", "consumer"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
+        public static Result IsAzureEventHubsOutboundOTel(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
+            .Properties(s => s
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                // Required
+                .Matches("messaging.system", "eventhubs")
+                .IsPresent("messaging.operation.name")
+                // Conditionally required
+                .IsPresent("messaging.destination.name")
+                .IsOptional("messaging.destination.partition.id")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("messaging.client.id")
+                .IsOptional("messaging.message.id")
+                .IsOptional("messaging.batch.message_count")
+                .Matches("component", "AzureEventHubs")
+                .MatchesOneOf("span.kind", "producer", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
+        public static Result IsGrpcClientOTel(this MockSpan span, ISet<string> excludeTags) => Result.FromSpan(span, excludeTags)
+            .WithMarkdownSection("gRPC Client")
+            .Properties(s => s
+                .Matches(Type, "grpc"))
+            .Tags(s => s
+                // Required
+                .Matches("rpc.system", "grpc")
+                // Conditionally required
+                .IsOptional("rpc.method")
+                .IsOptional("rpc.service")
+                .IsOptional("error.type")
+                // Recommended
+                .IsPresent("server.address")
+                .IsOptional("server.port")
+                .IsOptional("network.peer.address")
+                .IsOptional("network.peer.port")
+                // gRPC-specific
+                .IsPresent("rpc.grpc.status_code")
+                .Matches("component", "Grpc")
+                .Matches("span.kind", "client"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
+        public static Result IsGrpcServerOTel(this MockSpan span, ISet<string> excludeTags) => Result.FromSpan(span, excludeTags)
+            .WithMarkdownSection("gRPC Server")
+            .Properties(s => s
+                .Matches(Type, "grpc"))
+            .Tags(s => s
+                // Required
+                .Matches("rpc.system", "grpc")
+                // Conditionally required
+                .IsOptional("rpc.method")
+                .IsOptional("rpc.service")
+                .IsOptional("error.type")
+                // Recommended
+                .IsOptional("server.address")
+                .IsOptional("server.port")
+                .IsOptional("network.peer.address")
+                .IsOptional("network.peer.port")
+                // gRPC-specific
+                .IsPresent("rpc.grpc.status_code")
+                .Matches("component", "Grpc")
+                .Matches("span.kind", "server"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/
+        public static Result IsGraphQLOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .MatchesOneOf(Name, "graphql.execute", "graphql.validate")
+                .Matches(Type, "graphql"))
+            .Tags(s => s
+                .IsOptional("graphql.document")
+                .IsOptional("graphql.operation.name")
+                .IsOptional("graphql.operation.type")
+                .IsPresent("graphql.source")
+                .IsOptional("error.type")
+                .Matches("component", "GraphQL")
+                .Matches("span.kind", "server")
+                .IsOptional("events"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/graphql/graphql-spans/
+        public static Result IsHotChocolateOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .MatchesOneOf(Name, "graphql.execute", "graphql.validate")
+                .Matches(Type, "graphql"))
+            .Tags(s => s
+                .IsOptional("graphql.document")
+                .IsOptional("graphql.operation.name")
+                .IsOptional("graphql.operation.type")
+                .IsPresent("graphql.source")
+                .IsOptional("error.type")
+                .Matches("component", "HotChocolate")
+                .Matches("span.kind", "server")
+                .IsOptional("events"));
+
+        // See: https://opentelemetry.io/docs/specs/semconv/system/process/
+        public static Result IsProcessOTel(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Name, "command_execution")
+                .Matches(Type, "system"))
+            .Tags(s => s
+                .IsOptional("process.command")
+                .IsOptional("process.command_args")
+                .IsOptional("process.command_line")
+                .IsOptional("error.type")
+                .Matches("component", "process")
+                .Matches("span.kind", "internal"));
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -33,6 +33,7 @@ namespace Datadog.Trace.TestHelpers
             .IsOptional("error.msg")
             .IsOptional("error.type")
             .IsOptional("error.stack")
+            .IsOptional("http-client-handler-type")
             .IsOptional("_dd.git.repository_url")
             .IsOptional("_dd.git.commit.sha");
 

--- a/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/Http/HttpOtelHelperTests.cs
@@ -1,0 +1,171 @@
+// <copyright file="HttpOtelHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ClrProfiler.AutoInstrumentation.Http;
+
+public class HttpOtelHelperTests
+{
+    // ─── SetRequestMethod ────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    [InlineData("TRACE")]
+    [InlineData("PATCH")]
+    [InlineData("CONNECT")]
+    [InlineData("QUERY")]
+    public void SetRequestMethod_KnownMethod_SetsTagWithoutOriginal(string method)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetRequestMethod(span.Object, method);
+
+        span.Verify(s => s.SetTag("http.request.method", method), Times.Once);
+        span.Verify(s => s.SetTag("http.request.method_original", It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("PROPFIND")]
+    [InlineData("BOGUS")]
+    [InlineData("MKCOL")]
+    public void SetRequestMethod_UnknownMethod_SetsOtherAndPreservesOriginal(string method)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetRequestMethod(span.Object, method);
+
+        span.Verify(s => s.SetTag("http.request.method", "_OTHER"), Times.Once);
+        span.Verify(s => s.SetTag("http.request.method_original", method), Times.Once);
+        span.Verify(s => s.SetTag("http.request.method", method), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SetRequestMethod_NullOrEmpty_SetsNoTag(string method)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetRequestMethod(span.Object, method);
+
+        span.Verify(s => s.SetTag(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    // ─── SetClientUrl ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("http://host:8080/p?q=1", "http://host:8080/p?q=1")]
+    [InlineData("https://host/p", "https://host/p")]
+    public void SetClientUrl_NoCredentials_SetsUrlFullAsIs(string rawUrl, string expectedFull)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetClientUrl(span.Object, rawUrl);
+
+        span.Verify(s => s.SetTag("url.full", expectedFull), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("http://user:pass@host/p", "http://host/p")]
+    [InlineData("https://user:secret@host:8443/p?q=1", "https://host:8443/p?q=1")]
+    [InlineData("http://user@host/p", "http://host/p")]
+    public void SetClientUrl_CredentialsPresent_RedactsFromUrlFull(string rawUrl, string expectedFull)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetClientUrl(span.Object, rawUrl);
+
+        span.Verify(s => s.SetTag("url.full", expectedFull), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("http://host/p", "http")]
+    [InlineData("https://host/p", "https")]
+    [InlineData("http://host:8080/p", "http")]
+    public void SetClientUrl_SetsScheme(string rawUrl, string expectedScheme)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetClientUrl(span.Object, rawUrl);
+
+        span.Verify(s => s.SetTag("url.scheme", expectedScheme), Times.Once);
+    }
+
+    [Fact]
+    public void SetClientUrl_NonDefaultPort_SetsServerPort()
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetClientUrl(span.Object, "http://host:8080/p");
+
+        span.Verify(s => s.SetTag("server.port", "8080"), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("http://host/p")]    // port 80 is default for http
+    [InlineData("https://host/p")]   // port 443 is default for https
+    public void SetClientUrl_DefaultPort_DoesNotSetServerPort(string rawUrl)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetClientUrl(span.Object, rawUrl);
+
+        span.Verify(s => s.SetTag("server.port", It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void SetClientUrl_NullOrEmpty_SetsNoTag(string rawUrl)
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetClientUrl(span.Object, rawUrl);
+
+        span.Verify(s => s.SetTag(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    // ─── SetServerUrl ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetServerUrl_SetsSchemePathAndQuery()
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetServerUrl(span.Object, "http://host:8080/p/q?token=secret");
+
+        span.Verify(s => s.SetTag("url.scheme", "http"), Times.Once);
+        span.Verify(s => s.SetTag("url.path", "/p/q"), Times.Once);
+        span.Verify(s => s.SetTag("url.query", "token=secret"), Times.Once);
+        span.Verify(s => s.SetTag("server.port", "8080"), Times.Once);
+    }
+
+    [Fact]
+    public void SetServerUrl_DefaultPort_DoesNotSetServerPort()
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetServerUrl(span.Object, "https://host/p");
+
+        span.Verify(s => s.SetTag("server.port", It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void SetServerUrl_NoQuery_DoesNotSetUrlQuery()
+    {
+        var span = SpanMock();
+        HttpOtelHelper.SetServerUrl(span.Object, "http://host/p");
+
+        span.Verify(s => s.SetTag("url.query", It.IsAny<string>()), Times.Never);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static Mock<ISpan> SpanMock(string existingErrorType = null)
+    {
+        var mock = new Mock<ISpan>();
+        mock.Setup(s => s.SetTag(It.IsAny<string>(), It.IsAny<string>())).Returns(mock.Object);
+        mock.Setup(s => s.GetTag("error.type")).Returns(existingErrorType);
+        return mock;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SetHttpStatusCodeOtelTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SetHttpStatusCodeOtelTests.cs
@@ -1,0 +1,153 @@
+// <copyright file="SetHttpStatusCodeOtelTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Tests.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ExtensionMethods;
+
+public class SetHttpStatusCodeOtelTests
+{
+    private static readonly MutableSettings DefaultSettings =
+        MutableSettings.CreateForTesting(new TracerSettings(), new Dictionary<string, object?>());
+
+    // ─── http.response.status_code ───────────────────────────────────────────────
+
+    [Fact]
+    public void SetHttpStatusCode_OtelMode_SetsResponseStatusCodeTag()
+    {
+        var span = CreateSpan();
+        span.SetHttpStatusCode(200, isServer: true, DefaultSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("http.response.status_code").Should().Be("200");
+    }
+
+    [Fact]
+    public void SetHttpStatusCode_NonOtelMode_DoesNotSetResponseStatusCodeTag()
+    {
+        var span = CreateSpan();
+        span.SetHttpStatusCode(200, isServer: true, DefaultSettings, otelSemanticsEnabled: false);
+
+        span.GetTag("http.response.status_code").Should().BeNull();
+    }
+
+    // ─── error.type via SetErrorType ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(503)]
+    public void SetHttpStatusCode_OtelMode_ServerSpan_SetsErrorTypeFor5xx_ByDefault(int statusCode)
+    {
+        var span = CreateSpan();
+        span.SetHttpStatusCode(statusCode, isServer: true, DefaultSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("error.type").Should().Be(statusCode.ToString());
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    [InlineData(422)]
+    public void SetHttpStatusCode_OtelMode_ServerSpan_DoesNotSetErrorTypeFor4xx_ByDefault(int statusCode)
+    {
+        var span = CreateSpan();
+        span.SetHttpStatusCode(statusCode, isServer: true, DefaultSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("error.type").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    [InlineData(422)]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(503)]
+    public void SetHttpStatusCode_OtelMode_ServerSpan_SetsErrorTypeForServerErrorStatuses(int statusCode)
+    {
+        var userSettings = MutableSettings.CreateForTesting(new TracerSettings(), new Dictionary<string, object?> { { "DD_TRACE_HTTP_SERVER_ERROR_STATUSES", "400-599" } });
+
+        var span = CreateSpan();
+        span.SetHttpStatusCode(statusCode, isServer: true, userSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("error.type").Should().Be(statusCode.ToString());
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(401)]
+    [InlineData(404)]
+    // [InlineData(500)] // TODO: In OTel semantic mode, 5xx status codes SHOULD be considered errors for client spans
+    public void SetHttpStatusCode_OtelMode_ClientSpan_SetsErrorTypeFor4xxAnd5xx_ByDefault(int statusCode)
+    {
+        var span = CreateSpan();
+        span.SetHttpStatusCode(statusCode, isServer: false, DefaultSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("error.type").Should().Be(statusCode.ToString());
+    }
+
+    [Theory]
+    [InlineData(200)]
+    [InlineData(301)]
+    [InlineData(399)]
+    public void SetHttpStatusCode_OtelMode_ClientSpan_DoesNotSetErrorTypeBelow400_ByDefault(int statusCode)
+    {
+        var span = CreateSpan();
+        span.SetHttpStatusCode(statusCode, isServer: false, DefaultSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("error.type").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    [InlineData(422)]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(503)]
+    public void SetHttpStatusCode_OtelMode_ClientSpan_SetsErrorTypeForServerErrorStatuses(int statusCode)
+    {
+        var userSettings = MutableSettings.CreateForTesting(new TracerSettings(), new Dictionary<string, object?> { { "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES", "400-599" } });
+
+        var span = CreateSpan();
+        span.SetHttpStatusCode(statusCode, isServer: false, userSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("error.type").Should().Be(statusCode.ToString());
+    }
+
+    [Fact]
+    public void SetHttpStatusCode_OtelMode_DoesNotOverwriteExistingErrorType()
+    {
+        var span = CreateSpan();
+        span.SetTag("error.type", "System.Net.Http.HttpRequestException");
+        span.SetHttpStatusCode(500, isServer: true, DefaultSettings, otelSemanticsEnabled: true);
+
+        span.GetTag("error.type").Should().Be("System.Net.Http.HttpRequestException");
+    }
+
+    [Fact]
+    public void SetHttpStatusCode_NonOtelMode_DoesNotSetErrorType()
+    {
+        var span = CreateSpan();
+        span.SetHttpStatusCode(500, isServer: true, DefaultSettings, otelSemanticsEnabled: false);
+
+        span.GetTag("error.type").Should().BeNull();
+    }
+
+    private static Span CreateSpan()
+    {
+        var traceContext = new TraceContext(new StubDatadogTracer());
+        var spanContext = new SpanContext(parent: null, traceContext, serviceName: null);
+        return new Span(spanContext, DateTimeOffset.UtcNow);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetrySpecialTagRemapperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetrySpecialTagRemapperTests.cs
@@ -224,7 +224,7 @@ namespace Datadog.Trace.Tests
             OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span, openTelemetrySemanticsEnabled: true);
 
             span.GetTag(Tags.HttpStatusCode).Should().BeNull();
-            span.GetMetric(key).Should().Be((double)statusCode);
+            span.GetTag(key).Should().Be(statusCode.ToString());
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/NormalizerTraceProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/NormalizerTraceProcessorTests.cs
@@ -3,14 +3,51 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Text;
+using Datadog.Trace.Tagging;
+using Datadog.Trace.Tests.Util;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.TraceProcessors
 {
     public class NormalizerTraceProcessorTests
     {
+        [Fact]
+        public void HttpStatusCode_Null_IsNotSetToEmptyString()
+        {
+            var span = CreateWebSpan();
+            ((WebTags)span.Tags).HttpStatusCode = null;
+
+            new Trace.Processors.NormalizerTraceProcessor().Process(span);
+
+            span.GetTag(Tags.HttpStatusCode).Should().BeNull();
+        }
+
+        [Fact]
+        public void HttpStatusCode_Invalid_IsClearedToEmptyString()
+        {
+            var span = CreateWebSpan();
+            ((WebTags)span.Tags).HttpStatusCode = "not-a-code";
+
+            new Trace.Processors.NormalizerTraceProcessor().Process(span);
+
+            span.GetTag(Tags.HttpStatusCode).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void HttpStatusCode_Valid_IsLeftUnchanged()
+        {
+            var span = CreateWebSpan();
+            ((WebTags)span.Tags).HttpStatusCode = "200";
+
+            new Trace.Processors.NormalizerTraceProcessor().Process(span);
+
+            span.GetTag(Tags.HttpStatusCode).Should().Be("200");
+        }
+
         // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/traceutil/normalize_test.go#L17
         [Fact]
         public void NormalizeTagTests()
@@ -121,6 +158,13 @@ namespace Datadog.Trace.Tests.TraceProcessors
                 yield return new object[] { "Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.Too$Long$.", "too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_.too_long_." };
                 yield return new object[] { "bad$service", "bad_service" };
             }
+        }
+
+        private static Span CreateWebSpan()
+        {
+            var traceContext = new TraceContext(new StubDatadogTracer());
+            var spanContext = new SpanContext(parent: null, traceContext, serviceName: null);
+            return new Span(spanContext, DateTimeOffset.UtcNow, new WebTags());
         }
     }
 }

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_-query=test_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_-query=test_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_-query=test_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_-query=test_statusCode=200.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET Home/Index",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "{controller=home}/{action=index}/{id?}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "Index"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "19"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "url.query",
+                  "value": {
+                    "stringValue": "query=test"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,200 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET Home/Index",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "{controller=home}/{action=index}/{id?}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "Index"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "19"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,158 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET /api/delay/{seconds}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/api/delay/{seconds}"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/api/delay/0"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,226 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET bad-request",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "bad-request"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "ThrowException"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "50"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/bad-request"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ],
+              "events": [
+                {
+                  "timeUnixNano": "0",
+                  "name": "exception",
+                  "attributes": [
+                    {
+                      "key": "exception.type",
+                      "value": {
+                        "stringValue": "System.Exception"
+                      }
+                    },
+                    {
+                      "key": "exception.message",
+                      "value": {
+                        "stringValue": "This was a bad request."
+                      }
+                    },
+                    {
+                      "key": "exception.stacktrace",
+                      "value": {
+                        "stringValue": "System.Exception: This was a bad request.\n   at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException() in {SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs:line 52\n   at lambda_method6(Closure, Object, Object[])\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)\n   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.BlockingMiddleware.Invoke(HttpContext context)\n   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)\n   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)\n   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/branch/not-found"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "404"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/branch/ping"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,200 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET delay/{seconds}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "delay/{seconds}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "Delay"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "32"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/delay/0"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET handled-exception",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "handled-exception"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "HandledException"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "80"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/handled-exception"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/not-found"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "404"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/ping"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,0 +1,226 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code-string/{statusCode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code-string/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTestString"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "65"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code-string/%5B200%5D"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ],
+              "events": [
+                {
+                  "timeUnixNano": "0",
+                  "name": "exception",
+                  "attributes": [
+                    {
+                      "key": "exception.type",
+                      "value": {
+                        "stringValue": "System.Exception"
+                      }
+                    },
+                    {
+                      "key": "exception.message",
+                      "value": {
+                        "stringValue": "Input was not a status code"
+                      }
+                    },
+                    {
+                      "key": "exception.stacktrace",
+                      "value": {
+                        "stringValue": "System.Exception: Input was not a status code\n   at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input) in {SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs:line 74\n   at lambda_method8(Closure, Object, Object[])\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)\n   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.BlockingMiddleware.Invoke(HttpContext context)\n   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)\n   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)\n   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,200 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code/{statusCode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTest"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "57"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code/203"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "203"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code/{statusCode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTest"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "57"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code/402"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "402"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "402"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisOTelTestsWithOtlp.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMinimalApis"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code/{statusCode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTest"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "57"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code/500"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_-query=test_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_-query=test_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET {controller=home}/{action=index}/{id?},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.request.method: GET,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.response.status_code: 200,
+      http.route: {controller=home}/{action=index}/{id?},
+      language: dotnet,
+      runtime-id: Guid_1,
+      server.address: localhost:00000,
+      span.kind: server,
+      url.path: /,
+      url.scheme: http,
+      user_agent.original: testhelper,
+      version: 1.0.0,
+      _dd.code_origin.frames.0.column: 0,
+      _dd.code_origin.frames.0.file: tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Controllers\HomeController.cs,
+      _dd.code_origin.frames.0.index: 0,
+      _dd.code_origin.frames.0.line: 0,
+      _dd.code_origin.frames.0.method: Index,
+      _dd.code_origin.frames.0.type: Samples.AspNetCoreMvc.Controllers.HomeController,
+      _dd.code_origin.type: entry
+    },
+    Metrics: {
+      process_id: 0,
+      server.port: 00000.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_-query=test_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_-query=test_statusCode=200.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET {controller=home}/{action=index}/{id?}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "{controller=home}/{action=index}/{id?}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "Index"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "19"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "url.query",
+                  "value": {
+                    "stringValue": "query=test"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,200 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET {controller=home}/{action=index}/{id?}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "{controller=home}/{action=index}/{id?}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "Index"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "19"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,200 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET api/delay/{seconds}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "api/delay/{seconds}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "Delay"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.ApiController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/ApiController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "16"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/api/delay/0"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,226 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET bad-request",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "bad-request"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "ThrowException"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "50"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/bad-request"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ],
+              "events": [
+                {
+                  "timeUnixNano": "0",
+                  "name": "exception",
+                  "attributes": [
+                    {
+                      "key": "exception.type",
+                      "value": {
+                        "stringValue": "System.Exception"
+                      }
+                    },
+                    {
+                      "key": "exception.message",
+                      "value": {
+                        "stringValue": "This was a bad request."
+                      }
+                    },
+                    {
+                      "key": "exception.stacktrace",
+                      "value": {
+                        "stringValue": "System.Exception: This was a bad request.\n   at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException() in {SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs:line 52\n   at lambda_method70(Closure, Object, Object[])\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)\n   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/branch/not-found"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "404"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/branch/ping"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,200 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET delay/{seconds}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "delay/{seconds}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "Delay"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "32"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/delay/0"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET handled-exception",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "handled-exception"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "HandledException"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "80"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/handled-exception"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/not-found"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "404"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,146 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/ping"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,0 +1,226 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code-string/{statuscode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code-string/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTestString"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "65"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code-string/%5B200%5D"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ],
+              "events": [
+                {
+                  "timeUnixNano": "0",
+                  "name": "exception",
+                  "attributes": [
+                    {
+                      "key": "exception.type",
+                      "value": {
+                        "stringValue": "System.Exception"
+                      }
+                    },
+                    {
+                      "key": "exception.message",
+                      "value": {
+                        "stringValue": "Input was not a status code"
+                      }
+                    },
+                    {
+                      "key": "exception.stacktrace",
+                      "value": {
+                        "stringValue": "System.Exception: Input was not a status code\n   at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String input) in {SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs:line 74\n   at lambda_method2(Closure, Object, Object[])\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()\n--- End of stack trace from previous location ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\n   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)\n   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,200 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code/{statuscode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTest"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "57"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code/203"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "203"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code/{statuscode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTest"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "57"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code/402"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "402"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "402"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31OTelTestsWithOtlp.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,206 @@
+﻿{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "Samples.AspNetCoreMvc31"
+            }
+          },
+          {
+            "key": "service.version",
+            "value": {
+              "stringValue": "1.0.0"
+            }
+          },
+          {
+            "key": "deployment.environment.name",
+            "value": {
+              "stringValue": "integration_tests"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "sdk-name"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "dotnet"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "sdk-version"
+            }
+          },
+          {
+            "key": "git.commit.sha",
+            "value": {
+              "stringValue": "normalized-git-commit-sha"
+            }
+          },
+          {
+            "key": "git.repository_url",
+            "value": {
+              "stringValue": "https://github.com/DataDog/dd-trace-dotnet"
+            }
+          },
+          {
+            "key": "runtime-id",
+            "value": {
+              "stringValue": "Guid_1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "spans": [
+            {
+              "traceId": "normalized-trace-id",
+              "spanId": "normalized-span-id",
+              "name": "GET status-code/{statuscode}",
+              "kind": 2,
+              "startTimeUnixNano": "0",
+              "endTimeUnixNano": "0",
+              "attributes": [
+                {
+                  "key": "runtime-id",
+                  "value": {
+                    "stringValue": "Guid_1"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "status-code/{statuscode}"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.type",
+                  "value": {
+                    "stringValue": "entry"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.index",
+                  "value": {
+                    "stringValue": "0"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.method",
+                  "value": {
+                    "stringValue": "StatusCodeTest"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.type",
+                  "value": {
+                    "stringValue": "Samples.AspNetCoreMvc.Controllers.HomeController"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.file",
+                  "value": {
+                    "stringValue": "{SolutionDirectory}tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.line",
+                  "value": {
+                    "stringValue": "57"
+                  }
+                },
+                {
+                  "key": "_dd.code_origin.frames.0.column",
+                  "value": {
+                    "stringValue": "9"
+                  }
+                },
+                {
+                  "key": "http.request.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "url.scheme",
+                  "value": {
+                    "stringValue": "http"
+                  }
+                },
+                {
+                  "key": "url.path",
+                  "value": {
+                    "stringValue": "/status-code/500"
+                  }
+                },
+                {
+                  "key": "server.address",
+                  "value": {
+                    "stringValue": "localhost:00000"
+                  }
+                },
+                {
+                  "key": "user_agent.original",
+                  "value": {
+                    "stringValue": "testhelper"
+                  }
+                },
+                {
+                  "key": "http.request.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "datadog-header-tag",
+                  "value": {
+                    "stringValue": "asp-net-core"
+                  }
+                },
+                {
+                  "key": "error.type",
+                  "value": {
+                    "stringValue": "500"
+                  }
+                },
+                {
+                  "key": "http.response.headers.sample_correlation_identifier",
+                  "value": {
+                    "stringValue": "0000-0000-0000"
+                  }
+                },
+                {
+                  "key": "http.response.headers.server",
+                  "value": {
+                    "stringValue": "Kestrel"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "normalized-server-port"
+                  }
+                },
+                {
+                  "key": "http.response.status_code",
+                  "value": {
+                    "intValue": "500"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpTraces_DD_OtelSemantics.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.SubmitsOtlpTraces_DD_OtelSemantics.verified.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "resourceSpans": [
     {
       "resource": {


### PR DESCRIPTION
## Summary of changes

Updates the HTTP client and HTTP server integrations to generate span attributes that align with OpenTelemetry semantic conventions when configuration `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` is set

| | Datadog | OTel |
|---|---|---|
| method | `http.method` | `http.request.method`; verbs outside RFC 9110 (+PATCH/QUERY) → `_OTHER` + `http.request.method_original` |
| span name | `GET /route` / `GET` | unchanged for known methods (`{method} {route}` / `{method}`); **`HTTP`** for unknown methods |
| status | `http.status_code` | `http.response.status_code` |
| url (client) | `http.url` | `url.full`, embedded credentials redacted |
| url (server) | `http.url` | `url.path`, `url.scheme`, `url.query` (obfuscation preserved) |
| host / port | `out.host` / `network.destination.port` | `server.address` / `server.port` (client → scheme default 443/80) |
| user agent (server) | `http.useragent` | `user_agent.original` |
| client IP (server) | `http.client_ip` | `client.address` |
| peer address (server) | — | `network.peer.address` |
| route (server) | `http.route` | `http.route` (unchanged) |
| error | error flag | `error.type` = status: **client ≥400, server 5xx only** (server 4xx unset); no-clobber on an exception type |

## Reason for change

## Implementation details

### Shared
- Update `SpanExtensions.SetHttpStatusCode` to accept a new `bool otelSemanticsEnabled` parameter to set the tag `http.response.status_code` (OpenTelemetry span attribute key) instead of `http.status_code` (Datadog span attribute key)
- Manually updates the OTLP trace exporter to convert span attributes `http.response.status_code` and `server.port` to be emitted as OTLP IntValue's

### HTTP Client
- Update `AspNetCoreDiagnosticObserver` to only generate one server span (in alignment with OpenTelemetry AspNetCore instrumentation)
- Update `ScopeFactory.CreateInactiveOutboundHttpSpan` to set the OpenTelemetry HTTP client span attributes rather than their Datadog equivalents, including the request method method, client URL properties, and server address


### HTTP Server
- Update `SpanExtensions.DecorateWebServerSpan` to accept a new `bool otelSemanticsEnabled` parameter to set the OpenTelemetry HTTP server span attributes rather than their Datadog equivalents, including the request method, server URL properties, server address, and user agent

## Test coverage
- Add new `HttpMessageHandler.HttpClient_SubmitsTracesOTel` and `WebRequestTests.SubmitsTracesOTel` to run span assertion tests with the `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` configuration
- Add a new integration test class `AspNetCoreMvc31OTelTests` to do snapshot testing on the `Samples.AspNetCoreMvc31` test application with the `DD_TRACE_OTEL_SEMANTICS_ENABLED=true` configuration
- Add a new `tracer/test/Datadog.Trace.TestHelpers/SpanMetadataOTelRules.cs` to encode our span schema in our OpenTelemetry Semantics mode (similar to the previous v0/v1 schemas)
- Add a new '"/?query=test"' route to `AspNetCoreMvcTestBase` to test that query strings are recorded correctly

## Other details

