### PR TITLE
Add `StartDependencies.Profiler` to docker-compose.yml

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2896,10 +2896,19 @@ stages:
 
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
+          run --rm StartDependencies.Profiler
+      displayName: docker-compose run StartDependencies.Profiler
+      env:
+        DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        baseImage: $(baseImage)
+      retryCountOnTaskFailure: 5
+
+    - script: |
+        docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e baseImage=$(baseImage) \
           ProfilerIntegrationTests
-      displayName: docker-compose run --no-deps ProfilerIntegrationTests
+      displayName: docker-compose run ProfilerIntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         baseImage: $(baseImage) # for interpolation in the docker-compose file
@@ -2996,10 +3005,19 @@ stages:
 
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
+          run --rm StartDependencies.Profiler
+      displayName: docker-compose run StartDependencies.Profiler
+      env:
+        DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        baseImage: $(baseImage)
+      retryCountOnTaskFailure: 5
+
+    - script: |
+        docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e baseImage=$(baseImage) \
           ProfilerIntegrationTests
-      displayName: docker-compose run --no-deps ProfilerIntegrationTests
+      displayName: docker-compose run ProfilerIntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         baseImage: $(baseImage) # for interpolation in the docker-compose file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,6 +399,14 @@ services:
       LDAP_ADMIN_PASSWORD: "Passw0rd"
       LDAP_BASE_DN: "dc=dd-trace-dotnet,dc=com"
 
+  StartDependencies.Profiler:
+    image: andrewlock/wait-for-dependencies
+    depends_on:
+      - openldap
+    environment:
+      - TIMEOUT_LENGTH=120
+    command: openldap-server:389
+
   ProfilerIntegrationTests:
     build:
       context: ./tracer/build/_build/


### PR DESCRIPTION
## Summary of changes

- Add `StartDependencies.Profiler` to pipeline to ensure openldap is running before starting profiler tests
- Also provides a hook for pre-pulling

## Reason for change

Currently we're re-pulling `openldap` every time the pipeline runs, which can introduce flake

## Implementation details

Copy the same pattern as we use for tracing dependencies

## Test coverage

- [x] I'll do a [manual run of the profiling tests](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=203705&view=results), and make sure it passes for this branch

## Other details

I'll update the VM building docs to make sure we pull these dependencies too