### PR TITLE
[TESTS] Fix monitoring home calculation fallback for tests

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -371,7 +371,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             if (!IsRunningInCi())
             {
                 // native loader output folder
-                var binFolder = Path.Combine(GetSolutionDirectory(), "shared", "src", "Datadog.Trace.ClrProfiler.Native", "bin");
+                var binFolder = Path.Combine(GetSolutionDirectory(), "native-bin", "Datadog.Trace.ClrProfiler.Native", "bin");
 
                 return GetOS() switch
                 {

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogDiagnoser.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogDiagnoser.cs
@@ -148,8 +148,7 @@ public class DatadogDiagnoser : IDiagnoser
             "..",
             "..",
             "..",
-            "shared",
-            "bin",
+            "artifacts",
             "monitoring-home");
 #endif
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -105,8 +105,7 @@ namespace Datadog.Trace.TestHelpers
                 // default
                 monitoringHome = Path.Combine(
                     EnvironmentTools.GetSolutionDirectory(),
-                    "shared",
-                    "bin",
+                    "artifacts",
                     "monitoring-home");
             }
 


### PR DESCRIPTION
## Summary of changes
Update calculation method for monitoring home folder when env var is not set

## Reason for change
Tests were failing locally when monitoring home env var was missing

## Implementation details
Pointed to `artifacts/monitoring-home` instead of old `shared/bin/monitoring-home`

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
