### PR TITLE
Update DatadogTestLogger package versions to 0.0.54

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -92,6 +92,6 @@
     <ProjectReference Include="..\..\src\Tools\ReferenceChainExplorer\ReferenceChainModel\ReferenceChainModel.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.53" ExcludeAssets="compile" />
+    <PackageReference Include="DatadogTestLogger" Version="0.0.54" ExcludeAssets="compile" />
   </ItemGroup>
 </Project>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -59,8 +59,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestCollector" Version="0.0.53" ExcludeAssets="compile"/>
-    <PackageReference Include="DatadogTestLogger" Version="0.0.53" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestCollector" Version="0.0.54" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.54" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->

--- a/tracer/test/test.settings
+++ b/tracer/test/test.settings
@@ -12,7 +12,7 @@
             <InProcDataCollector
                     friendlyName="datadoginproc"
                     uri="InProcDataCollector://Datadog/collector/1.0"
-                    assemblyQualifiedName="DatadogCollector.DatadogInProcCollector, Datadog.collector, Version=0.0.50.0, Culture=neutral, PublicKeyToken=null"
+                    assemblyQualifiedName="DatadogCollector.DatadogInProcCollector, Datadog.collector, Version=0.0.54.0, Culture=neutral, PublicKeyToken=null"
                     codebase="Datadog.collector.dll"
                     enabled="True">
                 <Configuration>


### PR DESCRIPTION
## Summary of changes

Bump test logger to v0.0.54

## Reason for change

https://github.com/tonyredondo/datadog-test-logger/releases/tag/v0.0.54

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
