### PR TITLE
Fix `RunInstrumentationGenerator`

### DIFF
--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -119,7 +119,7 @@ partial class Build
 
            DotNetBuild(s => s
                            .SetDotnetPath(TargetPlatform)
-                           .SetFramework(TargetFramework.NET7_0)
+                           .SetFramework(TargetFramework.NET10_0)
                            .SetProjectFile(autoInstGenProj)
                            .SetConfiguration(Configuration.Release)
                            .SetNoWarnDotNetCore3());
@@ -128,7 +128,7 @@ partial class Build
            var dotnetRunSettings = new DotNetRunSettings()
                                   .SetDotnetPath(TargetPlatform)
                                   .SetNoBuild(true)
-                                  .SetFramework(TargetFramework.NET7_0)
+                                  .SetFramework(TargetFramework.NET10_0)
                                   .EnableNoLaunchProfile()
                                   .SetProjectFile(autoInstGenProj)
                                   .SetConfiguration(Configuration.Release);


### PR DESCRIPTION
## Summary of changes

Fix the broken `RunInstrumentationGenerator` tool

## Reason for change

It broke

## Implementation details

Fix the TFM it uses - it targets .NET 10, so we need to use that

## Test coverage

Ran it locally, it works
