### PR TITLE
Stop capturing static fields in DI snapshots

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -531,23 +531,6 @@ namespace Datadog.Trace.Debugger.Snapshots
             CaptureArgument(instance, "this", type);
         }
 
-        public void CaptureStaticFields<T>(ref CaptureInfo<T> info)
-        {
-            if (_omitCaptureData)
-            {
-                return;
-            }
-
-            if (info.IsAsyncCapture())
-            {
-                DebuggerSnapshotSerializer.SerializeStaticFields(info.AsyncCaptureInfo.KickoffInvocationTargetType, JsonWriter, _limitInfo);
-            }
-            else
-            {
-                DebuggerSnapshotSerializer.SerializeStaticFields(info.InvocationTargetType, JsonWriter, _limitInfo);
-            }
-        }
-
         internal void CaptureArgument<TArg>(TArg value, string name, Type? type = null)
         {
             if (_omitCaptureData)
@@ -621,7 +604,6 @@ namespace Datadog.Trace.Debugger.Snapshots
         internal void CaptureEntryMethodStartMarker<T>(ref CaptureInfo<T> info)
         {
             StartEntry();
-            CaptureStaticFields(ref info);
         }
 
         internal void CaptureEntryMethodEndMarker<TTarget>(TTarget value, Type type)
@@ -650,8 +632,6 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         private void ExitMethodStart<TReturnOrException>(ref CaptureInfo<TReturnOrException> info)
         {
-            CaptureStaticFields(ref info);
-
             switch (info.MethodState)
             {
                 case MethodState.ExitStartAsync:
@@ -758,7 +738,6 @@ namespace Datadog.Trace.Debugger.Snapshots
         internal void CaptureBeginLine<T>(ref CaptureInfo<T> info)
         {
             StartLines(info.LineCaptureInfo.LineNumber);
-            CaptureStaticFields(ref info);
         }
 
         internal void CaptureEndLine<TTarget>(ref CaptureInfo<TTarget> info)

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -45,13 +45,6 @@ namespace Datadog.Trace.Debugger.Snapshots
             SerializeInternal(source, type, jsonWriter, cts, currentDepth: 0, name, fieldsOnly: false, limitInfo, collectionsBeingSerialized);
         }
 
-        public static void SerializeStaticFields(Type declaringType, JsonTextWriter jsonWriter, CaptureLimitInfo limitInfo)
-        {
-            using var cts = CreateCancellationTimeout();
-            var collectionsBeingSerialized = new HashSet<object>(ObjectReferenceEqualityComparer.Instance);
-            WriteFields(null, declaringType, jsonWriter, cts, currentDepth: 0, writeStaticFields: true, limitInfo, collectionsBeingSerialized);
-        }
-
         private static bool SerializeInternal(
             object source,
             Type type,

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotStaticInitializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotStaticInitializerTests.cs
@@ -1,0 +1,184 @@
+// <copyright file="DebuggerSnapshotStaticInitializerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Debugger;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.Snapshots;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using Xunit;
+
+// The demonstration types below intentionally have static fields that are only ever read
+// reflectively by the snapshot serializer, so the compiler flags them as "assigned but never used".
+#pragma warning disable CS0414
+
+namespace Datadog.Trace.Tests.Debugger
+{
+    /// <summary>
+    /// Demonstrates that Dynamic Instrumentation's snapshot capture forces a type's
+    /// static constructor (.cctor / type initializer) to run at probe-fire time.
+    ///
+    /// When a snapshot is captured, <see cref="DebuggerSnapshotCreator.CaptureStaticFields{T}"/>
+    /// calls <see cref="DebuggerSnapshotSerializer.SerializeStaticFields"/> for the instrumented
+    /// method's declaring type. That reads every static field via <c>FieldInfo.GetValue(null)</c>,
+    /// and a static-field read is a trigger point for the declaring type's type initializer.
+    ///
+    /// For a type the application has not yet touched, this runs its .cctor earlier than the
+    /// application's own code would have. If that .cctor has an ordering/precondition dependency
+    /// and throws, the CLR permanently caches the failure and rethrows it on every later access,
+    /// crashing otherwise-correct application code.
+    ///
+    /// The demonstration types use an explicit static constructor (so they are NOT 'beforefieldinit')
+    /// purely to make the tests deterministic: with precise initialization semantics the .cctor
+    /// provably has not run until a static field is first accessed. In the wild, 'beforefieldinit'
+    /// types (the C# default for types with only static field initializers) are even more exposed,
+    /// because the application can hold live instances of them while their .cctor has still not run.
+    /// </summary>
+    public class DebuggerSnapshotStaticInitializerTests
+    {
+        [Fact]
+        public void SerializeStaticFields_ForcesStaticConstructorToRunEagerly()
+        {
+            // The type has not been touched, so its static constructor has not run.
+            Tracker.MechanismCctorRan.Should().BeFalse();
+
+            // DI captures the static fields of an instrumented method's declaring type.
+            SerializeStaticFields(typeof(TypeWithObservableStaticInitializer));
+
+            // Capturing the snapshot ran the static constructor, because the serializer
+            // reads each static field via field.GetValue(null), which triggers the type initializer.
+            Tracker.MechanismCctorRan.Should().BeTrue();
+        }
+
+        [Fact]
+        public void SerializeStaticFields_RunningCctorTooEarly_PoisonsType_AndBreaksLaterApplicationUse()
+        {
+            // The application has not finished initializing yet (e.g. configuration not loaded).
+            Tracker.ApplicationIsReady = false;
+
+            // A probe fires early and DI captures a snapshot. The serializer wraps every static read
+            // in a try/catch, so the capture itself "succeeds" and silently hides the problem.
+            Action capture = () => SerializeStaticFields(typeof(TypeWithPreconditionDependentStaticInitializer));
+            capture.Should().NotThrow("the serializer swallows exceptions thrown while reading a static member");
+
+            // The application has now finished initializing and legitimately uses the type.
+            Tracker.ApplicationIsReady = true;
+
+            // But the type is permanently poisoned: the CLR cached the type-initialization failure
+            // that DI triggered too early, and rethrows it on every later access. Correct application
+            // code now crashes through no fault of its own.
+            Action applicationUse = () => TypeWithPreconditionDependentStaticInitializer.ReadConfig();
+            applicationUse.Should().Throw<TypeInitializationException>();
+        }
+
+        [Fact]
+        public void CaptureEntryMethodStartMarker_RunsDeclaringTypeStaticConstructor()
+        {
+            // This drives the actual entry point our method-probe instrumentation calls at method entry,
+            // proving the eager static read is reached through the real capture flow (not just the
+            // low-level serializer helper).
+            Tracker.EntryPointCctorRan.Should().BeFalse();
+
+            var snapshotCreator = new DebuggerSnapshotCreator(
+                isFullSnapshot: true,
+                Datadog.Trace.Debugger.Expressions.ProbeLocation.Method,
+                hasCondition: false,
+                tags: [],
+                limitInfo: CreateLimitInfo(),
+                processTagsProvider: static () => null,
+                serviceNameProvider: static () => "test-service");
+
+            var method = typeof(TypeProbedAtEntry).GetMethod(nameof(TypeProbedAtEntry.InstanceMethodWithProbe));
+            var captureInfo = new CaptureInfo<Type>(
+                methodMetadataIndex: 0,
+                methodState: MethodState.EntryStart,
+                method: method,
+                type: typeof(TypeProbedAtEntry),
+                invocationTargetType: typeof(TypeProbedAtEntry));
+
+            snapshotCreator.CaptureEntryMethodStartMarker(ref captureInfo);
+
+            Tracker.EntryPointCctorRan.Should().BeTrue(
+                "CaptureEntryMethodStartMarker -> CaptureStaticFields -> SerializeStaticFields read the type's static fields");
+        }
+
+        private static void SerializeStaticFields(Type declaringType)
+        {
+            using var stringWriter = new StringWriter();
+            using var jsonWriter = new JsonTextWriter(stringWriter);
+            jsonWriter.WriteStartObject();
+            DebuggerSnapshotSerializer.SerializeStaticFields(declaringType, jsonWriter, CreateLimitInfo());
+            jsonWriter.WriteEndObject();
+        }
+
+        private static CaptureLimitInfo CreateLimitInfo()
+        {
+            return new CaptureLimitInfo(
+                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+                MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
+        }
+
+        // Observation state lives in a separate type so that checking a flag does not itself
+        // trigger the static constructor of the type under test.
+        private static class Tracker
+        {
+            public static bool MechanismCctorRan { get; set; }
+
+            public static bool EntryPointCctorRan { get; set; }
+
+            public static bool ApplicationIsReady { get; set; }
+        }
+
+        private class TypeWithObservableStaticInitializer
+        {
+            private static readonly string StaticField;
+
+            static TypeWithObservableStaticInitializer()
+            {
+                Tracker.MechanismCctorRan = true;
+                StaticField = "set-by-cctor";
+            }
+        }
+
+        private class TypeWithPreconditionDependentStaticInitializer
+        {
+            private static readonly string Config;
+
+            static TypeWithPreconditionDependentStaticInitializer()
+            {
+                // A realistic .cctor that assumes the application reached a certain point first
+                // (configuration loaded, DI container built, a singleton constructed, etc.).
+                if (!Tracker.ApplicationIsReady)
+                {
+                    throw new InvalidOperationException("Static initializer ran before the application was ready.");
+                }
+
+                Config = "loaded";
+            }
+
+            // Stands in for ordinary application code that reads the type's static state.
+            public static string ReadConfig() => Config;
+        }
+
+        private class TypeProbedAtEntry
+        {
+            private static readonly string StaticField;
+
+            static TypeProbedAtEntry()
+            {
+                Tracker.EntryPointCctorRan = true;
+                StaticField = "set-by-cctor";
+            }
+
+            public void InstanceMethodWithProbe()
+            {
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotStaticInitializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotStaticInitializerTests.cs
@@ -4,133 +4,78 @@
 // </copyright>
 
 using System;
-using System.IO;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Expressions;
 using Datadog.Trace.Debugger.Snapshots;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
 
-// The demonstration types below intentionally have static fields that are only ever read
-// reflectively by the snapshot serializer, so the compiler flags them as "assigned but never used".
+// StaticField is only read reflectively, so the compiler flags it as unused.
 #pragma warning disable CS0414
 
 namespace Datadog.Trace.Tests.Debugger
 {
     /// <summary>
-    /// Demonstrates that Dynamic Instrumentation's snapshot capture forces a type's
-    /// static constructor (.cctor / type initializer) to run at probe-fire time.
-    ///
-    /// When a snapshot is captured, <see cref="DebuggerSnapshotCreator.CaptureStaticFields{T}"/>
-    /// calls <see cref="DebuggerSnapshotSerializer.SerializeStaticFields"/> for the instrumented
-    /// method's declaring type. That reads every static field via <c>FieldInfo.GetValue(null)</c>,
-    /// and a static-field read is a trigger point for the declaring type's type initializer.
-    ///
-    /// For a type the application has not yet touched, this runs its .cctor earlier than the
-    /// application's own code would have. If that .cctor has an ordering/precondition dependency
-    /// and throws, the CLR permanently caches the failure and rethrows it on every later access,
-    /// crashing otherwise-correct application code.
-    ///
-    /// The demonstration types use an explicit static constructor (so they are NOT 'beforefieldinit')
-    /// purely to make the tests deterministic: with precise initialization semantics the .cctor
-    /// provably has not run until a static field is first accessed. In the wild, 'beforefieldinit'
-    /// types (the C# default for types with only static field initializers) are even more exposed,
-    /// because the application can hold live instances of them while their .cctor has still not run.
+    /// Regression tests for snapshot static-field capture. Reading a static field
+    /// (field.GetValue(null)) forces the declaring type's static constructor to run, which could
+    /// poison the type. Static-field capture was removed; these tests fail on the old behavior.
     /// </summary>
     public class DebuggerSnapshotStaticInitializerTests
     {
         [Fact]
-        public void SerializeStaticFields_ForcesStaticConstructorToRunEagerly()
+        public void MethodProbeEntry_DoesNotRunDeclaringTypeStaticConstructor()
         {
-            // The type has not been touched, so its static constructor has not run.
             Tracker.MechanismCctorRan.Should().BeFalse();
 
-            // DI captures the static fields of an instrumented method's declaring type.
-            SerializeStaticFields(typeof(TypeWithObservableStaticInitializer));
+            RunMethodProbeEntry(typeof(TypeWithObservableStaticInitializer));
 
-            // Capturing the snapshot ran the static constructor, because the serializer
-            // reads each static field via field.GetValue(null), which triggers the type initializer.
-            Tracker.MechanismCctorRan.Should().BeTrue();
+            // Capture must not read the type's statics, so its .cctor is not forced to run.
+            Tracker.MechanismCctorRan.Should().BeFalse();
         }
 
         [Fact]
-        public void SerializeStaticFields_RunningCctorTooEarly_PoisonsType_AndBreaksLaterApplicationUse()
+        public void MethodProbeEntry_OnTypeWithPreconditionDependentCctor_DoesNotPoisonType()
         {
-            // The application has not finished initializing yet (e.g. configuration not loaded).
             Tracker.ApplicationIsReady = false;
 
-            // A probe fires early and DI captures a snapshot. The serializer wraps every static read
-            // in a try/catch, so the capture itself "succeeds" and silently hides the problem.
-            Action capture = () => SerializeStaticFields(typeof(TypeWithPreconditionDependentStaticInitializer));
-            capture.Should().NotThrow("the serializer swallows exceptions thrown while reading a static member");
+            // Capturing before the app is ready must not trigger the fragile .cctor.
+            Action capture = () => RunMethodProbeEntry(typeof(TypeWithPreconditionDependentStaticInitializer));
+            capture.Should().NotThrow();
 
-            // The application has now finished initializing and legitimately uses the type.
+            // The type is not poisoned, so normal use succeeds once the app is ready.
             Tracker.ApplicationIsReady = true;
-
-            // But the type is permanently poisoned: the CLR cached the type-initialization failure
-            // that DI triggered too early, and rethrows it on every later access. Correct application
-            // code now crashes through no fault of its own.
-            Action applicationUse = () => TypeWithPreconditionDependentStaticInitializer.ReadConfig();
-            applicationUse.Should().Throw<TypeInitializationException>();
+            TypeWithPreconditionDependentStaticInitializer.ReadConfig().Should().Be("loaded");
         }
 
-        [Fact]
-        public void CaptureEntryMethodStartMarker_RunsDeclaringTypeStaticConstructor()
+        private static void RunMethodProbeEntry(Type invocationTargetType)
         {
-            // This drives the actual entry point our method-probe instrumentation calls at method entry,
-            // proving the eager static read is reached through the real capture flow (not just the
-            // low-level serializer helper).
-            Tracker.EntryPointCctorRan.Should().BeFalse();
-
             var snapshotCreator = new DebuggerSnapshotCreator(
                 isFullSnapshot: true,
                 Datadog.Trace.Debugger.Expressions.ProbeLocation.Method,
                 hasCondition: false,
                 tags: [],
-                limitInfo: CreateLimitInfo(),
+                limitInfo: new CaptureLimitInfo(
+                    MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
+                    MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
+                    MaxLength: DebuggerSettings.DefaultMaxStringLength,
+                    MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy),
                 processTagsProvider: static () => null,
                 serviceNameProvider: static () => "test-service");
 
-            var method = typeof(TypeProbedAtEntry).GetMethod(nameof(TypeProbedAtEntry.InstanceMethodWithProbe));
             var captureInfo = new CaptureInfo<Type>(
                 methodMetadataIndex: 0,
                 methodState: MethodState.EntryStart,
-                method: method,
-                type: typeof(TypeProbedAtEntry),
-                invocationTargetType: typeof(TypeProbedAtEntry));
+                type: invocationTargetType,
+                invocationTargetType: invocationTargetType);
 
+            // The entry point DI and Exception Replay call when capturing a snapshot.
             snapshotCreator.CaptureEntryMethodStartMarker(ref captureInfo);
-
-            Tracker.EntryPointCctorRan.Should().BeTrue(
-                "CaptureEntryMethodStartMarker -> CaptureStaticFields -> SerializeStaticFields read the type's static fields");
         }
 
-        private static void SerializeStaticFields(Type declaringType)
-        {
-            using var stringWriter = new StringWriter();
-            using var jsonWriter = new JsonTextWriter(stringWriter);
-            jsonWriter.WriteStartObject();
-            DebuggerSnapshotSerializer.SerializeStaticFields(declaringType, jsonWriter, CreateLimitInfo());
-            jsonWriter.WriteEndObject();
-        }
-
-        private static CaptureLimitInfo CreateLimitInfo()
-        {
-            return new CaptureLimitInfo(
-                MaxReferenceDepth: DebuggerSettings.DefaultMaxDepthToSerialize,
-                MaxCollectionSize: DebuggerSettings.DefaultMaxNumberOfItemsInCollectionToCopy,
-                MaxLength: DebuggerSettings.DefaultMaxStringLength,
-                MaxFieldCount: DebuggerSettings.DefaultMaxNumberOfFieldsToCopy);
-        }
-
-        // Observation state lives in a separate type so that checking a flag does not itself
-        // trigger the static constructor of the type under test.
+        // Separate type so reading a flag does not trigger the type under test's .cctor.
         private static class Tracker
         {
             public static bool MechanismCctorRan { get; set; }
-
-            public static bool EntryPointCctorRan { get; set; }
 
             public static bool ApplicationIsReady { get; set; }
         }
@@ -150,10 +95,9 @@ namespace Datadog.Trace.Tests.Debugger
         {
             private static readonly string Config;
 
+            // Fragile .cctor: throws unless the app is ready, like a container-resolving initializer.
             static TypeWithPreconditionDependentStaticInitializer()
             {
-                // A realistic .cctor that assumes the application reached a certain point first
-                // (configuration loaded, DI container built, a singleton constructed, etc.).
                 if (!Tracker.ApplicationIsReady)
                 {
                     throw new InvalidOperationException("Static initializer ran before the application was ready.");
@@ -162,23 +106,7 @@ namespace Datadog.Trace.Tests.Debugger
                 Config = "loaded";
             }
 
-            // Stands in for ordinary application code that reads the type's static state.
             public static string ReadConfig() => Config;
-        }
-
-        private class TypeProbedAtEntry
-        {
-            private static readonly string StaticField;
-
-            static TypeProbedAtEntry()
-            {
-                Tracker.EntryPointCctorRan = true;
-                StaticField = "set-by-cctor";
-            }
-
-            public void InstanceMethodWithProbe()
-            {
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Stop capturing static fields in Dynamic Instrumentation and Exception Replay snapshots

## Reason for change

Capture read each static field of the probed method's declaring type via `field.GetValue(null)`, which forces that type's static constructor to run. A cctor can throw, and the CLR then permanently poisons the type by caching the exception, crashing the app on later use.

## Implementation details

Removed `CaptureStaticFields` and `SerializeStaticFields`

## Test coverage

Added regression tests, look at the first commit for an example of a scenario where we caused it to fail

## Other details
<!-- Fixes #{issue} -->

Also reproduced in a heavier sample application, but not committing that as this seems to be simpler.
Assuming that this isn't the "best" option as it appears to be a breaking change as static fields will no longer show up in DI/Exception Replay.

Also assuming that there are a lot of snapshots that will fail because of this.

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
