### PR TITLE
Fix local MSBuild issue with `CompileSamples`

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1611,6 +1611,7 @@ partial class Build
                           // /nowarn:NU1701 - Package 'x' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.1'.
                           // /nowarn:NETSDK1138 - Package 'x' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.1'.
                           MSBuild(x => x
+                                      .SetMSBuildPath()
                                       .SetTargetPath(MsBuildProject)
                                       .SetTargets(target)
                                       .SetConfiguration(BuildConfiguration)
@@ -1643,6 +1644,7 @@ partial class Build
                   Logger.Information("Building sample {SampleName} with ApiVersion {ApiVersion} using MSBuild", SampleName, ApiVersion);
 
                   MSBuild(x => x.SetTargetPath(samples)
+                                .SetMSBuildPath()
                                 .SetTargets("Restore", "Build")
                                 .SetConfiguration(BuildConfiguration)
                                 .SetProperty("ApiVersion", ApiVersion)

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -142,6 +142,7 @@ partial class Build
         .Executes(() =>
         {
             MSBuild(s => s
+                .SetMSBuildPath()
                 .SetConfiguration(BuildConfiguration)
                 .SetTargetPlatform(TargetPlatform)
                 .SetProjectFile(Solution.GetProject(SampleName)));


### PR DESCRIPTION
## Summary of changes

Fixes `CompileSamples` failing locally when only Visual Studio 2026 is installed

## Reason for change

The version of Nuke we're using doesn't "know" about the newer version of Visual Studio . MSBuild, so we have a wrapper function that "teaches" it about these (and about the "custom" location we use in the GitLab install). The downside is that we have to make sure to use it everywhere, and we were missing a couple of places.

## Implementation details

Add missing `SetMSBuildPath()` calls

## Test coverage

Tested locally, it fixes things that were broken before
