### PR TITLE
[ASM] Keep persistent WAF arg pointers alive across context lifetime

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -28,6 +28,7 @@ internal sealed class Context : IContext
     private readonly Stopwatch _stopwatch;
     private readonly IWafLibraryInvoker _wafLibraryInvoker;
     private readonly IEncoder _encoder;
+    private readonly List<IntPtr> _persistentArgPointers;
     private readonly UserEventsState _userEventsState = new();
     private bool _disposed;
     private ulong _totalRuntimeOverRuns;
@@ -41,6 +42,7 @@ internal sealed class Context : IContext
         _encoder = encoder;
         _stopwatch = new Stopwatch();
         _encodeResults = new(64);
+        _persistentArgPointers = new(64);
     }
 
     ~Context() => Dispose(false);
@@ -160,14 +162,16 @@ internal sealed class Context : IContext
             // Calling _encoder.Encode(null) results in a null object that will cause the WAF to error
             // The WAF can be called with an empty dictionary (though we should avoid doing this).
 
-            DdwafObjectStruct pwPersistentArgs = default;
             DdwafObjectStruct pwEphemeralArgsValue = default;
+            DdwafObjectStruct* pwPersistentArgs = null;
 
             if (persistentAddressData is not null)
             {
                 var persistentArgs = _encoder.Encode(persistentAddressData, applySafetyLimits: true);
-                pwPersistentArgs = persistentArgs.ResultDdwafObject;
+                pwPersistentArgs = (DdwafObjectStruct*)System.Runtime.InteropServices.Marshal.AllocHGlobal(sizeof(DdwafObjectStruct));
+                *pwPersistentArgs = persistentArgs.ResultDdwafObject;
                 _encodeResults.Add(persistentArgs);
+                _persistentArgPointers.Add((IntPtr)pwPersistentArgs);
                 truncated |= persistentArgs.Truncated;
             }
 
@@ -190,7 +194,7 @@ internal sealed class Context : IContext
             }
 
             // WARNING: DO NOT DISPOSE pwPersistentArgs until the end of this class's lifecycle, i.e in the dispose. Otherwise waf might crash with fatal exception.
-            code = _waf.Run(_contextHandle, persistentAddressData != null ? &pwPersistentArgs : null, ephemeralArgs != null ? &pwEphemeralArgsValue : null, ref retNative, timeoutMicroSeconds);
+            code = _waf.Run(_contextHandle, pwPersistentArgs, ephemeralArgs != null ? &pwEphemeralArgsValue : null, ref retNative, timeoutMicroSeconds);
         }
 
         _stopwatch.Stop();
@@ -224,6 +228,11 @@ internal sealed class Context : IContext
             foreach (var encodeResult in _encodeResults)
             {
                 encodeResult.Dispose();
+            }
+
+            foreach (var persistentArgPointer in _persistentArgPointers)
+            {
+                System.Runtime.InteropServices.Marshal.FreeHGlobal(persistentArgPointer);
             }
 
             _wafLibraryInvoker.ContextDestroy(_contextHandle);


### PR DESCRIPTION
### Motivation
- Fix a dangling-pointer vulnerability where `Context.RunInternal` passed the address of a stack-local `DdwafObjectStruct` for persistent WAF args into the native `ddwaf_run` API even though the native contract requires persistent pointers to remain valid for the context lifetime.

### Description
- Added a `_persistentArgPointers` list to `Context` to retain stable unmanaged pointers for persistent args for the context lifetime.
- When persistent args are encoded, allocate unmanaged memory via `Marshal.AllocHGlobal`, copy the `DdwafObjectStruct` into that allocation, and pass the allocated pointer to `_waf.Run` instead of a stack address.
- Continue to keep the `IEncodeResult` instances in `_encodeResults` (as before) and add the unmanaged pointer to `_persistentArgPointers` for later cleanup.
- Free all retained unmanaged persistent-arg pointers in `Context.Dispose` after disposing encode results, preserving lifecycle semantics and avoiding native use-after-free.

### Testing
- Ran `dotnet test tracer/test/Datadog.Trace.Security.Unit.Tests/Datadog.Trace.Security.Unit.Tests.csproj --filter WafTests --nologo`; the project built successfully but test execution could not be fully validated in this environment due to missing native/runtime dependencies (ICU/libssl) and test-host crashes, causing the WAF-related tests to abort/fail; therefore tests could not conclusively assert runtime behavior here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05e121d0f88327bcca52f6dc8b46be)