### PR TITLE
Fix GitHub Actions bugs and update documentation

### DIFF
--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 #v4.1.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Login to Docker
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,11 @@ updates:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
       - dependency-name: "*" # Ignore patches for all integrations
         update-types: ["version-update:semver-patch"]
+    cooldown:
+      default-days: 2
 
   # Azure functions explicit testing - we can't include these with our "normal" process checks
   # Because they aren't compatible with the dotnet msbuild approach we're using
-    cooldown:
-      default-days: 2
   - package-ecosystem: "nuget"
     directory: "/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated"
     registries: "*"
@@ -43,10 +43,10 @@ updates:
     ignore:
       - dependency-name: "*" # Ignore patches for all integrations
         update-types: ["version-update:semver-patch"]
-
-  # Src libraries
     cooldown:
       default-days: 2
+
+  # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src"
     # This is a hacky way to get Dependabot to care primarily about

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -18,7 +18,7 @@ jobs:
       statuses: write # add a commit status check
 
     steps:
-    - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+    - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
       name: 'Get Milestones'
       id: milestones
       with:

--- a/.github/workflows/auto_deploy_aas_test_apps.yml
+++ b/.github/workflows/auto_deploy_aas_test_apps.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         name: 'Open Code Freeze Milestone'
         id: milestones
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Clone dd-trace-dotnet repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+    - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
       name: 'Close Code Freeze Milestone'
       id: milestones
       if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         name: 'Open Code Freeze Milestone'
         id: milestones
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/scheduled_aas_deploy.yml
+++ b/.github/workflows/scheduled_aas_deploy.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
       # Check skip milestone
-      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         if: steps.should_run.outputs.should_proceed == 'true'
         name: 'Check Skip Milestone'
         id: skip_milestone
@@ -79,7 +79,7 @@ jobs:
           fi
 
       # Close skip milestone if we're skipping
-      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         if: steps.should_run.outputs.should_proceed == 'true' && steps.check_skip.outputs.should_proceed == 'false'
         name: 'Close Skip Milestone'
         with:

--- a/.github/workflows/scheduled_code_freeze.yml
+++ b/.github/workflows/scheduled_code_freeze.yml
@@ -54,7 +54,7 @@ jobs:
           fi
 
       # Check skip milestone
-      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         if: steps.should_run.outputs.should_proceed == 'true'
         name: 'Check Skip Milestone'
         id: skip_milestone
@@ -80,7 +80,7 @@ jobs:
           fi
 
       # Open code freeze milestone
-      - uses: octokit/request-action@786351db496fa66730d8faa09ef279108da175a3 # v2.x
+      - uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         if: steps.check_skip.outputs.should_proceed == 'true'
         name: 'Open Code Freeze Milestone'
         id: open_freeze

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,7 @@ The tracer runs in-process with customer applications and must have minimal perf
 - `docs/development/AwsLambdaIntegrationTests.md` — AWS Lambda integration tests
 - `docs/development/UpdatingTheSdk.md` — SDK updates
 - `docs/development/QueryingDatadogAPIs.md` — Querying Datadog APIs for debugging (spans, logs)
+- `docs/development/GitHubActionsSecurity.md` — GitHub Actions SHA-pinning policy, action allowlist, and reviewer checklist
 
 **CI & Testing:**
 - `docs/development/CI/TroubleshootingCIFailures.md` — Investigating build/test failures in Azure DevOps

--- a/docs/development/GitHubActionsSecurity.md
+++ b/docs/development/GitHubActionsSecurity.md
@@ -46,8 +46,6 @@ SHA pins are kept current automatically. `.github/dependabot.yml` configures Dep
 
 Dependabot preserves the SHA-pin + `# vX.Y.Z` comment format when bumping. Review the bump PR and spot-check that the new SHA corresponds to the advertised tag on the upstream repo before merging.
 
-**Consider bumping the schedule to `weekly`** to receive security patches faster (currently `monthly`).
-
 ---
 
 ## Reviewer checklist

--- a/docs/development/GitHubActionsSecurity.md
+++ b/docs/development/GitHubActionsSecurity.md
@@ -1,0 +1,61 @@
+# GitHub Actions Security Policy
+
+## Policy
+
+All GitHub Actions workflow files (`.github/workflows/`) and composite actions (`.github/actions/`) must follow two rules:
+
+1. **Every third-party action must be pinned to a full 40-character commit SHA**, with a trailing `# vX.Y.Z` comment for human readability.
+2. **Only allowlisted actions may be used.** The allowlist is enforced via the GitHub repository/org settings ("Allow specified actions and reusable workflows").
+
+### Why SHA-pinning?
+
+A mutable tag (`@v4`, `@main`) can be force-pushed to point at different — potentially malicious — code at any time. A 40-char commit SHA is immutable: the action's code is locked to exactly that commit, regardless of what happens to tags or branches in the upstream repo.
+
+### Exempt references
+
+Local composite actions (`uses: ./.github/actions/...`) and local reusable workflows (`uses: ./.github/workflows/...`) move with the current commit and must **not** be version-pinned. Reviewers should leave these as-is.
+
+---
+
+## Allowlist
+
+The allowlist of permitted actions is managed by a repository admin in GitHub Settings → Actions → General → "Allow specified actions and reusable workflows" (or the equivalent IaC/Terraform field). It is not duplicated here to avoid going stale.
+
+If a workflow run is blocked with an "action is not allowed" error, ask a repository admin to add the action to the allowlist before merging.
+
+---
+
+## Adding a new action
+
+1. **Find the SHA** for the version you want. On the upstream repo, browse to the tag/release, note the full commit SHA (40 hex chars). Alternatively: `git ls-remote https://github.com/<owner>/<repo> refs/tags/<tag>` will print the commit SHA.
+2. **Ask a repository admin to add the action to the allowlist** before the PR merges — otherwise the workflow will be blocked at runtime with an "action is not allowed" error.
+3. **Write the `uses:` line** in the format:
+   ```yaml
+   uses: owner/repo@<40-char-sha> # vX.Y.Z
+   ```
+4. **Update CODEOWNERS if needed.** `.github/workflows/` is owned by `@DataDog/apm-dotnet`; keep the right team in the review chain.
+
+---
+
+## SHA management (Dependabot)
+
+SHA pins are kept current automatically. `.github/dependabot.yml` configures Dependabot for the `github-actions` ecosystem:
+- Runs **monthly**, scanning `/.github/workflows/`, `/.github/actions/*`, and `/.github/actions/*/*`.
+- Groups all updates into a single PR (`gh-actions-packages`).
+- Applies a 2-day cooldown before raising the PR.
+
+Dependabot preserves the SHA-pin + `# vX.Y.Z` comment format when bumping. Review the bump PR and spot-check that the new SHA corresponds to the advertised tag on the upstream repo before merging.
+
+**Consider bumping the schedule to `weekly`** to receive security patches faster (currently `monthly`).
+
+---
+
+## Reviewer checklist
+
+When reviewing a PR that touches `.github/workflows/` or `.github/actions/`:
+
+- [ ] Every new or changed `uses:` for a third-party action is pinned to a 40-char commit SHA (not a tag, branch, or version number).
+- [ ] Every new action is on the allowlist (or the allowlist has been updated in the same/accompanying change).
+- [ ] Local `./` refs (`uses: ./.github/actions/...`, `uses: ./.github/workflows/...`) are **not** version-pinned — leave them as-is.
+- [ ] The `# vX.Y.Z` comment reflects the actual version the SHA resolves to.
+

--- a/docs/development/GitHubActionsSecurity.md
+++ b/docs/development/GitHubActionsSecurity.md
@@ -13,7 +13,7 @@ A mutable tag (`@v4`, `@main`) can be force-pushed to point at different — pot
 
 ### Exempt references
 
-Local composite actions (`uses: ./.github/actions/...`) and local reusable workflows (`uses: ./.github/workflows/...`) move with the current commit and must **not** be version-pinned. Reviewers should leave these as-is.
+Local composite actions (`uses: ./.github/actions/...`) and local reusable workflows (`uses: ./.github/workflows/...`) move with the current commit and must **not** be version-pinned. Reviewers should leave these as-is. Also, all `actions/*`, `github/*`, and `DataDog/*` actions are allowed.
 
 ---
 
@@ -33,7 +33,6 @@ If a workflow run is blocked with an "action is not allowed" error, ask a reposi
    ```yaml
    uses: owner/repo@<40-char-sha> # vX.Y.Z
    ```
-4. **Update CODEOWNERS if needed.** `.github/workflows/` is owned by `@DataDog/apm-dotnet`; keep the right team in the review chain.
 
 ---
 


### PR DESCRIPTION
## Summary of changes

- Add documentation on GitHub actions restrictions
- Minor cleanup

## Reason for change

We are going to start _enforcing_ that all GitHub Actions are SHA pinned, and that you can't introduce a new action without updating the allowlist. The change is already made, this is just updating documentation.

## Implementation details

- Adds some docs about the process.
- Locked down the GitHub Actions in Settings -> Actions -> General
 
Also updated some "incorrect" SHA values:

- `octokit/request-action`: SHA replaced, The SHA `786351db...` turned out to be a that doesn't correspond to any release tag, it was pinned to a random post-release commit rather than the `v2.4.0` release.
- `.github/actions/create-system-test-docker-base-images/action.yml`: fixed space `#v4.1.0` → `# v4.1.0`.
- `dependabot.yml`: Both `cooldown:` blocks were inside their correct list items _syntactically_, but were visually after comment lines describing the _next_ entry, so just moved them up

## Test coverage

N/A

