### PR TITLE
[Profiler] Try fixing flakiness

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.IntegrationTests.Xunit;
 using Datadog.Trace;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -17,6 +16,7 @@ using MessagePack;
 using Perftools.Profiles;
 using Xunit;
 using Xunit.Abstractions;
+using ProfilerXunit = Datadog.Profiler.IntegrationTests.Xunit;
 
 namespace Datadog.Profiler.IntegrationTests.CodeHotspot
 {
@@ -239,7 +239,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
             Assert.Empty(tracingContexts);
         }
 
-        [Flaky("Endpoint association can race with the profiler's shutdown export on slow/32-bit runtimes")]
+        [ProfilerXunit.Flaky("Endpoint association can race with the profiler's shutdown export on slow/32-bit runtimes")]
         [TestAppFact("Samples.BuggyBits")]
         public void CheckEndpointsAreAttached(string appName, string framework, string appAssembly)
         {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.IntegrationTests.Xunit;
 using Datadog.Trace;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -238,6 +239,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
             Assert.Empty(tracingContexts);
         }
 
+        [Flaky("Endpoint association can race with the profiler's shutdown export on slow/32-bit runtimes")]
         [TestAppFact("Samples.BuggyBits")]
         public void CheckEndpointsAreAttached(string appName, string framework, string appAssembly)
         {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -22,6 +22,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
     public class CodeHotspotTest
     {
         private const string ScenarioCodeHotspot = "--scenario 256";
+        private const string ScenarioEndpoint = "--scenario 16";
         private static readonly Regex RuntimeIdPattern = new("runtime-id:(?<runtimeId>[A-Z0-9-]+)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
         private readonly ITestOutputHelper _output;
 
@@ -240,19 +241,21 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
         [TestAppFact("Samples.BuggyBits")]
         public void CheckEndpointsAreAttached(string appName, string framework, string appAssembly)
         {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: ScenarioCodeHotspot);
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: ScenarioEndpoint);
             runner.TestDurationInSeconds = 20;
 
             // By default, the endpoint profiling feature is activated
 
-            // The endpoint is only bound to a trace id when the web root span closes (the tracer then calls
-            // SetEndpointForTrace). libdatadog attaches the "trace endpoint" label to a sample only when that
-            // sample's "local root span id" matches an endpoint registered in the SAME profile generation. With the
-            // default 3s export period, a request's samples and its span close can land in different windows, so the
-            // label is never attached. On the slow 32-bit netcoreapp3.1 runtime (but even on newer ones), the sampling
-            // is sparse enough that this coincidence is missed in every window, making the test flaky.
-            // Use a single export window (flushed on shutdown, after every span has closed) so the association is
-            // deterministic on this runtime.
+            // The "trace endpoint" label is attached to a sample only when (a) the web root span closes (the tracer
+            // then calls SetEndpointForTrace) and (b) a sample carries that span's "local root span id", both within
+            // the SAME profile generation. We use the FormatExceptions scenario (the /Products/Sales endpoint) rather
+            // than the heavy IndexSlow page: IndexSlow builds a large response (10k products, O(n^2) string concat) and,
+            // on slow/32-bit runtimes, a single request can outlive the whole test window. Its root span then closes
+            // right as the profiler is shutting down, so SetEndpointForTrace races with (and is dropped by) the final
+            // export, and no label is attached. /Products/Sales does exception-driven, on-CPU work that is linear in
+            // the number of products, so it is reliably sampled with a trace context but completes with plenty of
+            // margin before shutdown. A single export window (flushed on shutdown) keeps the samples and the endpoints
+            // in the same generation.
             runner.Environment.SetVariable("DD_PROFILING_UPLOAD_PERIOD", "600");
 
             using var agent = MockDatadogAgent.CreateHttpAgent(runner.XUnitLogger);
@@ -263,13 +266,13 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
 
             var endpoints = GetEndpointsFromPprofFiles(runner.Environment.PprofDir);
 
-            endpoints.Distinct().Should().BeEquivalentTo("GET /products/indexslow");
+            endpoints.Distinct().Should().BeEquivalentTo("GET /products/sales");
         }
 
         [TestAppFact("Samples.BuggyBits")]
         public void NoEndpointsAttachedIfFeatureDeactivated(string appName, string framework, string appAssembly)
         {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: ScenarioCodeHotspot);
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: ScenarioEndpoint);
             runner.TestDurationInSeconds = 20;
             runner.Environment.SetVariable(EnvironmentVariables.EndpointProfilerEnabled, "0");
 


### PR DESCRIPTION
## Summary of changes

Change scenario to prevent this test from being flaky.


## Reason for change

This test is flaky on 32-bits windows in CI.
A previous run showed that only 2 request were sent: 1 was cancel (`SetEndpoint` not called) and the second one landed while the profiler was shutting down.

We use an exception scenario because it helps in the determinism of the test.

## Implementation details

Change to exception scenario instead.

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
