### PR TITLE
[Debugger] Avoid instantiating state machine attributes

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ILAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ILAnalyzer.cs
@@ -7,6 +7,7 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using Datadog.Trace.Debugger.Helpers;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
@@ -30,10 +31,9 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         private static MethodBase GetEffectiveMethod(MethodBase method)
         {
             // For async methods, analyze the MoveNext method
-            if (method.GetCustomAttribute<AsyncStateMachineAttribute>() is AsyncStateMachineAttribute asyncAttribute)
+            if (StateMachineAttributeHelper.TryGetAsyncStateMachineType(method, out var stateMachineType))
             {
-                var stateMachineType = asyncAttribute.StateMachineType;
-                return stateMachineType.GetMethod(
+                return stateMachineType?.GetMethod(
                            "MoveNext",
                            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public) ?? method;
             }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/MethodMatcher.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/MethodMatcher.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Util;
 
 #nullable enable
@@ -330,8 +331,7 @@ internal static class MethodMatcher
 
     private static bool HasMatchingAsyncMethodBuilder(MethodInfo method)
     {
-        return method.GetCustomAttributes()
-                    .Any(attr => attr.GetType().Name.EndsWith("AsyncStateMachineAttribute"));
+        return StateMachineAttributeHelper.HasAsyncStateMachineAttribute(method);
     }
 
     private static MethodInfo? ResolveIteratorMethod(MethodBase moveNextMethod)

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/AsyncHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/AsyncHelper.cs
@@ -172,7 +172,8 @@ namespace Datadog.Trace.Debugger.Helpers
             for (int i = 0; i < allMethods?.Length; i++)
             {
                 var currentMethod = allMethods[i];
-                if (currentMethod.GetCustomAttribute<AsyncStateMachineAttribute>()?.StateMachineType ==
+                if (StateMachineAttributeHelper.TryGetAsyncStateMachineType(currentMethod, out var candidateStateMachineType) &&
+                    candidateStateMachineType ==
                     (stateMachineType.IsGenericType ? stateMachineType.GetGenericTypeDefinition() : stateMachineType))
                 {
                     foundMethod = currentMethod;

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/MethodExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/MethodExtensions.cs
@@ -165,26 +165,15 @@ namespace Datadog.Trace.Debugger.Helpers
 
             foreach (MethodInfo candidateMethod in methods)
             {
-                var attributes = candidateMethod.GetCustomAttributes<StateMachineAttribute>(inherit: false);
-
-                bool foundAttribute = false, foundIteratorAttribute = false;
-                foreach (var attr in attributes)
-                {
-                    if (attr.StateMachineType == declaringType)
-                    {
-                        foundAttribute = true;
-                        foundIteratorAttribute |= attr is IteratorStateMachineAttribute || attr.GetType().Name == "AsyncIteratorStateMachineAttribute";
-                    }
-                }
-
-                if (foundAttribute)
+                if (StateMachineAttributeHelper.TryGetStateMachineType(candidateMethod, out var stateMachineType, out var isIterator) &&
+                    stateMachineType == declaringType)
                 {
                     // If this is an iterator (sync or async), mark the iterator as changed, so it gets the + annotation
                     // of the original method. Non-iterator async state machines resolve directly to their builder methods
                     // so aren't marked as changed.
                     method = candidateMethod;
                     declaringType = candidateMethod.DeclaringType;
-                    return foundIteratorAttribute;
+                    return isIterator;
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/StateMachineAttributeHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/StateMachineAttributeHelper.cs
@@ -1,0 +1,74 @@
+// <copyright file="StateMachineAttributeHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+
+#nullable enable
+namespace Datadog.Trace.Debugger.Helpers
+{
+    internal static class StateMachineAttributeHelper
+    {
+        private const string AsyncStateMachineAttributeName = "System.Runtime.CompilerServices.AsyncStateMachineAttribute";
+        private const string IteratorStateMachineAttributeName = "System.Runtime.CompilerServices.IteratorStateMachineAttribute";
+        private const string AsyncIteratorStateMachineAttributeName = "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute";
+
+        internal static bool HasAsyncStateMachineAttribute(MethodBase method)
+        {
+            return TryGetAsyncStateMachineType(method, out _);
+        }
+
+        internal static bool TryGetAsyncStateMachineType(MethodBase method, out Type? stateMachineType)
+        {
+            foreach (var attributeData in CustomAttributeData.GetCustomAttributes(method))
+            {
+                if (attributeData.AttributeType.FullName == AsyncStateMachineAttributeName)
+                {
+                    return TryGetStateMachineType(attributeData, out stateMachineType);
+                }
+            }
+
+            stateMachineType = null;
+            return false;
+        }
+
+        internal static bool TryGetStateMachineType(MethodBase method, out Type? stateMachineType, out bool isIterator)
+        {
+            foreach (var attributeData in CustomAttributeData.GetCustomAttributes(method))
+            {
+                var attributeName = attributeData.AttributeType.FullName;
+                if (attributeName != AsyncStateMachineAttributeName &&
+                    attributeName != IteratorStateMachineAttributeName &&
+                    attributeName != AsyncIteratorStateMachineAttributeName)
+                {
+                    continue;
+                }
+
+                if (TryGetStateMachineType(attributeData, out stateMachineType))
+                {
+                    isIterator = attributeName != AsyncStateMachineAttributeName;
+                    return true;
+                }
+            }
+
+            stateMachineType = null;
+            isIterator = false;
+            return false;
+        }
+
+        private static bool TryGetStateMachineType(CustomAttributeData attributeData, out Type? stateMachineType)
+        {
+            if (attributeData.ConstructorArguments.Count == 1 &&
+                attributeData.ConstructorArguments[0].Value is Type type)
+            {
+                stateMachineType = type;
+                return true;
+            }
+
+            stateMachineType = null;
+            return false;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/MethodMatcherTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/MethodMatcherTests.cs
@@ -438,7 +438,10 @@ public class MethodMatcherTests
             // Assert
             result.Should().BeTrue();
             ConstructorCountingAttribute.ConstructorCallCount.Should().Be(0, "state-machine resolution should inspect method attributes without instantiating them");
+            return;
         }
+
+        throw new InvalidOperationException("Test setup failed - expected async method to throw");
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/MethodMatcherTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/MethodMatcherTests.cs
@@ -409,6 +409,39 @@ public class MethodMatcherTests
     }
 
     [Fact]
+    public async Task IsMethodMatch_OverloadedAsyncMethod_DoesNotInstantiateMethodAttributes()
+    {
+        // Arrange
+        ConstructorCountingAttribute.ConstructorCallCount = 0;
+        try
+        {
+            await AsyncMethodWithConstructorCountingAttribute();
+        }
+        catch (Exception ex)
+        {
+            var firstFrame = ex.StackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None)[0];
+            var stackTraceMethodText = firstFrame.Substring(firstFrame.IndexOf("at ") + 3);
+            stackTraceMethodText = stackTraceMethodText.Substring(0, stackTraceMethodText.IndexOf(" in "));
+
+            var stateMachineType = typeof(MethodMatcherTests)
+                                  .GetNestedTypes(BindingFlags.NonPublic)
+                                  .FirstOrDefault(t => t.Name.Contains(nameof(AsyncMethodWithConstructorCountingAttribute)) && t.Name.Contains("d__"));
+
+            stateMachineType.Should().NotBeNull("Test setup failed - async state machine type not found");
+
+            var moveNextMethod = stateMachineType.GetMethod("MoveNext", BindingFlags.NonPublic | BindingFlags.Instance);
+            moveNextMethod.Should().NotBeNull("Test setup failed - MoveNext method not found");
+
+            // Act
+            var result = MethodMatcher.IsMethodMatch(stackTraceMethodText, moveNextMethod);
+
+            // Assert
+            result.Should().BeTrue();
+            ConstructorCountingAttribute.ConstructorCallCount.Should().Be(0, "state-machine resolution should inspect method attributes without instantiating them");
+        }
+    }
+
+    [Fact]
     public void IsMethodMatch_NestedGenericClass_MatchesCorrectly()
     {
         // Arrange
@@ -516,6 +549,19 @@ public class MethodMatcherTests
         throw new Exception("Test exception from generic async method");
     }
 
+    [ConstructorCounting]
+    private async Task AsyncMethodWithConstructorCountingAttribute()
+    {
+        await Task.Delay(1);
+        throw new Exception("Test exception from attributed async method");
+    }
+
+    [ConstructorCounting]
+    private async Task AsyncMethodWithConstructorCountingAttribute(int unused)
+    {
+        await Task.Delay(1);
+    }
+
     private async Task TestMethodWithAsyncLocalFunction()
     {
         async Task LocalFunction()
@@ -568,5 +614,16 @@ public class MethodMatcherTests
             await Task.Delay(1); // Simulate some async cleanup
             throw new Exception("Test exception during async dispose");
         }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    private class ConstructorCountingAttribute : Attribute
+    {
+        public ConstructorCountingAttribute()
+        {
+            ConstructorCallCount++;
+        }
+
+        public static int ConstructorCallCount { get; set; }
     }
 }


### PR DESCRIPTION
## Summary of changes
- Add a debugger helper that reads compiler state-machine attributes through `CustomAttributeData` instead of constructing attribute instances.
- Use the helper in exception replay method matching, async kickoff method lookup, fully-qualified method name resolution, and ILAnalyzer async `MoveNext` selection.
- Add regression coverage for overloaded async method matching with a custom method attribute whose constructor must not run.

## Reason for change
Debugger state-machine resolution only needs compiler metadata such as `AsyncStateMachineAttribute`, `IteratorStateMachineAttribute`, and `AsyncIteratorStateMachineAttribute`. Instantiating attributes can execute user attribute constructors, so these resolution paths should stay metadata-only.

## Implementation details
The helper compares attribute type full names and reads the state-machine type from `CustomAttributeData.ConstructorArguments`. It preserves the previous async/iterator behavior, including marking iterator and async-iterator state machines so `GetFullyQualifiedName()` still appends the `+MoveNext()` annotation where expected.

## Test coverage
- `MethodMatcherTests|ILAnalyzerTests`