### PR TITLE
[Debugger] Document reflection loading audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,13 @@ The tracer runs in-process with customer applications and must have minimal perf
 - **Avoid Allocation in Logging**: Use format strings (`Log("value: {0}", x)`) instead of interpolation (`Log($"value: {x}")`)
 - **Avoid params Array Allocations**: Provide overloads for common cases (0, 1, 2 args)
 
+## Debugger / Dynamic Instrumentation Safety
+
+Debugger code runs inside customer processes while inspecting live customer objects. Before changing debugger capture, expression evaluation, Exception Replay, Code Origin, or symbol-resolution paths, check:
+
+- **`docs/development/DebuggerReflectionLoadingAudit.md`** — guidance for reflection paths that may resolve customer assemblies/types/members early, trigger type initializers, or instantiate attributes.
+- **`docs/development/DebuggerCustomerCodeExecutionPolicy.md`** — policy for when capture and expression paths may execute customer code such as getters, enumerators, exception overrides, or `ToString()`.
+
 ## Testing
 
 **Frameworks:** xUnit (managed), GoogleTest (native)
@@ -263,6 +270,8 @@ The tracer runs in-process with customer applications and must have minimal perf
 - `docs/development/AzureFunctions.md` — Azure Functions integration
 - `docs/development/for-ai/AzureFunctions-Architecture.md` — Azure Functions architecture deep dive
 - `docs/development/AwsLambdaIntegrationTests.md` — AWS Lambda integration tests
+- `docs/development/DebuggerReflectionLoadingAudit.md` — Debugger reflection/type-loading safety guide
+- `docs/development/DebuggerCustomerCodeExecutionPolicy.md` — Debugger capture/expression customer-code execution policy
 - `docs/development/UpdatingTheSdk.md` — SDK updates
 - `docs/development/QueryingDatadogAPIs.md` — Querying Datadog APIs for debugging (spans, logs)
 

--- a/docs/development/DebuggerReflectionLoadingAudit.md
+++ b/docs/development/DebuggerReflectionLoadingAudit.md
@@ -1,0 +1,30 @@
+# Debugger Reflection Loading Audit
+
+This audit tracks debugger reflection paths that can resolve metadata into runtime objects, trigger static initialization, or execute customer code. It follows the `InstanceOf` early-load fix from PR #8785 and keeps three risks separate:
+
+- Early runtime resolution: resolving assemblies, types, members, generic signatures, or method tokens earlier than customer code would.
+- Static constructor execution: reading static members or otherwise using a type in a way that can run its type initializer.
+- Customer code execution: invoking getters, enumerators, `ToString()`, exception overrides, attribute constructors, or similar user-controlled code.
+
+## Classification
+
+| Area | Classification | Current status |
+| --- | --- | --- |
+| Code Origin endpoint discovery | Metadata-only scan through `EndpointDetector` and `System.Reflection.Metadata`; no runtime member resolution required. | No follow-up from this audit. |
+| Line probe resolution | Scans already loaded assemblies and symbol/PDB metadata. | No follow-up from this audit. |
+| SymDB symbol extraction/upload | Processes already loaded assemblies plus metadata/PDB information; dnlib paths may resolve metadata definitions but do not intentionally load new customer assemblies. | No follow-up from this audit. |
+| Debugger static member capture and expressions | Reading static fields/properties can trigger type initializers. | Fixed by PR #8814: guard static member capture and preserve literal/cctor-free statics. |
+| Exception Replay IL call scanning | `Module.ResolveMethod(token)` can resolve arbitrary call operands and load unavailable dependencies while looking for `ExceptionDispatchInfo.Throw`. | Fixed by PR #8815: inspect call operands with metadata instead of runtime resolution. |
+| Debugger state-machine attribute resolution | `GetCustomAttributes()` / typed `GetCustomAttribute<T>()` can instantiate attributes while resolving async/iterator methods. | Fixed by PR #8816: use metadata-only `CustomAttributeData` for state-machine attributes. |
+| Snapshot capture and expression evaluation | Some paths intentionally execute bounded customer code, such as expression property access and supported collection enumeration. | Policy and focused regression tests added by PR #8817. |
+
+## Review Guidance
+
+When reviewing debugger capture, expression, exception-replay, Code Origin, or symbol changes, classify each reflection operation before accepting it:
+
+- Metadata-only APIs are preferred for discovery and filtering.
+- Runtime `Type`, `MemberInfo`, or signature resolution should be justified and covered by a focused test when it can touch customer assemblies.
+- Static member reads must be guarded so they do not run customer type initializers unless explicitly allowed by policy.
+- Customer-code execution must be covered by the debugger customer-code execution policy and regression tests.
+
+The four child PRs above are intentionally independent so each behavior change has a narrow review surface and focused verification.

--- a/docs/development/DebuggerReflectionLoadingAudit.md
+++ b/docs/development/DebuggerReflectionLoadingAudit.md
@@ -1,6 +1,8 @@
 # Debugger Reflection Loading Audit
 
-This audit tracks debugger reflection paths that can resolve metadata into runtime objects, trigger static initialization, or execute customer code. It follows the `InstanceOf` early-load fix from PR #8785 and keeps three risks separate:
+This document tracks debugger reflection paths that can resolve metadata into runtime objects, trigger static initialization, or execute customer code. It is intended as review guidance for future debugger changes and as a record of the safety boundaries established after the `InstanceOf` early-load fix in PR #8785.
+
+Keep these risks separate when auditing or changing debugger code:
 
 - Early runtime resolution: resolving assemblies, types, members, generic signatures, or method tokens earlier than customer code would.
 - Static constructor execution: reading static members or otherwise using a type in a way that can run its type initializer.
@@ -16,7 +18,7 @@ This audit tracks debugger reflection paths that can resolve metadata into runti
 | Debugger static member capture and expressions | Reading static fields/properties can trigger type initializers. | Fixed by PR #8814: guard static member capture and preserve literal/cctor-free statics. |
 | Exception Replay IL call scanning | `Module.ResolveMethod(token)` can resolve arbitrary call operands and load unavailable dependencies while looking for `ExceptionDispatchInfo.Throw`. | Fixed by PR #8815: inspect call operands with metadata instead of runtime resolution. |
 | Debugger state-machine attribute resolution | `GetCustomAttributes()` / typed `GetCustomAttribute<T>()` can instantiate attributes while resolving async/iterator methods. | Fixed by PR #8816: use metadata-only `CustomAttributeData` for state-machine attributes. |
-| Snapshot capture and expression evaluation | Some paths intentionally execute bounded customer code, such as expression property access and supported collection enumeration. | Policy and focused regression tests added by PR #8817. |
+| Snapshot capture and expression evaluation | Some paths intentionally execute bounded customer code, such as expression property access and supported collection enumeration. | Governed by `DebuggerCustomerCodeExecutionPolicy.md`; focused regression tests added by PR #8817. |
 
 ## Review Guidance
 
@@ -25,6 +27,6 @@ When reviewing debugger capture, expression, exception-replay, Code Origin, or s
 - Metadata-only APIs are preferred for discovery and filtering.
 - Runtime `Type`, `MemberInfo`, or signature resolution should be justified and covered by a focused test when it can touch customer assemblies.
 - Static member reads must be guarded so they do not run customer type initializers unless explicitly allowed by policy.
-- Customer-code execution must be covered by the debugger customer-code execution policy and regression tests.
+- Customer-code execution must be covered by `DebuggerCustomerCodeExecutionPolicy.md` and regression tests.
 
-The four child PRs above are intentionally independent so each behavior change has a narrow review surface and focused verification.
+If a change intentionally crosses one of these boundaries, document why the runtime behavior is required and add a regression test that would fail if the boundary were crossed accidentally.


### PR DESCRIPTION
## Summary of changes
- Add a debugger reflection-loading audit document that separates early runtime resolution, static constructor execution, and customer-code execution risks.
- Classify the reviewed debugger, Code Origin, Line Probe, SymDB, Exception Replay, and snapshot/expression areas.
- Link the child PRs for tasks 2026-049 through 2026-052.

## Reason for change
Task 2026-048 is the umbrella audit for the debugger reflection-safety work. The concrete fixes were split into narrow child PRs, so this PR records the audit classification and ties the child outcomes together for reviewers.

## Implementation details
No product behavior changes are included in this branch. The audit identifies metadata-only paths, resolved risks, and the policy baseline for future debugger capture/expression changes.

## Test coverage
- Documentation-only PR.
- `git diff --check`

## Other details
Related child PRs:
- #8814: static member capture guard
- #8815: metadata-only Exception Replay IL call scanning
- #8816: metadata-only state-machine attribute checks
- #8817: customer-code execution policy and focused capture tests