### PR TITLE
[OTel] Bound OTLP metric cardinality with overflow series

### DIFF
--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricPoint.cs
@@ -13,18 +13,20 @@ using System.Threading;
 
 namespace Datadog.Trace.OpenTelemetry.Metrics;
 
-internal sealed class MetricPoint(string instrumentName, string meterName, string meterVersion, KeyValuePair<string, object?>[] meterTags, InstrumentType instrumentType, AggregationTemporality? temporality, Dictionary<string, object?> tags, string unit = "", string description = "", bool isLongType = false, double[]? explicitBounds = null)
+internal sealed class MetricPoint(string instrumentName, string meterName, string meterVersion, KeyValuePair<string, object?>[] meterTags, InstrumentType instrumentType, AggregationTemporality? temporality, Dictionary<string, object?> tags, string unit = "", string description = "", bool isLongType = false, double[]? explicitBounds = null, bool aggregateObservableValues = false)
 {
     internal static readonly double[] DefaultHistogramBounds = [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000];
     private readonly long[] _runningBucketCounts = instrumentType == InstrumentType.Histogram ? new long[DefaultHistogramBounds.Length + 1] : [];
     private readonly double[] _runningBucketBounds = instrumentType == InstrumentType.Histogram ? (explicitBounds ?? DefaultHistogramBounds) : [];
     private readonly object _histogramLock = new();
+    private readonly bool _aggregateObservableValues = aggregateObservableValues;
     private long _runningCountValue;
     private double _runningDoubleValue;
     private double _runningMin = double.PositiveInfinity;
     private double _runningMax = double.NegativeInfinity;
     private bool _hasMeasurements;
     private double _lastObservedCumulative = double.NaN;
+    private bool _retired;
 
     public string InstrumentName { get; } = instrumentName;
 
@@ -58,6 +60,8 @@ internal sealed class MetricPoint(string instrumentName, string meterName, strin
 
     internal double[] RunningBucketBounds => _runningBucketBounds;
 
+    internal bool IsRetired => Volatile.Read(ref _retired);
+
     public DateTimeOffset StartTime { get; internal set; } = DateTimeOffset.UtcNow;
 
     public DateTimeOffset EndTime { get; internal set; } = DateTimeOffset.UtcNow;
@@ -76,47 +80,73 @@ internal sealed class MetricPoint(string instrumentName, string meterName, strin
 
     public double[] SnapshotBucketBounds { get; internal set; } = [];
 
-    internal void UpdateCounter(double value)
+    internal bool UpdateCounter(double value)
     {
         lock (_histogramLock)
         {
+            if (_retired)
+            {
+                return false;
+            }
+
             _runningDoubleValue += value;
             _hasMeasurements = true;
+            return true;
         }
     }
 
-    internal void UpdateObservableCounter(double currentValue)
+    internal bool UpdateObservableCounter(double currentValue)
     {
         lock (_histogramLock)
         {
+            if (_retired)
+            {
+                return false;
+            }
+
             if (double.IsNaN(_lastObservedCumulative))
             {
                 _hasMeasurements = true;
             }
-            else if (currentValue != _lastObservedCumulative)
+            else if (currentValue != _lastObservedCumulative || _aggregateObservableValues)
             {
                 _hasMeasurements = true;
             }
 
-            _runningDoubleValue = currentValue;
+            _runningDoubleValue = _aggregateObservableValues
+                ? _runningDoubleValue + currentValue
+                : currentValue;
+
+            return true;
         }
     }
 
-    internal void UpdateGauge(double value)
+    internal bool UpdateGauge(double value)
     {
-        Interlocked.Exchange(ref _runningDoubleValue, value);
         lock (_histogramLock)
         {
+            if (_retired)
+            {
+                return false;
+            }
+
+            _runningDoubleValue = value;
             _hasMeasurements = true;
+            return true;
         }
     }
 
-    internal void UpdateHistogram(double value)
+    internal bool UpdateHistogram(double value)
     {
         var bucketIndex = FindBucketIndex(value);
 
         lock (_histogramLock)
         {
+            if (_retired)
+            {
+                return false;
+            }
+
             unchecked
             {
                 _runningCountValue++;
@@ -127,6 +157,7 @@ internal sealed class MetricPoint(string instrumentName, string meterName, strin
             _runningMin = Math.Min(_runningMin, value);
             _runningMax = Math.Max(_runningMax, value);
             _hasMeasurements = true;
+            return true;
         }
     }
 
@@ -217,10 +248,28 @@ internal sealed class MetricPoint(string instrumentName, string meterName, strin
 
                 StartTime = endTime;
             }
+            else if (_aggregateObservableValues && InstrumentType is InstrumentType.ObservableCounter or InstrumentType.ObservableUpDownCounter)
+            {
+                _runningDoubleValue = 0.0;
+            }
 
             _hasMeasurements = false;
 
             return snapshot;
+        }
+    }
+
+    internal bool TryRetireIfIdle()
+    {
+        lock (_histogramLock)
+        {
+            if (_retired || _hasMeasurements)
+            {
+                return false;
+            }
+
+            _retired = true;
+            return true;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricState.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricState.cs
@@ -42,9 +42,10 @@ internal sealed class MetricState
     private readonly AggregationTemporality? _temporality;
 
     private readonly ConcurrentDictionary<TagSet, MetricPoint> _points = new();
+    private readonly object _pointsLock = new();
     private readonly int _cardinalityLimit;
 
-    private volatile bool _overflowActive;
+    private int _realSeriesCount;
     private int _overflowLogged;
 
     public MetricState(MetricStreamIdentity identity, AggregationTemporality? temporality, int cardinalityLimit = DefaultCardinalityLimit)
@@ -66,24 +67,22 @@ internal sealed class MetricState
             return;
         }
 
-        var point = GetOrCreatePoint(tags);
-        switch (_identity.InstrumentType)
+        while (true)
         {
-            case InstrumentType.Counter:
-            case InstrumentType.UpDownCounter:
-                point.UpdateCounter(value);
-                break;
-            case InstrumentType.ObservableCounter:
-            case InstrumentType.ObservableUpDownCounter:
-                point.UpdateObservableCounter(value);
-                break;
-            case InstrumentType.Gauge:
-            case InstrumentType.ObservableGauge:
-                point.UpdateGauge(value);
-                break;
-            case InstrumentType.Histogram:
-                point.UpdateHistogram(value);
-                break;
+            var point = GetOrCreatePoint(tags);
+            var recorded = _identity.InstrumentType switch
+            {
+                InstrumentType.Counter or InstrumentType.UpDownCounter => point.UpdateCounter(value),
+                InstrumentType.ObservableCounter or InstrumentType.ObservableUpDownCounter => point.UpdateObservableCounter(value),
+                InstrumentType.Gauge or InstrumentType.ObservableGauge => point.UpdateGauge(value),
+                InstrumentType.Histogram => point.UpdateHistogram(value),
+                _ => true
+            };
+
+            if (recorded)
+            {
+                return;
+            }
         }
     }
 
@@ -99,24 +98,22 @@ internal sealed class MetricState
             return;
         }
 
-        var point = GetOrCreatePoint(tags);
-        switch (_identity.InstrumentType)
+        while (true)
         {
-            case InstrumentType.Counter:
-            case InstrumentType.UpDownCounter:
-                point.UpdateCounter(value);
-                break;
-            case InstrumentType.ObservableCounter:
-            case InstrumentType.ObservableUpDownCounter:
-                point.UpdateObservableCounter(value);
-                break;
-            case InstrumentType.Gauge:
-            case InstrumentType.ObservableGauge:
-                point.UpdateGauge(value);
-                break;
-            case InstrumentType.Histogram:
-                point.UpdateHistogram(value);
-                break;
+            var point = GetOrCreatePoint(tags);
+            var recorded = _identity.InstrumentType switch
+            {
+                InstrumentType.Counter or InstrumentType.UpDownCounter => point.UpdateCounter(value),
+                InstrumentType.ObservableCounter or InstrumentType.ObservableUpDownCounter => point.UpdateObservableCounter(value),
+                InstrumentType.Gauge or InstrumentType.ObservableGauge => point.UpdateGauge(value),
+                InstrumentType.Histogram => point.UpdateHistogram(value),
+                _ => true
+            };
+
+            if (recorded)
+            {
+                return;
+            }
         }
     }
 
@@ -127,15 +124,18 @@ internal sealed class MetricState
     /// </summary>
     public void BuildPoints(List<MetricPoint> into)
     {
-        foreach (var point in _points.Values)
+        foreach (var pair in _points)
         {
+            var point = pair.Value;
             if (!point.HasDataToExport())
             {
+                TryReclaimPoint(pair.Key, point);
                 continue;
             }
 
             var snapshot = point.CreateSnapshotAndReset();
             into.Add(snapshot);
+            TryReclaimPoint(pair.Key, point);
         }
     }
 
@@ -143,36 +143,61 @@ internal sealed class MetricState
     {
         var tagSet = TagSet.FromSpan(tags);
 
-        if (_points.TryGetValue(tagSet, out var existingPoint))
+        while (true)
         {
-            return existingPoint;
-        }
+            if (_points.TryGetValue(tagSet, out var existingPoint))
+            {
+                if (!existingPoint.IsRetired)
+                {
+                    return existingPoint;
+                }
 
-        // Cardinality limit (OpenTelemetry metrics SDK spec): once the stream is full, fold any
-        // new attribute set into a single overflow series tagged otel.metric.overflow=true. This
-        // bounds memory at _cardinalityLimit points per stream regardless of input, so a
-        // high-cardinality or attacker-controlled attribute value cannot exhaust memory.
-        // Already-tracked attribute sets keep updating via the fast path above. Once overflow is
-        // active we skip the (relatively expensive) Count check on the hot path.
-        if (_overflowActive || _points.Count >= _cardinalityLimit - 1)
-        {
-            return GetOrCreateOverflowPoint();
-        }
+                TryRemovePoint(tagSet, existingPoint);
+                continue;
+            }
 
-        var dict = new Dictionary<string, object?>(tags.Length);
-        for (int i = 0; i < tags.Length; i++)
-        {
-            var kv = tags[i];
-            dict[kv.Key] = kv.Value;
-        }
+            lock (_pointsLock)
+            {
+                if (_points.TryGetValue(tagSet, out existingPoint))
+                {
+                    if (!existingPoint.IsRetired)
+                    {
+                        return existingPoint;
+                    }
 
-        return _points.GetOrAdd(tagSet, _ => CreatePoint(dict));
+                    TryRemovePoint(tagSet, existingPoint);
+                    continue;
+                }
+
+                // Cardinality limit (OpenTelemetry metrics SDK spec): when the stream is full,
+                // fold any new attribute set into a single overflow series tagged
+                // otel.metric.overflow=true. Existing attribute sets keep updating via the fast
+                // path above, and new real-series insertion is synchronized so concurrent traffic
+                // cannot overshoot the configured number of real series.
+                if (Volatile.Read(ref _realSeriesCount) >= _cardinalityLimit)
+                {
+                    return GetOrCreateOverflowPoint();
+                }
+
+                var dict = new Dictionary<string, object?>(tags.Length);
+                for (int i = 0; i < tags.Length; i++)
+                {
+                    var kv = tags[i];
+                    dict[kv.Key] = kv.Value;
+                }
+
+                var point = CreatePoint(dict);
+                if (_points.TryAdd(tagSet, point))
+                {
+                    Interlocked.Increment(ref _realSeriesCount);
+                    return point;
+                }
+            }
+        }
     }
 
     private MetricPoint GetOrCreateOverflowPoint()
     {
-        _overflowActive = true;
-
         if (_points.TryGetValue(OverflowTagSet, out var overflowPoint))
         {
             return overflowPoint;
@@ -186,10 +211,32 @@ internal sealed class MetricState
         }
 
         var dict = new Dictionary<string, object?>(1) { [OverflowAttributeKey] = true };
-        return _points.GetOrAdd(OverflowTagSet, _ => CreatePoint(dict));
+        return _points.GetOrAdd(OverflowTagSet, _ => CreatePoint(dict, aggregateObservableValues: true));
     }
 
-    private MetricPoint CreatePoint(Dictionary<string, object?> tags)
+    private void TryReclaimPoint(TagSet tagSet, MetricPoint point)
+    {
+        if (tagSet.Equals(OverflowTagSet)
+         || _temporality != AggregationTemporality.Delta
+         || _identity.InstrumentType is not (InstrumentType.Counter or InstrumentType.Histogram)
+         || !point.TryRetireIfIdle())
+        {
+            return;
+        }
+
+        TryRemovePoint(tagSet, point);
+    }
+
+    private void TryRemovePoint(TagSet tagSet, MetricPoint point)
+    {
+        if (((ICollection<KeyValuePair<TagSet, MetricPoint>>)_points).Remove(new KeyValuePair<TagSet, MetricPoint>(tagSet, point))
+         && !tagSet.Equals(OverflowTagSet))
+        {
+            Interlocked.Decrement(ref _realSeriesCount);
+        }
+    }
+
+    private MetricPoint CreatePoint(Dictionary<string, object?> tags, bool aggregateObservableValues = false)
         => new MetricPoint(
             _identity.InstrumentName,
             _identity.MeterName,
@@ -200,6 +247,7 @@ internal sealed class MetricState
             tags,
             _identity.Unit,
             _identity.Description,
-            _identity.IsLongType);
+            _identity.IsLongType,
+            aggregateObservableValues: aggregateObservableValues);
 }
 #endif

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricState.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/MetricState.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.OpenTelemetry.Metrics;
@@ -20,15 +21,37 @@ namespace Datadog.Trace.OpenTelemetry.Metrics;
 internal sealed class MetricState
 {
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(MetricState));
+
+    /// <summary>
+    /// Default per-stream cardinality limit, matching the OpenTelemetry metrics SDK spec default.
+    /// Caps the number of distinct attribute sets tracked for a single instrument so that
+    /// high-cardinality (or attacker-controlled) attribute values cannot grow memory without bound.
+    /// </summary>
+    internal const int DefaultCardinalityLimit = 2000;
+
+    /// <summary>
+    /// Attribute key for the overflow series, as defined by the OpenTelemetry metrics SDK spec.
+    /// Measurements with new attribute sets beyond the cardinality limit are aggregated here.
+    /// </summary>
+    internal const string OverflowAttributeKey = "otel.metric.overflow";
+
+    private static readonly KeyValuePair<string, object?>[] OverflowTags = [new(OverflowAttributeKey, true)];
+    private static readonly TagSet OverflowTagSet = TagSet.FromSpan(OverflowTags);
+
     private readonly MetricStreamIdentity _identity;
     private readonly AggregationTemporality? _temporality;
 
     private readonly ConcurrentDictionary<TagSet, MetricPoint> _points = new();
+    private readonly int _cardinalityLimit;
 
-    public MetricState(MetricStreamIdentity identity, AggregationTemporality? temporality)
+    private volatile bool _overflowActive;
+    private int _overflowLogged;
+
+    public MetricState(MetricStreamIdentity identity, AggregationTemporality? temporality, int cardinalityLimit = DefaultCardinalityLimit)
     {
         _identity = identity;
         _temporality = temporality;
+        _cardinalityLimit = cardinalityLimit > 0 ? cardinalityLimit : DefaultCardinalityLimit;
     }
 
     public void RecordMeasurementLong(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
@@ -125,6 +148,17 @@ internal sealed class MetricState
             return existingPoint;
         }
 
+        // Cardinality limit (OpenTelemetry metrics SDK spec): once the stream is full, fold any
+        // new attribute set into a single overflow series tagged otel.metric.overflow=true. This
+        // bounds memory at _cardinalityLimit points per stream regardless of input, so a
+        // high-cardinality or attacker-controlled attribute value cannot exhaust memory.
+        // Already-tracked attribute sets keep updating via the fast path above. Once overflow is
+        // active we skip the (relatively expensive) Count check on the hot path.
+        if (_overflowActive || _points.Count >= _cardinalityLimit - 1)
+        {
+            return GetOrCreateOverflowPoint();
+        }
+
         var dict = new Dictionary<string, object?>(tags.Length);
         for (int i = 0; i < tags.Length; i++)
         {
@@ -132,19 +166,40 @@ internal sealed class MetricState
             dict[kv.Key] = kv.Value;
         }
 
-        return _points.GetOrAdd(
-            tagSet,
-            _ => new MetricPoint(
-                _identity.InstrumentName,
-                _identity.MeterName,
-                _identity.MeterVersion,
-                _identity.MeterTags,
-                _identity.InstrumentType,
-                _temporality,
-                dict,
-                _identity.Unit,
-                _identity.Description,
-                _identity.IsLongType));
+        return _points.GetOrAdd(tagSet, _ => CreatePoint(dict));
     }
+
+    private MetricPoint GetOrCreateOverflowPoint()
+    {
+        _overflowActive = true;
+
+        if (_points.TryGetValue(OverflowTagSet, out var overflowPoint))
+        {
+            return overflowPoint;
+        }
+
+        if (Interlocked.Exchange(ref _overflowLogged, 1) == 0)
+        {
+            Log.Warning(
+                "Cardinality limit ({CardinalityLimit}) reached for instrument '{InstrumentName}' from meter '{MeterName}'. Additional attribute sets are aggregated into an overflow series tagged 'otel.metric.overflow=true'. Reduce the cardinality of this metric's attributes.",
+                [_cardinalityLimit, _identity.InstrumentName, _identity.MeterName]);
+        }
+
+        var dict = new Dictionary<string, object?>(1) { [OverflowAttributeKey] = true };
+        return _points.GetOrAdd(OverflowTagSet, _ => CreatePoint(dict));
+    }
+
+    private MetricPoint CreatePoint(Dictionary<string, object?> tags)
+        => new MetricPoint(
+            _identity.InstrumentName,
+            _identity.MeterName,
+            _identity.MeterVersion,
+            _identity.MeterTags,
+            _identity.InstrumentType,
+            _temporality,
+            tags,
+            _identity.Unit,
+            _identity.Description,
+            _identity.IsLongType);
 }
 #endif

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpMetricsSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Metrics/OtlpMetricsSerializer.cs
@@ -415,7 +415,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
 
             foreach (var tag in metric.Tags)
             {
-                var attrData = SerializeKeyValue(tag.Key, tag.Value?.ToString() ?? string.Empty);
+                var attrData = SerializeKeyValue(tag.Key, tag.Value);
                 WriteTag(writer, FieldNumbers.NumberDataPointAttributes, LengthDelimited);
                 WriteVarInt(writer, attrData.Length);
                 writer.Write(attrData);
@@ -448,7 +448,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
 
             foreach (var tag in metric.Tags)
             {
-                var attrData = SerializeKeyValue(tag.Key, tag.Value?.ToString() ?? string.Empty);
+                var attrData = SerializeKeyValue(tag.Key, tag.Value);
                 WriteTag(writer, FieldNumbers.NumberDataPointAttributes, LengthDelimited);
                 WriteVarInt(writer, attrData.Length);
                 writer.Write(attrData);
@@ -473,7 +473,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
 
             foreach (var tag in metric.Tags)
             {
-                var attrData = SerializeKeyValue(tag.Key, tag.Value?.ToString() ?? string.Empty);
+                var attrData = SerializeKeyValue(tag.Key, tag.Value);
                 WriteTag(writer, FieldNumbers.HistogramDataPointAttributes, LengthDelimited);
                 WriteVarInt(writer, attrData.Length);
                 writer.Write(attrData);
@@ -518,14 +518,14 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
             return buffer.ToArray();
         }
 
-        private byte[] SerializeKeyValue(string key, string value)
+        private byte[] SerializeKeyValue(string key, object? value)
         {
             using var buffer = new MemoryStream();
             using var writer = new BinaryWriter(buffer, Encoding.UTF8);
 
             WriteStringField(writer, FieldNumbers.Key, key);
 
-            var anyValueData = SerializeStringAnyValue(value);
+            var anyValueData = SerializeAnyValue(value);
             WriteTag(writer, FieldNumbers.Value, LengthDelimited);
             WriteVarInt(writer, anyValueData.Length);
             writer.Write(anyValueData);
@@ -533,17 +533,25 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
             return buffer.ToArray();
         }
 
-        private byte[] SerializeStringAnyValue(string value)
+        internal static byte[] SerializeAnyValue(object? value)
         {
             using var buffer = new MemoryStream();
             using var writer = new BinaryWriter(buffer, Encoding.UTF8);
 
-            WriteStringField(writer, FieldNumbers.StringValue, value);
+            if (value is bool boolValue)
+            {
+                WriteTag(writer, FieldNumbers.BoolValue, VarInt);
+                writer.Write(boolValue);
+            }
+            else
+            {
+                WriteStringField(writer, FieldNumbers.StringValue, value?.ToString() ?? string.Empty);
+            }
 
             return buffer.ToArray();
         }
 
-        private void WriteStringField(BinaryWriter writer, int fieldNumber, string value)
+        private static void WriteStringField(BinaryWriter writer, int fieldNumber, string value)
         {
             if (!string.IsNullOrEmpty(value))
             {
@@ -552,24 +560,24 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
             }
         }
 
-        private void WriteTag(BinaryWriter writer, int fieldNumber, int wireType)
+        private static void WriteTag(BinaryWriter writer, int fieldNumber, int wireType)
         {
             WriteVarInt(writer, (fieldNumber << 3) | wireType);
         }
 
-        private void WriteString(BinaryWriter writer, string value)
+        private static void WriteString(BinaryWriter writer, string value)
         {
             var bytes = Encoding.UTF8.GetBytes(value);
             WriteVarInt(writer, bytes.Length);
             writer.Write(bytes);
         }
 
-        private void WriteVarInt(BinaryWriter writer, int value)
+        private static void WriteVarInt(BinaryWriter writer, int value)
         {
             WriteVarInt(writer, (uint)value);
         }
 
-        private void WriteVarInt(BinaryWriter writer, uint value)
+        private static void WriteVarInt(BinaryWriter writer, uint value)
         {
             while (value >= 0x80)
             {
@@ -663,6 +671,7 @@ namespace Datadog.Trace.OpenTelemetry.Metrics
 
             // AnyValue
             public const int StringValue = 1;
+            public const int BoolValue = 2;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/MeterListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/MeterListenerTests.cs
@@ -138,6 +138,48 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
+        public async Task EnforcesCardinalityLimit_FoldingExcessIntoOverflowSeries()
+        {
+            var settings = TracerSettings.Create(new());
+            var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            Tracer.UnsafeSetTracerInstance(tracer);
+
+            var testExporter = new InMemoryExporter();
+            await using var pipeline = new OtelMetricsPipeline(settings, testExporter);
+            pipeline.Start();
+
+            using var meter = new Meter("TestMeter");
+            var counter = meter.CreateCounter<long>("test.counter");
+
+            // Emit more distinct attribute sets than the cardinality limit allows. This mirrors the
+            // unbounded feature_flag.key cardinality scenario (APMSP-3500): a single instrument fed
+            // attacker-controlled / high-cardinality attribute values must not grow memory without bound.
+            const int distinctTagSets = MetricState.DefaultCardinalityLimit + 500;
+            for (var i = 0; i < distinctTagSets; i++)
+            {
+                counter.Add(1, new KeyValuePair<string, object>("feature_flag.key", $"flag-{i}"));
+            }
+
+            await pipeline.ForceCollectAndExportAsync();
+            var counterMetrics = testExporter.ExportedMetrics.Where(m => m.InstrumentName == "test.counter").ToList();
+
+            // The number of exported points is bounded at the cardinality limit, no matter how many
+            // distinct attribute sets were recorded.
+            counterMetrics.Count.Should().Be(MetricState.DefaultCardinalityLimit, "cardinality is capped at the limit regardless of input");
+
+            // Excess attribute sets are folded into a single overflow series tagged otel.metric.overflow=true.
+            var overflowPoints = counterMetrics.Where(m => m.Tags.ContainsKey(MetricState.OverflowAttributeKey)).ToList();
+            overflowPoints.Count.Should().Be(1, "excess attribute sets fold into exactly one overflow series");
+            overflowPoints[0].Tags[MetricState.OverflowAttributeKey].Should().Be(true);
+
+            // No measurements are dropped: the running total is preserved across the real + overflow series.
+            counterMetrics.Sum(m => m.SnapshotSum).Should().Be(distinctTagSets, "every measurement is still counted, only the per-key breakdown is lost past the cap");
+
+            // The overflow series absorbs everything beyond the (limit - 1) retained real series.
+            overflowPoints[0].SnapshotSum.Should().Be(distinctTagSets - (MetricState.DefaultCardinalityLimit - 1));
+        }
+
+        [Fact]
         public async Task DetectsDuplicateInstrumentsWithCaseInsensitiveNames()
         {
             // Arrange

--- a/tracer/test/Datadog.Trace.Tests/MeterListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/MeterListenerTests.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.OpenTelemetry.Metrics;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
+using OpenTelemetry.Proto.Common.V1;
 using VerifyXunit;
 using Xunit;
 
@@ -163,9 +164,9 @@ namespace Datadog.Trace.Tests
             await pipeline.ForceCollectAndExportAsync();
             var counterMetrics = testExporter.ExportedMetrics.Where(m => m.InstrumentName == "test.counter").ToList();
 
-            // The number of exported points is bounded at the cardinality limit, no matter how many
-            // distinct attribute sets were recorded.
-            counterMetrics.Count.Should().Be(MetricState.DefaultCardinalityLimit, "cardinality is capped at the limit regardless of input");
+            // The configured limit allows this many real attribute sets; once exceeded, measurements
+            // fold into a single overflow series.
+            counterMetrics.Count.Should().Be(MetricState.DefaultCardinalityLimit + 1, "cardinality is capped at the configured real series plus one overflow series");
 
             // Excess attribute sets are folded into a single overflow series tagged otel.metric.overflow=true.
             var overflowPoints = counterMetrics.Where(m => m.Tags.ContainsKey(MetricState.OverflowAttributeKey)).ToList();
@@ -175,9 +176,112 @@ namespace Datadog.Trace.Tests
             // No measurements are dropped: the running total is preserved across the real + overflow series.
             counterMetrics.Sum(m => m.SnapshotSum).Should().Be(distinctTagSets, "every measurement is still counted, only the per-key breakdown is lost past the cap");
 
-            // The overflow series absorbs everything beyond the (limit - 1) retained real series.
-            overflowPoints[0].SnapshotSum.Should().Be(distinctTagSets - (MetricState.DefaultCardinalityLimit - 1));
+            // The overflow series absorbs everything beyond the retained real series.
+            overflowPoints[0].SnapshotSum.Should().Be(distinctTagSets - MetricState.DefaultCardinalityLimit);
         }
+
+#nullable enable
+
+        [Fact]
+        public void AllowsConfiguredNumberOfRealSeriesBeforeUsingOverflow()
+        {
+            using var meter = new Meter("TestMeter");
+            var counter = meter.CreateCounter<long>("test.counter");
+            var state = new MetricState(new MetricStreamIdentity(counter, InstrumentType.Counter), AggregationTemporality.Delta, cardinalityLimit: 2);
+
+            state.RecordMeasurementLong(1, new[] { new KeyValuePair<string, object?>("id", "a") });
+            state.RecordMeasurementLong(1, new[] { new KeyValuePair<string, object?>("id", "b") });
+
+            var points = new List<MetricPoint>();
+            state.BuildPoints(points);
+
+            points.Count.Should().Be(2);
+            points.Should().NotContain(point => point.Tags.ContainsKey(MetricState.OverflowAttributeKey));
+        }
+
+        [Fact]
+        public void ReclaimsInactiveDeltaSeriesBeforeApplyingCardinalityLimit()
+        {
+            using var meter = new Meter("TestMeter");
+            var counter = meter.CreateCounter<long>("test.counter");
+            var state = new MetricState(new MetricStreamIdentity(counter, InstrumentType.Counter), AggregationTemporality.Delta, cardinalityLimit: 2);
+
+            state.RecordMeasurementLong(1, new[] { new KeyValuePair<string, object?>("id", "a") });
+            state.RecordMeasurementLong(1, new[] { new KeyValuePair<string, object?>("id", "b") });
+
+            var points = new List<MetricPoint>();
+            state.BuildPoints(points);
+            points.Should().HaveCount(2);
+
+            points.Clear();
+            state.RecordMeasurementLong(1, new[] { new KeyValuePair<string, object?>("id", "c") });
+            state.RecordMeasurementLong(1, new[] { new KeyValuePair<string, object?>("id", "d") });
+
+            state.BuildPoints(points);
+
+            points.Count.Should().Be(2);
+            points.Should().NotContain(point => point.Tags.ContainsKey(MetricState.OverflowAttributeKey));
+        }
+
+        [Fact]
+        public async Task ReservesCardinalitySlotsUnderConcurrentNewSeries()
+        {
+            const int cardinalityLimit = 8;
+            const int measurementCount = 128;
+            using var meter = new Meter("TestMeter");
+            var counter = meter.CreateCounter<long>("test.counter");
+            var state = new MetricState(new MetricStreamIdentity(counter, InstrumentType.Counter), AggregationTemporality.Delta, cardinalityLimit);
+
+            var tasks = Enumerable.Range(0, measurementCount)
+                                  .Select(i => Task.Run(() => state.RecordMeasurementLong(1, new[] { new KeyValuePair<string, object?>("id", i) })));
+
+            await Task.WhenAll(tasks);
+
+            var points = new List<MetricPoint>();
+            state.BuildPoints(points);
+            var realPoints = points.Where(point => !point.Tags.ContainsKey(MetricState.OverflowAttributeKey)).ToList();
+            var overflowPoint = points.Single(point => point.Tags.ContainsKey(MetricState.OverflowAttributeKey));
+
+            realPoints.Count.Should().Be(cardinalityLimit);
+            points.Count.Should().Be(cardinalityLimit + 1);
+            points.Sum(point => point.SnapshotSum).Should().Be(measurementCount);
+            overflowPoint.SnapshotSum.Should().Be(measurementCount - cardinalityLimit);
+        }
+
+        [Fact]
+        public void AggregatesObservableOverflowValuesBeforeDeltaCalculation()
+        {
+            using var meter = new Meter("TestMeter");
+            var counter = meter.CreateObservableCounter<long>("test.observable.counter", () => 0L);
+            var state = new MetricState(new MetricStreamIdentity(counter, InstrumentType.ObservableCounter), AggregationTemporality.Delta, cardinalityLimit: 1);
+
+            state.RecordMeasurementLong(10, new[] { new KeyValuePair<string, object?>("id", "a") });
+            state.RecordMeasurementLong(20, new[] { new KeyValuePair<string, object?>("id", "b") });
+            state.RecordMeasurementLong(30, new[] { new KeyValuePair<string, object?>("id", "c") });
+
+            var points = new List<MetricPoint>();
+            state.BuildPoints(points);
+            points.Single(point => point.Tags.ContainsKey(MetricState.OverflowAttributeKey)).SnapshotSum.Should().Be(50);
+
+            points.Clear();
+            state.RecordMeasurementLong(25, new[] { new KeyValuePair<string, object?>("id", "b") });
+            state.RecordMeasurementLong(40, new[] { new KeyValuePair<string, object?>("id", "c") });
+
+            state.BuildPoints(points);
+
+            points.Single(point => point.Tags.ContainsKey(MetricState.OverflowAttributeKey)).SnapshotSum.Should().Be(15);
+        }
+
+        [Fact]
+        public void SerializesBooleanMetricAttributesAsOtlpBoolValues()
+        {
+            var anyValue = AnyValue.Parser.ParseFrom(OtlpMetricsSerializer.SerializeAnyValue(true));
+
+            anyValue.ValueCase.Should().Be(AnyValue.ValueOneofCase.BoolValue);
+            anyValue.BoolValue.Should().BeTrue();
+        }
+
+#nullable restore
 
         [Fact]
         public async Task DetectsDuplicateInstrumentsWithCaseInsensitiveNames()


### PR DESCRIPTION
## Summary of changes

Enforce a per-stream cardinality limit (2000, the OpenTelemetry metrics-SDK default) in the OTLP metrics reader's `MetricState`, folding any excess attribute sets into a single overflow series tagged `otel.metric.overflow=true`.

## Reason for change

`MetricState` accumulated one `MetricPoint` per distinct attribute set in a `ConcurrentDictionary` with no upper bound. A high-cardinality or attacker-controlled attribute value — e.g. `feature_flag.key` emitted by the OpenFeature provider hook — could grow process memory and export-payload size without limit (APMSP-3500, medium-severity codex finding).

The defect lives in the reader, not the feature-flag hook, so it affected **every** enabled non-`System.*` meter (`http.route`, user IDs, raw SQL, etc.) — the OpenFeature hook merely made the pre-existing gap reachable.

## Implementation details

- `MetricState` now tracks at most `DefaultCardinalityLimit` (2000) distinct attribute sets per stream.
- Once full, new attribute sets fold into a single overflow series tagged `otel.metric.overflow=true`, per the [OTel metrics SDK spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits). Already-tracked series keep updating via the existing fast path; the aggregate total is preserved — only the per-attribute breakdown beyond the cap is lost.
- A `volatile` flag short-circuits the count check on the hot path once overflow is active, and a one-time warning is logged per stream when the cap engages.
- The limit is a constant for now (trivially promotable to a `TracerSettings`/`DD_*` key later); `MetricReaderHandler` picks it up via the constructor default, so no call-site change was needed.

## Test coverage

- `MeterListenerTests.EnforcesCardinalityLimit_FoldingExcessIntoOverflowSeries`: records 2,500 distinct attribute sets through the real `OtelMetricsPipeline`, then asserts exactly 2,000 exported points, exactly one `otel.metric.overflow=true` series, and that the summed total across real + overflow series equals the number of measurements (nothing dropped).
- Full `MeterListenerTests` suite passing on net10.0 (7/7).

## Other details

Resolves APMSP-3500.

Cross-SDK note: only the Java SDK bounds `feature_flag.evaluations` cardinality by default; .NET (until this PR), JS, Go, Python, and older Ruby do not. The `feature_flag.key` source-level cardinality remains a cross-language product decision and is tracked for the feature-flags team in the Jira ticket.
