### PR TITLE
Minor and performance updates for client-side-stats

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -428,7 +428,7 @@ namespace Datadog.Trace.Agent
         {
             if (results.BaseService is not null)
             {
-                return [EncodingHelpers.Utf8NoBom.GetBytes($"{Tags.BaseService}:{results.BaseService}")];
+                return [EncodeKeyValue(BaseServiceUtf8Prefix, results.BaseService)];
             }
 
             if (results.PeerTagCount == 0)
@@ -446,10 +446,27 @@ namespace Datadog.Trace.Agent
                 }
 
                 tagValue = IpAddressObfuscationUtil.QuantizePeerIpAddresses(tagValue);
-                result.Add(EncodingHelpers.Utf8NoBom.GetBytes($"{peerTag.Name}:{tagValue}"));
+                result.Add(EncodeKeyValue(peerTag.Utf8Prefix, tagValue));
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Builds a "key:value" UTF-8 byte array by reusing the pre-encoded <paramref name="utf8KeyPrefix"/>
+        /// (e.g. "tagKey:") and encoding only <paramref name="tagValue"/> directly into the destination
+        /// array — avoiding both the intermediate interpolated string and re-encoding the key prefix.
+        /// </summary>
+        private static byte[] EncodeKeyValue(byte[] utf8KeyPrefix, string tagValue)
+        {
+            var valueByteCount = EncodingHelpers.Utf8NoBom.GetByteCount(tagValue);
+            var encoded = new byte[utf8KeyPrefix.Length + valueByteCount];
+
+            // Copy the already-encoded "key:" bytes, then encode the value straight after them.
+            Buffer.BlockCopy(utf8KeyPrefix, 0, encoded, 0, utf8KeyPrefix.Length);
+            EncodingHelpers.Utf8NoBom.GetBytes(tagValue, charIndex: 0, charCount: tagValue.Length, encoded, byteIndex: utf8KeyPrefix.Length);
+
+            return encoded;
         }
 
         internal async Task Flush()

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -112,6 +112,7 @@ namespace Datadog.Trace.Agent
         /// StatsBuffer is not thread-safe, this property is not intended to be used outside of the class,
         /// except for tests.
         /// </summary>
+        [TestingAndPrivateOnly]
         internal StatsBuffer CurrentBuffer => _buffers[_currentBuffer];
 
         public bool? CanComputeStats

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -30,6 +30,51 @@ namespace Datadog.Trace.Agent
 
         public long Start { get; private set; }
 
+        // UTF-8 bytes for the constant map keys and values are embedded in the PE as static data via u8
+        // literals. Using ReadOnlySpan<byte> property getters and WriteStringBytes avoids re-encoding the
+        // same strings to UTF-8 on every serialization, matching the approach in SpanMessagePackFormatter.
+#pragma warning disable SA1516 // Elements should be separated by blank line
+        // payload header keys
+        private static ReadOnlySpan<byte> HostnameKeyBytes => "Hostname"u8;
+        private static ReadOnlySpan<byte> EnvKeyBytes => "Env"u8;
+        private static ReadOnlySpan<byte> VersionKeyBytes => "Version"u8;
+        private static ReadOnlySpan<byte> ProcessTagsKeyBytes => "ProcessTags"u8;
+        private static ReadOnlySpan<byte> LangKeyBytes => "Lang"u8;
+        private static ReadOnlySpan<byte> TracerVersionKeyBytes => "TracerVersion"u8;
+        private static ReadOnlySpan<byte> RuntimeIdKeyBytes => "RuntimeID"u8;
+        private static ReadOnlySpan<byte> SequenceKeyBytes => "Sequence"u8;
+        private static ReadOnlySpan<byte> GitCommitShaKeyBytes => "GitCommitSha"u8;
+
+        // bucket keys
+        private static ReadOnlySpan<byte> ServiceKeyBytes => "Service"u8;
+        private static ReadOnlySpan<byte> NameKeyBytes => "Name"u8;
+        private static ReadOnlySpan<byte> ResourceKeyBytes => "Resource"u8;
+        private static ReadOnlySpan<byte> SyntheticsKeyBytes => "Synthetics"u8;
+        private static ReadOnlySpan<byte> HttpStatusCodeKeyBytes => "HTTPStatusCode"u8;
+        private static ReadOnlySpan<byte> TypeKeyBytes => "Type"u8;
+        private static ReadOnlySpan<byte> HitsKeyBytes => "Hits"u8;
+        private static ReadOnlySpan<byte> ErrorsKeyBytes => "Errors"u8;
+        private static ReadOnlySpan<byte> OkSummaryKeyBytes => "OkSummary"u8;
+        private static ReadOnlySpan<byte> ErrorSummaryKeyBytes => "ErrorSummary"u8;
+        private static ReadOnlySpan<byte> TopLevelHitsKeyBytes => "TopLevelHits"u8;
+        private static ReadOnlySpan<byte> SpanKindKeyBytes => "SpanKind"u8;
+        private static ReadOnlySpan<byte> IsTraceRootKeyBytes => "IsTraceRoot"u8;
+        private static ReadOnlySpan<byte> HttpMethodKeyBytes => "HTTPMethod"u8;
+        private static ReadOnlySpan<byte> HttpEndpointKeyBytes => "HTTPEndpoint"u8;
+        private static ReadOnlySpan<byte> GrpcStatusCodeKeyBytes => "GRPCStatusCode"u8;
+        private static ReadOnlySpan<byte> ServiceSourceKeyBytes => "srv_src"u8; // Wire name per the Go agent's generated msgpack code
+        private static ReadOnlySpan<byte> PeerTagsKeyBytes => "PeerTags"u8;
+
+        // shared keys (used in multiple maps)
+        private static ReadOnlySpan<byte> StatsKeyBytes => "Stats"u8;
+        private static ReadOnlySpan<byte> StartKeyBytes => "Start"u8;
+        private static ReadOnlySpan<byte> DurationKeyBytes => "Duration"u8;
+
+        // constant values
+        private static ReadOnlySpan<byte> UnknownEnvValueBytes => "unknown-env"u8;
+        private static ReadOnlySpan<byte> LangValueBytes => "dotnet"u8; // TracerConstants.Language
+#pragma warning restore SA1516
+
         /// <summary>
         /// Returns true if any bucket has received hits in the current interval.
         /// Buckets with zero hits are retained for sketch reuse but should not trigger a flush.
@@ -96,43 +141,50 @@ namespace Datadog.Trace.Agent
 
             MessagePackBinary.WriteMapHeader(stream, count);
 
-            MessagePackBinary.WriteString(stream, "Hostname");
+            MessagePackBinary.WriteStringBytes(stream, HostnameKeyBytes);
             MessagePackBinary.WriteString(stream, _header.HostName ?? string.Empty);
 
-            MessagePackBinary.WriteString(stream, "Env");
-            MessagePackBinary.WriteString(stream, StringUtil.IsNullOrEmpty(details.Environment) ? "unknown-env" : details.Environment);
+            MessagePackBinary.WriteStringBytes(stream, EnvKeyBytes);
+            if (StringUtil.IsNullOrEmpty(details.Environment))
+            {
+                MessagePackBinary.WriteStringBytes(stream, UnknownEnvValueBytes);
+            }
+            else
+            {
+                MessagePackBinary.WriteString(stream, details.Environment);
+            }
 
-            MessagePackBinary.WriteString(stream, "Version");
+            MessagePackBinary.WriteStringBytes(stream, VersionKeyBytes);
             MessagePackBinary.WriteString(stream, details.Version ?? string.Empty);
 
             if (writeTags)
             {
-                MessagePackBinary.WriteString(stream, "ProcessTags");
+                MessagePackBinary.WriteStringBytes(stream, ProcessTagsKeyBytes);
                 MessagePackBinary.WriteString(stream, serializedTags);
             }
 
-            MessagePackBinary.WriteString(stream, "Stats");
+            MessagePackBinary.WriteStringBytes(stream, StatsKeyBytes);
             MessagePackBinary.WriteArrayHeader(stream, 1);
             SerializeBuckets(stream, bucketDuration);
 
-            MessagePackBinary.WriteString(stream, "Lang");
-            MessagePackBinary.WriteString(stream, TracerConstants.Language);
+            MessagePackBinary.WriteStringBytes(stream, LangKeyBytes);
+            MessagePackBinary.WriteStringBytes(stream, LangValueBytes);
 
-            MessagePackBinary.WriteString(stream, "TracerVersion");
-            MessagePackBinary.WriteString(stream, TracerConstants.AssemblyVersion);
+            MessagePackBinary.WriteStringBytes(stream, TracerVersionKeyBytes);
+            MessagePackBinary.WriteStringBytes(stream, TracerConstants.AssemblyVersionBytes);
 
-            MessagePackBinary.WriteString(stream, "RuntimeID");
+            MessagePackBinary.WriteStringBytes(stream, RuntimeIdKeyBytes);
             MessagePackBinary.WriteString(stream, Tracer.RuntimeId);
 
-            MessagePackBinary.WriteString(stream, "Sequence");
+            MessagePackBinary.WriteStringBytes(stream, SequenceKeyBytes);
             MessagePackBinary.WriteInt64(stream, _header.GetSequenceNumber());
 
-            MessagePackBinary.WriteString(stream, "Service");
+            MessagePackBinary.WriteStringBytes(stream, ServiceKeyBytes);
             MessagePackBinary.WriteString(stream, details.DefaultServiceName ?? string.Empty);
 
             if (writeGitCommitSha)
             {
-                MessagePackBinary.WriteString(stream, "GitCommitSha");
+                MessagePackBinary.WriteStringBytes(stream, GitCommitShaKeyBytes);
                 MessagePackBinary.WriteString(stream, details.GitCommitSha);
             }
         }
@@ -147,68 +199,66 @@ namespace Datadog.Trace.Agent
 
             MessagePackBinary.WriteMapHeader(stream, fieldCount);
 
-            // TODO: precompute the string constants in this file
-            MessagePackBinary.WriteString(stream, "Service");
+            MessagePackBinary.WriteStringBytes(stream, ServiceKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.Service);
 
-            MessagePackBinary.WriteString(stream, "Name");
+            MessagePackBinary.WriteStringBytes(stream, NameKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.OperationName);
 
-            MessagePackBinary.WriteString(stream, "Resource");
+            MessagePackBinary.WriteStringBytes(stream, ResourceKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.Resource);
 
-            MessagePackBinary.WriteString(stream, "Synthetics");
+            MessagePackBinary.WriteStringBytes(stream, SyntheticsKeyBytes);
             MessagePackBinary.WriteBoolean(stream, bucket.Key.IsSyntheticsRequest);
 
-            MessagePackBinary.WriteString(stream, "HTTPStatusCode");
+            MessagePackBinary.WriteStringBytes(stream, HttpStatusCodeKeyBytes);
             MessagePackBinary.WriteInt32(stream, bucket.Key.HttpStatusCode);
 
-            MessagePackBinary.WriteString(stream, "Type");
+            MessagePackBinary.WriteStringBytes(stream, TypeKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.Type);
 
-            MessagePackBinary.WriteString(stream, "Hits");
+            MessagePackBinary.WriteStringBytes(stream, HitsKeyBytes);
             MessagePackBinary.WriteInt64(stream, bucket.Hits);
 
-            MessagePackBinary.WriteString(stream, "Errors");
+            MessagePackBinary.WriteStringBytes(stream, ErrorsKeyBytes);
             MessagePackBinary.WriteInt64(stream, bucket.Errors);
 
-            MessagePackBinary.WriteString(stream, "Duration");
+            MessagePackBinary.WriteStringBytes(stream, DurationKeyBytes);
             MessagePackBinary.WriteInt64(stream, bucket.Duration);
 
-            MessagePackBinary.WriteString(stream, "OkSummary");
+            MessagePackBinary.WriteStringBytes(stream, OkSummaryKeyBytes);
             SerializeSketch(stream, bucket.OkSummary);
 
-            MessagePackBinary.WriteString(stream, "ErrorSummary");
+            MessagePackBinary.WriteStringBytes(stream, ErrorSummaryKeyBytes);
             SerializeSketch(stream, bucket.ErrorSummary);
 
-            MessagePackBinary.WriteString(stream, "TopLevelHits");
+            MessagePackBinary.WriteStringBytes(stream, TopLevelHitsKeyBytes);
             MessagePackBinary.WriteInt64(stream, bucket.TopLevelHits);
 
             // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/aggregation.go
-            MessagePackBinary.WriteString(stream, "SpanKind");
+            MessagePackBinary.WriteStringBytes(stream, SpanKindKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.SpanKind);
 
             // Spec defines Trilean: NOT_SET=0, TRUE=1, FALSE=2
-            MessagePackBinary.WriteString(stream, "IsTraceRoot");
+            MessagePackBinary.WriteStringBytes(stream, IsTraceRootKeyBytes);
             MessagePackBinary.WriteInt32(stream, bucket.Key.IsTraceRoot ? 1 : 2);
 
-            MessagePackBinary.WriteString(stream, "HTTPMethod");
+            MessagePackBinary.WriteStringBytes(stream, HttpMethodKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.HttpMethod);
 
-            MessagePackBinary.WriteString(stream, "HTTPEndpoint");
+            MessagePackBinary.WriteStringBytes(stream, HttpEndpointKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.HttpEndpoint);
 
-            MessagePackBinary.WriteString(stream, "GRPCStatusCode");
+            MessagePackBinary.WriteStringBytes(stream, GrpcStatusCodeKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.GrpcStatusCode);
 
-            // Wire name is "srv_src" per the Go agent's generated msgpack code
-            MessagePackBinary.WriteString(stream, "srv_src");
+            MessagePackBinary.WriteStringBytes(stream, ServiceSourceKeyBytes);
             MessagePackBinary.WriteString(stream, bucket.Key.ServiceSource);
 
             // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/span_concentrator.go#L53-L99
             if (bucket.PeerTags.Count != 0)
             {
-                MessagePackBinary.WriteString(stream, "PeerTags");
+                MessagePackBinary.WriteStringBytes(stream, PeerTagsKeyBytes);
                 MessagePackBinary.WriteArrayHeader(stream, bucket.PeerTags.Count);
                 foreach (var tag in bucket.PeerTags)
                 {
@@ -234,10 +284,10 @@ namespace Datadog.Trace.Agent
         {
             MessagePackBinary.WriteMapHeader(stream, 3);
 
-            MessagePackBinary.WriteString(stream, "Start");
+            MessagePackBinary.WriteStringBytes(stream, StartKeyBytes);
             MessagePackBinary.WriteInt64(stream, Start);
 
-            MessagePackBinary.WriteString(stream, "Duration");
+            MessagePackBinary.WriteStringBytes(stream, DurationKeyBytes);
             MessagePackBinary.WriteInt64(stream, bucketDuration);
 
             int count = 0;
@@ -251,7 +301,7 @@ namespace Datadog.Trace.Agent
                 }
             }
 
-            MessagePackBinary.WriteString(stream, "Stats");
+            MessagePackBinary.WriteStringBytes(stream, StatsKeyBytes);
             MessagePackBinary.WriteArrayHeader(stream, count);
 
             // Second pass for the actual serialization


### PR DESCRIPTION
## Summary of changes

- Mark testing only methods with `[TestingAndPrivateOnly]`
- Pre-encode header tags for static UTF-8 messagepack keys
- Avoid re-encoding the peer_tags, seeing as we already have that data

## Reason for change

Minor tweaks (mostly perf) before adding the additional client-side-stats features

## Implementation details

Mostly self-evident, written as distinct commits. The most interesting one is avoiding the additional interpolated string when encoding peer_tags. We also avoid re-encoding the tags seeing as we already do that work up front 

## Test coverage

Covered by existing tests, this is all refactoring

## Other details

Part of a client-side stats stack of PRs.

- https://github.com/DataDog/dd-trace-dotnet/pull/8822 👈
- https://github.com/DataDog/dd-trace-dotnet/pull/8766
- https://github.com/DataDog/dd-trace-dotnet/pull/8823
- https://github.com/DataDog/dd-trace-dotnet/pull/8824

https://datadoghq.atlassian.net/browse/APMLP-1446