### PR TITLE
Implement support for `DD_TAGS` in Client-Side stats

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/ClientStatsPayload.cs
+++ b/tracer/src/Datadog.Trace/Agent/ClientStatsPayload.cs
@@ -4,8 +4,11 @@
 // </copyright>
 #nullable enable
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Vendors.MessagePack;
 
 namespace Datadog.Trace.Agent
 {
@@ -24,8 +27,34 @@ namespace Datadog.Trace.Agent
             => Interlocked.Exchange(ref _settings, CreateSettings(settings));
 
         private static AppSettings CreateSettings(MutableSettings settings)
-            => new(settings.Environment, settings.ServiceVersion, settings.DefaultServiceName, settings.ProcessTags, settings.GitCommitSha);
+            => new(settings.Environment, settings.ServiceVersion, settings.DefaultServiceName, settings.ProcessTags, settings.GitCommitSha, BuildDdTags(settings.GlobalTags));
 
-        internal sealed record AppSettings(string? Environment, string? Version, string DefaultServiceName, ProcessTags? ProcessTags, string? GitCommitSha);
+        private static byte[][] BuildDdTags(ReadOnlyDictionary<string, string> globalTags)
+        {
+            if (globalTags.Count == 0)
+            {
+                return [];
+            }
+
+            var tags = new byte[globalTags.Count][];
+            var i = 0;
+            foreach (var kvp in globalTags)
+            {
+                var keyCount = StringEncoding.UTF8.GetByteCount(kvp.Key);
+                var valueCount = StringEncoding.UTF8.GetByteCount(kvp.Value);
+                var buffer = new byte[keyCount + 1 + valueCount];
+
+                StringEncoding.UTF8.GetBytes(kvp.Key, 0, kvp.Key.Length, buffer, 0);
+                buffer[keyCount] = (byte)':';
+                StringEncoding.UTF8.GetBytes(kvp.Value, 0, kvp.Value.Length, buffer, keyCount + 1);
+
+                tags[i] = buffer;
+                i++;
+            }
+
+            return tags;
+        }
+
+        internal sealed record AppSettings(string? Environment, string? Version, string DefaultServiceName, ProcessTags? ProcessTags, string? GitCommitSha, byte[][] DdTags);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -43,6 +43,7 @@ namespace Datadog.Trace.Agent
         private static ReadOnlySpan<byte> TracerVersionKeyBytes => "TracerVersion"u8;
         private static ReadOnlySpan<byte> RuntimeIdKeyBytes => "RuntimeID"u8;
         private static ReadOnlySpan<byte> SequenceKeyBytes => "Sequence"u8;
+        private static ReadOnlySpan<byte> TracerDdTags => "TracerDdTags"u8;
         private static ReadOnlySpan<byte> GitCommitShaKeyBytes => "GitCommitSha"u8;
 
         // bucket keys
@@ -124,7 +125,7 @@ namespace Datadog.Trace.Agent
 
         public void Serialize(Stream stream, long bucketDuration)
         {
-            var count = 9; // Base: Hostname, Env, Version, Stats, Lang, TracerVersion, RuntimeID, Sequence, Service
+            var count = 10; // Base: Hostname, Env, Version, Stats, Lang, TracerVersion, RuntimeID, Sequence, Service, TracerDdTags
             var details = _header.Details;
 
             var serializedTags = details.ProcessTags?.SerializedTags;
@@ -182,6 +183,14 @@ namespace Datadog.Trace.Agent
 
             MessagePackBinary.WriteStringBytes(stream, ServiceKeyBytes);
             MessagePackBinary.WriteString(stream, details.DefaultServiceName ?? string.Empty);
+
+            var ddTags = details.DdTags;
+            MessagePackBinary.WriteStringBytes(stream, TracerDdTags);
+            MessagePackBinary.WriteArrayHeader(stream, ddTags.Length);
+            foreach (var tag in ddTags)
+            {
+                MessagePackBinary.WriteStringBytes(stream, tag);
+            }
 
             if (writeGitCommitSha)
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientStatsPayload.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Stats/MockClientStatsPayload.cs
@@ -44,6 +44,9 @@ namespace Datadog.Trace.TestHelpers.Stats
         [Key("GitCommitSha")]
         public string GitCommitSha { get; set; }
 
+        [Key("TracerDdTags")]
+        public string[] TracerDdTags { get; set; }
+
         [Key("Stats")]
         public List<MockClientStatsBucket> Stats { get; set; }
     }

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsBufferTests.cs
@@ -201,6 +201,43 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public void Serialization_PopulatesTracerDdTagsFromGlobalTags()
+        {
+            var settings = MutableSettings.CreateForTesting(
+                new(),
+                new()
+                {
+                    { ConfigurationKeys.GlobalTags, "datacenter:us-east-1,tenant_id:acme-corp" },
+                });
+
+            var buffer = new StatsBuffer(new ClientStatsPayload(settings));
+            var key = CreateKey("resource", "service", "operation", "type", 200, false);
+            var bucket = new StatsBucket(key, EmptyTags, EmptyTags) { Duration = 1, Hits = 1, TopLevelHits = 1 };
+            buffer.Buckets.Add(key, bucket);
+
+            var stream = new MemoryStream();
+            buffer.Serialize(stream, 1);
+            var result = MessagePackSerializer.Deserialize<MockClientStatsPayload>(stream.ToArray());
+
+            result.TracerDdTags.Should().BeEquivalentTo("datacenter:us-east-1", "tenant_id:acme-corp");
+        }
+
+        [Fact]
+        public void Serialization_EmitsEmptyTracerDdTagsWhenNoGlobalTags()
+        {
+            var buffer = new StatsBuffer(new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])));
+            var key = CreateKey("resource", "service", "operation", "type", 200, false);
+            var bucket = new StatsBucket(key, EmptyTags, EmptyTags) { Duration = 1, Hits = 1, TopLevelHits = 1 };
+            buffer.Buckets.Add(key, bucket);
+
+            var stream = new MemoryStream();
+            buffer.Serialize(stream, 1);
+            var result = MessagePackSerializer.Deserialize<MockClientStatsPayload>(stream.ToArray());
+
+            result.TracerDdTags.Should().NotBeNull().And.BeEmpty();
+        }
+
+        [Fact]
         public void KeyEquality_NewDimensions()
         {
             // Different SpanKind


### PR DESCRIPTION
## Summary of changes

Adds support for adding `DD_TAGS` as span-derived primary tags (AKA Additional tags) in Client Side Stats

## Reason for change

Implements [the RFC](https://datadoghq.atlassian.net/wiki/spaces/APM/pages/6607667207/PENDING+DD_TAGS+Derived+Primary+Tags) for adding `DD_TAGS` to the client-side stats payload.

## Implementation details

Relatively simple: we just thread any `DD_TAGS` value through to the payload, and the backend/agent then ensures they're added as span-derived primary tags. There's no cardinality issues at play here, which simplifies things, and we can just include them in every payload

## Test coverage

Added some unit tests, system tests to follow...

## Other details

Part of a stack

- https://github.com/DataDog/dd-trace-dotnet/pull/8822
- https://github.com/DataDog/dd-trace-dotnet/pull/8766
- https://github.com/DataDog/dd-trace-dotnet/pull/8823👈
- https://github.com/DataDog/dd-trace-dotnet/pull/8824

https://datadoghq.atlassian.net/browse/APMLP-1446