### PR TITLE
Remove sampling-based weighting in Client Side Stats

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -509,13 +509,6 @@ namespace Datadog.Trace.Agent
             return ns << shift;
         }
 
-        // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/weight.go
-        private static double GetWeight(Span span)
-        {
-            var rate = span.Context.TraceContext.AppliedSamplingRate;
-            return (rate is > 0) ? 1.0 / rate.Value : 1.0;
-        }
-
         private void AddToBuffer(Span span)
         {
             // Based on https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/span_concentrator.go#L210-L217
@@ -540,25 +533,22 @@ namespace Datadog.Trace.Agent
                 buffer.Buckets.Add(key, bucket);
             }
 
-            var weight = GetWeight(span);
-            bucket.Hits += weight;
+            bucket.Hits++;
 
             if (span.IsTopLevel)
             {
-                bucket.TopLevelHits += weight;
+                bucket.TopLevelHits++;
             }
 
             var duration = span.Duration.ToNanoseconds();
 
-            // Duration is weighted by sampling rate, matching the Go agent behavior:
-            // https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/statsraw.go
-            bucket.Duration += duration * weight;
+            bucket.Duration += duration;
 
             // If we are using OTLP, the errors are tracked as a separate aggregation entirely (different AggregationKey)
             // As a result, if using OTLP we always add to the OkSummary sketch.
             if (span.Error && !_isOtlp)
             {
-                bucket.Errors += weight;
+                bucket.Errors++;
                 bucket.ErrorSummary.Add(ConvertTimestamp(duration));
             }
             else

--- a/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
@@ -22,21 +22,17 @@ namespace Datadog.Trace.Agent
 
         public StatsAggregationKey Key { get; }
 
-        // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/weight.go
-        // Hits, Errors, and TopLevelHits are doubles to accumulate fractional sampling weights (1/rate)
-        public double Hits { get; set; }
+        public long Hits { get; set; }
 
-        public double Errors { get; set; }
+        public long Errors { get; set; }
 
-        // Duration is a double to accumulate fractional sampling weights (1/rate), like Hits/Errors/TopLevelHits.
-        // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/statsraw.go
-        public double Duration { get; set; }
+        public long Duration { get; set; }
 
         public DDSketch OkSummary { get; }
 
         public DDSketch ErrorSummary { get; }
 
-        public double TopLevelHits { get; set; }
+        public long TopLevelHits { get; set; }
 
         public List<byte[]> PeerTags { get; }
 

--- a/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBuffer.cs
@@ -166,17 +166,14 @@ namespace Datadog.Trace.Agent
             MessagePackBinary.WriteString(stream, "Type");
             MessagePackBinary.WriteString(stream, bucket.Key.Type);
 
-            // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/weight.go
-            // Hits, Errors, TopLevelHits are weighted by 1/sampling_rate.
-            // Use stochastic rounding to convert to int64 to prevent systematic bias.
             MessagePackBinary.WriteString(stream, "Hits");
-            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.Hits));
+            MessagePackBinary.WriteInt64(stream, bucket.Hits);
 
             MessagePackBinary.WriteString(stream, "Errors");
-            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.Errors));
+            MessagePackBinary.WriteInt64(stream, bucket.Errors);
 
             MessagePackBinary.WriteString(stream, "Duration");
-            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.Duration));
+            MessagePackBinary.WriteInt64(stream, bucket.Duration);
 
             MessagePackBinary.WriteString(stream, "OkSummary");
             SerializeSketch(stream, bucket.OkSummary);
@@ -185,7 +182,7 @@ namespace Datadog.Trace.Agent
             SerializeSketch(stream, bucket.ErrorSummary);
 
             MessagePackBinary.WriteString(stream, "TopLevelHits");
-            MessagePackBinary.WriteInt64(stream, StochasticRound(bucket.TopLevelHits));
+            MessagePackBinary.WriteInt64(stream, bucket.TopLevelHits);
 
             // Based on https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/aggregation.go
             MessagePackBinary.WriteString(stream, "SpanKind");
@@ -231,22 +228,6 @@ namespace Datadog.Trace.Agent
             stream.WriteByte((byte)size);
 
             sketch.Serialize(stream);
-        }
-
-        /// <summary>
-        /// Converts a floating-point value to long using stochastic rounding.
-        /// The fractional part is used as a probability of rounding up, preventing
-        /// systematic bias that occurs with simple truncation.
-        /// </summary>
-        private static long StochasticRound(double value)
-        {
-            var truncated = (long)value;
-            if (ThreadSafeRandom.Shared.NextDouble() < value - truncated)
-            {
-                return truncated + 1;
-            }
-
-            return truncated;
         }
 
         private void SerializeBuckets(Stream stream, long bucketDuration)

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1122,42 +1122,6 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public async Task SamplingWeightIsApplied()
-        {
-            var start = DateTimeOffset.UtcNow;
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Mock.Of<IDiscoveryService>(), isOtlp: false);
-
-            try
-            {
-                // Span with sampling rate 0.1 → weight = 1/0.1 = 10
-                // GetWeight uses TraceContext.AppliedSamplingRate
-                var sampledTraceContext = new TraceContext(new StubDatadogTracer());
-                sampledTraceContext.AppliedSamplingRate = 0.1f;
-                var sampledSpan = new Span(new SpanContext(null, sampledTraceContext, "svc"), start);
-                sampledSpan.OperationName = "op";
-                sampledSpan.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                // Span with no sampling rate → weight = 1.0
-                var unweightedSpan = CreateTopLevelSpan(start, "svc2");
-                unweightedSpan.OperationName = "op";
-                unweightedSpan.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                aggregator.Add(sampledSpan, unweightedSpan);
-
-                var buffer = aggregator.CurrentBuffer;
-                var sampledKey = aggregator.BuildKey(sampledSpan);
-                var unweightedKey = aggregator.BuildKey(unweightedSpan);
-
-                buffer.Buckets[sampledKey].Hits.Should().BeApproximately(10.0, 0.001);
-                buffer.Buckets[unweightedKey].Hits.Should().BeApproximately(1.0, 0.001);
-            }
-            finally
-            {
-                await aggregator.DisposeAsync();
-            }
-        }
-
-        [Fact]
         public async Task PeerTagsCreateDistinctBuckets()
         {
             var start = DateTimeOffset.UtcNow;
@@ -1341,7 +1305,7 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         /// <summary>
-        /// Creates a top-level span with a TraceContext (required by GetWeight).
+        /// Creates a top-level span with a TraceContext.
         /// </summary>
         private static Span CreateTopLevelSpan(DateTimeOffset start, string serviceName = null)
         {


### PR DESCRIPTION
## Summary of changes

Removes the incorrect sampling-based weighting from Client-Side stats

## Reason for change

When implementing the updated CSS implementation in #8420, we compared with the canonicial Go implementation, and [added a `GetWeight()`](https://github.com/DataDog/datadog-agent/blob/ce22e11ee71e55be717b9d9a3f8f3d7721a9c6d7/pkg/trace/stats/weight.go) method based on this. However, the sampling rate that this is based on is based on the deprecated `_sample_rate` tag (which .NET never implemented), _not_ the normal sampling rate. Therefore this weighting causes overcounting.

## Implementation details

- Rip out GetWeight() and associated usages
- Revert various doubles back to `long`s
- Remove the unnecessary stochastic rounding

## Test coverage

- Removed one test for `GetWeight()` behavior
- TBC a system test that would catch this - serverless e2e tests (thanks @apiarian-datadog!) caught this one