### PR TITLE
[ASP.NET] Handle PlatformNotSupportedException when injecting headers into the request

### DIFF
--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.AspNet
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TracingHttpModule));
 
         private static bool _canReadHttpResponseHeaders = true;
+        private static bool _canInjectContextIntoRequestHeaders = true;
 
         private readonly string _httpContextScopeKey;
         private readonly string _requestOperationName;
@@ -210,10 +211,21 @@ namespace Datadog.Trace.AspNet
                 // Decorate the incoming HTTP Request with distributed tracing headers
                 // in case the next processor cannot access the stored Scope
                 // (e.g. WCF being hosted in IIS)
-                if (HttpRuntime.UsingIntegratedPipeline)
+                if (HttpRuntime.UsingIntegratedPipeline && _canInjectContextIntoRequestHeaders)
                 {
-                    var injectedContext = new PropagationContext(scope.Span.Context, Baggage.Current);
-                    tracer.TracerManager.SpanContextPropagator.Inject(injectedContext, requestHeaders.Wrap());
+                    try
+                    {
+                        var injectedContext = new PropagationContext(scope.Span.Context, Baggage.Current);
+                        tracer.TracerManager.SpanContextPropagator.Inject(injectedContext, requestHeaders.Wrap());
+                    }
+                    catch (PlatformNotSupportedException ex)
+                    {
+                        // Despite the HttpRuntime.UsingIntegratedPipeline check, writing to the request headers
+                        // can still fail in some hosting configurations (e.g. Sitefinity): "This operation requires IIS integrated pipeline mode".
+                        // This must not abort the rest of the request instrumentation, so swallow it and disable for the rest of the application lifetime.
+                        Log.Error(ex, "Unable to inject distributed tracing headers into the request. Disabling for the rest of the application lifetime.");
+                        _canInjectContextIntoRequestHeaders = false;
+                    }
                 }
 
                 httpContext.Items[_httpContextScopeKey] = new ScopeContainer(scope, inferredProxyScope);

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -223,7 +223,8 @@ namespace Datadog.Trace.AspNet
                         // Despite the HttpRuntime.UsingIntegratedPipeline check, writing to the request headers
                         // can still fail in some hosting configurations (e.g. Sitefinity): "This operation requires IIS integrated pipeline mode".
                         // This must not abort the rest of the request instrumentation, so swallow it and disable for the rest of the application lifetime.
-                        Log.Error(ex, "Unable to inject distributed tracing headers into the request. Disabling for the rest of the application lifetime.");
+                        // This is an expected environmental limitation of the host, not a tracer bug, so skip telemetry.
+                        Log.ErrorSkipTelemetry(ex, "Unable to inject distributed tracing headers into the request. Disabling for the rest of the application lifetime.");
                         _canInjectContextIntoRequestHeaders = false;
                     }
                 }

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -37,8 +37,11 @@ namespace Datadog.Trace.AspNet
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TracingHttpModule));
 
-        private static bool _canReadHttpResponseHeaders = true;
-        private static bool _canInjectContextIntoRequestHeaders = true;
+        // Tracks whether we can access HTTP headers for the current request. Even when the pipeline reports
+        // as integrated (HttpRuntime.UsingIntegratedPipeline), the request may not be backed by a real
+        // IIS7WorkerRequest (e.g. Sitefinity's Project Manager mode), in which case reading response headers
+        // and writing request headers both throw PlatformNotSupportedException.
+        private static bool _canAccessHttpHeaders = true;
 
         private readonly string _httpContextScopeKey;
         private readonly string _requestOperationName;
@@ -100,7 +103,7 @@ namespace Datadog.Trace.AspNet
             if (!Tracer.Instance.CurrentTraceSettings.Settings.HeaderTags.IsNullOrEmpty() &&
                 httpContext != null &&
                 HttpRuntime.UsingIntegratedPipeline &&
-                _canReadHttpResponseHeaders)
+                _canAccessHttpHeaders)
             {
                 try
                 {
@@ -110,7 +113,7 @@ namespace Datadog.Trace.AspNet
                 {
                     // Despite the HttpRuntime.UsingIntegratedPipeline check, we can still fail to access response headers, for example when using Sitefinity: "This operation requires IIS integrated pipeline mode"
                     Log.Error(ex, "Unable to access response headers when creating header tags. Disabling for the rest of the application lifetime.");
-                    _canReadHttpResponseHeaders = false;
+                    _canAccessHttpHeaders = false;
                 }
                 catch (Exception ex)
                 {
@@ -211,7 +214,7 @@ namespace Datadog.Trace.AspNet
                 // Decorate the incoming HTTP Request with distributed tracing headers
                 // in case the next processor cannot access the stored Scope
                 // (e.g. WCF being hosted in IIS)
-                if (HttpRuntime.UsingIntegratedPipeline && _canInjectContextIntoRequestHeaders)
+                if (HttpRuntime.UsingIntegratedPipeline && _canAccessHttpHeaders)
                 {
                     try
                     {
@@ -225,7 +228,7 @@ namespace Datadog.Trace.AspNet
                         // This must not abort the rest of the request instrumentation, so swallow it and disable for the rest of the application lifetime.
                         // This is an expected environmental limitation of the host, not a tracer bug, so skip telemetry.
                         Log.ErrorSkipTelemetry(ex, "Unable to inject distributed tracing headers into the request. Disabling for the rest of the application lifetime.");
-                        _canInjectContextIntoRequestHeaders = false;
+                        _canAccessHttpHeaders = false;
                     }
                 }
 
@@ -322,7 +325,7 @@ namespace Datadog.Trace.AspNet
                             var args = securityCoordinator.GetBasicRequestArgsForWaf();
                             args.Add(AddressesConstants.RequestPathParams, securityCoordinator.GetPathParams());
 
-                            if (HttpRuntime.UsingIntegratedPipeline && _canReadHttpResponseHeaders)
+                            if (HttpRuntime.UsingIntegratedPipeline && _canAccessHttpHeaders)
                             {
                                 // path params here for webforms cause there's no other hookpoint for path params, but for mvc/webapi, there's better hookpoint which only gives route params (and not {controller} and {actions} ones) so don't take precedence
                                 try
@@ -333,7 +336,7 @@ namespace Datadog.Trace.AspNet
                                 {
                                     // Despite the HttpRuntime.UsingIntegratedPipeline check, we can still fail to access response headers, for example when using Sitefinity: "This operation requires IIS integrated pipeline mode"
                                     Log.Error(ex, "Unable to access response headers when creating header tags. Disabling for the rest of the application lifetime.");
-                                    _canReadHttpResponseHeaders = false;
+                                    _canAccessHttpHeaders = false;
                                 }
                                 catch (Exception ex)
                                 {
@@ -348,7 +351,7 @@ namespace Datadog.Trace.AspNet
 
                         if (Iast.Iast.Instance.Settings.Enabled && IastModule.AddRequestVulnerabilitiesAllowed())
                         {
-                            if (rootSpan is not null && HttpRuntime.UsingIntegratedPipeline && _canReadHttpResponseHeaders)
+                            if (rootSpan is not null && HttpRuntime.UsingIntegratedPipeline && _canAccessHttpHeaders)
                             {
                                 try
                                 {
@@ -366,7 +369,7 @@ namespace Datadog.Trace.AspNet
                                 {
                                     // Despite the HttpRuntime.UsingIntegratedPipeline check, we can still fail to access response headers, for example when using Sitefinity: "This operation requires IIS integrated pipeline mode"
                                     Log.Error(ex, "Unable to access response headers when analyzing headers. Disabling for the rest of the application lifetime.");
-                                    _canReadHttpResponseHeaders = false;
+                                    _canAccessHttpHeaders = false;
                                 }
                                 catch (Exception ex)
                                 {


### PR DESCRIPTION
## Summary of changes

Guard the distributed-tracing header injection into the incoming request in `TracingHttpModule.OnBeginRequest` against `PlatformNotSupportedException`.

[Error tracking](https://app.datadoghq.com/error-tracking/issue/a7062160-3ae0-11f0-8770-da7ad0900002).

## Reason for change

On .NET Framework ASP.NET, the module writes tracing headers back into the request header collection (so downstream processors like IIS-hosted WCF can read the context). In some hosting configurations (e.g. Sitefinity), `HttpHeaderCollection.Set` throws `PlatformNotSupportedException` ("This operation requires IIS integrated pipeline mode") even though `HttpRuntime.UsingIntegratedPipeline` reports `true`.

Because the injection ran before `shouldDisposeScope = false`, the exception bubbled to the outer catch, the scope was disposed, and the entire `aspnet.request` span was lost — and an error was logged/telemetered on every request.

## Implementation details

Wrap the injection in a targeted `try/catch` and add a static `_canInjectContextIntoRequestHeaders` flag, mirroring the existing `_canReadHttpResponseHeaders` pattern. On `PlatformNotSupportedException`, log once, disable injection for the rest of the application lifetime, and continue the request instrumentation so the span is still created. Other exceptions still propagate as before.

## Test coverage

## Other details
