### PR TITLE
[CI Visibility] Avoid oversized coverage IPC messages

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Coverage/Backfill/CoverageBackfillDataStore.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Backfill/CoverageBackfillDataStore.cs
@@ -600,6 +600,59 @@ internal static class CoverageBackfillDataStore
         => TryReadCoverageIpcResults(testOptimization, sessionId, waitForResultFolder: false, out results);
 
     /// <summary>
+    /// Reads one persisted coverage IPC result referenced by a short IPC notification.
+    /// </summary>
+    /// <param name="testOptimization">Current Test Optimization instance that owns the run id and workspace.</param>
+    /// <param name="sessionId">Parent test-session span id.</param>
+    /// <param name="source">Coverage source that produced the result.</param>
+    /// <param name="resultId">Stable result identity returned when the result was persisted.</param>
+    /// <param name="result">Coverage result recovered from the shared run folder.</param>
+    /// <returns>True when the referenced result was recovered and matched the requested source.</returns>
+    internal static bool TryReadCoverageIpcResult(ITestOptimization testOptimization, ulong sessionId, CodeCoverageReportSource source, string? resultId, out CodeCoverageAggregationResult result)
+    {
+        result = default;
+        if (StringUtil.IsNullOrEmpty(resultId))
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var runFolder in GetRunFolderCandidates(testOptimization))
+            {
+                var filePath = Path.Combine(GetIpcResultFolder(runFolder, sessionId), GetIpcResultFileName(source, resultId!));
+                if (!File.Exists(filePath) &&
+                    !HasTemporaryAtomicFileForFinalPath(filePath))
+                {
+                    continue;
+                }
+
+                if (!TryReadAllTextWithRetry(testOptimization, filePath, waitForFile: true, out var contents) ||
+                    !TryDeserializeCoverageIpcResult(testOptimization, contents, sessionId, out var persistedResult))
+                {
+                    return false;
+                }
+
+                if (persistedResult.Source != source ||
+                    !string.Equals(persistedResult.ResultId, resultId, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                result = persistedResult;
+                return true;
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            testOptimization.Log.Debug(ex, "CoverageBackfillDataStore: Error reading referenced coverage IPC result state.");
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Reads persisted coverage results from child coverage collectors, if any were written before IPC delivery.
     /// </summary>
     /// <param name="testOptimization">Current Test Optimization instance that owns the run id and workspace.</param>

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Backfill/CoverageBackfillDataStore.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Backfill/CoverageBackfillDataStore.cs
@@ -608,7 +608,7 @@ internal static class CoverageBackfillDataStore
     /// <param name="resultId">Stable result identity returned when the result was persisted.</param>
     /// <param name="result">Coverage result recovered from the shared run folder.</param>
     /// <returns>True when the referenced result was recovered and matched the requested source.</returns>
-    internal static bool TryReadCoverageIpcResult(ITestOptimization testOptimization, ulong sessionId, CodeCoverageReportSource source, string? resultId, out CodeCoverageAggregationResult result)
+    internal static bool TryReadCoverageIpcResult(ITestOptimization testOptimization, ulong sessionId, CodeCoverageReportSource source, string resultId, out CodeCoverageAggregationResult result)
     {
         result = default;
         if (StringUtil.IsNullOrEmpty(resultId))
@@ -618,9 +618,10 @@ internal static class CoverageBackfillDataStore
 
         try
         {
+            var fileName = GetIpcResultFileName(source, resultId);
             foreach (var runFolder in GetRunFolderCandidates(testOptimization))
             {
-                var filePath = Path.Combine(GetIpcResultFolder(runFolder, sessionId), GetIpcResultFileName(source, resultId!));
+                var filePath = Path.Combine(GetIpcResultFolder(runFolder, sessionId), fileName);
                 if (!File.Exists(filePath) &&
                     !HasTemporaryAtomicFileForFinalPath(filePath))
                 {

--- a/tracer/src/Datadog.Trace/Ci/Ipc/Messages/SessionCodeCoverageReferenceMessage.cs
+++ b/tracer/src/Datadog.Trace/Ci/Ipc/Messages/SessionCodeCoverageReferenceMessage.cs
@@ -1,0 +1,44 @@
+// <copyright file="SessionCodeCoverageReferenceMessage.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Ci.Ipc.Messages;
+
+internal sealed class SessionCodeCoverageReferenceMessage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionCodeCoverageReferenceMessage"/> class for IPC deserialization.
+    /// </summary>
+    public SessionCodeCoverageReferenceMessage()
+    {
+        ResultId = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionCodeCoverageReferenceMessage"/> class.
+    /// </summary>
+    /// <param name="source">Coverage source that produced the persisted result.</param>
+    /// <param name="resultId">Stable persisted coverage result identity.</param>
+    public SessionCodeCoverageReferenceMessage(CodeCoverageReportSource source, string resultId)
+    {
+        Source = source;
+        ResultId = resultId;
+    }
+
+    /// <summary>
+    /// Gets or sets the coverage source that produced the persisted result.
+    /// </summary>
+    [JsonProperty("source")]
+    public CodeCoverageReportSource Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the stable persisted coverage result identity.
+    /// </summary>
+    [JsonProperty("result_id")]
+    public string ResultId { get; set; }
+}

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -44,6 +44,10 @@ public sealed class TestSession
     private readonly CodeCoverageResultAggregator _codeCoverageResults = new();
     private readonly object _coverageResultIdsLock = new();
     private readonly HashSet<string> _coverageResultIds = new(StringComparer.Ordinal);
+    // Tracks referenced persisted coverage results that failed immediate IPC resolution. The close-time persisted
+    // fallback removes entries it later recovers so stale read failures do not suppress publishable coverage.
+    private readonly object _coverageIpcReferenceLock = new();
+    private HashSet<string>? _unresolvedCoverageIpcReferences;
     private IpcServer? _ipcServer;
     private int _closing;
     private int _finished;
@@ -694,6 +698,7 @@ public sealed class TestSession
         foreach (var result in results)
         {
             RecordCodeCoverageResult(result);
+            RecordResolvedCoverageIpcReference(result.Source, result.ResultId);
             recorded = true;
         }
 
@@ -709,10 +714,44 @@ public sealed class TestSession
 
     private bool CanPublishAfterCoverageIpcReferenceReadFailure()
     {
+        // A reference can fail before the producer finishes flushing the persisted result, then be recovered by the
+        // close-time persisted fallback. Only fail closed while a referenced result is still unresolved.
+        if (!HasUnresolvedCoverageIpcReferences())
+        {
+            return true;
+        }
+
         // A missing referenced IPC result means a selected coverage-tool result could not be loaded.
         // Keep fail-closed behavior for tool sources, but do not drop an already selected external XML report.
         return _codeCoverageResults.HasBestPublishableResult(CodeCoverageReportSource.ExternalXml);
     }
+
+    private void RecordUnresolvedCoverageIpcReference(CodeCoverageReportSource source, string? resultId)
+    {
+        lock (_coverageIpcReferenceLock)
+        {
+            (_unresolvedCoverageIpcReferences ??= new HashSet<string>(StringComparer.Ordinal)).Add(GetCoverageIpcReferenceKey(source, resultId));
+        }
+    }
+
+    private void RecordResolvedCoverageIpcReference(CodeCoverageReportSource source, string? resultId)
+    {
+        lock (_coverageIpcReferenceLock)
+        {
+            _unresolvedCoverageIpcReferences?.Remove(GetCoverageIpcReferenceKey(source, resultId));
+        }
+    }
+
+    private bool HasUnresolvedCoverageIpcReferences()
+    {
+        lock (_coverageIpcReferenceLock)
+        {
+            return _unresolvedCoverageIpcReferences?.Count > 0;
+        }
+    }
+
+    private string GetCoverageIpcReferenceKey(CodeCoverageReportSource source, string? resultId)
+        => $"{source}:{resultId}";
 
     private void OnIpcMessageReceived(object message)
     {
@@ -759,10 +798,12 @@ public sealed class TestSession
                         codeCoverageReferenceMessage.ResultId,
                         out var codeCoverageResult))
                 {
+                    RecordResolvedCoverageIpcReference(codeCoverageReferenceMessage.Source, codeCoverageReferenceMessage.ResultId);
                     RecordCodeCoverageResult(codeCoverageResult);
                 }
                 else
                 {
+                    RecordUnresolvedCoverageIpcReference(codeCoverageReferenceMessage.Source, codeCoverageReferenceMessage.ResultId);
                     Interlocked.Exchange(ref _coverageIpcReferenceReadFailed, 1);
                     _testOptimization.Log.Warning<CodeCoverageReportSource>(
                         "TestSession.ReceiveMessage: Could not resolve persisted code coverage IPC result. Source={Source}",

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -59,6 +59,8 @@ public sealed class TestSession
     /// </summary>
     private int _coverageIpcMessageCount;
 
+    private int _coverageIpcReferenceReadFailed;
+
     private long _lastIpcMessageTicks;
 
     /// <summary>
@@ -647,6 +649,13 @@ public sealed class TestSession
     /// </summary>
     internal void PublishCodeCoverage()
     {
+        if (Volatile.Read(ref _coverageIpcReferenceReadFailed) == 1 &&
+            !CanPublishAfterCoverageIpcReferenceReadFailure())
+        {
+            _testOptimization.Log.Debug("TestSession.PublishCodeCoverage: skipped because a referenced coverage IPC result could not be read.");
+            return;
+        }
+
         if (!_codeCoverageResults.TryGetBestResult(out var result))
         {
             return;
@@ -698,6 +707,13 @@ public sealed class TestSession
         return _codeCoverageResults.HasBestPublishableResult(CodeCoverageReportSource.ExternalXml);
     }
 
+    private bool CanPublishAfterCoverageIpcReferenceReadFailure()
+    {
+        // A missing referenced IPC result means a selected coverage-tool result could not be loaded.
+        // Keep fail-closed behavior for tool sources, but do not drop an already selected external XML report.
+        return _codeCoverageResults.HasBestPublishableResult(CodeCoverageReportSource.ExternalXml);
+    }
+
     private void OnIpcMessageReceived(object message)
     {
         _testOptimization.Log.Debug("TestSession.OnIpcMessageReceived: {Message}", message);
@@ -726,6 +742,32 @@ public sealed class TestSession
                 {
                     _testOptimization.Log.Information("TestSession.ReceiveMessage (metric): {Name}={Value}", tagMessage.Name, tagMessage.NumberValue);
                     SetTag(tagMessage.Name, tagMessage.NumberValue);
+                }
+            }
+            else if (message is SessionCodeCoverageReferenceMessage codeCoverageReferenceMessage)
+            {
+                Interlocked.Increment(ref _coverageIpcMessageCount);
+                Interlocked.Exchange(ref _lastCoverageIpcMessageTicks, DateTime.UtcNow.Ticks);
+                _testOptimization.Log.Information<CodeCoverageReportSource>(
+                    "TestSession.ReceiveMessage (code coverage reference): Source={Source}",
+                    codeCoverageReferenceMessage.Source);
+
+                if (CoverageBackfillDataStore.TryReadCoverageIpcResult(
+                        _testOptimization,
+                        Tags.SessionId,
+                        codeCoverageReferenceMessage.Source,
+                        codeCoverageReferenceMessage.ResultId,
+                        out var codeCoverageResult))
+                {
+                    RecordCodeCoverageResult(codeCoverageResult);
+                }
+                else
+                {
+                    Interlocked.Exchange(ref _coverageIpcReferenceReadFailed, 1);
+                    _testOptimization.Log.Warning<CodeCoverageReportSource>(
+                        "TestSession.ReceiveMessage: Could not resolve persisted code coverage IPC result. Source={Source}",
+                        codeCoverageReferenceMessage.Source);
+                    CoverageBackfillDataStore.RecordCoverageIpcFailure(_testOptimization, Tags.SessionId, codeCoverageReferenceMessage.Source.ToString());
                 }
             }
             else if (message is SessionCodeCoverageMessage { Value: >= 0.0 } codeCoverageMessage)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/CoverageGetCoverageResultIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/CoverageGetCoverageResultIntegration.cs
@@ -133,22 +133,27 @@ public sealed class CoverageGetCoverageResultIntegration
                         Common.Log.Debug("DataCollector.Enabling IPC client: {Name}", name);
                         using var ipcClient = new IpcClient(name);
                         Common.Log.Debug("DataCollector.Sending session code coverage: {Value}", percentage);
-                        if (!ipcClient.TrySendMessage(
-                                new SessionCodeCoverageMessage(
-                                    CodeCoverageReportSource.Coverlet,
-                                    percentage,
-                                    backfilled,
-                                    coverageDetails.Total,
-                                    coverageDetails.Covered,
-                                    resultId: coverageResultId,
-                                    backfillValidated: backfillValidated,
-                                    backfillNotApplicable: backfillNotApplicable,
-                                    backfillValidation: backfillValidation)))
-                        {
-                            Common.Log.Warning("CoverageGetCoverageResultIntegration: Could not send Coverlet code coverage IPC message.");
-                            TelemetryFactory.Metrics.RecordCountCIVisibilityCodeCoverageErrors();
-                            CoverageBackfillDataStore.RecordCoverageIpcFailure(sessionSpanId, nameof(CodeCoverageReportSource.Coverlet));
-                        }
+                        var sessionCodeCoverageMessage = DotnetCommon.CreateSessionCodeCoverageIpcMessage(
+                            CodeCoverageReportSource.Coverlet,
+                            percentage,
+                            backfilled,
+                            coverageDetails.Total,
+                            coverageDetails.Covered,
+                            diagnostic: null,
+                            inlineResultId: coverageResultId,
+                            persistedResultId: coverageResultId,
+                            backfillValidated: backfillValidated,
+                            backfillNotApplicable: backfillNotApplicable,
+                            backfillValidation: backfillValidation);
+                        DotnetCommon.TrySendSessionCodeCoverageIpcMessage(
+                            ipcClient,
+                            sessionCodeCoverageMessage,
+                            () =>
+                            {
+                                Common.Log.Warning("CoverageGetCoverageResultIntegration: Could not send Coverlet code coverage IPC message.");
+                                TelemetryFactory.Metrics.RecordCountCIVisibilityCodeCoverageErrors();
+                                CoverageBackfillDataStore.RecordCoverageIpcFailure(sessionSpanId, nameof(CodeCoverageReportSource.Coverlet));
+                            });
                     }
                     catch (Exception ex)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
@@ -1033,7 +1033,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
             var supersededResultIds = coverageReports.Count > 1 ?
                                           coverageReports.Select(coverageReport => GetCoverletXmlFallbackResultId(sessionSpanId, coverageReport)).ToArray() :
                                           null;
-            _ = CoverageBackfillDataStore.RecordCoverageIpcResult(
+            var coverageResultId = CoverageBackfillDataStore.RecordCoverageIpcResult(
                 TestOptimization.Instance,
                 sessionSpanId,
                 CodeCoverageReportSource.CoverletXmlFallback,
@@ -1052,27 +1052,103 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
                 Log.Debug("CoverletXmlFallback.Enabling IPC client: {Name}", name);
                 using var ipcClient = new IpcClient(name);
                 Log.Debug("CoverletXmlFallback.Sending session code coverage: {Value}", coverageResult.Percentage);
-                if (!ipcClient.TrySendMessage(
-                        new SessionCodeCoverageMessage(
-                            CodeCoverageReportSource.CoverletXmlFallback,
-                            coverageResult.Percentage,
-                            coverageResult.Backfilled,
-                            coverageResult.ExecutableLines,
-                            coverageResult.CoveredLines,
-                            coverageResult.Diagnostic,
-                            stableCoverageResultId,
-                            backfillValidated,
-                            supersededResultIds: supersededResultIds)))
-                {
-                    Log.Warning("RunCiCommand: Could not send Coverlet XML fallback code coverage IPC message.");
-                    RecordCoverletXmlFallbackIpcFailure(sessionSpanId);
-                }
+                var sessionCodeCoverageMessage = CreateSessionCodeCoverageIpcMessage(
+                    CodeCoverageReportSource.CoverletXmlFallback,
+                    coverageResult.Percentage,
+                    coverageResult.Backfilled,
+                    coverageResult.ExecutableLines,
+                    coverageResult.CoveredLines,
+                    coverageResult.Diagnostic,
+                    inlineResultId: stableCoverageResultId,
+                    persistedResultId: coverageResultId,
+                    backfillValidated: backfillValidated,
+                    supersededResultIds: supersededResultIds);
+                TrySendSessionCodeCoverageIpcMessage(
+                    ipcClient,
+                    sessionCodeCoverageMessage,
+                    () =>
+                    {
+                        Log.Warning("RunCiCommand: Could not send Coverlet XML fallback code coverage IPC message.");
+                        RecordCoverletXmlFallbackIpcFailure(sessionSpanId);
+                    });
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "RunCiCommand: Error enabling IPC client and sending Coverlet XML fallback coverage data.");
                 RecordCoverletXmlFallbackIpcFailure(sessionSpanId);
             }
+        }
+
+        /// <summary>
+        /// Creates the coverage IPC notification sent by child coverage producers.
+        /// </summary>
+        /// <param name="source">Coverage source that produced the result.</param>
+        /// <param name="percentage">Line coverage percentage reported by the source.</param>
+        /// <param name="backfilled">Whether backend ITR coverage backfill was used.</param>
+        /// <param name="executableLines">Executable-line count, when available.</param>
+        /// <param name="coveredLines">Covered-line count, when available.</param>
+        /// <param name="diagnostic">Compact diagnostic text, when available.</param>
+        /// <param name="inlineResultId">Result id to preserve when falling back to a slim inline message.</param>
+        /// <param name="persistedResultId">Result id returned by persisted storage, or null when persistence failed.</param>
+        /// <param name="backfillValidated">Whether backend ITR coverage was reconciled without unsafe path ambiguity.</param>
+        /// <param name="backfillNotApplicable">Whether backend ITR coverage was evaluated and did not apply.</param>
+        /// <param name="backfillValidation">Backend ITR coverage validation data that requires persisted storage.</param>
+        /// <param name="supersededResultIds">Stable identities of partial producer results represented by this merged result.</param>
+        /// <returns>A small reference IPC message when persistence succeeded, a slim inline coverage message when safe, or null when delivery must fail closed.</returns>
+        internal static object? CreateSessionCodeCoverageIpcMessage(
+            CodeCoverageReportSource source,
+            double percentage,
+            bool backfilled,
+            double? executableLines,
+            double? coveredLines,
+            string? diagnostic,
+            string? inlineResultId,
+            string? persistedResultId,
+            bool backfillValidated = false,
+            bool backfillNotApplicable = false,
+            CodeCoverageBackfillValidation? backfillValidation = null,
+            string[]? supersededResultIds = null)
+        {
+            if (persistedResultId is not null)
+            {
+                return new SessionCodeCoverageReferenceMessage(source, persistedResultId);
+            }
+
+            if (backfillValidation is not null ||
+                supersededResultIds is { Length: > 0 })
+            {
+                return null;
+            }
+
+            return new SessionCodeCoverageMessage(
+                source,
+                percentage,
+                backfilled,
+                executableLines,
+                coveredLines,
+                diagnostic,
+                inlineResultId,
+                backfillValidated,
+                backfillNotApplicable);
+        }
+
+        /// <summary>
+        /// Sends a coverage IPC notification, or records the producer failure when no safe IPC message exists.
+        /// </summary>
+        /// <param name="ipcClient">IPC client connected to the parent test session.</param>
+        /// <param name="message">Coverage IPC message to send, or null when the producer must fail closed.</param>
+        /// <param name="recordFailure">Failure callback that records telemetry and a coverage IPC failure marker.</param>
+        /// <returns>True when a message was sent successfully.</returns>
+        internal static bool TrySendSessionCodeCoverageIpcMessage(IpcClient ipcClient, object? message, Action recordFailure)
+        {
+            if (message is not null &&
+                ipcClient.TrySendMessage(message))
+            {
+                return true;
+            }
+
+            recordFailure();
+            return false;
         }
 
         private static void RecordCoverletXmlFallbackIpcFailure(ulong sessionSpanId)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/ManagedVanguardStopIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/ManagedVanguardStopIntegration.cs
@@ -215,20 +215,24 @@ public sealed class ManagedVanguardStopIntegration
             Common.Log.Debug("DataCollector.Enabling IPC client: {Name}", name);
             using var ipcClient = new IpcClient(name);
             Common.Log.Debug("DataCollector.Sending session code coverage: {Value}", coverageResult.Percentage);
-            if (!ipcClient.TrySendMessage(
-                    new SessionCodeCoverageMessage(
-                        CodeCoverageReportSource.MicrosoftCodeCoverage,
-                        coverageResult.Percentage,
-                        coverageResult.Backfilled,
-                        coverageResult.ExecutableLines,
-                        coverageResult.CoveredLines,
-                        coverageResult.Diagnostic,
-                        coverageResultId,
-                        backfillValidated)))
-            {
-                Common.Log.Warning("ManagedVanguardStopIntegration: Could not send Microsoft CodeCoverage IPC message.");
-                RecordMicrosoftCoverageIpcFailure(sessionSpanId);
-            }
+            var sessionCodeCoverageMessage = DotnetCommon.CreateSessionCodeCoverageIpcMessage(
+                CodeCoverageReportSource.MicrosoftCodeCoverage,
+                coverageResult.Percentage,
+                coverageResult.Backfilled,
+                coverageResult.ExecutableLines,
+                coverageResult.CoveredLines,
+                coverageResult.Diagnostic,
+                inlineResultId: stableResultId,
+                persistedResultId: coverageResultId,
+                backfillValidated: backfillValidated);
+            DotnetCommon.TrySendSessionCodeCoverageIpcMessage(
+                ipcClient,
+                sessionCodeCoverageMessage,
+                () =>
+                {
+                    Common.Log.Warning("ManagedVanguardStopIntegration: Could not send Microsoft CodeCoverage IPC message.");
+                    RecordMicrosoftCoverageIpcFailure(sessionSpanId);
+                });
         }
         catch (Exception ex)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/SeleniumTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/SeleniumTests.cs
@@ -78,7 +78,7 @@ public class SeleniumTests : TestingFrameworkEvpTest
         ipcServer.SetMessageReceivedCallback(
             o =>
             {
-                codeCoverageReceived.Value = codeCoverageReceived.Value || o is SessionCodeCoverageMessage;
+                codeCoverageReceived.Value = codeCoverageReceived.Value || o is SessionCodeCoverageMessage or SessionCodeCoverageReferenceMessage;
             });
 
         using var agent = MockTracerAgent.Create(Output);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -1274,6 +1274,8 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 
         if (message is SessionCodeCoverageReferenceMessage referenceMessage)
         {
+            // Reference messages are the production path for persisted coverage payloads. Resolve the
+            // exact source/result id so the test exercises the same handoff as TestSession.
             if (CoverageBackfillDataStore.TryReadCoverageIpcResult(testOptimization, sessionId, referenceMessage.Source, referenceMessage.ResultId, out result))
             {
                 return true;
@@ -1287,6 +1289,10 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 
     private static ITestOptimization CreateCoverageIpcTestOptimization(string runId)
     {
+        // InjectSession gives the sample process a run id and .dd folder through child-process
+        // environment variables. The IPC callback runs in this test process, so use an explicit
+        // TestOptimization context instead of relying on TestOptimization.Instance or mutating
+        // process-wide environment variables shared by parallel integration tests.
         var testOptimization = new Mock<ITestOptimization>();
         testOptimization.Setup(x => x.RunId).Returns(runId);
         testOptimization.Setup(x => x.CIValues).Returns(new CoverageIpcTestEnvironmentValues(System.Environment.CurrentDirectory));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -8,6 +8,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Datadog.Trace.Ci;
+using Datadog.Trace.Ci.CiEnvironment;
 using Datadog.Trace.Ci.Coverage;
 using Datadog.Trace.Ci.Coverage.Backfill;
 using Datadog.Trace.Ci.Ipc;
@@ -15,12 +17,14 @@ using Datadog.Trace.Ci.Ipc.Messages;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.Ci;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using FluentAssertions;
+using Moq;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -789,12 +793,13 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         Output.WriteLine("RunId: {0}", runId);
         SetEnvironmentVariable(ConfigurationKeys.CIVisibility.TestSessionCommand, sessionCommand);
 
+        var coverageIpcTestOptimization = CreateCoverageIpcTestOptimization(runId);
         var ipcServerName = $"session_{sessionId}";
         using var ipcServer = new IpcServer(ipcServerName);
         ipcServer.SetMessageReceivedCallback(
             message =>
             {
-                if (TryResolveCoverageIpcMessage(sessionId, message, out var coverageResult, out var unresolvedReference))
+                if (TryResolveCoverageIpcMessage(coverageIpcTestOptimization, sessionId, message, out var coverageResult, out var unresolvedReference))
                 {
                     lock (coverageResults)
                     {
@@ -994,12 +999,13 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         Output.WriteLine("CoverageBackfillMatrixCase: {0}", matrixCase);
         SetEnvironmentVariable(ConfigurationKeys.CIVisibility.TestSessionCommand, sessionCommand);
 
+        var coverageIpcTestOptimization = CreateCoverageIpcTestOptimization(runId);
         var ipcServerName = $"session_{sessionId}";
         using var ipcServer = new IpcServer(ipcServerName);
         ipcServer.SetMessageReceivedCallback(
             message =>
             {
-                if (TryResolveCoverageIpcMessage(sessionId, message, out var coverageResult, out var unresolvedReference))
+                if (TryResolveCoverageIpcMessage(coverageIpcTestOptimization, sessionId, message, out var coverageResult, out var unresolvedReference))
                 {
                     lock (coverageResults)
                     {
@@ -1244,7 +1250,7 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
            .ConfigureAwait(false);
     }
 
-    private static bool TryResolveCoverageIpcMessage(ulong sessionId, object message, out CodeCoverageAggregationResult result, out string unresolvedReference)
+    private static bool TryResolveCoverageIpcMessage(ITestOptimization testOptimization, ulong sessionId, object message, out CodeCoverageAggregationResult result, out string unresolvedReference)
     {
         result = default;
         unresolvedReference = null;
@@ -1268,23 +1274,24 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 
         if (message is SessionCodeCoverageReferenceMessage referenceMessage)
         {
-            if (CoverageBackfillDataStore.TryReadCoverageIpcResults(sessionId, out var persistedResults))
+            if (CoverageBackfillDataStore.TryReadCoverageIpcResult(testOptimization, sessionId, referenceMessage.Source, referenceMessage.ResultId, out result))
             {
-                foreach (var persistedResult in persistedResults)
-                {
-                    if (persistedResult.Source == referenceMessage.Source &&
-                        string.Equals(persistedResult.ResultId, referenceMessage.ResultId, System.StringComparison.Ordinal))
-                    {
-                        result = persistedResult;
-                        return true;
-                    }
-                }
+                return true;
             }
 
             unresolvedReference = $"{referenceMessage.Source}:{referenceMessage.ResultId}";
         }
 
         return false;
+    }
+
+    private static ITestOptimization CreateCoverageIpcTestOptimization(string runId)
+    {
+        var testOptimization = new Mock<ITestOptimization>();
+        testOptimization.Setup(x => x.RunId).Returns(runId);
+        testOptimization.Setup(x => x.CIValues).Returns(new CoverageIpcTestEnvironmentValues(System.Environment.CurrentDirectory));
+        testOptimization.Setup(x => x.Log).Returns(DatadogLogging.GetLoggerFor(typeof(XUnitEvpTests)));
+        return testOptimization.Object;
     }
 
     private static bool ShouldSkipSimplePassTest(string matrixCase)
@@ -1408,4 +1415,16 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 
     private static bool HasCorrectCompressionTag(string[] tags, bool isGzipped)
         => isGzipped ? tags.Contains("rq_compressed:true") : !tags.Contains("rq_compressed:true");
+
+    private sealed class CoverageIpcTestEnvironmentValues : CIEnvironmentValues
+    {
+        public CoverageIpcTestEnvironmentValues(string workspacePath)
+        {
+            WorkspacePath = workspacePath;
+        }
+
+        protected override void Setup(IGitInfo gitInfo)
+        {
+        }
+    }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Ci.Coverage.Backfill;
 using Datadog.Trace.Ci.Ipc;
 using Datadog.Trace.Ci.Ipc.Messages;
 using Datadog.Trace.Ci.Tags;
@@ -453,7 +454,7 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         ipcServer.SetMessageReceivedCallback(
             o =>
             {
-                codeCoverageReceived.Value = codeCoverageReceived.Value || o is SessionCodeCoverageMessage;
+                codeCoverageReceived.Value = codeCoverageReceived.Value || o is SessionCodeCoverageMessage or SessionCodeCoverageReferenceMessage;
             });
 
         string[] messages = null;
@@ -770,7 +771,8 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
             "Coverlet collector writes a Cobertura attachment on Linux under auto instrumentation but does not invoke the in-process callback validated by this IPC smoke test.");
 
         var tests = new List<MockCIVisibilityTest>();
-        var coverageMessages = new List<SessionCodeCoverageMessage>();
+        var coverageResults = new List<CodeCoverageAggregationResult>();
+        var unresolvedCoverageReferences = new List<string>();
         var evpRequests = new List<string>();
         var skippableRequestBodies = new List<string>();
 
@@ -792,11 +794,18 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         ipcServer.SetMessageReceivedCallback(
             message =>
             {
-                if (message is SessionCodeCoverageMessage coverageMessage)
+                if (TryResolveCoverageIpcMessage(sessionId, message, out var coverageResult, out var unresolvedReference))
                 {
-                    lock (coverageMessages)
+                    lock (coverageResults)
                     {
-                        coverageMessages.Add(coverageMessage);
+                        coverageResults.Add(coverageResult);
+                    }
+                }
+                else if (unresolvedReference is not null)
+                {
+                    lock (unresolvedCoverageReferences)
+                    {
+                        unresolvedCoverageReferences.Add(unresolvedReference);
                     }
                 }
             });
@@ -920,21 +929,29 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         skippedTest.Meta[TestTags.SkipReason].Should().Be(IntelligentTestRunnerTags.SkippedByReason);
         skippedTest.CorrelationId.Should().Be(correlationId);
 
-        SessionCodeCoverageMessage[] receivedCoverageMessages;
-        lock (coverageMessages)
+        string[] receivedUnresolvedCoverageReferences;
+        lock (unresolvedCoverageReferences)
         {
-            receivedCoverageMessages = coverageMessages.ToArray();
+            receivedUnresolvedCoverageReferences = unresolvedCoverageReferences.ToArray();
+        }
+
+        receivedUnresolvedCoverageReferences.Should().BeEmpty();
+
+        CodeCoverageAggregationResult[] receivedCoverageResults;
+        lock (coverageResults)
+        {
+            receivedCoverageResults = coverageResults.ToArray();
         }
 
         // This target uses an injected out-of-process session, so the testhost proves coverage backfill through the IPC message consumed by the parent session.
-        var coverageMessage = receivedCoverageMessages.Should().ContainSingle().Subject;
-        coverageMessage.Source.Should().Be(CodeCoverageReportSource.Coverlet);
-        coverageMessage.Backfilled.Should().BeTrue();
-        coverageMessage.ExecutableLines.Should().HaveValue();
-        coverageMessage.CoveredLines.Should().HaveValue();
+        var coverageResult = receivedCoverageResults.Should().ContainSingle().Subject;
+        coverageResult.Source.Should().Be(CodeCoverageReportSource.Coverlet);
+        coverageResult.Backfilled.Should().BeTrue();
+        coverageResult.ExecutableLines.Should().HaveValue();
+        coverageResult.CoveredLines.Should().HaveValue();
 
-        var executableLines = coverageMessage.ExecutableLines.GetValueOrDefault();
-        var coveredLines = coverageMessage.CoveredLines.GetValueOrDefault();
+        var executableLines = coverageResult.ExecutableLines.GetValueOrDefault();
+        var coveredLines = coverageResult.CoveredLines.GetValueOrDefault();
         var coveredLinesWithoutBackfill = coveredLines - SimplePassTestBackfilledLineCount;
         var rawBackfilledPercentage = coveredLines / executableLines * 100;
         var rawPercentageWithoutBackfill = coveredLinesWithoutBackfill / executableLines * 100;
@@ -944,8 +961,8 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 
         executableLines.Should().BeGreaterThan(0);
         coveredLinesWithoutBackfill.Should().BeGreaterThanOrEqualTo(0);
-        coverageMessage.Value.Should().BeApproximately(expectedBackfilledPercentage, 0.0001);
-        coverageMessage.Value.Should().BeGreaterThan(expectedPercentageWithoutBackfill);
+        coverageResult.Percentage.Should().BeApproximately(expectedBackfilledPercentage, 0.0001);
+        coverageResult.Percentage.Should().BeGreaterThan(expectedPercentageWithoutBackfill);
     }
 
     /// <summary>
@@ -958,7 +975,8 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
     public virtual async Task ItrCoverageBackfillSkippableDecisionMatrixMatchesJavaBehavior(string packageVersion, string evpVersionToRemove, bool expectedGzip, string matrixCase)
     {
         var tests = new List<MockCIVisibilityTest>();
-        var coverageMessages = new List<SessionCodeCoverageMessage>();
+        var coverageResults = new List<CodeCoverageAggregationResult>();
+        var unresolvedCoverageReferences = new List<string>();
         var evpRequests = new List<string>();
         var skippableRequestBodies = new List<string>();
 
@@ -981,11 +999,18 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
         ipcServer.SetMessageReceivedCallback(
             message =>
             {
-                if (message is SessionCodeCoverageMessage coverageMessage)
+                if (TryResolveCoverageIpcMessage(sessionId, message, out var coverageResult, out var unresolvedReference))
                 {
-                    lock (coverageMessages)
+                    lock (coverageResults)
                     {
-                        coverageMessages.Add(coverageMessage);
+                        coverageResults.Add(coverageResult);
+                    }
+                }
+                else if (unresolvedReference is not null)
+                {
+                    lock (unresolvedCoverageReferences)
+                    {
+                        unresolvedCoverageReferences.Add(unresolvedReference);
                     }
                 }
             });
@@ -1092,13 +1117,21 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 
         if (ShouldAssertNoBackfilledCoverageMessages(matrixCase))
         {
-            SessionCodeCoverageMessage[] receivedCoverageMessages;
-            lock (coverageMessages)
+            string[] receivedUnresolvedCoverageReferences;
+            lock (unresolvedCoverageReferences)
             {
-                receivedCoverageMessages = coverageMessages.ToArray();
+                receivedUnresolvedCoverageReferences = unresolvedCoverageReferences.ToArray();
             }
 
-            receivedCoverageMessages.Should().NotContain(message => message.Backfilled);
+            receivedUnresolvedCoverageReferences.Should().BeEmpty();
+
+            CodeCoverageAggregationResult[] receivedCoverageResults;
+            lock (coverageResults)
+            {
+                receivedCoverageResults = coverageResults.ToArray();
+            }
+
+            receivedCoverageResults.Should().NotContain(result => result.Backfilled);
         }
     }
 
@@ -1209,6 +1242,49 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
                     },
                     useDotnetExec: false))
            .ConfigureAwait(false);
+    }
+
+    private static bool TryResolveCoverageIpcMessage(ulong sessionId, object message, out CodeCoverageAggregationResult result, out string unresolvedReference)
+    {
+        result = default;
+        unresolvedReference = null;
+
+        if (message is SessionCodeCoverageMessage coverageMessage)
+        {
+            result = new CodeCoverageAggregationResult(
+                coverageMessage.Source,
+                coverageMessage.Value,
+                coverageMessage.Backfilled,
+                coverageMessage.ExecutableLines,
+                coverageMessage.CoveredLines,
+                coverageMessage.Diagnostic,
+                coverageMessage.ResultId,
+                coverageMessage.BackfillValidated,
+                coverageMessage.BackfillNotApplicable,
+                coverageMessage.BackfillValidation,
+                coverageMessage.SupersededResultIds);
+            return true;
+        }
+
+        if (message is SessionCodeCoverageReferenceMessage referenceMessage)
+        {
+            if (CoverageBackfillDataStore.TryReadCoverageIpcResults(sessionId, out var persistedResults))
+            {
+                foreach (var persistedResult in persistedResults)
+                {
+                    if (persistedResult.Source == referenceMessage.Source &&
+                        string.Equals(persistedResult.ResultId, referenceMessage.ResultId, System.StringComparison.Ordinal))
+                    {
+                        result = persistedResult;
+                        return true;
+                    }
+                }
+            }
+
+            unresolvedReference = $"{referenceMessage.Source}:{referenceMessage.ResultId}";
+        }
+
+        return false;
     }
 
     private static bool ShouldSkipSimplePassTest(string matrixCase)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
@@ -301,7 +301,7 @@ public class XUnitEvpTestsV3 : TestingFrameworkEvpTest
         ipcServer.SetMessageReceivedCallback(
             o =>
             {
-                codeCoverageReceived.Value = codeCoverageReceived.Value || o is SessionCodeCoverageMessage;
+                codeCoverageReceived.Value = codeCoverageReceived.Value || o is SessionCodeCoverageMessage or SessionCodeCoverageReferenceMessage;
             });
 
         string[] messages = null;

--- a/tracer/test/Datadog.Trace.Tests/Ci/CoverageBackfillDataStoreTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/CoverageBackfillDataStoreTests.cs
@@ -1250,6 +1250,189 @@ public class CoverageBackfillDataStoreTests
     }
 
     [Fact]
+    public void TryReadCoverageIpcResultReadsFullBackfillMetadata()
+    {
+        var workspacePath = CreateWorkspacePath();
+        try
+        {
+            var testOptimization = CreateTestOptimization(workspacePath);
+            var backfillValidation = CodeCoverageBackfillValidation.Create(
+                requiredBackendFilesWithCoverage: 1,
+                expectedCoveredLinesByBackendPath: new Dictionary<string, int>
+                {
+                    ["src/Calculator.cs"] = 2
+                },
+                representedBackendLinesByBackendPath: new Dictionary<string, HashSet<int>>
+                {
+                    ["src/Calculator.cs"] = [10, 11]
+                },
+                localCandidateByBackendPath: new Dictionary<string, string>
+                {
+                    ["src/Calculator.cs"] = "/repo/src/Calculator.cs"
+                },
+                requiredBackendPathsWithCoverage: ["src/Calculator.cs"],
+                requiredBackendLinesByBackendPath: new Dictionary<string, HashSet<int>>
+                {
+                    ["src/Calculator.cs"] = [10, 11]
+                });
+
+            var resultId = CoverageBackfillDataStore.RecordCoverageIpcResult(
+                testOptimization.Object,
+                sessionId: 123,
+                CodeCoverageReportSource.CoverletXmlFallback,
+                percentage: 75,
+                backfilled: true,
+                executableLines: 4,
+                coveredLines: 3,
+                diagnostic: "persisted-reference",
+                resultId: "merged-result",
+                backfillValidated: true,
+                backfillValidation: backfillValidation,
+                supersededResultIds: ["partial-a", "partial-b"]);
+
+            resultId.Should().Be("merged-result");
+
+            CoverageBackfillDataStore.TryReadCoverageIpcResult(
+                testOptimization.Object,
+                sessionId: 123,
+                CodeCoverageReportSource.CoverletXmlFallback,
+                resultId,
+                out var result).Should().BeTrue();
+
+            result.Source.Should().Be(CodeCoverageReportSource.CoverletXmlFallback);
+            result.ResultId.Should().Be("merged-result");
+            result.Percentage.Should().Be(75);
+            result.Backfilled.Should().BeTrue();
+            result.ExecutableLines.Should().Be(4);
+            result.CoveredLines.Should().Be(3);
+            result.Diagnostic.Should().Be("persisted-reference");
+            result.BackfillValidated.Should().BeTrue();
+            result.BackfillValidation.Should().NotBeNull();
+            result.BackfillValidation.CanPublish().Should().BeTrue();
+            result.BackfillValidation.LocalCandidateByBackendPath.Should().Contain("src/Calculator.cs", "/repo/src/Calculator.cs");
+            result.SupersededResultIds.Should().Equal("partial-a", "partial-b");
+        }
+        finally
+        {
+            DeleteWorkspacePath(workspacePath);
+        }
+    }
+
+    [Theory]
+    [InlineData(456, nameof(CodeCoverageReportSource.CoverletXmlFallback), "merged-result")]
+    [InlineData(123, nameof(CodeCoverageReportSource.Coverlet), "merged-result")]
+    [InlineData(123, nameof(CodeCoverageReportSource.CoverletXmlFallback), "missing-result")]
+    [InlineData(123, nameof(CodeCoverageReportSource.CoverletXmlFallback), "")]
+    [InlineData(123, nameof(CodeCoverageReportSource.CoverletXmlFallback), null)]
+    public void TryReadCoverageIpcResultRejectsWrongReference(ulong sessionId, string sourceName, string resultId)
+    {
+        var workspacePath = CreateWorkspacePath();
+        try
+        {
+            var testOptimization = CreateTestOptimization(workspacePath);
+            CoverageBackfillDataStore.RecordCoverageIpcResult(
+                testOptimization.Object,
+                sessionId: 123,
+                CodeCoverageReportSource.CoverletXmlFallback,
+                percentage: 75,
+                backfilled: true,
+                executableLines: 4,
+                coveredLines: 3,
+                diagnostic: "persisted-reference",
+                resultId: "merged-result");
+
+            var source = (CodeCoverageReportSource)Enum.Parse(typeof(CodeCoverageReportSource), sourceName);
+            CoverageBackfillDataStore.TryReadCoverageIpcResult(
+                testOptimization.Object,
+                sessionId,
+                source,
+                resultId,
+                out var result).Should().BeFalse();
+
+            result.Should().Be(default(CodeCoverageAggregationResult));
+        }
+        finally
+        {
+            DeleteWorkspacePath(workspacePath);
+        }
+    }
+
+    [Fact]
+    public void TryReadCoverageIpcResultRejectsInvalidJson()
+    {
+        var workspacePath = CreateWorkspacePath();
+        try
+        {
+            var testOptimization = CreateTestOptimization(workspacePath);
+            CoverageBackfillDataStore.RecordCoverageIpcResult(
+                testOptimization.Object,
+                sessionId: 123,
+                CodeCoverageReportSource.Coverlet,
+                percentage: 75,
+                backfilled: true,
+                executableLines: 4,
+                coveredLines: 3,
+                diagnostic: "persisted-reference",
+                resultId: "merged-result");
+            var resultFolder = GetIpcResultFolder(workspacePath, sessionId: 123);
+            var resultFile = Directory.GetFiles(resultFolder, "*.json", SearchOption.TopDirectoryOnly).Should().ContainSingle().Subject;
+            File.WriteAllText(resultFile, "{ invalid json");
+
+            CoverageBackfillDataStore.TryReadCoverageIpcResult(
+                testOptimization.Object,
+                sessionId: 123,
+                CodeCoverageReportSource.Coverlet,
+                "merged-result",
+                out var result).Should().BeFalse();
+
+            result.Should().Be(default(CodeCoverageAggregationResult));
+        }
+        finally
+        {
+            DeleteWorkspacePath(workspacePath);
+        }
+    }
+
+    [Theory]
+    [InlineData(nameof(CodeCoverageReportSource.MicrosoftCodeCoverage), "merged-result")]
+    [InlineData(nameof(CodeCoverageReportSource.Coverlet), "other-result")]
+    public void TryReadCoverageIpcResultRejectsTamperedResultPayload(string embeddedSourceName, string embeddedResultId)
+    {
+        var workspacePath = CreateWorkspacePath();
+        try
+        {
+            var testOptimization = CreateTestOptimization(workspacePath);
+            CoverageBackfillDataStore.RecordCoverageIpcResult(
+                testOptimization.Object,
+                sessionId: 123,
+                CodeCoverageReportSource.Coverlet,
+                percentage: 75,
+                backfilled: true,
+                executableLines: 4,
+                coveredLines: 3,
+                diagnostic: "persisted-reference",
+                resultId: "merged-result");
+            var resultFolder = GetIpcResultFolder(workspacePath, sessionId: 123);
+            var resultFile = Directory.GetFiles(resultFolder, "*.json", SearchOption.TopDirectoryOnly).Should().ContainSingle().Subject;
+            var embeddedSource = (CodeCoverageReportSource)Enum.Parse(typeof(CodeCoverageReportSource), embeddedSourceName);
+            File.WriteAllText(resultFile, CreateCoverageIpcResultJson(embeddedResultId, embeddedSource, 75, true, 4, 3, "tampered"));
+
+            CoverageBackfillDataStore.TryReadCoverageIpcResult(
+                testOptimization.Object,
+                sessionId: 123,
+                CodeCoverageReportSource.Coverlet,
+                "merged-result",
+                out var result).Should().BeFalse();
+
+            result.Should().Be(default(CodeCoverageAggregationResult));
+        }
+        finally
+        {
+            DeleteWorkspacePath(workspacePath);
+        }
+    }
+
+    [Fact]
     public void StableCoverageIpcResultIdIsEncodedForFileNameOnly()
     {
         var workspacePath = CreateWorkspacePath();

--- a/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
@@ -5,6 +5,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci.Coverage;
@@ -124,6 +125,103 @@ public class IpcTests
         receivedCoverageMessage.BackfillValidation!.CanPublish().Should().BeTrue();
         receivedCoverageMessage.BackfillValidation.LocalCandidateByBackendPath.Should().Contain("src/Calculator.cs", "/repo/src/Calculator.cs");
         receivedCoverageMessage.SupersededResultIds.Should().Equal("partial-a", "partial-b");
+    }
+
+    [Fact]
+    public async Task IpcClientCanSendCoverageResultReferenceMessage()
+    {
+        var name = nameof(IpcClientCanSendCoverageResultReferenceMessage) + "-" + Guid.NewGuid().ToString("n");
+        using var server = new IpcServer(name);
+        using var client = new IpcClient(name);
+        var receivedMessage = new TaskCompletionSource<SessionCodeCoverageReferenceMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        server.SetMessageReceivedCallback(
+            message =>
+            {
+                if (message is SessionCodeCoverageReferenceMessage referenceMessage)
+                {
+                    receivedMessage.TrySetResult(referenceMessage);
+                }
+            });
+
+        client.TrySendMessage(
+            new SessionCodeCoverageReferenceMessage(
+                CodeCoverageReportSource.Coverlet,
+                "result-123")).Should().BeTrue();
+
+        var completedTask = await Task.WhenAny(receivedMessage.Task, Task.Delay(30_000));
+        completedTask.Should().Be(receivedMessage.Task);
+        var receivedReferenceMessage = await receivedMessage.Task;
+        receivedReferenceMessage.Source.Should().Be(CodeCoverageReportSource.Coverlet);
+        receivedReferenceMessage.ResultId.Should().Be("result-123");
+    }
+
+    [Fact]
+    public async Task IpcClientCanSendCoverageResultReferenceWithOversizedPersistedBackfillValidation()
+    {
+        var name = nameof(IpcClientCanSendCoverageResultReferenceWithOversizedPersistedBackfillValidation) + "-" + Guid.NewGuid().ToString("n");
+        using var server = new IpcServer(name);
+        using var client = new IpcClient(name);
+        var receivedMessage = new TaskCompletionSource<SessionCodeCoverageReferenceMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var largeBackfillValidation = CreateLargeBackfillValidation(fileCount: 200);
+
+        server.SetMessageReceivedCallback(
+            message =>
+            {
+                if (message is SessionCodeCoverageReferenceMessage referenceMessage)
+                {
+                    receivedMessage.TrySetResult(referenceMessage);
+                }
+            });
+
+        var inlineMessageWasTooLarge = client.TrySendMessage(
+            new SessionCodeCoverageMessage(
+                CodeCoverageReportSource.Coverlet,
+                value: 100,
+                backfilled: true,
+                executableLines: 100,
+                coveredLines: 100,
+                resultId: "large-result",
+                backfillValidation: largeBackfillValidation));
+        inlineMessageWasTooLarge.Should().BeFalse("this reproduces the old oversized IPC payload shape");
+
+        client.TrySendMessage(
+            new SessionCodeCoverageReferenceMessage(
+                CodeCoverageReportSource.Coverlet,
+                "large-result")).Should().BeTrue();
+
+        var completedTask = await Task.WhenAny(receivedMessage.Task, Task.Delay(30_000));
+        completedTask.Should().Be(receivedMessage.Task);
+        var receivedReferenceMessage = await receivedMessage.Task;
+        receivedReferenceMessage.Source.Should().Be(CodeCoverageReportSource.Coverlet);
+        receivedReferenceMessage.ResultId.Should().Be("large-result");
+    }
+
+    private static CodeCoverageBackfillValidation CreateLargeBackfillValidation(int fileCount)
+    {
+        var expectedLines = new Dictionary<string, int>(StringComparer.Ordinal);
+        var representedLines = new Dictionary<string, HashSet<int>>(StringComparer.Ordinal);
+        var localCandidates = new Dictionary<string, string>(StringComparer.Ordinal);
+        var requiredPaths = new List<string>();
+        var requiredLines = new Dictionary<string, HashSet<int>>(StringComparer.Ordinal);
+
+        for (var i = 0; i < fileCount; i++)
+        {
+            var backendPath = $"src/components/component-{i:D4}/subsystem/VeryLongFileNameForCoverageBackfillValidation{i:D4}.cs";
+            expectedLines[backendPath] = 25;
+            representedLines[backendPath] = Enumerable.Range(1, 25).ToHashSet();
+            localCandidates[backendPath] = $"/workspace/customer/repository/{backendPath}";
+            requiredPaths.Add(backendPath);
+            requiredLines[backendPath] = Enumerable.Range(1, 25).ToHashSet();
+        }
+
+        return CodeCoverageBackfillValidation.Create(
+            fileCount,
+            expectedLines,
+            representedLines,
+            localCandidates,
+            requiredPaths,
+            requiredLines);
     }
 
     private class TestMessage(int serverValue, int clientValue)

--- a/tracer/test/Datadog.Trace.Tests/Ci/ManagedVanguardStopIntegrationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/ManagedVanguardStopIntegrationTests.cs
@@ -11,6 +11,7 @@ using System.IO;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Coverage;
 using Datadog.Trace.Ci.Coverage.Backfill;
+using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
@@ -83,6 +84,62 @@ public class ManagedVanguardStopIntegrationTests
             result.Percentage.Should().Be(100);
             result.Backfilled.Should().BeTrue();
             result.BackfillValidated.Should().BeTrue();
+        }
+        finally
+        {
+            try
+            {
+                session?.Close(TestStatus.Pass);
+                TestOptimization.Instance.Close();
+                TestOptimization.Instance.Reset();
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(previousCurrentDirectory);
+                DeleteWorkspacePath(workspacePath);
+            }
+        }
+    }
+
+    [Fact]
+    public void SendsReferenceCoverageIpcMessageAndSessionPublishesPersistedMicrosoftCoverage()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-vanguard-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workspacePath);
+        var reportPath = Path.Combine(workspacePath, "coverage.xml");
+        var previousCurrentDirectory = Environment.CurrentDirectory;
+        TestSession? session = null;
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspacePath);
+            TestOptimization.Instance.Reset();
+            Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, Path.Combine(Environment.CurrentDirectory, ".dd", TestOptimization.Instance.RunId));
+            const string CoverageXml =
+                """
+                <report>
+                  <file path="src/Calculator.cs">
+                    <line number="1" hits="0" />
+                  </file>
+                </report>
+                """;
+            File.WriteAllText(reportPath, CoverageXml);
+            CoverageBackfillDataStore.Persist(TestOptimization.Instance, CoverageBackfillData.FromBackendCoverage(new Dictionary<string, string> { ["src/Calculator.cs"] = Convert.ToBase64String([0b_1000_0000]) }));
+            session = TestSession.GetOrCreate("dotnet test", workingDirectory: workspacePath, framework: null, startDate: null, propagateEnvironmentVariables: true);
+            session.EnableIpcServer().Should().BeTrue();
+            CoverageBackfillDataStore.RecordActualItrSkip(session.Tags.SessionId);
+            var proxy = new ManagedVanguardProxy([reportPath]);
+
+            ManagedVanguardStopIntegration.OnMethodEnd(proxy, exception: null, default(CallTargetState));
+
+            CoverageBackfillDataStore.TryReadCoverageIpcResults(session.Tags.SessionId, out var persistedResults).Should().BeTrue();
+            persistedResults.Should().ContainSingle().Which.Source.Should().Be(CodeCoverageReportSource.MicrosoftCodeCoverage);
+            session.DrainIpcMessages(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(50), waitForFirstMessage: true);
+            session.PublishCodeCoverage();
+
+            session.Tags.GetMetric(CodeCoverageTags.PercentageOfTotalLines).Should().Be(100);
+            session.Tags.GetTag(CodeCoverageTags.Backfilled).Should().Be("true");
+            CoverageBackfillDataStore.TryReadCoverageIpcFailure(session.Tags.SessionId, out _).Should().BeFalse();
         }
         finally
         {

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestSessionCoverageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestSessionCoverageTests.cs
@@ -292,6 +292,169 @@ public class TestSessionCoverageTests
     }
 
     [Fact]
+    public void IpcCoverageReferenceLoadsFullPersistedResultMetadata()
+    {
+        var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, runFolder);
+        var session = CreateSession();
+        try
+        {
+            CoverageBackfillDataStore.RecordCoverageIpcResult(
+                TestOptimization.Instance,
+                session.Tags.SessionId,
+                CodeCoverageReportSource.Coverlet,
+                percentage: 80,
+                backfilled: true,
+                executableLines: 10,
+                coveredLines: 8,
+                diagnostic: "persisted-reference",
+                resultId: "coverlet-reference",
+                backfillValidated: true,
+                backfillValidation: CreateSimpleBackfillValidation());
+
+            InvokeIpcMessageReceived(
+                session,
+                new SessionCodeCoverageReferenceMessage(
+                    CodeCoverageReportSource.Coverlet,
+                    "coverlet-reference"));
+
+            session.SuppressUnvalidatedCodeCoverageResult(CodeCoverageReportSource.Coverlet);
+            session.PublishCodeCoverage();
+
+            session.Tags.GetMetric(CodeCoverageTags.PercentageOfTotalLines).Should().Be(80);
+            session.Tags.GetTag(CodeCoverageTags.Backfilled).Should().Be("true");
+        }
+        finally
+        {
+            CloseAndReset(session);
+            if (Directory.Exists(runFolder))
+            {
+                Directory.Delete(runFolder, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void IpcCoverageReferenceLoadsSupersededResultIds()
+    {
+        var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, runFolder);
+        var session = CreateSession();
+        try
+        {
+            session.RecordCodeCoverage(CodeCoverageReportSource.Coverlet, 0, backfilled: false, executableLines: 1, coveredLines: 0);
+            session.RecordCodeCoverage(CodeCoverageReportSource.CoverletXmlFallback, 0, backfilled: true, executableLines: 2, coveredLines: 0, resultId: "fallback-a");
+            CoverageBackfillDataStore.RecordCoverageIpcResult(
+                TestOptimization.Instance,
+                session.Tags.SessionId,
+                CodeCoverageReportSource.CoverletXmlFallback,
+                percentage: 50,
+                backfilled: true,
+                executableLines: 2,
+                coveredLines: 1,
+                resultId: "fallback-group",
+                supersededResultIds: ["fallback-a", "fallback-b"]);
+
+            InvokeIpcMessageReceived(
+                session,
+                new SessionCodeCoverageReferenceMessage(
+                    CodeCoverageReportSource.CoverletXmlFallback,
+                    "fallback-group"));
+            session.RecordCodeCoverage(CodeCoverageReportSource.CoverletXmlFallback, 100, backfilled: true, executableLines: 2, coveredLines: 2, resultId: "fallback-b");
+            session.PublishCodeCoverage();
+
+            session.Tags.GetMetric(CodeCoverageTags.PercentageOfTotalLines).Should().Be(50);
+            session.Tags.GetTag(CodeCoverageTags.Backfilled).Should().Be("true");
+        }
+        finally
+        {
+            CloseAndReset(session);
+            if (Directory.Exists(runFolder))
+            {
+                Directory.Delete(runFolder, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void IpcCoverageReferenceMissingResultFailsClosed()
+    {
+        var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, runFolder);
+        var session = CreateSession();
+        try
+        {
+            session.RecordCodeCoverage(
+                CodeCoverageReportSource.Coverlet,
+                10,
+                backfilled: false,
+                executableLines: 10,
+                coveredLines: 1,
+                diagnostic: "stale-prior-coverage");
+
+            InvokeIpcMessageReceived(
+                session,
+                new SessionCodeCoverageReferenceMessage(
+                    CodeCoverageReportSource.Coverlet,
+                    "missing-result"));
+
+            session.PublishCodeCoverage();
+
+            session.Tags.GetMetric(CodeCoverageTags.PercentageOfTotalLines).Should().BeNull();
+            session.Tags.GetTag(CodeCoverageTags.Backfilled).Should().BeNull();
+            CoverageBackfillDataStore.TryReadCoverageIpcFailure(session.Tags.SessionId, out var reason).Should().BeTrue();
+            reason.Should().Contain(nameof(CodeCoverageReportSource.Coverlet));
+        }
+        finally
+        {
+            CloseAndReset(session);
+            if (Directory.Exists(runFolder))
+            {
+                Directory.Delete(runFolder, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void IpcCoverageReferenceMissingResultDoesNotBlockExternalXmlCoverage()
+    {
+        var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, runFolder);
+        var session = CreateSession();
+        try
+        {
+            session.RecordCodeCoverage(
+                CodeCoverageReportSource.ExternalXml,
+                90,
+                backfilled: false,
+                executableLines: 10,
+                coveredLines: 9,
+                diagnostic: "external-xml");
+
+            InvokeIpcMessageReceived(
+                session,
+                new SessionCodeCoverageReferenceMessage(
+                    CodeCoverageReportSource.Coverlet,
+                    "missing-result"));
+
+            session.PublishCodeCoverage();
+
+            session.Tags.GetMetric(CodeCoverageTags.PercentageOfTotalLines).Should().Be(90);
+            session.Tags.GetTag(CodeCoverageTags.Backfilled).Should().BeNull();
+            CoverageBackfillDataStore.TryReadCoverageIpcFailure(session.Tags.SessionId, out var reason).Should().BeTrue();
+            reason.Should().Contain(nameof(CodeCoverageReportSource.Coverlet));
+        }
+        finally
+        {
+            CloseAndReset(session);
+            if (Directory.Exists(runFolder))
+            {
+                Directory.Delete(runFolder, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void SuppressUnvalidatedCodeCoverageKeepsValidatedCoverletResult()
     {
         var session = CreateSession();
@@ -2706,6 +2869,50 @@ public class TestSessionCoverageTests
     }
 
     [Fact]
+    public void CloseProcessesCoverageReferenceDeliveredThroughRealIpc()
+    {
+        var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, runFolder);
+        var session = CreateSession();
+        IpcClient? client = null;
+        try
+        {
+            session.EnableIpcServer().Should().BeTrue();
+            client = new IpcClient($"session_{session.Tags.SessionId}");
+            CoverageBackfillDataStore.RecordCoverageIpcResult(
+                TestOptimization.Instance,
+                session.Tags.SessionId,
+                CodeCoverageReportSource.Coverlet,
+                percentage: 80,
+                backfilled: true,
+                executableLines: 10,
+                coveredLines: 8,
+                diagnostic: "real-ipc-reference",
+                resultId: "coverlet-reference");
+
+            SendIpcMessage(
+                client,
+                new SessionCodeCoverageReferenceMessage(
+                    CodeCoverageReportSource.Coverlet,
+                    "coverlet-reference"));
+            session.DrainIpcMessages(TimeSpan.FromMilliseconds(250), TimeSpan.FromMilliseconds(50), waitForFirstMessage: true);
+            session.Close(TestStatus.Pass);
+
+            session.Tags.GetMetric(CodeCoverageTags.PercentageOfTotalLines).Should().Be(80);
+            session.Tags.GetTag(CodeCoverageTags.Backfilled).Should().Be("true");
+        }
+        finally
+        {
+            client?.Dispose();
+            CloseAndReset(session);
+            if (Directory.Exists(runFolder))
+            {
+                Directory.Delete(runFolder, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void CloseWaitsForCoverageIpcWhenLowerPriorityCoverageAlreadyExists()
     {
         Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibility.TestSessionCommand, "dotnet test --collect \"XPlat Code Coverage\"");
@@ -3031,6 +3238,148 @@ public class TestSessionCoverageTests
         DotnetCommon.IsVSTestArtifactsPostprocessCommand(commandLine).Should().BeFalse();
     }
 
+    [Fact]
+    public void CreateSessionCodeCoverageIpcMessageUsesReferenceWhenPersistenceSucceeded()
+    {
+        var message = DotnetCommon.CreateSessionCodeCoverageIpcMessage(
+            CodeCoverageReportSource.Coverlet,
+            percentage: 80,
+            backfilled: true,
+            executableLines: 10,
+            coveredLines: 8,
+            diagnostic: "persisted",
+            inlineResultId: "inline-id",
+            persistedResultId: "persisted-id",
+            backfillValidated: true,
+            backfillNotApplicable: false,
+            backfillValidation: CreateSimpleBackfillValidation(),
+            supersededResultIds: ["partial-a"]);
+
+        var referenceMessage = message.Should().BeOfType<SessionCodeCoverageReferenceMessage>().Subject;
+        referenceMessage.Source.Should().Be(CodeCoverageReportSource.Coverlet);
+        referenceMessage.ResultId.Should().Be("persisted-id");
+    }
+
+    [Fact]
+    public void CreateSessionCodeCoverageIpcMessageUsesSlimInlineCoverageWhenPersistenceFailed()
+    {
+        var message = DotnetCommon.CreateSessionCodeCoverageIpcMessage(
+            CodeCoverageReportSource.CoverletXmlFallback,
+            percentage: 75,
+            backfilled: true,
+            executableLines: 4,
+            coveredLines: 3,
+            diagnostic: "inline-fallback",
+            inlineResultId: "stable-inline-id",
+            persistedResultId: null,
+            backfillValidated: true,
+            backfillNotApplicable: false,
+            backfillValidation: null,
+            supersededResultIds: null);
+
+        var inlineMessage = message.Should().BeOfType<SessionCodeCoverageMessage>().Subject;
+        inlineMessage.Source.Should().Be(CodeCoverageReportSource.CoverletXmlFallback);
+        inlineMessage.Value.Should().Be(75);
+        inlineMessage.Backfilled.Should().BeTrue();
+        inlineMessage.ExecutableLines.Should().Be(4);
+        inlineMessage.CoveredLines.Should().Be(3);
+        inlineMessage.Diagnostic.Should().Be("inline-fallback");
+        inlineMessage.ResultId.Should().Be("stable-inline-id");
+        inlineMessage.BackfillValidated.Should().BeTrue();
+        inlineMessage.BackfillValidation.Should().BeNull();
+        inlineMessage.SupersededResultIds.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateSessionCodeCoverageIpcMessageTreatsEmptySupersededResultIdsAsSlimInlineSafe()
+    {
+        var message = DotnetCommon.CreateSessionCodeCoverageIpcMessage(
+            CodeCoverageReportSource.CoverletXmlFallback,
+            percentage: 75,
+            backfilled: true,
+            executableLines: 4,
+            coveredLines: 3,
+            diagnostic: "inline-fallback",
+            inlineResultId: "stable-inline-id",
+            persistedResultId: null,
+            backfillValidated: true,
+            backfillNotApplicable: false,
+            backfillValidation: null,
+            supersededResultIds: []);
+
+        var inlineMessage = message.Should().BeOfType<SessionCodeCoverageMessage>().Subject;
+        inlineMessage.Source.Should().Be(CodeCoverageReportSource.CoverletXmlFallback);
+        inlineMessage.ResultId.Should().Be("stable-inline-id");
+        inlineMessage.BackfillValidation.Should().BeNull();
+        inlineMessage.SupersededResultIds.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void CreateSessionCodeCoverageIpcMessageFailsClosedWhenPersistenceFailsForMetadataDependentResult(bool hasBackfillValidation, bool hasSupersededResultIds)
+    {
+        var message = DotnetCommon.CreateSessionCodeCoverageIpcMessage(
+            CodeCoverageReportSource.CoverletXmlFallback,
+            percentage: 75,
+            backfilled: true,
+            executableLines: 4,
+            coveredLines: 3,
+            diagnostic: "metadata-dependent",
+            inlineResultId: "stable-inline-id",
+            persistedResultId: null,
+            backfillValidated: true,
+            backfillNotApplicable: false,
+            backfillValidation: hasBackfillValidation ? CreateSimpleBackfillValidation() : null,
+            supersededResultIds: hasSupersededResultIds ? ["partial-a", "partial-b"] : null);
+
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void TrySendSessionCodeCoverageIpcMessageRecordsFailureWhenMessageFactoryFailsClosed()
+    {
+        var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, runFolder);
+        var session = CreateSession();
+        IpcClient? client = null;
+        try
+        {
+            client = new IpcClient($"session_{session.Tags.SessionId}");
+            var message = DotnetCommon.CreateSessionCodeCoverageIpcMessage(
+                CodeCoverageReportSource.CoverletXmlFallback,
+                percentage: 75,
+                backfilled: true,
+                executableLines: 4,
+                coveredLines: 3,
+                diagnostic: "metadata-dependent",
+                inlineResultId: "stable-inline-id",
+                persistedResultId: null,
+                backfillValidated: true,
+                backfillNotApplicable: false,
+                backfillValidation: CreateSimpleBackfillValidation());
+
+            message.Should().BeNull();
+            DotnetCommon.TrySendSessionCodeCoverageIpcMessage(
+                client,
+                message,
+                () => CoverageBackfillDataStore.RecordCoverageIpcFailure(session.Tags.SessionId, nameof(CodeCoverageReportSource.CoverletXmlFallback))).Should().BeFalse();
+
+            CoverageBackfillDataStore.TryReadCoverageIpcFailure(session.Tags.SessionId, out var reason).Should().BeTrue();
+            reason.Should().Contain(nameof(CodeCoverageReportSource.CoverletXmlFallback));
+        }
+        finally
+        {
+            client?.Dispose();
+            CloseAndReset(session);
+            if (Directory.Exists(runFolder))
+            {
+                Directory.Delete(runFolder, recursive: true);
+            }
+        }
+    }
+
     private static TestSession CreateSession(bool propagateEnvironmentVariables = false, string? workingDirectory = null, string command = "dotnet test")
     {
         TestOptimization.Instance.Reset();
@@ -3083,6 +3432,15 @@ public class TestSessionCoverageTests
 
         return CoverageBackfillData.FromBackendCoverage(coverage);
     }
+
+    private static CodeCoverageBackfillValidation CreateSimpleBackfillValidation()
+        => CodeCoverageBackfillValidation.Create(
+            requiredBackendFilesWithCoverage: 1,
+            expectedCoveredLinesByBackendPath: new Dictionary<string, int> { ["src/Calculator.cs"] = 1 },
+            representedBackendLinesByBackendPath: new Dictionary<string, HashSet<int>> { ["src/Calculator.cs"] = [1] },
+            localCandidateByBackendPath: new Dictionary<string, string> { ["src/Calculator.cs"] = "/repo/src/Calculator.cs" },
+            requiredBackendPathsWithCoverage: ["src/Calculator.cs"],
+            requiredBackendLinesByBackendPath: new Dictionary<string, HashSet<int>> { ["src/Calculator.cs"] = [1] });
 
     private static void SetPrivateField(TestSession session, string fieldName, int value)
     {

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestSessionCoverageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestSessionCoverageTests.cs
@@ -416,6 +416,47 @@ public class TestSessionCoverageTests
     }
 
     [Fact]
+    public void IpcCoverageReferenceRecoveredByPersistedFallbackPublishesCoverage()
+    {
+        var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");
+        Environment.SetEnvironmentVariable(ConfigurationKeys.CIVisibilityItrCoverageBackfillRunFolder, runFolder);
+        var session = CreateSession();
+        try
+        {
+            InvokeIpcMessageReceived(
+                session,
+                new SessionCodeCoverageReferenceMessage(
+                    CodeCoverageReportSource.Coverlet,
+                    "late-coverlet-result"));
+
+            CoverageBackfillDataStore.RecordCoverageIpcResult(
+                TestOptimization.Instance,
+                session.Tags.SessionId,
+                CodeCoverageReportSource.Coverlet,
+                percentage: 80,
+                backfilled: true,
+                executableLines: 10,
+                coveredLines: 8,
+                diagnostic: "late-coverlet-result",
+                resultId: "late-coverlet-result");
+
+            session.RecordPersistedCoverageIpcResults().Should().BeTrue();
+            session.PublishCodeCoverage();
+
+            session.Tags.GetMetric(CodeCoverageTags.PercentageOfTotalLines).Should().Be(80);
+            session.Tags.GetTag(CodeCoverageTags.Backfilled).Should().Be("true");
+        }
+        finally
+        {
+            CloseAndReset(session);
+            if (Directory.Exists(runFolder))
+            {
+                Directory.Delete(runFolder, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void IpcCoverageReferenceMissingResultDoesNotBlockExternalXmlCoverage()
     {
         var runFolder = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-coverage-ipc-{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary of changes

- Send CI coverage IPC notifications as small persisted-result references instead of inline coverage payloads when persistence succeeds.
- Add `SessionCodeCoverageReferenceMessage` and a single-result lookup path in `CoverageBackfillDataStore`.
- Resolve referenced coverage results in the parent `TestSession`, preserving fail-closed behavior only while referenced tool coverage remains unresolved.
- Update Coverlet, Coverlet XML fallback, and Microsoft CodeCoverage producers to use reference messages, with slim inline fallback only when metadata-heavy fields are not required.
- Update unit and integration tests to cover reference IPC round trips, oversized persisted metadata, missing references, close-time fallback recovery, slim inline fallback, producer/session behavior, and XUnit EVP reference resolution.

## Reason for change

`SessionCodeCoverageMessage` can include backfill validation dictionaries and superseded result ids. On large codebases, the serialized payload can exceed the `CircularChannel` body limit and trigger `CircularChannel.Writer: Message size exceeds maximum allowed size.` ([Example](https://app.datadoghq.com/error-tracking/issue/90a7630c-6fff-11f1-8f09-da7ad0900002), [Case](https://app.datadoghq.com/cases/DOTNET-27))

The full coverage payload is already persisted for the parent session fallback path, so the IPC channel only needs to notify the parent session which persisted result to load.

## Implementation details

- `CoverageBackfillDataStore.TryReadCoverageIpcResult(...)` reads one persisted result by session id, source, and result id, and rejects mismatched or invalid payloads.
- `TestSession` handles `SessionCodeCoverageReferenceMessage`, records the resolved result through the existing arbitration path, and records an IPC failure marker if the reference cannot be resolved.
- `TestSession` tracks unresolved coverage references by source and result id, so close-time persisted fallback recovery can clear a previously failed immediate reference read before publishing coverage.
- `DotnetCommon.CreateSessionCodeCoverageIpcMessage(...)` centralizes producer behavior:
  - persisted result available: send a reference message;
  - persistence failed and the result has no heavy metadata: send a slim inline message;
  - persistence failed and the result depends on backfill validation or superseded ids: fail closed and record IPC failure.
- Integration tests that previously treated only `SessionCodeCoverageMessage` as coverage IPC now also accept reference messages and resolve persisted results before asserting coverage values.
- XUnit EVP integration tests resolve reference messages with the injected sample run id and workspace, so the IPC callback reads the same persisted Coverlet result that production `TestSession` would load instead of using the integration-test process run context.

## Test coverage

- `git diff --check`
- `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj --configuration Release --framework net8.0 --filter "FullyQualifiedName~TestSessionCoverageTests.IpcCoverageReference"`
  - Passed: 5/5
- `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj --configuration Release --framework net8.0 --filter "FullyQualifiedName~CoverageBackfillDataStoreTests.TryReadCoverageIpcResult|FullyQualifiedName~IpcTests.IpcClientCanSendCoverageResultReference|FullyQualifiedName~TestSessionCoverageTests.IpcCoverageReference|FullyQualifiedName~TestSessionCoverageTests.CloseProcessesCoverageReferenceDeliveredThroughRealIpc|FullyQualifiedName~TestSessionCoverageTests.CreateSessionCodeCoverageIpcMessage|FullyQualifiedName~TestSessionCoverageTests.TrySendSessionCodeCoverageIpcMessageRecordsFailureWhenMessageFactoryFailsClosed|FullyQualifiedName~ManagedVanguardStopIntegrationTests.SendsReferenceCoverageIpcMessageAndSessionPublishesPersistedMicrosoftCoverage"`
  - Passed: 36/36
- `dotnet build tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj --configuration Release --framework net8.0`
  - Passed: 0 warnings, 0 errors
- Azure consolidated pipeline build 204276:
  - `integration_tests_linux`: passed
  - `integration_tests_arm64`: passed

## Other details

I also attempted `dotnet test tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj --configuration Release --framework net8.0 --no-build --filter "FullyQualifiedName~Datadog.Trace.ClrProfiler.IntegrationTests.CI.TcpXUnitEvpTests.ItrCoverageBackfillSkippableDecisionMatrixMatchesJavaBehavior"` locally. On macOS arm64 it failed before reaching the coverage-reference assertions because the sample produced no EVP requests, so the Linux CI matrix is the representative validation for this path.
<!-- Fixes #{issue} -->
