### PR TITLE
Update `TruncateUTF8` to never split a code point and improve perf

### DIFF
--- a/tracer/src/Datadog.Trace/Processors/TraceUtil.cs
+++ b/tracer/src/Datadog.Trace/Processors/TraceUtil.cs
@@ -18,29 +18,94 @@ namespace Datadog.Trace.Processors
 
         private static readonly UTF8Encoding Encoding = new UTF8Encoding(false);
 
+        /// <summary>
+        /// Truncates <paramref name="value"/> so its UTF-8 byte length is at most <paramref name="limit"/>,
+        /// cutting at a code-point boundary so it never splits a UTF-8 multi-byte sequence (UTF-16 surrogate
+        /// pair). Matches the current trace-agent's strict-byte-ceiling behavior.
+        /// </summary>
+        /// <returns>true if the value was truncated. false otherwise</returns>
         // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/traceutil/truncate.go#L36-L51
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TruncateUTF8(ref string value, int limit)
         {
-            if (string.IsNullOrEmpty(value) || Encoding.GetByteCount(value) <= limit)
+            // Each UTF-16 char is at most 3 UTF-8 bytes, so a string of length <= limit/3 can never exceed the byte limit.
+            if (string.IsNullOrEmpty(value) || value.Length <= limit / 3)
             {
                 return false;
             }
 
-            var charArray = new char[1];
-            var length = 0;
-            for (var i = 0; i < value.Length - 1; i++)
+            // Each char is at least 1 byte, so length > limit guarantees we're over the limit.
+            // We only count when length <= limit, where we need to count up to limit chars.
+            if (value.Length <= limit && Encoding.GetByteCount(value) <= limit)
             {
-                charArray[0] = value[i];
-                length += Encoding.GetByteCount(charArray, 0, 1);
-                if (length > limit)
-                {
-                    value = value.Substring(0, i);
-                    return true;
-                }
+                return false;
             }
 
-            return false;
+            // Extracted as uncommon slow path, to aid inlining
+            value = TruncateUTF8Slow(value, limit);
+            return true;
+
+            static string TruncateUTF8Slow(string value, int limit)
+            {
+                // Binary search to find the cutoff point
+                // Find the largest prefix whose UTF-8 byte count is <= limit by counting only (never
+                // materializing UTF-8 bytes), then cut there. Seed lo at limit/3 (a limit/3-char prefix
+                // always fits, since each char is <= 3 bytes) and cap hi at limit (the cut can't exceed
+                // `limit` chars, since each char is >= 1 byte).
+                var lo = limit / 3;
+                var hi = Math.Min(value.Length, limit);
+#if NETCOREAPP
+                while (lo < hi)
+                {
+                    // Bias the midpoint up so lo strictly advances and the loop terminates.
+                    var mid = lo + ((hi - lo + 1) >> 1);
+                    if (Encoding.GetByteCount(value.AsSpan(0, mid)) <= limit)
+                    {
+                        lo = mid;
+                    }
+                    else
+                    {
+                        hi = mid - 1;
+                    }
+                }
+#else
+                // .NET Framework / netstandard2.0 lack the span GetByteCount overload, and we avoid `fixed`.
+                // Copy the bounded prefix (at most `limit` chars) into a pooled buffer and count ranges of it.
+                var buffer = ArrayPool<char>.Shared.Rent(hi);
+                try
+                {
+                    value.CopyTo(0, buffer, 0, hi);
+                    while (lo < hi)
+                    {
+                        var mid = lo + ((hi - lo + 1) >> 1);
+                        if (Encoding.GetByteCount(buffer, 0, mid) <= limit)
+                        {
+                            lo = mid;
+                        }
+                        else
+                        {
+                            hi = mid - 1;
+                        }
+                    }
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.Return(buffer);
+                }
+#endif
+                var cut = lo;
+
+                // A count probe can land between a high and low surrogate. Drop a trailing lone high
+                // surrogate to snap back to a code-point boundary (this only reduces the byte count, so the
+                // result stays within the limit). Like the trace-agent, we cut at a code-point (rune)
+                // boundary only - no combining-mark / grapheme-cluster handling.
+                if (cut > 0 && char.IsHighSurrogate(value[cut - 1]))
+                {
+                    cut--;
+                }
+
+                return value.Substring(0, cut);
+            }
         }
 
         // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L214-L219

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/TruncatorTraceProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/TruncatorTraceProcessorTests.cs
@@ -11,17 +11,92 @@ namespace Datadog.Trace.Tests.TraceProcessors
 {
     public class TruncatorTraceProcessorTests
     {
-        // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/traceutil/truncate_test.go#L15-L23
+        // Mirrors the current trace-agent strict-byte-ceiling behavior
+        // (pkg/trace/traceutil/normalize/truncate.go): the result never exceeds the byte limit and is
+        // never split mid-code-point. "é" (e-acute) is 2 UTF-8 bytes, so "télé" is 6
+        // bytes and @5 truncates to "tél" (4 bytes).
         [Fact]
         public void TruncateString()
         {
             Assert.Equal(string.Empty, TruncateUTF8(string.Empty, 5));
-            Assert.Equal("télé", TruncateUTF8("télé", 5));
+            Assert.Equal("tél", TruncateUTF8("télé", 5));
             Assert.Equal("t", TruncateUTF8("télé", 2));
             Assert.Equal("éé", TruncateUTF8("ééééé", 5));
             Assert.Equal("ééééé", TruncateUTF8("ééééé", 18));
             Assert.Equal("ééééé", TruncateUTF8("ééééé", 10));
             Assert.Equal("ééé", TruncateUTF8("ééééé", 6));
+
+            static string TruncateUTF8(string value, int limit)
+            {
+                Trace.Processors.TraceUtil.TruncateUTF8(ref value, limit);
+                return value;
+            }
+        }
+
+        [Fact]
+        public void TruncateString_NeverSplitsCodePoint()
+        {
+            // A surrogate-pair code point (U+1F600) is 4 UTF-8 bytes and 2 UTF-16 chars. Truncating at any
+            // byte limit that would bisect the second one must drop it whole, never leaving a lone
+            // surrogate (which would be invalid UTF-8).
+            var twoEmoji = "\U0001F600\U0001F600"; // 8 bytes
+            for (var limit = 4; limit < 8; limit++)
+            {
+                var result = TruncateUTF8(twoEmoji, limit);
+                Assert.Equal("\U0001F600", result); // exactly one emoji kept; never a split pair
+                AssertValidUtf8(result);
+                Assert.True(Encoding.UTF8.GetByteCount(result) <= limit);
+            }
+
+            // A base letter + combining acute accent (U+0301): 'e' (1 byte) + U+0301 (2 bytes) = 3 bytes,
+            // followed by 'z' (1 byte). Like the trace-agent we cut at a code-point boundary only (no
+            // grapheme handling), so at limit 2 the combining mark doesn't fit and we keep the bare base
+            // 'e'; at limit 3 the 'e' and its mark both fit.
+            var combining = "éz";
+            Assert.Equal("e", TruncateUTF8(combining, 2));
+            Assert.Equal("é", TruncateUTF8(combining, 3));
+
+            static string TruncateUTF8(string value, int limit)
+            {
+                Trace.Processors.TraceUtil.TruncateUTF8(ref value, limit);
+                return value;
+            }
+
+            static void AssertValidUtf8(string value)
+            {
+                // A round-trip through a throw-on-invalid UTF-8 encoder fails if value contains a lone surrogate.
+                var strict = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+                strict.GetBytes(value);
+            }
+        }
+
+        [Fact]
+        public void TruncateString_LongAsciiTruncatesToExactByteLimit()
+        {
+            // A long ASCII string (each char = 1 byte) far over the limit. The `length > limit` fast-path
+            // short-circuit skips the byte count and goes straight to the slow path, which must cut to
+            // exactly `limit` chars / bytes.
+            const int limit = 5000;
+            var result = TruncateUTF8(new string('a', 100_000), limit);
+            Assert.Equal(limit, result.Length);
+            Assert.Equal(limit, Encoding.UTF8.GetByteCount(result));
+
+            static string TruncateUTF8(string value, int limit)
+            {
+                Trace.Processors.TraceUtil.TruncateUTF8(ref value, limit);
+                return value;
+            }
+        }
+
+        [Fact]
+        public void TruncateString_LoneSurrogateDoesNotThrow()
+        {
+            // A lone high surrogate is malformed UTF-16. Truncation must not throw (the byte count uses a
+            // non-throwing encoder that substitutes U+FFFD), and the result must stay within the byte limit.
+            // The ASCII padding keeps the value over the limit so it reaches the slow path.
+            var result = TruncateUTF8("\uD83D" + new string('a', 300), 200);
+            Assert.True(result.Length <= 200);
+            Assert.True(Encoding.UTF8.GetByteCount(result) <= 200);
 
             static string TruncateUTF8(string value, int limit)
             {


### PR DESCRIPTION
## Summary of changes

Improves the `TraceUtil.TruncateUTF8()` method performance and correctness

## Reason for change

The previous version would iterate over every character in a string to work out where to chop a UTF-8 string to keep the UTF-8 size the same. This is relatively slow, misses some fast-path cases, and also fails on a "correctness" level in that it could generate incorrect utf8 bytes if it split a surrogate pair.

## Implementation details

- Handle fast paths for length (e.g. if length > limit / 3 then we know we're fine)
- Only call `Encoding.GetByteCount(value)` on the whole string if there's a _chance_ it might be in range
- Use a binary search to find where to make the cut
  - On .NET Core we can use the `Span<T>` overloads to remove allocation
  - On .NET Framework we make a single copy (up to size `limit`) so that we can check the size of sub segments
- Backtrack on the final cut to handle split surrogate pairs

Note that we _don't_ handle split combining-mark / grapheme-cluster, because the agent doesn't handle those either. It makes our life simpler, and is a rare edge case, for an already oversized string

## Test coverage

Tweaked existing unit test to demonstrate the split surrogate issue, and added some extra unit tests.

Ran various benchmarks comparing the old to new - the new version is faster in all cases, and in some cases allocates much less 🎉 


| Method   | Runtime              | Scenario             |           Mean | Allocated |
| -------- | -------------------- | -------------------- | -------------: | --------: |
| Original | .NET 10.0            | ShortAscii           |      2.8301 ns |         - |
| Current  | .NET 10.0            | ShortAscii           |      0.2683 ns |         - |
| Original | .NET 6.0             | ShortAscii           |      3.4347 ns |         - |
| Current  | .NET 6.0             | ShortAscii           |      0.2441 ns |         - |
| Original | .NET Framework 4.7.2 | ShortAscii           |      6.5876 ns |         - |
| Current  | .NET Framework 4.7.2 | ShortAscii           |      0.2579 ns |         - |
|          |                      |                      |                |           |
| Original | .NET 10.0            | AsciiAtLimit         |      5.4113 ns |         - |
| Current  | .NET 10.0            | AsciiAtLimit         |      4.6095 ns |         - |
| Original | .NET 6.0             | AsciiAtLimit         |      7.3724 ns |         - |
| Current  | .NET 6.0             | AsciiAtLimit         |      7.1666 ns |         - |
| Original | .NET Framework 4.7.2 | AsciiAtLimit         |     25.2299 ns |         - |
| Current  | .NET Framework 4.7.2 | AsciiAtLimit         |     25.1155 ns |         - |
|          |                      |                      |                |           |
| Original | .NET 10.0            | AsciiJustOver        |    472.1849 ns |         - |
| Current  | .NET 10.0            | AsciiJustOver        |     67.7282 ns |     424 B |
| Original | .NET 6.0             | AsciiJustOver        |    873.6068 ns |     456 B |
| Current  | .NET 6.0             | AsciiJustOver        |     73.7649 ns |     424 B |
| Original | .NET Framework 4.7.2 | AsciiJustOver        |    780.5378 ns |     465 B |
| Current  | .NET Framework 4.7.2 | AsciiJustOver        |    237.3104 ns |     433 B |
|          |                      |                      |                |           |
| Original | .NET 10.0            | LongAsciiResource    | 12,202.0970 ns |   10056 B |
| Current  | .NET 10.0            | LongAsciiResource    |  1,241.6327 ns |   10024 B |
| Original | .NET 6.0             | LongAsciiResource    | 21,344.1692 ns |   10056 B |
| Current  | .NET 6.0             | LongAsciiResource    |  1,367.5132 ns |   10024 B |
| Original | .NET Framework 4.7.2 | LongAsciiResource    | 28,561.6945 ns |   10095 B |
| Current  | .NET Framework 4.7.2 | LongAsciiResource    |  6,330.6863 ns |   10056 B |
|          |                      |                      |                |           |
| Original | .NET 10.0            | Emoji                | 36,750.6962 ns |  190096 B |
| Current  | .NET 10.0            | Emoji                |  4,626.4329 ns |    5808 B |
| Original | .NET 6.0             | Emoji                | 50,897.8086 ns |  190096 B |
| Current  | .NET 6.0             | Emoji                |  4,658.5506 ns |    5808 B |
| Original | .NET Framework 4.7.2 | Emoji                | 45,684.4763 ns |  163906 B |
| Current  | .NET Framework 4.7.2 | Emoji                | 25,695.7428 ns |    5724 B |
|          |                      |                      |                |           |
| Original | .NET 10.0            | TwoByte              |  9,284.9370 ns |   33336 B |
| Current  | .NET 10.0            | TwoByte              |  2,223.1208 ns |    5024 B |
| Original | .NET 6.0             | TwoByte              | 13,769.0937 ns |    5056 B |
| Current  | .NET 6.0             | TwoByte              |  2,635.3342 ns |    5024 B |
| Original | .NET Framework 4.7.2 | TwoByte              | 11,619.9163 ns |    5082 B |
| Current  | .NET Framework 4.7.2 | TwoByte              |  7,858.6355 ns |    5049 B |


<details><summary>Benchmark Details</summary>
<p>

```csharp
// <copyright file="TruncateUtf8Benchmark.cs" company="Datadog">
// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
// </copyright>

#nullable enable

using System;
using System.Buffers;
using System.Collections.Generic;
using System.Runtime.CompilerServices;
using System.Text;
using BenchmarkDotNet.Attributes;

namespace Benchmarks.Trace;

/// <summary>
/// Compares the current <c>TraceUtil.TruncateUTF8</c> implementation against the original (pre-rewrite)
/// per-char implementation, across the common inputs plus a couple of edge cases. Both are reproduced
/// inline so the comparison can be re-run independently of the production code.
///  - <see cref="Original"/> : the pre-branch implementation (full byte count, then a per-char loop).
///  - <see cref="Current"/>  : the shipped implementation (length-bounds fast path + count-based binary
///                             search; span on .NET Core, pooled char[] on .NET Framework).
/// </summary>
[MemoryDiagnoser]
[BenchmarkCategory(Constants.TracerCategory, Constants.RunOnPrs, Constants.RunOnMaster)]
public class TruncateUtf8Benchmark
{
    private static readonly UTF8Encoding Encoding = new UTF8Encoding(false);

    // Built once; referenced by the scenarios below.
    private static readonly string ShortAscii = new string('a', 20);
    private static readonly string AsciiAtLimit = new string('a', 200);
    private static readonly string AsciiJustOverLimit = new string('a', 250);
    private static readonly string LongAsciiResource = new string('a', 100_000);
    private static readonly string TwoByteOverLimit = new string('é', 4000); // é (precomposed) = 2 UTF-8 bytes
    private static readonly string EmojiOverLimit = Repeat("\U0001F600", 2000);  // 😀 = 2 chars / 4 bytes

    [ParamsSource(nameof(Scenarios))]
    public TruncateScenario? Scenario { get; set; }

    public static IEnumerable<TruncateScenario> Scenarios()
    {
        // Limits mirror real call sites: 200 (meta/metric keys), 5000 (resource / meta value).

        // Common cases.
        yield return new TruncateScenario("ShortAscii_NoTruncate", ShortAscii, 200);
        yield return new TruncateScenario("AsciiAtLimit_NoTruncate", AsciiAtLimit, 200);
        yield return new TruncateScenario("AsciiJustOver", AsciiJustOverLimit, 200);
        yield return new TruncateScenario("TwoByte", TwoByteOverLimit, 5000);

        // Edge cases.
        yield return new TruncateScenario("LongAsciiResource_Degenerate", LongAsciiResource, 5000);
        yield return new TruncateScenario("Emoji", EmojiOverLimit, 5000);
    }

    [Benchmark(Baseline = true)]
    public string Original()
    {
        var value = Scenario!.Value;
        OriginalImpl(ref value, Scenario.Limit);
        return value;
    }

    [Benchmark]
    public string Current()
    {
        var value = Scenario!.Value;
        CurrentImpl(ref value, Scenario.Limit);
        return value;
    }

    private static string Repeat(string unit, int count)
    {
        var sb = new StringBuilder(unit.Length * count);
        for (var i = 0; i < count; i++)
        {
            sb.Append(unit);
        }

        return sb.ToString();
    }

    // ---- Candidate implementations -------------------------------------------------------------

    // The pre-branch implementation: full byte count, then a per-char GetByteCount loop.
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    private static bool OriginalImpl(ref string value, int limit)
    {
        if (string.IsNullOrEmpty(value) || Encoding.GetByteCount(value) <= limit)
        {
            return false;
        }

        var charArray = new char[1];
        var length = 0;
        for (var i = 0; i < value.Length - 1; i++)
        {
            charArray[0] = value[i];
            length += Encoding.GetByteCount(charArray, 0, 1);
            if (length > limit)
            {
                value = value.Substring(0, i);
                return true;
            }
        }

        return false;
    }

    // The shipped implementation, copied from TraceUtil.TruncateUTF8.
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    private static bool CurrentImpl(ref string value, int limit)
    {
        // Each UTF-16 char is at most 3 UTF-8 bytes, so length <= limit/3 can never exceed the byte limit.
        if (string.IsNullOrEmpty(value) || value.Length <= limit / 3)
        {
            return false;
        }

        // Each char is at least 1 byte, so length > limit guarantees we're over. We only count when
        // length <= limit, so GetByteCount scans at most `limit` chars.
        if (value.Length <= limit && Encoding.GetByteCount(value) <= limit)
        {
            return false;
        }

        value = CurrentSlow(value, limit);
        return true;

        static string CurrentSlow(string value, int limit)
        {
            // Find the largest prefix whose UTF-8 byte count is <= limit by counting only. Seed lo at
            // limit/3 (a limit/3-char prefix always fits) and cap hi at limit (the cut can't exceed limit chars).
            var lo = limit / 3;
            var hi = Math.Min(value.Length, limit);
#if NETCOREAPP
            while (lo < hi)
            {
                var mid = lo + ((hi - lo + 1) >> 1);
                if (Encoding.GetByteCount(value.AsSpan(0, mid)) <= limit)
                {
                    lo = mid;
                }
                else
                {
                    hi = mid - 1;
                }
            }
#else
            var buffer = ArrayPool<char>.Shared.Rent(hi);
            try
            {
                value.CopyTo(0, buffer, 0, hi);
                while (lo < hi)
                {
                    var mid = lo + ((hi - lo + 1) >> 1);
                    if (Encoding.GetByteCount(buffer, 0, mid) <= limit)
                    {
                        lo = mid;
                    }
                    else
                    {
                        hi = mid - 1;
                    }
                }
            }
            finally
            {
                ArrayPool<char>.Shared.Return(buffer);
            }
#endif
            var cut = lo;

            // Drop a trailing lone high surrogate so the cut lands on a code-point boundary.
            if (cut > 0 && char.IsHighSurrogate(value[cut - 1]))
            {
                cut--;
            }

            return value.Substring(0, cut);
        }
    }

    public class TruncateScenario
    {
        public TruncateScenario(string name, string value, int limit)
        {
            Name = name;
            Value = value;
            Limit = limit;
        }

        public string Name { get; }

        public string Value { get; }

        public int Limit { get; }

        public override string ToString() => Name;
    }
}
```
</p>
</details> 

## Other details

I explored some other approaches too, e.g. using `fixed` to avoid the need for the array pool, but I preferred this approach for simplicity.