### PR TITLE
[Profiler] ManagedCodeCache updates synchronously

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1567,7 +1567,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
     // Use managed code cache
     if (_pConfiguration->UseManagedCodeCache())
     {
-        _managedCodeCache = std::make_unique<ManagedCodeCache>(_pCorProfilerInfo);
+        _managedCodeCache = std::make_unique<ManagedCodeCache>(_pCorProfilerInfo, _metricsRegistry);
         if (!_managedCodeCache->Initialize())
         {
             Log::Error("Failed to initialize managed code cache. The profiler will not run.");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1583,7 +1583,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
     // Use managed code cache
     if (_pConfiguration->UseManagedCodeCache())
     {
-        _managedCodeCache = std::make_unique<ManagedCodeCache>(_pCorProfilerInfo);
+        _managedCodeCache = std::make_unique<ManagedCodeCache>(_pCorProfilerInfo, _metricsRegistry);
         if (!_managedCodeCache->Initialize())
         {
             Log::Error("Failed to initialize managed code cache. The profiler will not run.");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
@@ -454,27 +454,6 @@ void ManagedCodeCache::AddModuleRangesToCache(std::vector<ModuleCodeRange> modul
     }
 }
 
-void ManagedCodeCache::EnsurePageExists(uint64_t page)
-{
-    // Check if page exists (with shared lock first - fast path)
-    {
-        std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
-        if (_pagesMap.find(page) != _pagesMap.end())
-        {
-            return;  // Already exists
-        }
-    }
-    
-    // Page doesn't exist, create it (with exclusive lock)
-    std::unique_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
-    
-    // Double-check after acquiring exclusive lock (another thread might have created it)
-    if (_pagesMap.find(page) == _pagesMap.end())
-    {
-        _pagesMap[page] = PageEntry();
-    }
-}
-
 std::vector<ModuleCodeRange> ManagedCodeCache::GetModuleCodeRanges(ModuleID moduleId)
 {
     std::vector<ModuleCodeRange> result;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
@@ -6,10 +6,61 @@
 #include "Configuration.h"
 
 #include <algorithm>
+#include <chrono>
 #include <set>
 #include <variant>
 
+#ifndef _WINDOWS
+#include <pthread.h>
+#include <signal.h>
+#endif
+
 #include "Log.h"
+
+// Maximum time the signal-handler read path waits to acquire a cache lock
+// before giving up and returning std::nullopt.
+static constexpr auto SignalLockTimeout = std::chrono::microseconds(500);
+
+namespace {
+
+// RAII guard that blocks the profiler signals (SIGPROF for the timer_create CPU
+// profiler, SIGUSR1 for wall-time stack collection) for the duration of a cache
+// write. This guarantees the writing thread cannot be interrupted by a profiler
+// signal whose handler would try to acquire a reader lock on the same mutex,
+// which would otherwise deadlock. The signals are deferred (not dropped) and
+// delivered once the previous mask is restored.
+class ScopedProfilerSignalBlocker
+{
+public:
+#ifndef _WINDOWS
+    ScopedProfilerSignalBlocker()
+    {
+        sigset_t toBlock;
+        sigemptyset(&toBlock);
+        sigaddset(&toBlock, SIGPROF);
+        sigaddset(&toBlock, SIGUSR1);
+        pthread_sigmask(SIG_BLOCK, &toBlock, &_previous);
+    }
+
+    ~ScopedProfilerSignalBlocker()
+    {
+        pthread_sigmask(SIG_SETMASK, &_previous, nullptr);
+    }
+
+private:
+    sigset_t _previous;
+#else
+    ScopedProfilerSignalBlocker() = default;
+    ~ScopedProfilerSignalBlocker() = default;
+#endif
+
+    ScopedProfilerSignalBlocker(const ScopedProfilerSignalBlocker&) = delete;
+    ScopedProfilerSignalBlocker& operator=(const ScopedProfilerSignalBlocker&) = delete;
+    ScopedProfilerSignalBlocker(ScopedProfilerSignalBlocker&&) = delete;
+    ScopedProfilerSignalBlocker& operator=(ScopedProfilerSignalBlocker&&) = delete;
+};
+
+} // namespace
 
 template <typename Container, typename Value>
 std::optional<typename Container::value_type> FindRange(Container const& container, Value const& value)
@@ -38,47 +89,31 @@ struct IMAGE_NT_HEADERS_GENERIC
 };
 
 ManagedCodeCache::ManagedCodeCache(ICorProfilerInfo4* pProfilerInfo)
-    : _profilerInfo(pProfilerInfo),
-      _workerQueueEvent(false),
-      _requestStop(false)
+    : _profilerInfo(pProfilerInfo)
 {
 }
 
-ManagedCodeCache::~ManagedCodeCache()
-{
-    if (_worker.joinable())
-    {
-        _requestStop = true;
-        _workerQueueEvent.Set();
-        _worker.join();
-    }
-}
+ManagedCodeCache::~ManagedCodeCache() = default;
 
 bool ManagedCodeCache::Initialize()
 {
-    std::promise<void> startPromise;
-    auto future = startPromise.get_future();
-    _worker = std::thread(&ManagedCodeCache::WorkerThread, this, std::move(startPromise));
-    if (future.wait_for(2s) == std::future_status::ready)
-    {
-        Log::Info("ManagedCodeCache initialized successfully");
-        return true;
-    }
-    Log::Error("Failed to initialize ManagedCodeCache");
-    return false;
+    Log::Info("ManagedCodeCache initialized successfully");
+    return true;
 }
 
 std::optional<bool> ManagedCodeCache::IsCodeInR2RModule(std::uintptr_t ip, bool signalSafe) const noexcept
 {
     // IsCodeInR2RModule can be called in a signal handler or not.
-    // If it's called in a signal handler, we need to use a shared lock with try_to_lock.
-    // If it's called not in a signal handler, we need to use a shared lock with defer_lock.
-    auto moduleLock = [](std::shared_mutex& mutex, bool signalSafe) {
+    // If it's called in a signal handler, we use a time-based acquire so the
+    // handler waits a bounded amount of time for a writer on another thread
+    // instead of failing immediately (and never blocks indefinitely).
+    // If it's called not in a signal handler, we use a plain blocking shared lock.
+    auto moduleLock = [](std::shared_timed_mutex& mutex, bool signalSafe) {
         if (signalSafe)
         {
-            return std::shared_lock<std::shared_mutex>(mutex, std::try_to_lock);
+            return std::shared_lock<std::shared_timed_mutex>(mutex, SignalLockTimeout);
         }
-        return std::shared_lock<std::shared_mutex>(mutex);
+        return std::shared_lock<std::shared_timed_mutex>(mutex);
     }(_modulesMutex, signalSafe);
 
     if (!moduleLock.owns_lock())
@@ -128,10 +163,7 @@ std::optional<FunctionID> ManagedCodeCache::GetFunctionId(std::uintptr_t ip) noe
     auto functionId = GetFunctionFromIP_Original(ip);
     if (functionId.has_value() && functionId.value() != InvalidFunctionId) {
         // We found a function id and we can add it synchronously to our cache.
-        // It's safe to do this synchronously because this function is called
-        // by a native thread belonging to profiler.
-        // This thread won't be interrupted by the profiler.
-        AddFunctionImpl(functionId.value(), false);
+        AddFunctionImpl(functionId.value());
         return std::optional<FunctionID>(functionId.value());
     }
     // If we arrive here, it means that the call to GetFunctionFromIP_Original possibly crashed.
@@ -183,7 +215,7 @@ std::optional<FunctionID> ManagedCodeCache::GetFunctionIdImpl(std::uintptr_t ip)
     uint64_t page = GetPageNumber(static_cast<UINT_PTR>(ip));
     
     // Level 1: Find the page (shared lock on map structure)
-    std::shared_lock<std::shared_mutex> mapLock(_pagesMutex);
+    std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
     auto pageIt = _pagesMap.find(page);
     if (pageIt == _pagesMap.end())
     {
@@ -191,7 +223,7 @@ std::optional<FunctionID> ManagedCodeCache::GetFunctionIdImpl(std::uintptr_t ip)
     }
     
     // Level 2: Binary search within the page's ranges (shared lock on page)
-    std::shared_lock<std::shared_mutex> pageLock(pageIt->second.lock);
+    std::shared_lock<std::shared_timed_mutex> pageLock(pageIt->second.lock);
     auto range = FindRange(pageIt->second.ranges, static_cast<UINT_PTR>(ip));
     if (range.has_value())
     {
@@ -204,21 +236,10 @@ std::optional<FunctionID> ManagedCodeCache::GetFunctionIdImpl(std::uintptr_t ip)
 // can be called in a signal handler
 std::optional<bool> ManagedCodeCache::IsManaged(std::uintptr_t ip) const noexcept
 {
-    // This is temporary workaround to try at best identifying an instruction pointer.
-    // Once ManagedCodeCache has a better concurrent data structure, we can remove this function.
-    // Best effort to get the managed code address range
-    // If IsManaged returns nullopt (which means that we failed at acquiring the lock),
-    // we try MaxRetries times.
-    auto constexpr MaxRetries = 5;
-    for (auto i = 0; i < MaxRetries; i++)
-    {
-        auto result = IsManagedImpl(ip);
-        if (result.has_value())
-        {
-            return result;
-        }
-    }
-    return std::nullopt;
+    // Best effort to identify an instruction pointer. When called from a signal
+    // handler, IsManagedImpl uses a time-based lock acquire (bounded wait) and
+    // returns std::nullopt if a lock cannot be acquired within the timeout.
+    return IsManagedImpl(ip);
 }
 
 std::optional<bool> ManagedCodeCache::IsManagedImpl(std::uintptr_t ip) const noexcept
@@ -227,7 +248,7 @@ std::optional<bool> ManagedCodeCache::IsManagedImpl(std::uintptr_t ip) const noe
     
     {
         // Level 1: Find the page (shared lock on map structure)
-        std::shared_lock<std::shared_mutex> mapLock(_pagesMutex, std::try_to_lock);
+        std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex, SignalLockTimeout);
         if (!mapLock.owns_lock())
         {
             return std::nullopt;
@@ -236,7 +257,7 @@ std::optional<bool> ManagedCodeCache::IsManagedImpl(std::uintptr_t ip) const noe
         if (pageIt != _pagesMap.end())
         {
             // Level 2: Binary search within the page's ranges (shared lock on page)
-            std::shared_lock<std::shared_mutex> pageLock(pageIt->second.lock, std::try_to_lock);
+            std::shared_lock<std::shared_timed_mutex> pageLock(pageIt->second.lock, SignalLockTimeout);
             if (!pageLock.owns_lock())
             {
                 return std::nullopt;
@@ -255,11 +276,11 @@ std::optional<bool> ManagedCodeCache::IsManagedImpl(std::uintptr_t ip) const noe
 
 void ManagedCodeCache::AddFunction(FunctionID functionId)
 {
-    AddFunctionImpl(functionId, true);
+    AddFunctionImpl(functionId);
 }
 
 // Maybe rename this into OnJitCompilation
-void ManagedCodeCache::AddFunctionImpl(FunctionID functionId, bool isAsync)
+void ManagedCodeCache::AddFunctionImpl(FunctionID functionId)
 {
     auto ranges = GetCodeRanges(functionId);
 
@@ -268,26 +289,11 @@ void ManagedCodeCache::AddFunctionImpl(FunctionID functionId, bool isAsync)
         return;
     }
 
-    if (isAsync)
-    {
-        // IMPORTANT: Defer to background thread to avoid deadlock
-        //
-        // Why we can't do this synchronously:
-        // 1. JITCompilationFinished is called on a managed thread (Thread A)
-        // 2. If we called AppendRangesToCache directly here, Thread A would acquire 
-        //    writer lock on PageEntry
-        // 3. CPU profiler signal could interrupt Thread A (async)
-        // 4. Signal handler calls IsManaged, tries to acquire reader lock on same PageEntry
-        // 5. DEADLOCK: Reader lock waits for writer lock held by same thread
-        //
-        // Solution: Enqueue work to background thread. Thread A never acquires PageEntry 
-        // locks, so signal handler can safely acquire locks without deadlock.
-        AddFunctionCodeRangesAsync(std::move(ranges));
-    }
-    else
-    {
-        AddFunctionRangesToCache(std::move(ranges));
-    }
+    // The write is performed synchronously. AddFunctionRangesToCache blocks the
+    // profiler signals while it holds the writer locks, so the calling (managed)
+    // thread cannot be interrupted into a signal handler that would try to take a
+    // reader lock on the same mutex (which would otherwise deadlock).
+    AddFunctionRangesToCache(std::move(ranges));
 }
 
 // Maybe rename this into OnModuleLoaded
@@ -311,21 +317,11 @@ void ManagedCodeCache::AddModule(ModuleID moduleId)
         Log::Debug("ManagedCodeCache::AddModule: Module code ranges for module id: ", moduleId, " are: ", ss.str());
     }
 
-    // IMPORTANT: Defer to background thread to avoid deadlock
-    //
-    // Scenario: ModuleLoadFinished is called on a managed thread (Thread A)
-    // 1. Thread A calls AddModuleRanges, acquires writer lock if done synchronously
-    // 2. CPU profiler signal interrupts Thread A (async)
-    // 3. Signal handler calls IsManaged, tries to acquire reader lock
-    // 4. DEADLOCK: Reader lock waits for writer lock held by same thread
-    //
-    // Solution: Enqueue work to background thread. Thread A holds no locks
-    // when it returns from this callback, so signal handler can safely
-    // acquire locks.
-    //
-    // Additional benefit: Reduces callback latency and avoids holding
-    // CLR-internal locks longer than necessary.
-    AddModuleCodeRangesAsync(std::move(moduleCodeRanges));
+    // The write is performed synchronously. AddModuleRangesToCache blocks the
+    // profiler signals while it holds the writer lock, so the calling (managed)
+    // thread cannot be interrupted into a signal handler that would try to take a
+    // reader lock on the same mutex (which would otherwise deadlock).
+    AddModuleRangesToCache(std::move(moduleCodeRanges));
 }
 
 void ManagedCodeCache::RemoveModule(ModuleID moduleId)
@@ -336,7 +332,10 @@ void ManagedCodeCache::RemoveModule(ModuleID moduleId)
         return;
     }
 
-    std::unique_lock<std::shared_mutex> moduleLock(_modulesMutex);
+    // Block profiler signals while holding the writer lock so this thread cannot
+    // be interrupted into a signal handler that would deadlock on the same mutex.
+    ScopedProfilerSignalBlocker signalBlocker;
+    std::unique_lock<std::shared_timed_mutex> moduleLock(_modulesMutex);
     for (auto const& range : moduleCodeRanges)
     {
         auto it = std::find_if(_modulesCodeRanges.begin(), _modulesCodeRanges.end(),
@@ -386,14 +385,17 @@ std::vector<CodeRange> ManagedCodeCache::GetCodeRanges(FunctionID functionId)
 void ManagedCodeCache::InsertCodeRangeIntoPage(PagesMap::iterator pageIt,
     const CodeRange& range)
 {
-    std::unique_lock<std::shared_mutex> pageLock(pageIt->second.lock);
+    std::unique_lock<std::shared_timed_mutex> pageLock(pageIt->second.lock);
     auto& ranges = pageIt->second.ranges;
     ranges.insert(std::upper_bound(ranges.begin(), ranges.end(), range), range);
 }
 
-// This function must be called by the worker thread only
 void ManagedCodeCache::AddFunctionRangesToCache(std::vector<CodeRange> newRanges)
 {
+    // Block profiler signals for the whole write so this thread cannot be
+    // interrupted into a signal handler that would deadlock on the same mutex.
+    ScopedProfilerSignalBlocker signalBlocker;
+
     for (const auto& range : newRanges)
     {
         // Method code range can span over 2 pages (in some weird cases, it could span over more than 2 pages).
@@ -404,7 +406,7 @@ void ManagedCodeCache::AddFunctionRangesToCache(std::vector<CodeRange> newRanges
         {  
             // Check if page exists (with shared lock first - fast path)
             {
-                std::shared_lock<std::shared_mutex> mapLock(_pagesMutex);
+                std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
                 auto pageIt = _pagesMap.find(page);
                 if (pageIt != _pagesMap.end())
                 {
@@ -414,7 +416,7 @@ void ManagedCodeCache::AddFunctionRangesToCache(std::vector<CodeRange> newRanges
             }
             
             // Page doesn't exist, create it (with exclusive lock)
-            std::unique_lock<std::shared_mutex> mapLock(_pagesMutex);
+            std::unique_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
             
             auto [pageIt, _] = _pagesMap.try_emplace(page);
             InsertCodeRangeIntoPage(pageIt, range);
@@ -424,7 +426,11 @@ void ManagedCodeCache::AddFunctionRangesToCache(std::vector<CodeRange> newRanges
 
 void ManagedCodeCache::AddModuleRangesToCache(std::vector<ModuleCodeRange> moduleCodeRanges)
 {
-    std::unique_lock<std::shared_mutex> moduleLock(_modulesMutex);
+    // Block profiler signals for the whole write so this thread cannot be
+    // interrupted into a signal handler that would deadlock on the same mutex.
+    ScopedProfilerSignalBlocker signalBlocker;
+
+    std::unique_lock<std::shared_timed_mutex> moduleLock(_modulesMutex);
     for (const auto& moduleCodeRange : moduleCodeRanges)
     {
         auto insertPos = std::upper_bound(
@@ -442,7 +448,7 @@ void ManagedCodeCache::EnsurePageExists(uint64_t page)
 {
     // Check if page exists (with shared lock first - fast path)
     {
-        std::shared_lock<std::shared_mutex> mapLock(_pagesMutex);
+        std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
         if (_pagesMap.find(page) != _pagesMap.end())
         {
             return;  // Already exists
@@ -450,86 +456,13 @@ void ManagedCodeCache::EnsurePageExists(uint64_t page)
     }
     
     // Page doesn't exist, create it (with exclusive lock)
-    std::unique_lock<std::shared_mutex> mapLock(_pagesMutex);
+    std::unique_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
     
     // Double-check after acquiring exclusive lock (another thread might have created it)
     if (_pagesMap.find(page) == _pagesMap.end())
     {
         _pagesMap[page] = PageEntry();
     }
-}
-
-// Template struct for appending ranges work items
-template<typename T>
-struct AppendRangesWork
-{
-    std::vector<T> ranges;
-    
-    explicit AppendRangesWork(std::vector<T> r) 
-        : ranges(std::move(r)) {}
-};
-
-// Type aliases for specific work item types
-using AppendCodeRangesWork = AppendRangesWork<CodeRange>;
-using AppendModuleRangesWork = AppendRangesWork<ModuleCodeRange>;
-
-void ManagedCodeCache::WorkerThread(std::promise<void> startPromise)
-{
-    startPromise.set_value();
-
-    while (!_requestStop)
-    {
-        _workerQueueEvent.Wait();
-
-        if (_requestStop)
-        {
-            break;
-        }
-
-        std::deque<std::function<void()>> workItems;
-        {
-            std::unique_lock<std::mutex> lock(_queueMutex);
-            std::swap(_workerQueue, workItems);
-        }
-
-        for (auto& workItem : workItems)
-        {
-            workItem();
-        }
-    }
-}
-
-// Private helper template
-template<typename WorkType>
-void ManagedCodeCache::EnqueueWork(WorkType work)
-{
-    auto workFunction = [this, work = std::move(work)]() mutable{
-        using T = std::decay_t<WorkType>;
-        
-        if constexpr (std::is_same_v<T, AppendCodeRangesWork>) {
-            AddFunctionRangesToCache(std::move(work.ranges));
-        }
-        else if constexpr (std::is_same_v<T, AppendModuleRangesWork>) {
-            AddModuleRangesToCache(std::move(work.ranges));
-        }
-    };
-
-    {
-        std::unique_lock<std::mutex> lock(_queueMutex);
-        _workerQueue.push_back(std::move(workFunction));
-    }
-    
-    _workerQueueEvent.Set();
-}
-
-void ManagedCodeCache::AddFunctionCodeRangesAsync(std::vector<CodeRange> ranges)
-{
-    EnqueueWork(AppendCodeRangesWork(std::move(ranges)));
-}
-
-void ManagedCodeCache::AddModuleCodeRangesAsync(std::vector<ModuleCodeRange> moduleCodeRanges)
-{
-    EnqueueWork(AppendModuleRangesWork(std::move(moduleCodeRanges)));
 }
 
 std::vector<ModuleCodeRange> ManagedCodeCache::GetModuleCodeRanges(ModuleID moduleId)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
@@ -4,6 +4,8 @@
 #include "ManagedCodeCache.h"
 
 #include "Configuration.h"
+#include "CounterMetric.h"
+#include "MetricsRegistry.h"
 
 #include <algorithm>
 #include <chrono>
@@ -88,8 +90,9 @@ struct IMAGE_NT_HEADERS_GENERIC
     WORD    Magic;
 };
 
-ManagedCodeCache::ManagedCodeCache(ICorProfilerInfo4* pProfilerInfo)
-    : _profilerInfo(pProfilerInfo)
+ManagedCodeCache::ManagedCodeCache(ICorProfilerInfo4* pProfilerInfo, MetricsRegistry& metricsRegistry)
+    : _profilerInfo(pProfilerInfo),
+      _lockFailureMetric(metricsRegistry.GetOrRegister<CounterMetric>("dotnet_managed_code_cache_lock_failures"))
 {
 }
 
@@ -239,7 +242,14 @@ std::optional<bool> ManagedCodeCache::IsManaged(std::uintptr_t ip) const noexcep
     // Best effort to identify an instruction pointer. When called from a signal
     // handler, IsManagedImpl uses a time-based lock acquire (bounded wait) and
     // returns std::nullopt if a lock cannot be acquired within the timeout.
-    return IsManagedImpl(ip);
+    auto result = IsManagedImpl(ip);
+    if (!result.has_value())
+    {
+        // Lock could not be acquired within the timeout: record it. Incr() is an
+        // atomic increment, so this is safe to call from a signal handler.
+        _lockFailureMetric->Incr();
+    }
+    return result;
 }
 
 std::optional<bool> ManagedCodeCache::IsManagedImpl(std::uintptr_t ip) const noexcept

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.cpp
@@ -111,12 +111,12 @@ std::optional<bool> ManagedCodeCache::IsCodeInR2RModule(std::uintptr_t ip, bool 
     // handler waits a bounded amount of time for a writer on another thread
     // instead of failing immediately (and never blocks indefinitely).
     // If it's called not in a signal handler, we use a plain blocking shared lock.
-    auto moduleLock = [](std::shared_timed_mutex& mutex, bool signalSafe) {
+    auto moduleLock = [](CodeCacheMutex& mutex, bool signalSafe) {
         if (signalSafe)
         {
-            return std::shared_lock<std::shared_timed_mutex>(mutex, SignalLockTimeout);
+            return std::shared_lock<CodeCacheMutex>(mutex, SignalLockTimeout);
         }
-        return std::shared_lock<std::shared_timed_mutex>(mutex);
+        return std::shared_lock<CodeCacheMutex>(mutex);
     }(_modulesMutex, signalSafe);
 
     if (!moduleLock.owns_lock())
@@ -218,7 +218,7 @@ std::optional<FunctionID> ManagedCodeCache::GetFunctionIdImpl(std::uintptr_t ip)
     uint64_t page = GetPageNumber(static_cast<UINT_PTR>(ip));
     
     // Level 1: Find the page (shared lock on map structure)
-    std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
+    std::shared_lock<CodeCacheMutex> mapLock(_pagesMutex);
     auto pageIt = _pagesMap.find(page);
     if (pageIt == _pagesMap.end())
     {
@@ -226,7 +226,7 @@ std::optional<FunctionID> ManagedCodeCache::GetFunctionIdImpl(std::uintptr_t ip)
     }
     
     // Level 2: Binary search within the page's ranges (shared lock on page)
-    std::shared_lock<std::shared_timed_mutex> pageLock(pageIt->second.lock);
+    std::shared_lock<CodeCacheMutex> pageLock(pageIt->second.lock);
     auto range = FindRange(pageIt->second.ranges, static_cast<UINT_PTR>(ip));
     if (range.has_value())
     {
@@ -258,7 +258,7 @@ std::optional<bool> ManagedCodeCache::IsManagedImpl(std::uintptr_t ip) const noe
     
     {
         // Level 1: Find the page (shared lock on map structure)
-        std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex, SignalLockTimeout);
+        std::shared_lock<CodeCacheMutex> mapLock(_pagesMutex, SignalLockTimeout);
         if (!mapLock.owns_lock())
         {
             return std::nullopt;
@@ -267,7 +267,7 @@ std::optional<bool> ManagedCodeCache::IsManagedImpl(std::uintptr_t ip) const noe
         if (pageIt != _pagesMap.end())
         {
             // Level 2: Binary search within the page's ranges (shared lock on page)
-            std::shared_lock<std::shared_timed_mutex> pageLock(pageIt->second.lock, SignalLockTimeout);
+            std::shared_lock<CodeCacheMutex> pageLock(pageIt->second.lock, SignalLockTimeout);
             if (!pageLock.owns_lock())
             {
                 return std::nullopt;
@@ -345,7 +345,7 @@ void ManagedCodeCache::RemoveModule(ModuleID moduleId)
     // Block profiler signals while holding the writer lock so this thread cannot
     // be interrupted into a signal handler that would deadlock on the same mutex.
     ScopedProfilerSignalBlocker signalBlocker;
-    std::unique_lock<std::shared_timed_mutex> moduleLock(_modulesMutex);
+    std::unique_lock<CodeCacheMutex> moduleLock(_modulesMutex);
     for (auto const& range : moduleCodeRanges)
     {
         auto it = std::find_if(_modulesCodeRanges.begin(), _modulesCodeRanges.end(),
@@ -395,7 +395,7 @@ std::vector<CodeRange> ManagedCodeCache::GetCodeRanges(FunctionID functionId)
 void ManagedCodeCache::InsertCodeRangeIntoPage(PagesMap::iterator pageIt,
     const CodeRange& range)
 {
-    std::unique_lock<std::shared_timed_mutex> pageLock(pageIt->second.lock);
+    std::unique_lock<CodeCacheMutex> pageLock(pageIt->second.lock);
     auto& ranges = pageIt->second.ranges;
     ranges.insert(std::upper_bound(ranges.begin(), ranges.end(), range), range);
 }
@@ -416,7 +416,7 @@ void ManagedCodeCache::AddFunctionRangesToCache(std::vector<CodeRange> newRanges
         {  
             // Check if page exists (with shared lock first - fast path)
             {
-                std::shared_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
+                std::shared_lock<CodeCacheMutex> mapLock(_pagesMutex);
                 auto pageIt = _pagesMap.find(page);
                 if (pageIt != _pagesMap.end())
                 {
@@ -426,7 +426,7 @@ void ManagedCodeCache::AddFunctionRangesToCache(std::vector<CodeRange> newRanges
             }
             
             // Page doesn't exist, create it (with exclusive lock)
-            std::unique_lock<std::shared_timed_mutex> mapLock(_pagesMutex);
+            std::unique_lock<CodeCacheMutex> mapLock(_pagesMutex);
             
             auto [pageIt, _] = _pagesMap.try_emplace(page);
             InsertCodeRangeIntoPage(pageIt, range);
@@ -440,7 +440,7 @@ void ManagedCodeCache::AddModuleRangesToCache(std::vector<ModuleCodeRange> modul
     // interrupted into a signal handler that would deadlock on the same mutex.
     ScopedProfilerSignalBlocker signalBlocker;
 
-    std::unique_lock<std::shared_timed_mutex> moduleLock(_modulesMutex);
+    std::unique_lock<CodeCacheMutex> moduleLock(_modulesMutex);
     for (const auto& moduleCodeRange : moduleCodeRanges)
     {
         auto insertPos = std::upper_bound(

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
@@ -3,22 +3,15 @@
 
 #pragma once
 
-#include "ServiceBase.h"
-#include "AutoResetEvent.h"
-
 #include <atomic>
-#include <future>
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
 #include <optional>
 #include <shared_mutex>
-#include <thread>
 #include <mutex>
 #include <set>
 #include <algorithm>
-#include <deque>
-#include <functional>
 
 
 #include "cor.h"
@@ -99,7 +92,7 @@ private:
     // Each page has its own data + lock for fine-grained concurrency
     struct PageEntry {
         std::vector<CodeRange> ranges;  // Sorted by startAddress
-        mutable std::shared_mutex lock;  // Reader-writer lock
+        mutable std::shared_timed_mutex lock;  // Reader-writer lock (timed for signal-handler reads)
         
         PageEntry() = default;
         
@@ -142,26 +135,23 @@ public:
     void AddModuleRangesToCache(std::vector<ModuleCodeRange> moduleCodeRanges);
 #ifdef DD_TEST
     // Test-only hooks to simulate signal-handler contention. IsManaged uses
-    // try_to_lock semantics on these two mutexes and returns std::nullopt when
-    // ownership cannot be acquired. Holding an exclusive lock on either mutex
-    // from another thread deterministically reproduces that "contended" state.
-    std::unique_lock<std::shared_mutex> LockPagesMutexExclusiveForTest()
+    // a time-based acquire on these two mutexes and returns std::nullopt when
+    // ownership cannot be acquired within the timeout. Holding an exclusive lock
+    // on either mutex from another thread deterministically reproduces that
+    // "contended" state.
+    std::unique_lock<std::shared_timed_mutex> LockPagesMutexExclusiveForTest()
     {
-        return std::unique_lock<std::shared_mutex>(_pagesMutex);
+        return std::unique_lock<std::shared_timed_mutex>(_pagesMutex);
     }
-    std::unique_lock<std::shared_mutex> LockModulesMutexExclusiveForTest()
+    std::unique_lock<std::shared_timed_mutex> LockModulesMutexExclusiveForTest()
     {
-        return std::unique_lock<std::shared_mutex>(_modulesMutex);
+        return std::unique_lock<std::shared_timed_mutex>(_modulesMutex);
     }
 private:
 #endif
-    void AddModuleCodeRangesAsync(std::vector<ModuleCodeRange> moduleCodeRanges);
-    void AddFunctionCodeRangesAsync(std::vector<CodeRange> ranges);
     std::vector<ModuleCodeRange> GetModuleCodeRanges(ModuleID moduleId);
     void InsertCodeRangeIntoPage(PagesMap::iterator pageIt, const CodeRange& range);
 
-    void WorkerThread(std::promise<void> startPromise);
-    
     // Helper: Ensure a page exists in the map
     void EnsurePageExists(uint64_t page);
     std::optional<bool> IsManagedImpl(std::uintptr_t ip) const noexcept;
@@ -169,28 +159,19 @@ private:
     // Map from page number -> page entry (with its own lock)
     PagesMap _pagesMap;
     std::vector<ModuleCodeRange> _modulesCodeRanges;
-    mutable std::shared_mutex _modulesMutex;
+    mutable std::shared_timed_mutex _modulesMutex;
     
     // Coarse lock ONLY for modifying the map structure itself
     // (adding/removing pages, not modifying page contents)
-    mutable std::shared_mutex _pagesMutex;
+    mutable std::shared_timed_mutex _pagesMutex;
     
     // Profiler interface (ICorProfilerInfo4 is available in .NET Framework 4.5+)
     ICorProfilerInfo4* _profilerInfo;
-    std::thread _worker;
-    std::atomic<bool> _requestStop;
-    
-    std::deque<std::function<void()>> _workerQueue;
-    std::mutex _queueMutex;
 
-    template<typename WorkType>
-    void EnqueueWork(WorkType work);
     std::optional<FunctionID> GetFunctionIdImpl(std::uintptr_t ip) const noexcept;
     std::optional<bool> IsCodeInR2RModule(std::uintptr_t ip, bool signalSafe) const noexcept;
     std::optional<FunctionID> GetFunctionFromIP_Original(std::uintptr_t ip) noexcept;
-    void AddFunctionImpl(FunctionID functionId, bool isAsync);
-    
-    AutoResetEvent _workerQueueEvent;
+    void AddFunctionImpl(FunctionID functionId);
 };
 
 // Compile-time checks for signal-safety

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
@@ -156,8 +156,6 @@ private:
     std::vector<ModuleCodeRange> GetModuleCodeRanges(ModuleID moduleId);
     void InsertCodeRangeIntoPage(PagesMap::iterator pageIt, const CodeRange& range);
 
-    // Helper: Ensure a page exists in the map
-    void EnsurePageExists(uint64_t page);
     std::optional<bool> IsManagedImpl(std::uintptr_t ip) const noexcept;
 
     // Map from page number -> page entry (with its own lock)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
@@ -16,6 +17,9 @@
 
 #include "cor.h"
 #include "corprof.h"
+
+class CounterMetric;
+class MetricsRegistry;
 
 // Represents a single contiguous code range
 struct CodeRange {
@@ -73,7 +77,7 @@ class ManagedCodeCache {
 public:
     static constexpr FunctionID InvalidFunctionId = -1;
 
-    explicit ManagedCodeCache(ICorProfilerInfo4* pProfilerInfo);
+    ManagedCodeCache(ICorProfilerInfo4* pProfilerInfo, MetricsRegistry& metricsRegistry);
     ~ManagedCodeCache();
 
     // Signal-safe lookup methods (no allocation)
@@ -167,6 +171,10 @@ private:
     
     // Profiler interface (ICorProfilerInfo4 is available in .NET Framework 4.5+)
     ICorProfilerInfo4* _profilerInfo;
+
+    // Counts how many times IsManaged failed to acquire a lock within the timeout
+    // (signal-handler read path backing off instead of blocking).
+    std::shared_ptr<CounterMetric> _lockFailureMetric;
 
     std::optional<FunctionID> GetFunctionIdImpl(std::uintptr_t ip) const noexcept;
     std::optional<bool> IsCodeInR2RModule(std::uintptr_t ip, bool signalSafe) const noexcept;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedCodeCache.h
@@ -18,8 +18,25 @@
 #include "cor.h"
 #include "corprof.h"
 
+#ifndef _WINDOWS
+#include "ReaderWriterSpinningMutex.hpp"
+#endif
+
 class CounterMetric;
 class MetricsRegistry;
+
+// The cache read paths can run inside the profiler's signal handlers (SIGPROF for
+// the timer_create CPU profiler, SIGUSR1 for wall-time stack collection). The timed
+// acquire of std::shared_timed_mutex lowers to pthread_rwlock_timedrdlock, which
+// POSIX does not list as async-signal-safe. ReaderWriterSpinningMutex implements the
+// same SharedTimedMutex requirements using only atomics, so it can be used with
+// std::shared_lock/std::unique_lock unchanged.
+// Windows has no signal-based sampling, so the standard type is used there.
+#ifdef _WINDOWS
+using CodeCacheMutex = std::shared_timed_mutex;
+#else
+using CodeCacheMutex = ReaderWriterSpinningMutex;
+#endif
 
 // Represents a single contiguous code range
 struct CodeRange {
@@ -96,7 +113,7 @@ private:
     // Each page has its own data + lock for fine-grained concurrency
     struct PageEntry {
         std::vector<CodeRange> ranges;  // Sorted by startAddress
-        mutable std::shared_timed_mutex lock;  // Reader-writer lock (timed for signal-handler reads)
+        mutable CodeCacheMutex lock;  // Reader-writer lock (timed for signal-handler reads)
         
         PageEntry() = default;
         
@@ -143,13 +160,13 @@ public:
     // ownership cannot be acquired within the timeout. Holding an exclusive lock
     // on either mutex from another thread deterministically reproduces that
     // "contended" state.
-    std::unique_lock<std::shared_timed_mutex> LockPagesMutexExclusiveForTest()
+    std::unique_lock<CodeCacheMutex> LockPagesMutexExclusiveForTest()
     {
-        return std::unique_lock<std::shared_timed_mutex>(_pagesMutex);
+        return std::unique_lock<CodeCacheMutex>(_pagesMutex);
     }
-    std::unique_lock<std::shared_timed_mutex> LockModulesMutexExclusiveForTest()
+    std::unique_lock<CodeCacheMutex> LockModulesMutexExclusiveForTest()
     {
-        return std::unique_lock<std::shared_timed_mutex>(_modulesMutex);
+        return std::unique_lock<CodeCacheMutex>(_modulesMutex);
     }
 private:
 #endif
@@ -161,11 +178,11 @@ private:
     // Map from page number -> page entry (with its own lock)
     PagesMap _pagesMap;
     std::vector<ModuleCodeRange> _modulesCodeRanges;
-    mutable std::shared_timed_mutex _modulesMutex;
+    mutable CodeCacheMutex _modulesMutex;
     
     // Coarse lock ONLY for modifying the map structure itself
     // (adding/removing pages, not modifying page contents)
-    mutable std::shared_timed_mutex _pagesMutex;
+    mutable CodeCacheMutex _pagesMutex;
     
     // Profiler interface (ICorProfilerInfo4 is available in .NET Framework 4.5+)
     ICorProfilerInfo4* _profilerInfo;

--- a/profiler/test/Datadog.Profiler.Native.Tests/FrameStoreTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/FrameStoreTest.cpp
@@ -6,6 +6,7 @@
 
 #include "FrameStore.h"
 #include "ManagedCodeCache.h"
+#include "MetricsRegistry.h"
 #include "MockProfilerInfo.h"
 
 #include <memory>
@@ -86,7 +87,8 @@ TEST(FrameStoreTest, GetFrame_WithCache_NativeIp_ReturnsNotResolvedAndDropped)
 
     // Empty cache => any IP resolves to InvalidFunctionId (there are no registered
     // JIT ranges and no R2R modules), which is exactly the "native IP" case.
-    auto cache = std::make_unique<ManagedCodeCache>(&mockProfiler);
+    MetricsRegistry metricsRegistry;
+    auto cache = std::make_unique<ManagedCodeCache>(&mockProfiler, metricsRegistry);
     cache->Initialize();
 
     FrameStore frameStore(
@@ -161,7 +163,8 @@ TEST(FrameStoreTest, GetFrame_WithCache_CachedPathNullopt_ReturnsResolvedPlaceho
 {
     auto mockProfiler = MockProfilerInfo{};
 
-    auto cache = std::make_unique<ManagedCodeCache>(&mockProfiler);
+    MetricsRegistry metricsRegistry;
+    auto cache = std::make_unique<ManagedCodeCache>(&mockProfiler, metricsRegistry);
     cache->Initialize();
 
     // Register an R2R module range so GetFunctionId falls through to

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -166,7 +166,7 @@ public:
 
 #ifdef ARM64
         // TODO maybe a mock of ICorProfilerInfo to avoid crashing
-        _pManagedCodeCache = std::make_unique<ManagedCodeCache>(nullptr);
+        _pManagedCodeCache = std::make_unique<ManagedCodeCache>(nullptr, _metricsRegistry);
         _pUnwinder = std::make_unique<HybridUnwinder>(_pManagedCodeCache.get());
 #else
         _pUnwinder = std::make_unique<Backtrace2Unwinder>();

--- a/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
@@ -44,11 +44,6 @@ protected:
                 return S_OK;
             });
     }
-
-    // Helper: Wait for async worker thread
-    void WaitForWorkerThread(int milliseconds = 100) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
-    }
 };
 
 // Test: Single code range
@@ -60,8 +55,6 @@ TEST_F(ManagedCodeCacheTest, AddFunction_SingleRange_GetFunctionIdReturnsCorrect
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
 
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Test IPs within range
     EXPECT_EQ(testFuncId, cache->GetFunctionId(codeStart).value_or(0));
     EXPECT_EQ(testFuncId, cache->GetFunctionId(codeStart + 0x100).value_or(0));
@@ -87,16 +80,12 @@ TEST_F(ManagedCodeCacheTest, AddFunction_MultipleRanges_AccumulatesCorrectly) {
     // First JIT (Tier 0)
     SetupMockCodeInfo(testFuncId, tier0Start, tier0Size);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Verify Tier 0 works
     EXPECT_EQ(testFuncId, cache->GetFunctionId(tier0Start + 0x50).value_or(0));
 
     // Second JIT (Tier 1)
     SetupMockCodeInfo(testFuncId, tier1Start, tier1Size);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Both ranges should work (accumulation)
     EXPECT_EQ(testFuncId, cache->GetFunctionId(tier0Start + 0x50).value_or(0));
     EXPECT_EQ(testFuncId, cache->GetFunctionId(tier1Start + 0x100).value_or(0));
@@ -110,8 +99,6 @@ TEST_F(ManagedCodeCacheTest, IsManaged_ValidManagedIP_ReturnsTrue) {
 
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     EXPECT_TRUE(cache->IsManaged(codeStart + 0x50));
 }
 
@@ -138,8 +125,6 @@ TEST_F(ManagedCodeCacheTest, AddFunction_MultipleFunctions_NoInterference) {
 
     cache->AddFunction(func1);
     cache->AddFunction(func2);
-    WaitForWorkerThread();
-
     EXPECT_EQ(func1, cache->GetFunctionId(code1Start + 0x50).value_or(0));
     EXPECT_EQ(func2, cache->GetFunctionId(code2Start + 0x50).value_or(0));
 
@@ -180,8 +165,6 @@ TEST_F(ManagedCodeCacheTest, AddFunction_ConcurrentCalls_ThreadSafe) {
         thread.join();
     }
 
-    WaitForWorkerThread(500);  // Wait longer for all async operations
-
     // Verify every function is retrievable by IP
     for (int t = 0; t < numThreads; t++) {
         for (int i = 0; i < functionsPerThread; i++) {
@@ -216,8 +199,6 @@ TEST_F(ManagedCodeCacheTest, IsManaged_ConcurrentAccess) {
 
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Concurrent IsManaged calls (simulating signal handler scenario)
     const int numCalls = 1000;
     std::atomic<int> successCount{0};
@@ -249,8 +230,6 @@ TEST_F(ManagedCodeCacheTest, GetFunctionId_BoundaryIPs_CorrectBehavior) {
 
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Exact boundaries
     EXPECT_EQ(testFuncId, cache->GetFunctionId(codeStart).value_or(0));  // First byte (inclusive)
     EXPECT_EQ(testFuncId, cache->GetFunctionId(codeStart + codeSize - 1).value_or(0));  // Last byte (inclusive)
@@ -267,7 +246,7 @@ TEST_F(ManagedCodeCacheTest, GetFunctionId_BoundaryIPs_CorrectBehavior) {
 // Regression: GetCodeRanges used `startAddress + size - 1` without guarding
 // size==0.  For startAddress==0 this gives endAddress==UINTPTR_MAX and the
 // page-insertion loop `for (page=0; page<=UINTPTR_MAX/pageSize; ++page)` runs
-// for billions of iterations, permanently hanging the background worker.
+// for billions of iterations, permanently hanging the (now synchronous) insert.
 // For non-zero startAddress the loop silently skips (endPage < startPage) but
 // the degenerate CodeRange still pollutes the sorted range vector.
 TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_DoesNotPolluteCacheNonZeroBase) {
@@ -277,8 +256,6 @@ TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_DoesNotPolluteCacheNonZer
 
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // A zero-size range has no valid code; no IP should be reported as managed.
     auto codeStartIp = cache->IsManaged(codeStart);
     EXPECT_TRUE(codeStartIp.has_value());
@@ -295,18 +272,17 @@ TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRange_DoesNotPolluteCacheNonZer
 }
 
 // For startAddress==0 with size==0 the page loop would run from page 0 to
-// ~UINTPTR_MAX/pageSize, hanging the worker forever.  After the fix the worker
-// must complete within the normal wait and IsManaged must return false.
-TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRangeAtAddressZero_WorkerDoesNotHang) {
+// ~UINTPTR_MAX/pageSize, hanging forever.  After the fix AddFunction (now
+// synchronous) must return promptly and IsManaged must return false.
+TEST_F(ManagedCodeCacheTest, AddFunction_ZeroSizeRangeAtAddressZero_DoesNotHang) {
     FunctionID testFuncId = 778;
     uintptr_t codeStart = 0;
     ULONG32 codeSize = 0;
 
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
+    // If the synchronous insert is stuck this call blocks until the test times out.
     cache->AddFunction(testFuncId);
 
-    // If the worker is stuck this call blocks until the test times out.
-    WaitForWorkerThread(200);
     auto codeStartPlusOneThousand = cache->IsManaged(0x1000);
     EXPECT_TRUE(codeStartPlusOneThousand.has_value());
     EXPECT_FALSE(codeStartPlusOneThousand.value())
@@ -321,8 +297,6 @@ TEST_F(ManagedCodeCacheTest, AddFunction_LargeCodeRange_WorksCorrectly) {
 
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Test various points in large range
     EXPECT_EQ(testFuncId, cache->GetFunctionId(codeStart).value_or(0));
     EXPECT_EQ(testFuncId, cache->GetFunctionId(codeStart + 0x8000).value_or(0));
@@ -344,8 +318,6 @@ TEST_F(ManagedCodeCacheTest, AddFunction_GetCodeInfo2Fails_HandledGracefully) {
         .WillOnce(Return(E_FAIL));
 
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Should not crash
     auto nullIp = cache->GetFunctionId(0x1000);
     EXPECT_TRUE(nullIp.has_value());
@@ -392,8 +364,6 @@ TEST_F(ManagedCodeCacheTest, IsManaged_WriterHoldsPagesMutex_ReturnsNullopt) {
 
     SetupMockCodeInfo(testFuncId, codeStart, codeSize);
     cache->AddFunction(testFuncId);
-    WaitForWorkerThread();
-
     // Sanity: with no contention, IsManaged returns a concrete value.
     auto baseline = cache->IsManaged(codeStart + 0x50);
     ASSERT_TRUE(baseline.has_value());

--- a/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ManagedCodeCacheTest.cpp
@@ -3,7 +3,9 @@
 
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "CounterMetric.h"
 #include "ManagedCodeCache.h"
+#include "MetricsRegistry.h"
 #include "MockProfilerInfo.h"
 
 #include <thread>
@@ -15,11 +17,12 @@ using namespace testing;
 class ManagedCodeCacheTest : public Test {
 protected:
     MockProfilerInfo* mockProfiler;
+    MetricsRegistry metricsRegistry;
     std::unique_ptr<ManagedCodeCache> cache;
 
     void SetUp() override {
         mockProfiler = new MockProfilerInfo();
-        cache = std::make_unique<ManagedCodeCache>(mockProfiler);
+        cache = std::make_unique<ManagedCodeCache>(mockProfiler, metricsRegistry);
         cache->Initialize();
     }
 
@@ -43,6 +46,15 @@ protected:
                 }
                 return S_OK;
             });
+    }
+
+    // Helper: read (and reset) the IsManaged lock-failure counter.
+    // GetMetrics() exchanges the underlying atomic to 0, so each call returns the
+    // number of failures recorded since the previous read.
+    uint64_t GetLockFailureCount() {
+        auto metric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_managed_code_cache_lock_failures");
+        auto metrics = metric->GetMetrics();
+        return metrics.empty() ? 0 : static_cast<uint64_t>(metrics.front().second);
     }
 };
 
@@ -402,6 +414,47 @@ TEST_F(ManagedCodeCacheTest, IsManaged_WriterHoldsPagesMutex_ReturnsNullopt) {
     auto afterRelease = cache->IsManaged(codeStart + 0x50);
     ASSERT_TRUE(afterRelease.has_value());
     EXPECT_TRUE(afterRelease.value());
+}
+
+// Test: IsManaged increments the lock-failure metric when it cannot acquire the
+// pages mutex within the timeout, and leaves it untouched on the success path.
+TEST_F(ManagedCodeCacheTest, IsManaged_LockAcquisitionFailure_IncrementsMetric) {
+    FunctionID testFuncId = 0x4321;
+    uintptr_t codeStart = 0xD000;
+    ULONG32 codeSize = 0x100;
+
+    SetupMockCodeInfo(testFuncId, codeStart, codeSize);
+    cache->AddFunction(testFuncId);
+
+    // Success path must not increment the failure metric.
+    ASSERT_TRUE(cache->IsManaged(codeStart + 0x50).value_or(false));
+    EXPECT_EQ(0u, GetLockFailureCount());
+
+    // Hold the pages mutex exclusively so IsManaged times out and returns nullopt.
+    std::atomic<bool> writerHoldsLock{false};
+    std::atomic<bool> readerDone{false};
+    std::thread writer([&]() {
+        auto lock = cache->LockPagesMutexExclusiveForTest();
+        writerHoldsLock.store(true);
+        while (!readerDone.load())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+
+    while (!writerHoldsLock.load())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    auto contended = cache->IsManaged(codeStart + 0x50);
+    EXPECT_FALSE(contended.has_value());
+
+    readerDone.store(true);
+    writer.join();
+
+    // The failed acquisition must have been recorded exactly once.
+    EXPECT_EQ(1u, GetLockFailureCount());
 }
 
 // Test: IsManaged must also return nullopt when the writer holds the modules

--- a/tracer/build/_build/NativeValidation/native-profiler-symbols-alpine-arm64.verified.txt
+++ b/tracer/build/_build/NativeValidation/native-profiler-symbols-alpine-arm64.verified.txt
@@ -15,6 +15,7 @@ blaze_read_elf_build_id
 btowc
 calloc
 clock_gettime
+clock_nanosleep
 close
 closedir
 ddog_crasht_CrashInfo_upload_to_endpoint

--- a/tracer/build/_build/NativeValidation/native-profiler-symbols-alpine-x64.verified.txt
+++ b/tracer/build/_build/NativeValidation/native-profiler-symbols-alpine-x64.verified.txt
@@ -16,6 +16,7 @@ btowc
 calloc
 ceil
 clock_gettime
+clock_nanosleep
 close
 closedir
 ddog_crasht_CrashInfo_upload_to_endpoint


### PR DESCRIPTION
## Summary of changes

Make `ManagedCodeCache` updates synchronous.

## Reason for change

Today, when a jit/module event is received by the profiler, we store in a queue a work item to update the cache. This asynchronous behavior can impact the unwinding: The thread is just after interrupted, during unwinding a call to `IsManaged` is done, but returns `false`.

Both values could lead to a crash:
- When unwinding native frames, if `IsManaged` returns `false` (cache not yet updated), we will call libunwind to get previous/next frame. This could lead to a crash directly or later.
- When unwinding managed frames, if `IsManaged` returns `false`, we will assume that it's managed or native frames with frame-pointer pushed. If it's not the case (ex: frames from libc/musl-libc), we could crash the application.

## Implementation details

- When receiving the CLR event to update the case, we block the profiler signals (`SIGUSR1`  and `SIGPROF`) before updating the case.
- Replace the `std::shared_mutex` by `std::shared_timed_mutex` to avoid doing retries without yielding.
- Add metrics to identify contention between writer and reader threads that ended in reader to bail.

## Test coverage

Current tests  should be ok.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
