### PR TITLE
fix(tracer): prevent catastrophic backtracking in query string obfuscation on multibyte URL-encoded filenames

### DIFF
--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
@@ -12,6 +12,18 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
     internal sealed class Obfuscator : ObfuscatorBase
     {
         private const string ReplacementString = "<redacted>";
+
+        // Matches URL-encoded high-byte sequences (%80–%FF) which represent multibyte (non-ASCII)
+        // characters such as Korean, Japanese, or Chinese filenames.
+        // Credential patterns (tokens, keys, passwords) are always ASCII; these sequences cannot
+        // contain sensitive data and are safe to strip before applying the obfuscation regex.
+        // Stripping them eliminates the trigger condition for catastrophic backtracking on
+        // the default obfuscation pattern. See: https://github.com/DataDog/dd-trace-dotnet/issues/XXXXX
+        private static readonly Regex HighByteUrlEncodingRegex = new(
+            @"(?:%[89A-Fa-f][0-9A-Fa-f])+",
+            RegexOptions.Compiled,
+            TimeSpan.FromMilliseconds(200));
+
         private readonly Regex _regex;
         private readonly TimeSpan _timeout;
         private readonly IDatadogLogger _logger;
@@ -21,9 +33,22 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
             _timeout = timeout;
             _logger = logger;
 
+            // NonBacktracking (available in .NET 7+) guarantees O(n) matching time and eliminates
+            // catastrophic backtracking on URL-encoded multibyte content (e.g. Korean/CJK filenames).
+            // The default obfuscation regex contains alternation patterns such as (?:%2[^2]|%[^2]|[^"%])+
+            // and ey[I-L](?:[\w=-]|%3D)+ that backtrack catastrophically when applied to
+            // URL-encoded high-byte sequences like %EC%84%A4%EA%B3%84..., causing sustained CPU spikes.
+            // See: https://github.com/DataDog/dd-trace-dotnet/issues/XXXXX
+#if NET7_0_OR_GREATER
+            const RegexOptions options = RegexOptions.Compiled |
+                                         RegexOptions.IgnoreCase |
+                                         RegexOptions.IgnorePatternWhitespace |
+                                         RegexOptions.NonBacktracking;
+#else
             const RegexOptions options = RegexOptions.Compiled |
                                          RegexOptions.IgnoreCase |
                                          RegexOptions.IgnorePatternWhitespace;
+#endif
 
             _regex = new Regex(pattern, options, _timeout);
 
@@ -51,7 +76,12 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
 
             try
             {
-                return _regex.Replace(queryString, ReplacementString);
+                // Strip URL-encoded high-byte sequences before applying the obfuscation regex.
+                // Multibyte-encoded characters (%80–%FF) cannot contain credential patterns
+                // (tokens, keys, passwords are ASCII-only) and their presence triggers catastrophic
+                // backtracking in the default obfuscation regex when combined with auth parameters.
+                var sanitized = HighByteUrlEncodingRegex.Replace(queryString, string.Empty);
+                return _regex.Replace(sanitized, ReplacementString);
             }
             catch (RegexMatchTimeoutException exception)
             {

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
@@ -106,4 +106,53 @@ public class QueryStringObfuscatorTests
         var result = queryStringObfuscator.Obfuscate(queryString);
         result.Should().Be("?<redacted>&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&<redacted>&<redacted>");
     }
+
+    [Theory]
+    [InlineData(
+        // Vault file download URL with Korean filename + auth ticket — the pattern that caused
+        // catastrophic backtracking with the default regex (CPU spike to 90% in production).
+        // High-byte URL-encoded sequences (%EC, %84, %A4...) must be stripped before obfuscation
+        // so that the regex engine does not attempt to match them against JWT/SSH/bearer patterns.
+        "dbName=CPMS&fileId=F4D7D9C025CF4FB29023189592B261D1&fileName=%EC%84%A4%EA%B3%84%EC%9E%90%EB%A3%8C%EC%86%A1%EB%B6%80%EC%84%9C_.xlsx&vaultId=67BBB9204FE84A8981ED8313049BA06C&token=VAULTTOKEN1234567",
+        "dbName=CPMS&fileId=F4D7D9C025CF4FB29023189592B261D1&fileName=_.xlsx&vaultId=67BBB9204FE84A8981ED8313049BA06C&<redacted>")]
+    [InlineData(
+        // Japanese filename — same high-byte URL encoding pattern
+        "filename=%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%83%86%E3%82%B9%E3%83%88.pdf&token=abc1234567890ab",
+        "filename=.pdf&<redacted>")]
+    [InlineData(
+        // ASCII-only URL — high-byte stripping must NOT affect ASCII credential parameters
+        "key1=val1&token=abc1234567890ab&key2=val2",
+        "key1=val1&<redacted>&key2=val2")]
+    [InlineData(
+        // Mixed: ASCII params + Korean filename — only ticket should be redacted
+        "database=CPMS&fileName=%EC%84%A4%EA%B3%84.xlsx&user=emma.bae",
+        "database=CPMS&fileName=.xlsx&user=emma.bae")]
+    public void ObfuscateWithDefaultPattern_MultibyteUrlEncoding(string queryString, string expected)
+    {
+        var logger = new Mock<IDatadogLogger>();
+        var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettingsConstants.DefaultObfuscationQueryStringRegex, logger.Object);
+        var result = queryStringObfuscator.Obfuscate(queryString);
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ObfuscateWithDefaultPattern_MultibyteUrlEncoding_CompletesWithinTimeout()
+    {
+        // Regression test: the default obfuscation regex must complete well within the timeout
+        // when applied to a URL containing a long URL-encoded Korean filename + auth ticket.
+        // Before the fix, RegexInterpreter.Go() consumed 16+ seconds/min on this pattern.
+        var logger = new Mock<IDatadogLogger>();
+        var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettingsConstants.DefaultObfuscationQueryStringRegex, logger.Object);
+
+        var longKoreanFilename = string.Concat(Enumerable.Repeat("%EC%84%A4%EA%B3%84%EC%9E%90%EB%A3%8C", 10));
+        var queryString = $"dbName=CPMS&fileId=ABC123&fileName={longKoreanFilename}_.xlsx&vaultId=67BBB9204FE84A8981ED8313049BA06C&token=VAULTTOKEN1234567";
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var result = queryStringObfuscator.Obfuscate(queryString);
+        stopwatch.Stop();
+
+        // Must not time out (return empty string) and must complete in well under 1 second
+        result.Should().NotBeEmpty("obfuscation must not time out on multibyte URL-encoded filenames");
+        stopwatch.ElapsedMilliseconds.Should().BeLessThan(1000, "catastrophic backtracking must not occur");
+    }
 }


### PR DESCRIPTION
## Summary

URL-encoded multibyte filenames (Korean/Japanese/CJK) in query string parameters trigger catastrophic backtracking in the default `DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP` when combined with auth-related parameters (e.g. a Vault `ticket` parameter).

In production this caused `RegexInterpreter.Go()` to consume **16.34s/min** (vs 3ms baseline), and `system.cpu.user` to spike from **~1.6% to 90%** with zero application code changes after APM instrumentation.

Datadog Continuous Profiler confirmed the root cause via A/B comparison: `TrackPush`, `StackPush`, and `Goto` (backtracking-only methods) were completely absent before instrumentation and spiked immediately after.

## Root Cause

The three backtracking-prone patterns in the default regex fire simultaneously on Vault file download URLs containing URL-encoded Korean filenames:

- `(?:%2[^2]|%[^2]|[^"%])+` — 70+ `%XX` bytes accumulate before failing to find closing `"`, then full rollback
- `ey[I-L](?:[\w=-]|%3D)+\.ey[I-L]...` — greedily matches filename chars, fails on required `.` separator
- `(?:[a-z0-9/.+]|%2F|%5C|%2B){100,}` — 100+ iterations across `%2F`-containing encoded content

Example triggering URL:
```
/Vault/vaultserver.aspx
  ?fileName=%EC%84%A4%EA%B3%84%EC%9E%90%EB%A3%8C_.xlsx
  &vaultId=67BBB9204FE84A8981ED8313049BA06C
  &ticket=VAULT_TOKEN
```

## Changes

**`Obfuscator.cs`** — two complementary fixes:

1. **Pre-strip high-byte URL-encoded sequences** (`%80–%FF`) before running the obfuscation regex. Credential patterns (tokens, keys, passwords) are ASCII-only; multibyte-encoded characters cannot contain sensitive data, so stripping them removes the backtracking trigger while keeping all ASCII parameters intact.

2. **`RegexOptions.NonBacktracking` on .NET 7+** — guarantees O(n) matching time regardless of input, as defense-in-depth.

**`QueryStringObfuscatorTests.cs`** — regression tests:
- Korean/Japanese filename + token parameter (exact production trigger)
- ASCII-only URLs (no regression in existing behavior)
- Performance assertion: completes within 1s on long encoded filenames

## Test Plan

- [ ] `QueryStringObfuscatorTests.ObfuscateWithDefaultPattern_MultibyteUrlEncoding` — correctness
- [ ] `QueryStringObfuscatorTests.ObfuscateWithDefaultPattern_MultibyteUrlEncoding_CompletesWithinTimeout` — performance regression guard
- [ ] All existing `ObfuscateWithDefaultPattern` tests still pass

## Affected Customers

Any customer where HTTP request URLs contain URL-encoded multibyte characters **and** a parameter name matching the default regex keyword list (`token`, `auth`, `sign`, `secret`, `key`, `password`, etc.). Particularly likely in Korean/Japanese/Chinese deployments, document management systems, and file servers.
