### PR TITLE
Update CI VMs to use latest images

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2403,11 +2403,6 @@ stages:
         retryCountForRunCommand: 3
 
     - script: |
-        docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
-      displayName: docker pull latest ddapm-test-agent image (we rely on a newer version than the one in the base image)
-      retryCountOnTaskFailure: 3
-
-    - script: |
         docker-compose -p $(DockerComposeProjectName)-g$(dockerGroup) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
         docker-compose -p $(DockerComposeProjectName)-g$(dockerGroup) run --rm StartDependencies.Group$(dockerGroup)
       env:
@@ -3451,11 +3446,6 @@ stages:
             command: "BuildIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
-
-        - script: |
-            docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
-          displayName: docker pull latest ddapm-test-agent image (we rely on a newer version than the one in the base image)
-          retryCountOnTaskFailure: 3
 
         - script: |
             docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) IntegrationTests.ARM64

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -72,8 +72,8 @@ variables:
   nativeBuildDotnetSdkVersion: 7.0.306
   # These are the Managed DevOps pool names we use
   linuxTasksPool: azure-managed-linux-tasks
-  linuxX64SmokePool: azure-managed-linux-smoke
-  linuxX64Pool: azure-managed-linux-x64-1
+  linuxX64SmokePool: azure-managed-linux-smoke-2
+  linuxX64Pool: azure-managed-linux-x64-2
   linuxArm64Pool: azure-managed-linux-arm64-1
   windowsX64Pool: azure-managed-windows-x64-2
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2486,19 +2486,19 @@ stages:
       matrix:
         net6:
           publishTargetFramework: "net6.0"
-          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:6"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:6@sha256:c48000be860898f1a1c5bbffc1801673927942fd516f14fee458167ebe1dfa02"
         net7:
           publishTargetFramework: "net7.0"
-          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:7"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:7@sha256:5434516a138eb44786c9c3a4dc557fc2ad1cd87dc31c4c1043e0df456fa89fbe"
         net8:
           publishTargetFramework: "net8.0"
-          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:8"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:8@sha256:e3a1b5ed15641105f82d90123047e96f58d16ae90c6700efafb08e7c9e95234c"
         net9:
           publishTargetFramework: "net9.0"
-          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:9"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:9@sha256:353e19a79580031dc1b2faf8e421af08f57b5f8d4eea7faae256c5a751e09cc0"
         net10:
           publishTargetFramework: "net10.0"
-          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:10"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:10@sha256:ca784b95a4d6d09cd7c3f447833f80527ee7d7b644a955b26a59c2cfe2354296"
     pool:
       name: $(linuxX64Pool)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -74,7 +74,7 @@ variables:
   linuxTasksPool: azure-managed-linux-tasks
   linuxX64SmokePool: azure-managed-linux-smoke-2
   linuxX64Pool: azure-managed-linux-x64-2
-  linuxArm64Pool: azure-managed-linux-arm64-1
+  linuxArm64Pool: azure-managed-linux-arm64-2
   windowsX64Pool: azure-managed-windows-x64-2
 
   relativeArtifacts: /artifacts/output

--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -84,7 +84,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
 
   StartDependencies.Serverless:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
     - serverless-lambda-no-param-sync
     - serverless-lambda-one-param-sync
@@ -1348,7 +1348,7 @@ services:
 
   # The serverless function calls this API, which always returns 200 OK
   serverless-dummy-api:
-    image: andrewlock/ok-api:latest
+    image: andrewlock/ok-api:latest@sha256:ca0149fef76574b72116add387a1b395e3bafc56cb58b5e45b3c825f742e3911
     ports:
     - "9005:9005"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "4566:4566"
 
   elasticsearch7_arm64:
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.10.1@sha256:7cd88158f6ac75d43b447fdd98c4eb69483fa7bf1be5616a85fe556262dc864a
     ports:
     - "9200"
     - "9300"
@@ -20,13 +20,13 @@ services:
     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   mongo_arm64:
-    image: mongo:5.0.31
+    image: mongo:5.0.31@sha256:54bcd8da3ea5eec561b68c605046c55c6b304387dc4c2bf5b3a5f5064fbb7495
     ports:
       - "27017"
     command: mongod
 
   mysql_arm64:
-    image: mysql/mysql-server:8.0
+    image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     environment:
     - MYSQL_DATABASE=world
     - MYSQL_ROOT_PASSWORD=mysqldb
@@ -36,7 +36,7 @@ services:
     - "3306"
 
   postgres_arm64:
-    image: postgres:10.5-alpine
+    image: postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117
     environment:
     - POSTGRES_PASSWORD=postgres
     - POSTGRES_USER=postgres
@@ -45,20 +45,20 @@ services:
     - "5432"
 
   rabbitmq_arm64:
-    image: rabbitmq:3-management
+    image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
     command: rabbitmq-server
     ports:
       - "5672"
       - "15672"
 
   servicestackredis_arm64:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     command: redis-server --bind 0.0.0.0
     ports:
     - "6379"
 
   sqledge_arm64:
-    image: mcr.microsoft.com/azure-sql-edge:latest
+    image: mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf
     ports:
     - "1433"
     environment:
@@ -66,25 +66,25 @@ services:
     - SA_PASSWORD=Strong!Passw0rd
 
   cosmosdb-emulator_arm64:
-    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview@sha256:54d7bc334494c50cea867c270880671a7db080626a9732832b34c0d69342f9b0
     command: ["--protocol", "https"]
 
   stackexchangeredis_arm64:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     hostname: stackexchangeredis_arm64
     command: redis-server --bind 0.0.0.0
     ports:
     - "6379"
 
   stackexchangeredis_arm64-replica:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     hostname: stackexchangeredis_arm64-replica
     command: redis-server --bind 0.0.0.0 --slaveof stackexchangeredis_arm64 6379
     ports:
     - "127.0.0.1:6390:6379"
 
   stackexchangeredis_arm64-single:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     hostname: stackexchangeredis_arm64-single
     command: redis-server --bind 0.0.0.0
     ports:
@@ -105,7 +105,7 @@ services:
       - "./.localstack:/tmp"
 
   rabbitmq:
-    image: rabbitmq:3-management
+    image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
     profiles: ["group1"]
     command: rabbitmq-server
     ports:
@@ -113,14 +113,14 @@ services:
       - "127.0.0.1:15672:15672"
 
   servicestackredis:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     profiles: ["group1"]
     command: redis-server --bind 0.0.0.0
     ports:
     - "127.0.0.1:6379:6379"
 
   stackexchangeredis:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     profiles: ["group1"]
     hostname: stackexchangeredis
     command: redis-server --bind 0.0.0.0
@@ -128,7 +128,7 @@ services:
     - "127.0.0.1:6389:6379"
 
   stackexchangeredis-replica:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     profiles: ["group1"]
     hostname: stackexchangeredis-replica
     command: redis-server --bind 0.0.0.0 --slaveof stackexchangeredis 6379
@@ -136,7 +136,7 @@ services:
     - "127.0.0.1:6390:6379"
 
   stackexchangeredis-single:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     profiles: ["group1"]
     hostname: stackexchangeredis-single
     command: redis-server --bind 0.0.0.0
@@ -144,21 +144,21 @@ services:
     - "127.0.0.1:6391:6379"
 
   mongo:
-    image: mongo:5.0.31
+    image: mongo:5.0.31@sha256:54bcd8da3ea5eec561b68c605046c55c6b304387dc4c2bf5b3a5f5064fbb7495
     profiles: ["group2"]
     ports:
       - "127.0.0.1:27017:27017"
     command: mongod
 
   couchbase:
-    image: bentonam/couchbase-docker:community-5.0.1
+    image: bentonam/couchbase-docker:community-5.0.1@sha256:847440848c80b95d82b12c8834856a14b1bfde854bd03b6acd0f9d0ac3484c63
     profiles: ["group1"]
     ports:
       - "8091-8094:8091-8094"
       - "11210:11210"
 
   elasticsearch7:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.1@sha256:2dcd2f31e246a8b13995ba24922da2edc3d88e65532ff301d0b92cb1be358af5
     profiles: ["group2"]
     ports:
     - "127.0.0.1:9210:9200"
@@ -168,7 +168,7 @@ services:
     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   elasticsearch6:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2@sha256:3da16b2f3b1d4e151c44f1a54f4f29d8be64884a64504b24ebcbdb4e14c80aa1
     profiles: ["group2"]
     ports:
     - "127.0.0.1:9200:9200"
@@ -178,7 +178,7 @@ services:
     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   elasticsearch5:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16@sha256:9ffbb6d9d0f383d70b8249117e5758dcf9c628a5ab3a78fd6a520ef1d0f416a2
     profiles: ["group2"]
     ports:
     - "127.0.0.1:9205:9200"
@@ -188,7 +188,7 @@ services:
     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   postgres:
-    image: postgres:10.5-alpine
+    image: postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117
     profiles: ["group1"]
     environment:
     - POSTGRES_PASSWORD=postgres
@@ -198,7 +198,7 @@ services:
     - "127.0.0.1:5432:5432"
 
   mysql:
-    image: mysql/mysql-server:8.0
+    image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     profiles: ["group1"]
     environment:
     - MYSQL_DATABASE=world
@@ -209,7 +209,7 @@ services:
     - "127.0.0.1:3307:3306"
 
   mysql57:
-    image: mysql/mysql-server:5.7
+    image: mysql/mysql-server:5.7@sha256:1178cdd375f758968cd834ac4057bae41307e64b7c69a9e145896e7b11f48064
     profiles: ["group1"]
     environment:
     - MYSQL_DATABASE=world
@@ -220,7 +220,7 @@ services:
     - "127.0.0.1:3407:3306"
 
   sqlserver:
-    image: mcr.microsoft.com/mssql/server:latest
+    image: mcr.microsoft.com/mssql/server:latest@sha256:2cd0aec4a3bfc3cf9205bed3f7922f4c6208f7c767dc62edcee308d0fd7d56d0
     profiles: ["group1"]
     ports:
     - "127.0.0.1:1433:1433"
@@ -229,14 +229,14 @@ services:
     - SA_PASSWORD=Strong!Passw0rd
 
   sqledge:
-    image: mcr.microsoft.com/azure-sql-edge:latest
+    image: mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf
     profiles: ["group2"]
     environment:
     - ACCEPT_EULA=Y
     - MSSQL_SA_PASSWORD=Strong!Passw0rd
 
   azureservicebus-emulator:
-    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2@sha256:353913ece3d9124cebd40f4b91d00dd197846b8cf86eae9a4790698709c64a1d
     profiles: ["group2"]
     depends_on:
       - sqledge
@@ -250,7 +250,7 @@ services:
       - ./docker/servicebus-emulator-config.json:/ServiceBus_Emulator/ConfigFiles/Config.json:ro
 
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:latest
+    image: mcr.microsoft.com/azure-storage/azurite:latest@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37
     profiles: ["group2"]
     hostname: azurite
     container_name: azurite
@@ -260,7 +260,7 @@ services:
       - "10002:10002"
 
   azure-eventhubs-emulator:
-    image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest
+    image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest@sha256:2c8e0d4dd93a5fc078df2721eeb3e211442d555d61293ac3972df931c6d9333a
     profiles: ["group2"]
     depends_on:
       - azurite
@@ -274,7 +274,7 @@ services:
       - ./docker/eventhubs-emulator-config.json:/Eventhubs_Emulator/ConfigFiles/Config.json:ro
 
   cosmosdb-emulator:
-    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview@sha256:54d7bc334494c50cea867c270880671a7db080626a9732832b34c0d69342f9b0
     profiles: ["group2"]
     command: ["--protocol", "https"]
 
@@ -294,7 +294,7 @@ services:
   # See https://github.com/confluentinc/cp-all-in-one/blob/6.1.1-post/cp-all-in-one/docker-compose.yml
   # For original definitions
   kafka-zookeeper:
-    image: confluentinc/cp-zookeeper:6.1.1
+    image: confluentinc/cp-zookeeper:6.1.1@sha256:a7c0a20dce46a705300cd464e511e9c70ac55ec7e62c024867470a19ce210563
     profiles: ["group1"]
     hostname: kafka-zookeeper
     container_name: kafka-zookeeper
@@ -306,7 +306,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka-broker:
-    image: confluentinc/cp-server:6.1.1
+    image: confluentinc/cp-server:6.1.1@sha256:4a1ff92bd03e361759ba339c97b4c4b7dbb52d7cea478dda22d034261a8991e4
     profiles: ["group1"]
     hostname: kafka-broker
     container_name: kafka-broker
@@ -337,7 +337,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   openldap:
-    image: osixia/openldap:latest
+    image: osixia/openldap:latest@sha256:3f68751292b43564a2586fc29fb7337573e2dad692b92d4e78e49ad5c22e567b
     ports:
       - "389:369"
       - "636:636"
@@ -349,7 +349,7 @@ services:
       LDAP_BASE_DN: "dc=dd-trace-dotnet,dc=com"
 
   StartDependencies.Profiler:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
       - openldap
     environment:
@@ -650,7 +650,7 @@ services:
       - DD_LOGGER_DD_TAGS
 
   StartDependencies.Group1:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     profiles: ["group1"]
     depends_on:
       - servicestackredis
@@ -671,7 +671,7 @@ services:
     command: servicestackredis:6379 stackexchangeredis:6379 stackexchangeredis-replica:6379 stackexchangeredis-single:6379 sqlserver:1433 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 couchbase:11210 test-agent:8126 test-agent:4317 test-agent:4318
 
   StartDependencies.Group2:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     profiles: ["group2"]
     depends_on:
       - elasticsearch7
@@ -775,7 +775,7 @@ services:
       - cosmosdb-emulator_arm64
 
   StartDependencies.ARM64:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
       - servicestackredis_arm64
       - stackexchangeredis_arm64
@@ -845,7 +845,7 @@ services:
       - RANDOM_SEED
 
   test-agent:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest@sha256:8165e1f1f7c891261ea5af9d7bf24413f75351a6fffbdf5e9277c9ac7c9029be
     volumes:
     - ./tracer/build/smoke_test_snapshots:/snapshots
     - ./artifacts/build_data/snapshots:/debug_snapshots
@@ -861,7 +861,7 @@ services:
     - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,meta.network.client.ip,meta.http.client_ip,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers,meta._dd.appsec.fp.http.endpoint,meta._dd.appsec.fp.http.header,meta._dd.appsec.fp.http.network
 
   StartDependencies.OSXARM64:
-    image: andrewlock/wait-for-dependencies
+    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
       - servicestackredis_osx_arm64
       - stackexchangeredis_osx_arm64
@@ -893,7 +893,7 @@ services:
       - "./.localstack:/tmp"
 
   elasticsearch7_osx_arm64:
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.10.1@sha256:7cd88158f6ac75d43b447fdd98c4eb69483fa7bf1be5616a85fe556262dc864a
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -902,13 +902,13 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   mongo_osx_arm64:
-    image: mongo:5.0.31
+    image: mongo:5.0.31@sha256:54bcd8da3ea5eec561b68c605046c55c6b304387dc4c2bf5b3a5f5064fbb7495
     ports:
       - "27017:27017"
     command: mongod
 
   mysql_osx_arm64:
-    image: mysql/mysql-server:8.0
+    image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
     environment:
       - MYSQL_DATABASE=world
       - MYSQL_ROOT_PASSWORD=mysqldb
@@ -918,7 +918,7 @@ services:
       - "3306:3306"
 
   postgres_osx_arm64:
-    image: postgres:10.5-alpine
+    image: postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
@@ -927,41 +927,41 @@ services:
       - "5432:5432"
 
   rabbitmq_osx_arm64:
-    image: rabbitmq:3-management
+    image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
     command: rabbitmq-server
     ports:
       - "5672:5672"
       - "15672:15672"
 
   servicestackredis_osx_arm64:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     command: redis-server --bind 0.0.0.0
     ports:
       - "6379:6379"
 
   stackexchangeredis_osx_arm64:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     hostname: stackexchangeredis_osx_arm64
     command: redis-server --bind 0.0.0.0
     ports:
       - "6392:6379"
 
   stackexchangeredis_osx_arm64-replica:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     hostname: stackexchangeredis_osx_arm64-replica
     command: redis-server --bind 0.0.0.0 --slaveof stackexchangeredis_osx_arm64 6379
     ports:
       - "6390:6379"
 
   stackexchangeredis_osx_arm64-single:
-    image: redis:4-alpine
+    image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
     hostname: stackexchangeredis_osx_arm64-single
     command: redis-server --bind 0.0.0.0
     ports:
       - "6391:6379"
 
   sqledge_osx_arm64:
-    image: mcr.microsoft.com/azure-sql-edge:latest
+    image: mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf
     ports:
       - "1433:1433"
     environment:
@@ -970,4 +970,4 @@ services:
 
   # keep syncronized image version with tracer\test\Datadog.Trace.TestHelpers.AutoInstrumentation\Containers\AerospikeFixture.cs
   aerospike:
-    image: aerospike/aerospike-server:6.2.0.6
+    image: aerospike/aerospike-server:6.2.0.6@sha256:ec8959a17598dd1e2a254489c127f9cba2172a51272f0ba4cb26194028e28324

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # ARM64 dependencies
   localstack_arm64:
-    image: localstack/localstack
+    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
     environment:
       - SERVICES=sns,sqs,kinesis,dynamodb,events,s3,stepfunctions,lambda
       - DEBUG=1
@@ -92,7 +92,7 @@ services:
 
 # Dependencies
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
     profiles: ["group2"]
     environment:
       - SERVICES=sns,sqs,kinesis,dynamodb,events,s3,stepfunctions,lambda
@@ -881,7 +881,7 @@ services:
   # OSX ARM64 dependencies
 
   localstack_osx_arm64:
-    image: localstack/localstack
+    image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
     environment:
       - SERVICES=sns,sqs,kinesis,dynamodb,events,s3,stepfunctions,lambda
       - DEBUG=1


### PR DESCRIPTION
## Summary of changes

- Update CI VMs
- Pin to specific docker versions in docker-compose files

## Reason for change

We recently made some updates that broke our caching, so this updates the VMs.

Additionally, stop doing an explicitly `docker pull` of the test agent, as that can hit rate limits, and we already pre-pull v1.62.0 (latest right now).

Finally, add pinning for all docker images for supply chain reasons

## Implementation details

- Run the VM update procedure
- Grab the current versions of the docker images, and pin them in the docker-compose files etc

## Test coverage

This is the test - also started an "all TFMs" run [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=204536&view=results)

## Other details

https://datadoghq.atlassian.net/browse/APMLP-1344