### PR TITLE
[Debugger] Log over-length identifier redaction at Warning instead of Error

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Redaction.cs" company="Datadog">
+// <copyright file="Redaction.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -393,7 +393,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
             if (identifier.Length > MaxStackAlloc)
             {
-                Log.Error("Identifier length {Length} exceeds maximum allowed length of {MaxSize}, hence we are going to redact this identifier", identifier.Length, property1: MaxStackAlloc);
+                Log.Warning("Identifier length {Length} exceeds maximum allowed length of {MaxSize}, hence we are going to redact this identifier", identifier.Length, property1: MaxStackAlloc);
                 return false;
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -393,7 +393,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
             if (identifier.Length > MaxStackAlloc)
             {
-                Log.Warning("Identifier length {Length} exceeds maximum allowed length of {MaxSize}, hence we are going to redact this identifier", identifier.Length, property1: MaxStackAlloc);
+                Log.Warning("Identifier length {Length} exceeds maximum allowed length of {MaxSize}, so it cannot be normalized and will be skipped for redaction matching", identifier.Length, property1: MaxStackAlloc);
                 return false;
             }
 


### PR DESCRIPTION
## Summary of changes

Lower the severity of the "identifier length exceeds maximum allowed length" log in `Redaction.TryNormalize` from `Log.Error` to `Log.Warning`, and strip a stray UTF-8 BOM from the top of `Redaction.cs` to match the repo's `charset = utf-8` convention.

## Reason for change

This message fires on the Dynamic Instrumentation snapshot-redaction path whenever a customer field/property name exceeds `MaxStackAlloc` (512 chars). It is an expected, controlled situation driven by customer data — not a tracer bug — yet because it was logged at `Error` it surfaced in Error Tracking as noise:

[Error Tracking issue](https://app.datadoghq.com/error-tracking/issue/1c3c9aa8-4f45-11f1-8e60-da7ad0900002)

## Implementation details

- `Log.Error(...)` → `Log.Warning(...)` in `Redaction.TryNormalize`.
- Removed the UTF-8 BOM from line 1 of `Redaction.cs` (the file was one of the few `.cs` files still carrying one).

## Test coverage

Log-severity-only change; no behavioral change and no new tests required.

## Other details

N/A
