### PR TITLE
Attempt to prevent crash on module unload

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1682,12 +1682,29 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownFinished(AppDomainID app
         return S_OK;
     }
 
+    // On .NET Framework a failed AppDomain unload (e.g. CannotUnloadAppDomainException) can leave the
+    // AppDomain alive with Datadog.Trace.dll still loaded and methods still being JIT'd. Tearing down any
+    // AppDomain-scoped state in that case would leave a live domain internally inconsistent: IAST would lose
+    // its per-domain state while instrumentation keeps running, the loaded-assembly marker would disappear so
+    // instrumentation silently stops, and the first-JIT marker would be lost causing duplicate startup-hook
+    // injection. So we only clean up AppDomain-scoped state when the unload actually succeeded; on failure we
+    // leave it all intact. A stale entry for a genuinely-dead domain is a bounded, benign leak (the
+    // AppDomainID is never reused), which is the safer trade compared to corrupting a still-live domain.
+    if (FAILED(hrStatus))
+    {
+        DBG("AppDomainShutdownFinished: AppDomain: ", appDomainId,
+            " reported a failed unload (hrStatus=", hrStatus,
+            "); leaving AppDomain-scoped state intact in case the domain is still alive");
+        return S_OK;
+    }
+
     if (_dataflow != nullptr)
     {
         _dataflow->AppDomainShutdown(appDomainId);
     }
 
-    // remove appdomain metadata from map
+    // remove appdomain metadata from maps
+    managed_profiler_loaded_app_domains.Get()->erase(appDomainId);
     const auto& count = first_jit_compilation_app_domains.erase(appDomainId);
 
     DBG("AppDomainShutdownFinished: AppDomain: ", appDomainId, ", removed ", count, " elements");

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -361,7 +361,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
         {
             Logger::Info("AssemblyLoadFinished: Datadog.Trace.dll v", assembly_version, " matched profiler version v",
                          expected_version);
-            managed_profiler_loaded_app_domains.insert({assembly_info.app_domain_id, assembly_info.manifest_module_id});
+            managed_profiler_loaded_app_domains.Get()->insert(
+                {assembly_info.app_domain_id, assembly_info.manifest_module_id});
 
             // Load defaults values if the version are the same as expected
             if (assembly_metadata.version == expected_assembly_reference.version)
@@ -1256,24 +1257,48 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
     auto new_end = std::remove(modules.begin(), modules.end(), module_id);
     modules.erase(new_end, modules.end());
 
-    const auto& moduleInfo = GetModuleInfo(this->info_, module_id);
-    if (!moduleInfo.IsValid())
+    auto new_internal_end = std::remove(managedInternalModules_.begin(), managedInternalModules_.end(), module_id);
+    managedInternalModules_.erase(new_internal_end, managedInternalModules_.end());
+
+    // If the domain-neutral Datadog.Trace module is unloading, clear the cached id. This is an atomic
+    // scalar, so it does not need (and must not take) the loaded-app-domains lock here.
+    if (managed_profiler_domain_neutral_module_id == module_id)
     {
-        DBG("ModuleUnloadStarted: ", module_id);
-        return S_OK;
+        managed_profiler_domain_neutral_module_id = 0;
     }
 
-    DBG("ModuleUnloadStarted: ", module_id, " ", moduleInfo.assembly.name, " AppDomain ",
-        moduleInfo.assembly.app_domain_id, " ", moduleInfo.assembly.app_domain_name);
-
-    const auto is_instrumentation_assembly = moduleInfo.assembly.name == managed_profiler_name;
-    if (is_instrumentation_assembly)
+    // Clear the loaded-assembly marker for any AppDomain whose recorded Datadog.Trace.dll manifest module is
+    // this module. A Datadog.Trace.dll module can unload independently of an AppDomain shutdown (e.g. a
+    // collectible AssemblyLoadContext), in which case AppDomainShutdownFinished never fires for it; leaving a
+    // stale entry would make ProfilerAssemblyIsLoadedIntoAppDomain() keep returning true and
+    // GetProfilerAssemblyModuleId() hand back an unloaded ModuleID. The scan is O(AppDomains-with-tracer)
+    // (tiny) and race-free: the map is Synchronized and we hold its lock for the duration of the scan.
+    //
+    // Pre-existing limitation (not introduced or worsened here): managed_profiler_loaded_app_domains records a
+    // single ModuleID per AppDomainID (AssemblyLoadFinished uses first-wins insert), so it cannot represent
+    // multiple Datadog.Trace.dll instances sharing one AppDomain (e.g. several AssemblyLoadContexts on .NET
+    // Core). Modeling that requires a per-AppDomain set plus resolving GetProfilerAssemblyModuleId's single-
+    // module contract (Dataflow::GetAspectsModule depends on it); tracked as separate work.
     {
-        const auto appDomainId = moduleInfo.assembly.app_domain_id;
-
-        // remove appdomain id from managed_profiler_loaded_app_domains set
-        managed_profiler_loaded_app_domains.erase(appDomainId);
+        auto loadedAppDomains = managed_profiler_loaded_app_domains.Get();
+        auto& loadedAppDomainsMap = loadedAppDomains.Ref();
+        for (auto it = loadedAppDomainsMap.begin(); it != loadedAppDomainsMap.end();)
+        {
+            if (it->second == module_id)
+            {
+                it = loadedAppDomainsMap.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
     }
+
+    // We do not call ICorProfilerInfo::GetModuleInfo2() here. During ModuleUnloadStarted the CLR is already
+    // unloading this module, and querying module flags/assembly information can hit partially torn-down CLR
+    // state and fault fatally inside the runtime.
+    DBG("ModuleUnloadStarted: ", module_id);
 
     return S_OK;
 }
@@ -1307,7 +1332,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
         Logger::Debug("   ModuleIds: ", modules->size());
         Logger::Debug("   IntegrationDefinitions: ", integration_definitions_.size());
         Logger::Debug("   DefinitionsIds: ", definitions->size());
-        Logger::Debug("   ManagedProfilerLoadedAppDomains: ", managed_profiler_loaded_app_domains.size());
+        Logger::Debug("   ManagedProfilerLoadedAppDomains: ", managed_profiler_loaded_app_domains.Get()->size());
         Logger::Debug("   FirstJitCompilationAppDomains: ", first_jit_compilation_app_domains.size());
     }
     Logger::Info("Stats: ", Stats::Instance()->ToString());
@@ -2412,8 +2437,13 @@ bool CorProfiler::GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleI
 
 bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id)
 {
-    return managed_profiler_domain_neutral_module_id > 0 ||
-           managed_profiler_loaded_app_domains.find(app_domain_id) != managed_profiler_loaded_app_domains.end();
+    if (managed_profiler_domain_neutral_module_id > 0)
+    {
+        return true;
+    }
+
+    auto loadedAppDomains = managed_profiler_loaded_app_domains.Get();
+    return loadedAppDomains->find(app_domain_id) != loadedAppDomains->end();
 }
 
 ModuleID CorProfiler::GetProfilerAssemblyModuleId(AppDomainID appDomainId)
@@ -2423,8 +2453,9 @@ ModuleID CorProfiler::GetProfilerAssemblyModuleId(AppDomainID appDomainId)
         return managed_profiler_domain_neutral_module_id;
     }
 
-    auto it = managed_profiler_loaded_app_domains.find(appDomainId);
-    if (it != managed_profiler_loaded_app_domains.end())
+    auto loadedAppDomains = managed_profiler_loaded_app_domains.Get();
+    auto it = loadedAppDomains->find(appDomainId);
+    if (it != loadedAppDomains->end())
     {
         return it->second;
     }

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1260,25 +1260,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
     auto new_internal_end = std::remove(managedInternalModules_.begin(), managedInternalModules_.end(), module_id);
     managedInternalModules_.erase(new_internal_end, managedInternalModules_.end());
 
-    // If the domain-neutral Datadog.Trace module is unloading, clear the cached id. This is an atomic
-    // scalar, so it does not need (and must not take) the loaded-app-domains lock here.
+    // Clear the cached domain-neutral Datadog.Trace.dll module id if this is it.
     if (managed_profiler_domain_neutral_module_id == module_id)
     {
         managed_profiler_domain_neutral_module_id = 0;
     }
 
-    // Clear the loaded-assembly marker for any AppDomain whose recorded Datadog.Trace.dll manifest module is
-    // this module. A Datadog.Trace.dll module can unload independently of an AppDomain shutdown (e.g. a
-    // collectible AssemblyLoadContext), in which case AppDomainShutdownFinished never fires for it; leaving a
-    // stale entry would make ProfilerAssemblyIsLoadedIntoAppDomain() keep returning true and
-    // GetProfilerAssemblyModuleId() hand back an unloaded ModuleID. The scan is O(AppDomains-with-tracer)
-    // (tiny) and race-free: the map is Synchronized and we hold its lock for the duration of the scan.
-    //
-    // Pre-existing limitation (not introduced or worsened here): managed_profiler_loaded_app_domains records a
-    // single ModuleID per AppDomainID (AssemblyLoadFinished uses first-wins insert), so it cannot represent
-    // multiple Datadog.Trace.dll instances sharing one AppDomain (e.g. several AssemblyLoadContexts on .NET
-    // Core). Modeling that requires a per-AppDomain set plus resolving GetProfilerAssemblyModuleId's single-
-    // module contract (Dataflow::GetAspectsModule depends on it); tracked as separate work.
+    // Datadog.Trace.dll can unload without AppDomainShutdownFinished, such as from a collectible
+    // AssemblyLoadContext. Remove entries pointing at this module without querying CLR metadata.
+    // Pre-existing limitation: the map tracks one profiler module per AppDomain.
     {
         auto loadedAppDomains = managed_profiler_loaded_app_domains.Get();
         auto& loadedAppDomainsMap = loadedAppDomains.Ref();
@@ -1295,9 +1285,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
         }
     }
 
-    // We do not call ICorProfilerInfo::GetModuleInfo2() here. During ModuleUnloadStarted the CLR is already
-    // unloading this module, and querying module flags/assembly information can hit partially torn-down CLR
-    // state and fault fatally inside the runtime.
+    // Do not query CLR metadata here; ModuleUnloadStarted can run after module state is partially torn down.
     DBG("ModuleUnloadStarted: ", module_id);
 
     return S_OK;
@@ -1682,14 +1670,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownFinished(AppDomainID app
         return S_OK;
     }
 
-    // On .NET Framework a failed AppDomain unload (e.g. CannotUnloadAppDomainException) can leave the
-    // AppDomain alive with Datadog.Trace.dll still loaded and methods still being JIT'd. Tearing down any
-    // AppDomain-scoped state in that case would leave a live domain internally inconsistent: IAST would lose
-    // its per-domain state while instrumentation keeps running, the loaded-assembly marker would disappear so
-    // instrumentation silently stops, and the first-JIT marker would be lost causing duplicate startup-hook
-    // injection. So we only clean up AppDomain-scoped state when the unload actually succeeded; on failure we
-    // leave it all intact. A stale entry for a genuinely-dead domain is a bounded, benign leak (the
-    // AppDomainID is never reused), which is the safer trade compared to corrupting a still-live domain.
+    // A failed AppDomain unload can leave the domain alive, so preserve per-domain state unless unload succeeds.
     if (FAILED(hrStatus))
     {
         DBG("AppDomainShutdownFinished: AppDomain: ", appDomainId,

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -62,12 +62,9 @@ private:
     bool corlib_module_loaded = false;
     ModuleID corlib_module_id = 0;
     AppDomainID corlib_app_domain_id = 0;
-    // Scalar cached id; atomic because it is written from AssemblyLoadFinished / ModuleUnloadStarted and
-    // read from the JIT/ReJIT rewrite paths, which run on different CLR-callback threads.
+    // Written and read from different CLR callback threads.
     std::atomic<ModuleID> managed_profiler_domain_neutral_module_id{0};
-    // Guarded by its own dedicated lock (NOT module_ids). It is accessed from AssemblyLoadFinished,
-    // AppDomainShutdownFinished, ProfilerAssemblyIsLoadedIntoAppDomain and GetProfilerAssemblyModuleId,
-    // which run on different threads and do not all hold module_ids, so module_ids cannot serialize it.
+    // Uses a dedicated lock because these accesses do not all happen under module_ids.
     Synchronized<std::unordered_map<AppDomainID, ModuleID>> managed_profiler_loaded_app_domains;
     std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
     bool is_desktop_iis = false;

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -62,8 +62,13 @@ private:
     bool corlib_module_loaded = false;
     ModuleID corlib_module_id = 0;
     AppDomainID corlib_app_domain_id = 0;
-    ModuleID managed_profiler_domain_neutral_module_id = 0;
-    std::unordered_map<AppDomainID, ModuleID> managed_profiler_loaded_app_domains;
+    // Scalar cached id; atomic because it is written from AssemblyLoadFinished / ModuleUnloadStarted and
+    // read from the JIT/ReJIT rewrite paths, which run on different CLR-callback threads.
+    std::atomic<ModuleID> managed_profiler_domain_neutral_module_id{0};
+    // Guarded by its own dedicated lock (NOT module_ids). It is accessed from AssemblyLoadFinished,
+    // AppDomainShutdownFinished, ProfilerAssemblyIsLoadedIntoAppDomain and GetProfilerAssemblyModuleId,
+    // which run on different threads and do not all hold module_ids, so module_ids cannot serialize it.
+    Synchronized<std::unordered_map<AppDomainID, ModuleID>> managed_profiler_loaded_app_domains;
     std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
     bool is_desktop_iis = false;
 


### PR DESCRIPTION

## Summary of changes

Avoid querying CLR module metadata during `ModuleUnloadStarted`; clean up cached profiler module/AppDomain state using locally tracked module ids instead.

## Reason for change

Calling back into the CLR for module info while a module is unloading can fault inside runtime teardown and crash the instrumented process (or at least that is what it appears so).

## Implementation details

Synchronize access to `managed_profiler_loaded_app_domains`, make the domain-neutral profiler module id atomic, remove unloaded module ids from cached profiler state, and only clean up AppDomain-scoped state after successful AppDomain unload.

This mainly removes the call to `GetModuleInfo` during the unload event.

## Test coverage

Unsure really, I haven't been able to reproduce this hoping that existing tests cover the change 😬 

## Other details

<!-- Fixes #{issue} -->

https://app.datadoghq.com/error-tracking/issue/f7978b74-55cd-11f1-8366-da7ad0900002
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
