### PR TITLE
Remove unused kafka services from docker-compose.ym

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,63 +331,10 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
-      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://kafka-schema-registry:8081
       CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: kafka-broker:29092
       CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
       CONFLUENT_METRICS_ENABLE: 'true'
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
-
-  kafka-schema-registry:
-    image: confluentinc/cp-schema-registry:6.1.1
-    profiles: ["group1"]
-    hostname: kafka-schema-registry
-    container_name: kafka-schema-registry
-    depends_on:
-      - kafka-broker
-    ports:
-      - "8081:8081"
-    restart: unless-stopped
-    environment:
-      SCHEMA_REGISTRY_HOST_NAME: kafka-schema-registry
-      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka-broker:29092'
-      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
-
-  kafka-control-center:
-    image: confluentinc/cp-enterprise-control-center:6.1.1
-    profiles: ["group1"]
-    hostname: kafka-control-center
-    container_name: kafka-control-center
-    depends_on:
-      - kafka-broker
-      - kafka-schema-registry
-    ports:
-      - "9021:9021"
-    restart: unless-stopped
-    environment:
-      CONTROL_CENTER_BOOTSTRAP_SERVERS: 'kafka-broker:29092'
-      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://kafka-schema-registry:8081"
-      CONTROL_CENTER_REPLICATION_FACTOR: 1
-      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
-      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
-      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
-      PORT: 9021
-
-  kafka-rest-proxy:
-    image: confluentinc/cp-kafka-rest:6.1.1
-    profiles: ["group1"]
-    depends_on:
-      - kafka-broker
-      - kafka-schema-registry
-    ports:
-      - 8082:8082
-    hostname: kafka-rest-proxy
-    container_name: kafka-rest-proxy
-    restart: unless-stopped
-    environment:
-      KAFKA_REST_HOST_NAME: kafka-rest-proxy
-      KAFKA_REST_BOOTSTRAP_SERVERS: 'kafka-broker:29092'
-      KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
-      KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://kafka-schema-registry:8081'
 
   openldap:
     image: osixia/openldap:latest


### PR DESCRIPTION
## Summary of changes

Remove unused kafka services from docker-compose.yml

## Reason for change

These services are never started and are not required

## Implementation details

Delete the lines from the docker-compose. I checked, and the `KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL` URL is optional (and the service was never started in practice _anyway_, so it was potentially harmful too😅)

## Test coverage

This is the test - if the tests pass we're good

## Other details

Noticed while pinning docker images and updating VMs