### PR TITLE
[OTLP Logs] Fix ArgumentOutOfRangeException serializing large log batches

### DIFF
--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpExporter.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpExporter.cs
@@ -185,6 +185,15 @@ internal sealed class OtlpExporter : IOtlpExporter
             var startPosition = _protocol == OtlpProtocol.Grpc ? 5 : 0;
             var otlpPayload = OtlpLogsSerializer.SerializeLogs(logs, _resourceTags, startPosition);
 
+            if (otlpPayload is null)
+            {
+                // The batch is too large to serialize and cannot be sent. Drop it (retrying would
+                // just overflow again) but report success so the batching sink doesn't trip its
+                // circuit breaker for a non-transient issue.
+                Log.Warning<int>("Dropping OTLP log batch of {Count} logs: serialized payload exceeds the maximum size.", logs.Count);
+                return true;
+            }
+
             return _protocol switch
             {
                 OtlpProtocol.HttpProtobuf => await SendHttpProtobufRequest(otlpPayload).ConfigureAwait(false),

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpLogsSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpLogsSerializer.cs
@@ -37,6 +37,38 @@ internal static class OtlpLogsSerializer
         }
 
         var buffer = new byte[64 * 1024];
+
+        // The batch may not fit in the initial buffer. On overflow, grow the buffer (doubling,
+        // up to ProtobufSerializer.MaxBufferSize) and retry from the start, mirroring the
+        // resize-and-retry strategy the vendored OTLP serializers use. If the buffer cannot
+        // grow any further, the overflow exception propagates so the caller drops the batch.
+        while (true)
+        {
+            try
+            {
+                return SerializeLogs(buffer, logs, settings, startPosition);
+            }
+            catch (ArgumentException)
+            {
+                // A span/array write ran past the end of the buffer.
+                if (!ProtobufSerializer.IncreaseBufferSize(ref buffer, OtlpSignalType.Logs))
+                {
+                    throw;
+                }
+            }
+            catch (IndexOutOfRangeException)
+            {
+                // Same overflow condition, surfaced as an index-based write past the end.
+                if (!ProtobufSerializer.IncreaseBufferSize(ref buffer, OtlpSignalType.Logs))
+                {
+                    throw;
+                }
+            }
+        }
+    }
+
+    private static byte[] SerializeLogs(byte[] buffer, IReadOnlyList<LogPoint> logs, ResourceTags settings, int startPosition)
+    {
         int writePosition = startPosition;
 
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, LogsData_Resource_Logs, ProtobufWireType.LEN);

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpLogsSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpLogsSerializer.cs
@@ -26,22 +26,35 @@ internal static class OtlpLogsSerializer
     private const int TraceIdSize = 16;
     private const int SpanIdSize = 8;
 
+    private const int InitialBufferSize = 64 * 1024;
+
+    // Upper bound for a serialized batch. The buffer grows up to this cap; a batch that still
+    // doesn't fit is dropped rather than allocating without bound. The intake rejects payloads
+    // far larger than this anyway, and it matches the default trace payload cap (DD_TRACE_BUFFER_SIZE).
+    private const int MaxBufferSize = 10 * 1024 * 1024;
+
     /// <summary>
-    /// Serializes logs to OTLP LogsData binary format using vendored protobuf serializer
+    /// Serializes logs to OTLP LogsData binary format using vendored protobuf serializer.
     /// </summary>
-    public static byte[] SerializeLogs(IReadOnlyList<LogPoint> logs, ResourceTags settings, int startPosition = 0)
+    /// <param name="logs">The batch of logs to serialize.</param>
+    /// <param name="settings">Resource-level tags applied to the payload.</param>
+    /// <param name="startPosition">Offset at which to start writing (e.g. a reserved gRPC frame header).</param>
+    /// <returns>
+    /// The serialized payload, an empty array when there is nothing to serialize, or <c>null</c>
+    /// when the batch is too large to fit within <see cref="MaxBufferSize"/>.
+    /// </returns>
+    public static byte[]? SerializeLogs(IReadOnlyList<LogPoint> logs, ResourceTags settings, int startPosition = 0)
     {
         if (logs.Count == 0)
         {
             return Array.Empty<byte>();
         }
 
-        var buffer = new byte[64 * 1024];
+        var buffer = new byte[InitialBufferSize];
 
         // The batch may not fit in the initial buffer. On overflow, grow the buffer (doubling,
-        // up to ProtobufSerializer.MaxBufferSize) and retry from the start, mirroring the
-        // resize-and-retry strategy the vendored OTLP serializers use. If the buffer cannot
-        // grow any further, the overflow exception propagates so the caller drops the batch.
+        // up to MaxBufferSize) and retry from the start. If it's already at the cap and still
+        // overflows, return null so the caller drops the batch instead of growing without bound.
         while (true)
         {
             try
@@ -51,20 +64,31 @@ internal static class OtlpLogsSerializer
             catch (ArgumentException)
             {
                 // A span/array write ran past the end of the buffer.
-                if (!ProtobufSerializer.IncreaseBufferSize(ref buffer, OtlpSignalType.Logs))
+                if (!TryGrowBuffer(ref buffer))
                 {
-                    throw;
+                    return null;
                 }
             }
             catch (IndexOutOfRangeException)
             {
                 // Same overflow condition, surfaced as an index-based write past the end.
-                if (!ProtobufSerializer.IncreaseBufferSize(ref buffer, OtlpSignalType.Logs))
+                if (!TryGrowBuffer(ref buffer))
                 {
-                    throw;
+                    return null;
                 }
             }
         }
+    }
+
+    private static bool TryGrowBuffer(ref byte[] buffer)
+    {
+        if (buffer.Length >= MaxBufferSize)
+        {
+            return false;
+        }
+
+        buffer = new byte[Math.Min(buffer.Length * 2, MaxBufferSize)];
+        return true;
     }
 
     private static byte[] SerializeLogs(byte[] buffer, IReadOnlyList<LogPoint> logs, ResourceTags settings, int startPosition)

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpLogsSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Logs/OtlpLogsSerializer.cs
@@ -29,9 +29,9 @@ internal static class OtlpLogsSerializer
     private const int InitialBufferSize = 64 * 1024;
 
     // Upper bound for a serialized batch. The buffer grows up to this cap; a batch that still
-    // doesn't fit is dropped rather than allocating without bound. The intake rejects payloads
-    // far larger than this anyway, and it matches the default trace payload cap (DD_TRACE_BUFFER_SIZE).
-    private const int MaxBufferSize = 10 * 1024 * 1024;
+    // doesn't fit is dropped rather than allocating without bound. Matches the 3MB payload cap
+    // used by our own direct log submission (DirectSubmissionLogSink.MaxTotalSizeBytes).
+    private const int MaxBufferSize = 3 * 1024 * 1024;
 
     /// <summary>
     /// Serializes logs to OTLP LogsData binary format using vendored protobuf serializer.

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Logs/OtlpLogsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Logs/OtlpLogsSerializerTests.cs
@@ -45,12 +45,7 @@ namespace Datadog.Trace.Tests.OpenTelemetry.Logs
             // Each message is ~2 KB; 200 logs serialize to well over the initial 64 KB buffer,
             // forcing multiple buffer resizes. Before the grow-and-retry fix this threw
             // ArgumentOutOfRangeException from WriteLogRecord once writePosition passed 64 KB.
-            var largeMessage = new string('x', 2048);
-            var logs = new List<LogPoint>();
-            for (var i = 0; i < 200; i++)
-            {
-                logs.Add(new LogPoint { Message = largeMessage, LogLevel = 2, CategoryName = "Test" });
-            }
+            var logs = CreateLogs(count: 200, messageSize: 2048);
 
             byte[] payload = null;
             var act = () => payload = OtlpLogsSerializer.SerializeLogs(logs, CreateResourceTags());
@@ -61,6 +56,19 @@ namespace Datadog.Trace.Tests.OpenTelemetry.Logs
             // The serialized payload must be larger than the initial buffer, proving the
             // buffer grew rather than silently truncating the batch.
             payload!.Length.Should().BeGreaterThan(InitialBufferSize);
+        }
+
+        [Fact]
+        public void SerializeLogs_BatchExceedingMaxSize_ReturnsNull()
+        {
+            // ~11 MB of messages exceeds the 10 MB cap, so the batch can never fit.
+            // The serializer must give up and return null (signalling a drop) rather than
+            // growing without bound or throwing.
+            var logs = CreateLogs(count: 11, messageSize: 1024 * 1024);
+
+            var payload = OtlpLogsSerializer.SerializeLogs(logs, CreateResourceTags());
+
+            payload.Should().BeNull();
         }
 
         [Fact]
@@ -75,7 +83,20 @@ namespace Datadog.Trace.Tests.OpenTelemetry.Logs
             const int startPosition = 5;
             var payload = OtlpLogsSerializer.SerializeLogs(logs, CreateResourceTags(), startPosition);
 
-            payload.Length.Should().BeGreaterThan(startPosition);
+            payload.Should().NotBeNull();
+            payload!.Length.Should().BeGreaterThan(startPosition);
+        }
+
+        private static List<LogPoint> CreateLogs(int count, int messageSize)
+        {
+            var message = new string('x', messageSize);
+            var logs = new List<LogPoint>(count);
+            for (var i = 0; i < count; i++)
+            {
+                logs.Add(new LogPoint { Message = message, LogLevel = 2, CategoryName = "Test" });
+            }
+
+            return logs;
         }
 
         private static OtlpLogsSerializer.ResourceTags CreateResourceTags()

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Logs/OtlpLogsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Logs/OtlpLogsSerializerTests.cs
@@ -61,10 +61,10 @@ namespace Datadog.Trace.Tests.OpenTelemetry.Logs
         [Fact]
         public void SerializeLogs_BatchExceedingMaxSize_ReturnsNull()
         {
-            // ~11 MB of messages exceeds the 10 MB cap, so the batch can never fit.
+            // ~4 MB of messages exceeds the 3 MB cap, so the batch can never fit.
             // The serializer must give up and return null (signalling a drop) rather than
             // growing without bound or throwing.
-            var logs = CreateLogs(count: 11, messageSize: 1024 * 1024);
+            var logs = CreateLogs(count: 4, messageSize: 1024 * 1024);
 
             var payload = OtlpLogsSerializer.SerializeLogs(logs, CreateResourceTags());
 

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Logs/OtlpLogsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Logs/OtlpLogsSerializerTests.cs
@@ -1,0 +1,90 @@
+// <copyright file="OtlpLogsSerializerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_1_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Datadog.Trace.OpenTelemetry.Logs;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.OpenTelemetry.Logs
+{
+    public class OtlpLogsSerializerTests
+    {
+        private const int InitialBufferSize = 64 * 1024;
+
+        [Fact]
+        public void SerializeLogs_SmallBatch_ProducesPayload()
+        {
+            var logs = new List<LogPoint>
+            {
+                new() { Message = "hello", LogLevel = 2, CategoryName = "Test" },
+            };
+
+            var payload = OtlpLogsSerializer.SerializeLogs(logs, CreateResourceTags());
+
+            payload.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void SerializeLogs_EmptyBatch_ReturnsEmpty()
+        {
+            var payload = OtlpLogsSerializer.SerializeLogs(new List<LogPoint>(), CreateResourceTags());
+
+            payload.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void SerializeLogs_BatchLargerThanInitialBuffer_GrowsAndSucceeds()
+        {
+            // Each message is ~2 KB; 200 logs serialize to well over the initial 64 KB buffer,
+            // forcing multiple buffer resizes. Before the grow-and-retry fix this threw
+            // ArgumentOutOfRangeException from WriteLogRecord once writePosition passed 64 KB.
+            var largeMessage = new string('x', 2048);
+            var logs = new List<LogPoint>();
+            for (var i = 0; i < 200; i++)
+            {
+                logs.Add(new LogPoint { Message = largeMessage, LogLevel = 2, CategoryName = "Test" });
+            }
+
+            byte[] payload = null;
+            var act = () => payload = OtlpLogsSerializer.SerializeLogs(logs, CreateResourceTags());
+
+            act.Should().NotThrow();
+            payload.Should().NotBeNull();
+
+            // The serialized payload must be larger than the initial buffer, proving the
+            // buffer grew rather than silently truncating the batch.
+            payload!.Length.Should().BeGreaterThan(InitialBufferSize);
+        }
+
+        [Fact]
+        public void SerializeLogs_RespectsStartPosition()
+        {
+            var logs = new List<LogPoint>
+            {
+                new() { Message = "hello", LogLevel = 2, CategoryName = "Test" },
+            };
+
+            // gRPC reserves 5 bytes at the start for the frame header.
+            const int startPosition = 5;
+            var payload = OtlpLogsSerializer.SerializeLogs(logs, CreateResourceTags(), startPosition);
+
+            payload.Length.Should().BeGreaterThan(startPosition);
+        }
+
+        private static OtlpLogsSerializer.ResourceTags CreateResourceTags()
+            => new(
+                serviceName: "test-service",
+                environment: "test-env",
+                serviceVersion: "1.0.0",
+                globalTags: new ReadOnlyDictionary<string, string>(new Dictionary<string, string>()));
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes
Fix an `ArgumentOutOfRangeException` when serializing OTLP log batches that exceed 64 KB, and bound the serialization buffer.

Seen [here](https://app.datadoghq.com/error-tracking/issue/0d68eea2-0e57-11f1-9f2a-da7ad0900002).

## Reason for change
`OtlpLogsSerializer.SerializeLogs` wrote into a fixed 64 KB buffer with no bounds checking or resizing. Once a batch's serialized size crossed 64 KB, the next write threw `ArgumentOutOfRangeException` (surfacing in `WriteLogRecord` due to inlining), the batch failed to send, and it was dropped.

This is rare in practice — error tracking shows very few occurrences — but when it does happen it's a hard failure that silently drops the batch, so it's worth guarding against.

## Implementation details
- Grow the buffer (doubling) and retry serialization on overflow, instead of assuming 64 KB is always enough. Overflow is detected via the `ArgumentException`/`IndexOutOfRangeException` the writers already throw; since overflow is the rare case, exception-driven detection keeps the common path allocation-free rather than pre-sizing every batch.
- Cap growth at a hardcoded 10 MB (matching the default trace payload cap); a batch that still doesn't fit returns `null` so it's dropped rather than allocating without bound.
- `OtlpExporter` logs a warning and reports success on a dropped batch, so the batching sink doesn't trip its circuit breaker for this non-transient case.

## Test coverage
Added `OtlpLogsSerializerTests`: small/empty batches, grow-and-succeed (the original crash repro), oversized batch returns null, and start-position handling.

## Other details
