### PR TITLE
Move webhook url to protected environment

### DIFF
--- a/.github/workflows/auto_bump_smoke_test_docker_images.yml
+++ b/.github/workflows/auto_bump_smoke_test_docker_images.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   bump_smoke_test_docker_images:
     runs-on: windows-latest
+    environment: version-bump-env
     permissions:
       actions: read # read secrets
       id-token: write # Required for dd-octo-sts authentication
@@ -77,4 +78,4 @@ jobs:
               "github_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBOOK_URL_GENERATEPACKAGEVERSIONS }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GENERATEPACKAGEVERSIONS }}

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   bump_package_versions:
     runs-on: windows-latest
+    environment: version-bump-env
     permissions:
       actions: read # read secrets
       id-token: write # Required for dd-octo-sts authentication
@@ -77,4 +78,4 @@ jobs:
               "github_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBOOK_URL_GENERATEPACKAGEVERSIONS }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GENERATEPACKAGEVERSIONS }}


### PR DESCRIPTION
## Summary of changes

Moves the webhook url for the testing version bump PRs to be a protected environment secret

## Reason for change

We want to move all our repo secrets to be protected environment secrets

## Implementation details

- [Add a new Environment](https://github.com/DataDog/dd-trace-dotnet/settings/environments), that may only be executed against `master` (they already do this anyway)
- Add an environment secret with the "correct" name (old one had a typo)

Once this is merged, and we've confirmed it works, we can delete the old one

## Test coverage

Can't test this until it's merged

## Other details

I'm making similar changes to the release workflows, so this seemed like a good test bed