### PR TITLE
Move secrets to be protected environment secrets

### DIFF
--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -26,13 +26,6 @@ jobs:
     permissions:
       contents: read # actions/checkout uses the workflow token to clone
       id-token: write # required for dd-octo-sts OIDC and NuGet trusted publishing
-    env:
-      # Have to use external token with explicit workflow permissions because we are creating
-      # a release from an arbitrary SHA. For "reasons", the built-in token does not _always_
-      # work in that scenario, so using an external token is required. See issue
-      # https://github.com/cli/cli/issues/9514 for more details.
-      AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -115,6 +108,7 @@ jobs:
           TargetBranch: ${{ github.ref }}
           CommitSha: "${{ steps.set_sha.outputs.sha }}"
           GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
+          AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
 
       - name: "Generate release notes"
         id: release_notes

--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -16,11 +16,6 @@ on:
         description: 'Is this a hotfix release? If true, skips vNext milestone renaming'
         required: true
         type: boolean
-    secrets:
-      AZURE_DEVOPS_TOKEN:
-        required: true
-      NUGET_TRUSTED_PUBLISHING_USERNAME:
-        required: true
 
 jobs:
   create_draft_release:

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -28,8 +28,6 @@ jobs:
       contents: read
       actions: read # read secrets
       packages: write # pushing to ghcr.io
-    env:
-      AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
     steps:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,6 +47,7 @@ jobs:
       run: ./tracer/build.sh DownloadAzurePipelineFromBuild
       env:
         AzureDevopsBuildId: "${{ github.event.inputs.azdo_build_id }}"
+        AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
 
     - name: "Sanitize branch name"
       id: image_tag

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   build-and-publish-base-image:
     runs-on: ubuntu-latest
+    environment: publish-debug-symbols-env
     permissions:
       contents: read
       actions: read # read secrets

--- a/.github/workflows/create_hotfix_draft_release.yml
+++ b/.github/workflows/create_hotfix_draft_release.yml
@@ -37,6 +37,3 @@ jobs:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}
             is_hotfix: true
-        secrets:
-            AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-            NUGET_TRUSTED_PUBLISHING_USERNAME: ${{ secrets.NUGET_TRUSTED_PUBLISHING_USERNAME }}

--- a/.github/workflows/create_normal_draft_release.yml
+++ b/.github/workflows/create_normal_draft_release.yml
@@ -37,6 +37,3 @@ jobs:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}
             is_hotfix: false
-        secrets:
-            AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
-            NUGET_TRUSTED_PUBLISHING_USERNAME: ${{ secrets.NUGET_TRUSTED_PUBLISHING_USERNAME }}


### PR DESCRIPTION
## Summary of changes

- Don't pass secrets down, instead obtain directly from environment
- Only expose secret on steps that need it (Nuke step)

## Reason for change

We're moving `AZURE_DEVOPS_TOKEN` from being a repo secret to a protected environment secret. This does some of the associated cleanup.

## Implementation details

- **Don't try to pass the secrets in to the worfklow**. AFAICT, this technically wasn't working as we expected 😅 The "top level" `create_normal_draft_release` workflow was trying to access and pass in the variables, but as it wasn't running in an `environment`, this was passing an empty string. However, this didn't break anything, because `{{ secrets.AZURE_DEVOPS_TOKEN }}` was transparently accessing the environment secret _anyway_. So we can just stop _trying_ to pass them in now.
- `create-system-test-docker-base-images.yml` needs to be in the "release" env, because it needs the azure devops token to grab the build results from CI (avoiding rate limits)

Additionally, I duplicated the repo-secret `AZURE_DEVOPS_TOKEN` into the existing `publish-debug-symbols-env` environment, so when we merge this, everything should "just work".

Finally, we can make the `publish-debug-symbols-env`, "protected" so it only runs on release branches.

## Test coverage

Nope, we can't really test any of this 🙁 Hence why I want to babysit it the first time 😅 

## Other details

I'd like to change `publish-debug-symbols-env` to be called `release-env` (or something similar), but that means changing a whole bunch of `sts` token stuff, across multiple repos, and it doesn't seem worth the hassle 😅 