### PR TITLE
Add `environment` to subject in chainguard policies

### DIFF
--- a/.github/chainguard/self.auto_bump_smoke_test_docker_images.create-pr.sts.yaml
+++ b/.github/chainguard/self.auto_bump_smoke_test_docker_images.create-pr.sts.yaml
@@ -1,8 +1,9 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: repo:DataDog/dd-trace-dotnet:.*
+subject: repo:DataDog/dd-trace-dotnet:environment:version-bump-env
 
 claim_pattern:
+  environment: version-bump-env
   event_name: (schedule|workflow_dispatch)
   ref: refs/heads/master
   ref_protected: "true"

--- a/.github/chainguard/self.auto_bump_test_package_versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.auto_bump_test_package_versions.create-pr.sts.yaml
@@ -1,8 +1,9 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject_pattern: repo:DataDog/dd-trace-dotnet:.*
+subject: repo:DataDog/dd-trace-dotnet:environment:version-bump-env
 
 claim_pattern:
+  environment: version-bump-env
   event_name: (schedule|workflow_dispatch|pull_request_target)
   ref: refs/heads/master
   ref_protected: "true"


### PR DESCRIPTION
## Summary of changes

Tightens up the chainguard policies for the version bump PRs

## Reason for change

#8863 updated the docker image version bump and the test package version bump workflows to run inside a protected environment. It probably makes sense to tighten up the sts policies around these workflows too.

## Implementation details

Add `environment` to the `subject` and `claim_pattern`

## Test coverage

Can't test until we merge 🙈 

## Other details

Follow up to 
- https://github.com/DataDog/dd-trace-dotnet/pull/8863

Related to 
- https://github.com/DataDog/dd-trace-dotnet/pull/8865

I checked with `/dd-octo-sts` and it said:

> The changes are correct and make the policies meaningfully more secure.