### PR TITLE
Update `CODEOWNERS` to remove IDM from DSM and expand DSM ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 # Capabilities, API, and OpenTelemetry
 
 /tracer/src/Datadog.Trace.Manual/                                                                       @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace.Manual/DataStreams.cs                                                         @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet @DataDog/data-streams-monitoring
 /tracer/src/Datadog.Trace/Activity/                                                                     @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/                                @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/                        @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet
@@ -31,13 +32,17 @@
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs                        @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs                        @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet
 
+/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/DataStreamsInstrumentationTests.cs               @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet @DataDog/data-streams-monitoring
+
 ## DBM and DSM
 /tracer/src/Datadog.Trace/DatabaseMonitoring/                                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/DataStreamsMonitoring/                                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
-/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/                                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/src/Datadog.Trace/DataStreamsMonitoring/                                                        @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/                                                 @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/                                           @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
 
 ## auto instrumentations
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/                                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/DataStreams/            @DataDog/apm-sdk-capabilities-dotnet @DataDog/tracing-dotnet @DataDog/data-streams-monitoring
 
 ## co-owned auto instrumentations
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/asm-dotnet
@@ -48,7 +53,7 @@
 
 ## integration tests for auto-instrumentations
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/                                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/**/DataStreamsMonitoring*                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/**/DataStreamsMonitoring*                       @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
 
 ### co-owned integrations tests
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/asm-dotnet
@@ -62,7 +67,7 @@
 /tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.netstandard/         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/test/test-applications/integrations/dependency-libs/Samples.WebRequestHelper.NetFramework20/    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.DataStreams.*/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/test-applications/integrations/Samples.DataStreams.*/                                      @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
 
 
 ## NON-IDM


### PR DESCRIPTION
## Summary of changes

Follow up of https://github.com/DataDog/dd-trace-dotnet/pull/7915 to remove IDM from the now DSM-owned files.
Additionally tacked on some other files that are DSM-specific to include them as owners, mainly in the manual instrumentation API. I left SDK as owner as well in those however.

## Reason for change

Was noted as something we may want to do and as we are following up on test flake owners having more accurate ownership for tests is beneficial

## Implementation details



## Test coverage

## Other details
<!-- Fixes #{issue} -->

Unsure if we want `@DataDog/apm-sdk-capabilities-dotnet` as the first owner for the new ones for the manual, just following the existing way. Also fine if we just want to scope to removing IDM from the DSM ownership

#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
