### PR TITLE
Fix ADO.NET dropped trace test flakes

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -36,7 +36,7 @@ namespace Samples
         private static readonly MethodInfo? ExtractMethod = SpanContextExtractorType?.GetMethod("Extract", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         private static readonly MethodInfo? InjectMethod = SpanContextInjectorType?.GetMethod("Inject", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         private static readonly MethodInfo? SetParent = SpanCreationSettingsType?.GetProperty("Parent")?.SetMethod;
-        private static readonly MethodInfo? ForceFlushAsyncMethod = TracerType?.GetMethod("ForceFlushAsync", BindingFlags.Public | BindingFlags.Instance);
+        private static readonly MethodInfo? FlushAsyncMethod = TracerType?.GetMethod("FlushAsync", BindingFlags.Public | BindingFlags.Instance);
         private static readonly MethodInfo? ActiveScopeProperty = TracerType?.GetProperty("ActiveScope")?.GetMethod;
         private static readonly MethodInfo? ConfigureMethod = TracerType?.GetMethod("Configure");
         private static readonly MethodInfo? TraceIdProperty = SpanContextType?.GetProperty("TraceId")?.GetMethod;
@@ -273,13 +273,13 @@ namespace Samples
 
         public static Task ForceTracerFlushAsync()
         {
-            if (GetTracerInstance is null || ForceFlushAsyncMethod is null)
+            if (GetTracerInstance is null || FlushAsyncMethod is null)
             {
                 return Task.CompletedTask;
             }
 
             var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
-            return (Task?)ForceFlushAsyncMethod.Invoke(tracer, Array.Empty<object>()) ?? Task.CompletedTask;
+            return (Task?)FlushAsyncMethod.Invoke(tracer, Array.Empty<object>()) ?? Task.CompletedTask;
         }
 
         public static IDisposable GetActiveScope()

--- a/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
@@ -27,6 +27,11 @@ namespace Samples.Microsoft.Data.SqlClient
                 await RelationalDatabaseTestHarness.RunAllAsync<SqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
             }
 
+            // Flush the first phase's trace before starting the next phase. Each phase produces a single
+            // large trace, so draining this one first stops the two from competing for the writer's buffers
+            // (a locally dropped trace here would fail the exact span-count assertion in the test).
+            await SampleHelpers.ForceTracerFlushAsync();
+
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
@@ -44,8 +49,8 @@ namespace Samples.Microsoft.Data.SqlClient
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
 
-            // allow time to flush
-            await Task.Delay(2000, cts.Token);
+            // Flush before exit so all spans are delivered (deterministic, unlike a fixed delay).
+            await SampleHelpers.ForceTracerFlushAsync();
             return 0;
         }
 

--- a/tracer/test/test-applications/integrations/Samples.MySql/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MySql/Program.cs
@@ -23,6 +23,11 @@ namespace Samples.MySql
                 await RelationalDatabaseTestHarness.RunAllAsync<MySqlCommand>(connection, commandFactory, commandExecutor, cts.Token, useTransactionScope: false);
             }
 
+            // Flush the first phase's trace before starting the next phase. Each phase produces a single
+            // large trace, so draining this one first stops the two from competing for the writer's buffers
+            // (a locally dropped trace here would fail the exact span-count assertion in the test).
+            await SampleHelpers.ForceTracerFlushAsync();
+
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
@@ -33,8 +38,8 @@ namespace Samples.MySql
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token, useTransactionScope: false);
             }
 
-            // allow time to flush
-            await Task.Delay(2000, cts.Token);
+            // Flush before exit so all spans are delivered (deterministic, unlike a fixed delay).
+            await SampleHelpers.ForceTracerFlushAsync();
         }
 
         private static DbConnection OpenConnection(Type connectionType)

--- a/tracer/test/test-applications/integrations/Samples.MySqlConnector/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MySqlConnector/Program.cs
@@ -26,6 +26,11 @@ namespace Samples.MySqlConnector
                 await RelationalDatabaseTestHarness.RunAllAsync<MySqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
             }
 
+            // Flush the first phase's trace before starting the next phase. Each phase produces a single
+            // large trace, so draining this one first stops the two from competing for the writer's buffers
+            // (a locally dropped trace here would fail the exact span-count assertion in the test).
+            await SampleHelpers.ForceTracerFlushAsync();
+
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
@@ -36,8 +41,8 @@ namespace Samples.MySqlConnector
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
 
-            // allow time to flush
-            await Task.Delay(2000, cts.Token);
+            // Flush before exit so all spans are delivered (deterministic, unlike a fixed delay).
+            await SampleHelpers.ForceTracerFlushAsync();
         }
 
         private static DbConnection OpenConnection(Type connectionType)

--- a/tracer/test/test-applications/integrations/Samples.Npgsql/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Npgsql/Program.cs
@@ -21,6 +21,11 @@ namespace Samples.Npgsql
                 await RelationalDatabaseTestHarness.RunAllAsync<NpgsqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
             }
 
+            // Flush the first phase's trace before starting the next phase. Each phase produces a single
+            // large trace, so draining this one first stops the two from competing for the writer's buffers
+            // (a locally dropped trace here would fail the exact span-count assertion in the test).
+            await SampleHelpers.ForceTracerFlushAsync();
+
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
@@ -31,8 +36,8 @@ namespace Samples.Npgsql
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
 
-            // allow time to flush
-            await Task.Delay(2000, cts.Token);
+            // Flush before exit so all spans are delivered (deterministic, unlike a fixed delay).
+            await SampleHelpers.ForceTracerFlushAsync();
         }
 
         private static DbConnection OpenConnection(Type connectionType)

--- a/tracer/test/test-applications/integrations/Samples.SqlServer/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.SqlServer/Program.cs
@@ -71,6 +71,11 @@ namespace Samples.SqlServer
                 await RelationalDatabaseTestHarness.RunSingleAsync(connection, commandFactory, commandExecutorVb, cts.Token);
             }
 
+            // Flush the first phase's traces before starting the next phase. The default-provider phase
+            // produces large traces, so draining them first stops them from competing with the next phase
+            // for the writer's buffers (a locally dropped trace here would fail the exact span-count assertion in the test).
+            await SampleHelpers.ForceTracerFlushAsync();
+
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
@@ -91,8 +96,8 @@ namespace Samples.SqlServer
             // we don't have tests for stored procedures
             await StoredProcedure.RunStoredProcedureTestAsync(connectionString, cts.Token);
 
-            // allow time to flush
-            await Task.Delay(2000, cts.Token);
+            // Flush before exit so all spans are delivered (deterministic, unlike a fixed delay).
+            await SampleHelpers.ForceTracerFlushAsync();
 
             return 0;
         }


### PR DESCRIPTION
## Summary of changes

Fix flaky ADO.NET integration tests where large sample traces can be dropped locally before reaching the mock tracer agent.

## Reason for change

Sql tests flaked and in the log file was `1 traces were dropped since the last flush operation` which doesn't give us much to go on at all. Saw the same pattern over the past month with the other ADO.NET integration tests.

This attempts to force a flush sooner after that first trace is sent (as the first trace was dropped).

## Implementation details

Fix `SampleHelpers.ForceTracerFlushAsync()` to call `Datadog.Trace.Tracer.FlushAsync()`
Previously it reflected `ForceFlushAsync()` which does not exist, so the helper was effectively a no-op.

Flush between large ADO.NET sample phases
Replace `Task.Delay(2000)` with a manual flush

## Test coverage



## Other details
<!-- Fixes #{issue} -->

We unfortunately don't know why it was dropped, so modifying logic to attempt to help with that.

Investigating the dropped traces seems like a different issue we should investigate later


#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
