### PR TITLE
Make transaction early-flush writer test deterministic

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -76,6 +76,13 @@ internal sealed class DataStreamsWriter : IDataStreamsWriter
     public event EventHandler<EventArgs>? FlushComplete;
 
     /// <summary>
+    /// Raised when a flush is requested, before the asynchronous flush runs. For testing only:
+    /// lets tests observe that the transaction byte-threshold requested an early flush on the
+    /// dedicated processing thread, independently of the thread pool that performs the send.
+    /// </summary>
+    internal event Action? FlushRequested;
+
+    /// <summary>
     /// Gets the number of points dropped due to a full buffer or disabled DSM.
     /// Public for testing only
     /// </summary>
@@ -241,6 +248,7 @@ internal sealed class DataStreamsWriter : IDataStreamsWriter
     private void RequestFlush()
     {
         _forceFlush.TrySetResult(true);
+        FlushRequested?.Invoke();
     }
 
     private async Task FlushTaskLoopAsync()

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -86,10 +86,18 @@ public class DataStreamsWriterTests
     [Fact]
     public async Task WhenSupported_TriggersEarlyFlush_WhenTransactionsExceedThreshold()
     {
+        // The periodic timer never fires (int.MaxValue), so the only thing that can request a
+        // flush here is the transaction byte-threshold check in the writer's processing loop.
+        // That loop runs on a dedicated (LongRunning) thread, so observing the flush *request*
+        // is deterministic and does not depend on the thread pool that drives the actual send.
+        // Asserting on api.Sent would instead race a (potentially starved) thread pool.
         var bucketDuration = int.MaxValue; // timer will never fire
         var api = new StubApi();
         var writer = CreateWriter(api, out var discovery, bucketDuration);
         TriggerSupportUpdate(discovery, isSupported: true);
+
+        var flushRequested = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        writer.FlushRequested += () => flushRequested.TrySetResult(true);
 
         var id = new string('x', 512);
         var byteCount = new DataStreamsTransactionInfo(id, 0L, "cp").GetByteCount();
@@ -100,8 +108,8 @@ public class DataStreamsWriterTests
             writer.AddTransaction(new DataStreamsTransactionInfo(id, (long)i, "cp"));
         }
 
-        await api.WaitForCount(1, 30_000);
-        api.Sent.Should().NotBeEmpty();
+        var requested = await Task.WhenAny(flushRequested.Task, Task.Delay(30_000)) == flushRequested.Task;
+        requested.Should().BeTrue("crossing the transaction byte threshold should request an early flush");
 
         await writer.DisposeAsync();
     }


### PR DESCRIPTION
## Summary of changes

Assert that crossing the transaction byte threshold *requests* a flush, instead of polling `api.Sent`. Adds an `internal event Action? FlushRequested` on `DataStreamsWriter` (test-only, like the existing `FlushComplete`).

## Reason for change

`WhenSupported_TriggersEarlyFlush_WhenTransactionsExceedThreshold` flaked in CI (`Expected api.Sent not to be empty`, ~41s vs a 30s budget). With the timer disabled, the test relied solely on the flush pipeline's thread-pool, which stalls under a saturated pool.

## Implementation details
The test now awaits `FlushRequested` instead of the pool-driven send.

## Test coverage

Test now asserts the event/action is triggered instead of waiting for the flush to occur

## Other details
<!-- Fixes #{issue} -->
#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
