### PR TITLE
Bumps IpcClientTest timeout and update CI Vis CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,6 +180,7 @@ Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 
 # CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/test/Datadog.Trace.Tests/Ci/                          @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/PDBs/MethodSymbolResolver.cs        @DataDog/ci-app-libraries-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/  @DataDog/ci-app-libraries-dotnet

--- a/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/Ipc/IpcTests.cs
@@ -72,7 +72,7 @@ public class IpcTests
 
         client.TrySendMessage(new TestMessage(0, 0));
 
-        var delayTask = Task.Delay(30_000);
+        var delayTask = Task.Delay(40_000);
         var ipcTasks = Task.WhenAll(serverTaskCompletion.Task, clientTaskCompletion.Task);
         if (await Task.WhenAny(ipcTasks, delayTask) == delayTask)
         {


### PR DESCRIPTION
## Summary of changes

Increase the `IpcClientTest` timeout from 30s to 40s, and add a missing CODEOWNERS entry for the Ci unit test directory.

## Reason for change

`IpcClientTest` was flaking with a `TimeoutException` even though both sides had reached the expected message count `CircularChannel` polls every 100ms and the test needs ~40 round trips, so occasional CI scheduling delays can push it past 30s. 

`tracer/test/Datadog.Trace.Tests/Ci/` had no CODEOWNERS entry

## Implementation details

bumped the timeout to 40s

Added CI Vis to the owner

## Test coverage

Same tests

## Other details
<!-- Fixes #{issue} -->
#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
