### PR TITLE
Improve console sample startup handling in ConsoleTestHelper

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -110,8 +110,20 @@ public abstract class ConsoleTestHelper : ToolTestHelper
 
         if (completed == helper.Task)
         {
+            // Startup exited before readiness. Include the exit code and drained output so
+            // crashes show native exit codes and any stack traces from the child process.
+            var exitCode = helper.Process.HasExited ? helper.Process.ExitCode : (int?)null;
+            var standardOutput = helper.StandardOutput;
+            var errorOutput = helper.ErrorOutput;
+
             helper.Dispose();
-            throw new Exception("The target process unexpectedly exited");
+
+            var exitCodeText = exitCode is { } code ? $"0x{code:X8}" : "unknown";
+
+            throw new Exception(
+                $"The target process unexpectedly exited with exit code {exitCodeText}" + Environment.NewLine +
+                "Standard output:" + Environment.NewLine + standardOutput + Environment.NewLine +
+                "Error output:" + Environment.NewLine + errorOutput);
         }
 
         // Try to capture a memory dump before giving up

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -98,14 +98,17 @@ public abstract class ConsoleTestHelper : ToolTestHelper
 
         var helper = new CustomProcessHelper(agent, Process.Start(processStart)!, callback);
 
+        var timeoutTask = Task.Delay(TimeSpan.FromSeconds(30));
         var completed = await Task.WhenAny(
                             helper.Task,
                             startedTask.Task,
-                            Task.Delay(TimeSpan.FromSeconds(30)));
+                            timeoutTask);
 
         // Crash samples can print "Waiting" and exit before this await resumes. If both
-        // tasks are complete, WhenAny may return either, so readiness should win.
-        if (startedTask.Task.IsCompleted)
+        // the process-exit and readiness tasks are complete, WhenAny may return either,
+        // so readiness should win. Don't apply that to timeouts: readiness after the
+        // timeout must still take the timeout/memory-dump path.
+        if (completed == startedTask.Task || (completed == helper.Task && startedTask.Task.IsCompleted))
         {
             return helper;
         }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -103,7 +103,9 @@ public abstract class ConsoleTestHelper : ToolTestHelper
                             startedTask.Task,
                             Task.Delay(TimeSpan.FromSeconds(30)));
 
-        if (completed == startedTask.Task)
+        // Crash samples can print "Waiting" and exit before this await resumes. If both
+        // tasks are complete, WhenAny may return either, so readiness should win.
+        if (startedTask.Task.IsCompleted)
         {
             return helper;
         }


### PR DESCRIPTION
## Summary of changes

Improves `ConsoleTestHelper` startup handling by treating signaled readiness as success even if the process exits immediately afterward, and includes exit code/stdout/stderr when startup exits before readiness.

## Reason for change

Flaky tests when the test application crashed(?) before we expected it to crash as we make it crash in the test. But there really wasn't much information to go off of at all, so just trying to to do a potential fix with `startedTask.Task.IsCompleted` and try and get a little more information than just "The target process unexpectedly exited"

## Implementation details

- Checks `startedTask.Task.IsCompleted` instead of relying only on the task returned by `Task.WhenAny`.
- Captures process exit code, standard output, and error output before disposing the helper when startup exits early.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
