### PR TITLE
[Debugger] Prevent expression member access from invoking getters

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -93,13 +93,13 @@ internal sealed partial class ProbeExpressionParser<T>
             left = ParseTree(reader, parameters, itParameter);
             if (left.Type == ProbeExpressionParserHelper.UndefinedValueType)
             {
-                return ReturnDefaultValueExpression();
+                return RedactDictionaryUndefinedOperation(left);
             }
 
             right = ParseTree(reader, parameters, itParameter);
             if (right.Type == ProbeExpressionParserHelper.UndefinedValueType)
             {
-                return ReturnDefaultValueExpression();
+                return RedactDictionaryUndefinedOperation(right);
             }
 
             if (left.Type == typeof(string) && right.Type == typeof(string))

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -450,39 +450,29 @@ internal partial class ProbeExpressionParser<T>
 
     private bool TryGetCollectionIteratorProperty(ParameterExpression itParameter, string propertyName, out Expression propertyExpression)
     {
-        propertyExpression = null;
+        return TryGetDictionaryEntryMember(itParameter, propertyName, out propertyExpression);
+    }
 
-        if (itParameter.Type == typeof(DictionaryEntry))
+    private bool TryGetDictionaryEntryMember(Expression dictionaryEntryExpression, string propertyName, out Expression memberExpression)
+    {
+        memberExpression = null;
+
+        if (!IsDictionaryEntryType(dictionaryEntryExpression.Type))
         {
-            switch (propertyName)
-            {
-                case nameof(KeyValuePair<int, int>.Key):
-                    propertyExpression = Expression.Property(itParameter, propertyName);
-                    return true;
-                case nameof(KeyValuePair<int, int>.Value):
-                    propertyExpression = TryRedactDictionaryValueMember(itParameter, out var redactedValue) ? redactedValue : Expression.Property(itParameter, propertyName);
-                    return true;
-                default:
-                    return false;
-            }
+            return false;
         }
 
-        if (itParameter.Type.IsGenericType && itParameter.Type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+        switch (propertyName)
         {
-            switch (propertyName)
-            {
-                case nameof(KeyValuePair<int, int>.Key):
-                    propertyExpression = Expression.Property(itParameter, propertyName);
-                    return true;
-                case nameof(KeyValuePair<int, int>.Value):
-                    propertyExpression = TryRedactDictionaryValueMember(itParameter, out var redactedValue) ? redactedValue : Expression.Property(itParameter, propertyName);
-                    return true;
-                default:
-                    return false;
-            }
+            case nameof(KeyValuePair<int, int>.Key):
+                memberExpression = Expression.Property(dictionaryEntryExpression, propertyName);
+                return true;
+            case nameof(KeyValuePair<int, int>.Value):
+                memberExpression = TryRedactDictionaryValueMember(dictionaryEntryExpression, out var redactedValue) ? redactedValue : Expression.Property(dictionaryEntryExpression, propertyName);
+                return true;
+            default:
+                return false;
         }
-
-        return false;
     }
 
     private bool TryRedactDictionaryValueMember(Expression dictionaryEntryExpression, out Expression redactedValue)
@@ -548,7 +538,10 @@ internal partial class ProbeExpressionParser<T>
         if (!TryResolveSafeMemberExpression(valueExpression, propertyOrFieldValue, out var memberExpression, out var reason))
         {
             AddError($"{valueExpression}.{propertyOrFieldValue}", reason);
-            return UndefinedValue();
+            var undefinedValue = UndefinedValue();
+            (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
+               .Add(undefinedValue, new RedactedDictionaryValueExpression(redactedDictionaryValue.ShouldRedactExpression, undefinedValue));
+            return undefinedValue;
         }
 
         (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
@@ -579,6 +572,11 @@ internal partial class ProbeExpressionParser<T>
         return TryGetRedactedDictionaryValue(source, out var redactedDictionaryValue)
                    ? RedactDictionaryOperationWithGuard(redactedDictionaryValue.ShouldRedactExpression, operation)
                    : operation;
+    }
+
+    private Expression RedactDictionaryUndefinedOperation(Expression source)
+    {
+        return RedactDictionaryOperation(source, ReturnDefaultValueExpression());
     }
 
     private Expression RedactDictionaryOperationWithGuard(Expression shouldRedact, Expression operation)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Collection.cs
@@ -454,26 +454,32 @@ internal partial class ProbeExpressionParser<T>
 
         if (itParameter.Type == typeof(DictionaryEntry))
         {
-            var property = Expression.Property(itParameter, propertyName);
-            propertyExpression = propertyName switch
+            switch (propertyName)
             {
-                nameof(KeyValuePair<int, int>.Key) => property,
-                nameof(KeyValuePair<int, int>.Value) when TryRedactDictionaryValueMember(itParameter, out var redactedValue) => redactedValue,
-                _ => property,
-            };
-            return true;
+                case nameof(KeyValuePair<int, int>.Key):
+                    propertyExpression = Expression.Property(itParameter, propertyName);
+                    return true;
+                case nameof(KeyValuePair<int, int>.Value):
+                    propertyExpression = TryRedactDictionaryValueMember(itParameter, out var redactedValue) ? redactedValue : Expression.Property(itParameter, propertyName);
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         if (itParameter.Type.IsGenericType && itParameter.Type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
         {
-            var property = Expression.Property(itParameter, propertyName);
-            propertyExpression = propertyName switch
+            switch (propertyName)
             {
-                nameof(KeyValuePair<int, int>.Key) => property,
-                nameof(KeyValuePair<int, int>.Value) when TryRedactDictionaryValueMember(itParameter, out var redactedValue) => redactedValue,
-                _ => property,
-            };
-            return true;
+                case nameof(KeyValuePair<int, int>.Key):
+                    propertyExpression = Expression.Property(itParameter, propertyName);
+                    return true;
+                case nameof(KeyValuePair<int, int>.Value):
+                    propertyExpression = TryRedactDictionaryValueMember(itParameter, out var redactedValue) ? redactedValue : Expression.Property(itParameter, propertyName);
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         return false;
@@ -536,10 +542,15 @@ internal partial class ProbeExpressionParser<T>
         return false;
     }
 
-    private MemberExpression RedactedDictionaryValueMember(RedactedDictionaryValueExpression redactedDictionaryValue, string propertyOrFieldValue)
+    private Expression RedactedDictionaryValueMember(RedactedDictionaryValueExpression redactedDictionaryValue, string propertyOrFieldValue)
     {
         var valueExpression = redactedDictionaryValue.ValueExpression;
-        var memberExpression = Expression.PropertyOrField(valueExpression, propertyOrFieldValue);
+        if (!TryResolveSafeMemberExpression(valueExpression, propertyOrFieldValue, out var memberExpression, out var reason))
+        {
+            AddError($"{valueExpression}.{propertyOrFieldValue}", reason);
+            return UndefinedValue();
+        }
+
         (_redactedDictionaryValues ??= new Dictionary<Expression, RedactedDictionaryValueExpression>())
            .Add(memberExpression, new RedactedDictionaryValueExpression(redactedDictionaryValue.ShouldRedactExpression, memberExpression));
         return memberExpression;

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -511,10 +511,9 @@ internal partial class ProbeExpressionParser<T>
                 return RedactedValue();
             }
 
-            if (propertyOrFieldValue == nameof(KeyValuePair<int, int>.Value) &&
-                TryRedactDictionaryValueMember(expression, out var redactedValue))
+            if (TryGetDictionaryEntryMember(expression, propertyOrFieldValue, out var dictionaryEntryMember))
             {
-                return redactedValue;
+                return dictionaryEntryMember;
             }
 
             if (TryGetRedactedDictionaryValue(expression, out var redactedDictionaryValue))

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -7,9 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -18,7 +18,9 @@ namespace Datadog.Trace.Debugger.Expressions;
 
 internal partial class ProbeExpressionParser<T>
 {
-    private const BindingFlags GetMemberFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy;
+    private const BindingFlags InstanceMemberFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+    private const BindingFlags StaticMemberFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly;
+    private const BindingFlags AllMemberFlags = InstanceMemberFlags | StaticMemberFlags;
 
     // https://learn.microsoft.com/en-us/dotnet/standard/base-types/conversion-tables
     private static Type GetWiderNumericType(Type left, Type right)
@@ -242,6 +244,163 @@ internal partial class ProbeExpressionParser<T>
         return type.FullName ?? type.Name;
     }
 
+    private static bool TryResolveSafeMemberExpression(Expression source, string memberName, [NotNullWhen(true)] out Expression memberExpression, [NotNullWhen(false)] out string reason)
+    {
+        memberExpression = null;
+        reason = null;
+
+        var sourceType = source?.Type;
+        if (sourceType == null)
+        {
+            reason = "The source expression type is null.";
+            return false;
+        }
+
+        if (sourceType.ContainsGenericParameters)
+        {
+            reason = $"The property or field cannot be safely read because {sourceType} contains generic parameters.";
+            return false;
+        }
+
+        var currentType = sourceType;
+        while (currentType != null && currentType != typeof(object))
+        {
+            try
+            {
+                var field = currentType.GetField(memberName, AllMemberFlags);
+                if (field != null)
+                {
+                    return TryCreateFieldExpression(source, field, out memberExpression, out reason);
+                }
+            }
+            catch (Exception)
+            {
+                reason = "The property or field cannot be safely resolved.";
+                return false;
+            }
+
+            try
+            {
+                var property = currentType.GetProperty(memberName, AllMemberFlags);
+                if (property != null)
+                {
+                    return TryCreateAutoPropertyBackingFieldExpression(source, property, out memberExpression, out reason);
+                }
+            }
+            catch (Exception)
+            {
+                reason = "The property or field cannot be safely resolved.";
+                return false;
+            }
+
+            currentType = currentType.BaseType;
+        }
+
+        reason = $"The property or field does not exist in {sourceType}";
+        return false;
+    }
+
+    private static bool TryCreateAutoPropertyBackingFieldExpression(Expression source, PropertyInfo property, [NotNullWhen(true)] out Expression memberExpression, out string reason)
+    {
+        memberExpression = null;
+        reason = null;
+
+        MethodInfo getMethod;
+        Type declaringType;
+        try
+        {
+            getMethod = property.GetGetMethod(true);
+            declaringType = property.DeclaringType;
+        }
+        catch (Exception)
+        {
+            reason = "The property cannot be safely read without invoking its getter.";
+            return false;
+        }
+
+        if (getMethod == null || declaringType == null)
+        {
+            reason = "The property cannot be safely read without invoking its getter.";
+            return false;
+        }
+
+        if (property.PropertyType.ContainsGenericParameters ||
+            declaringType.ContainsGenericParameters ||
+            property.ReflectedType?.ContainsGenericParameters == true ||
+            property.PropertyType.IsGenericTypeDefinition)
+        {
+            reason = "The property cannot be safely read without invoking its getter.";
+            return false;
+        }
+
+        var backingFieldName = "<" + property.Name + ">k__BackingField";
+        FieldInfo backingField;
+        try
+        {
+            backingField = declaringType.GetField(backingFieldName, AllMemberFlags);
+        }
+        catch (Exception)
+        {
+            reason = "The property cannot be safely read without invoking its getter.";
+            return false;
+        }
+
+        if (backingField == null ||
+            backingField.DeclaringType != declaringType ||
+            backingField.FieldType != property.PropertyType ||
+            backingField.IsStatic != getMethod.IsStatic ||
+            !backingField.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false))
+        {
+            reason = "The property cannot be safely read without invoking its getter.";
+            return false;
+        }
+
+        return TryCreateFieldExpression(source, backingField, out memberExpression, out reason);
+    }
+
+    private static bool TryCreateFieldExpression(Expression source, FieldInfo field, [NotNullWhen(true)] out Expression memberExpression, out string reason)
+    {
+        memberExpression = null;
+        reason = null;
+
+        if (field.FieldType.ContainsGenericParameters ||
+            field.DeclaringType?.ContainsGenericParameters == true ||
+            field.ReflectedType?.ContainsGenericParameters == true ||
+            field.FieldType.IsGenericTypeDefinition)
+        {
+            reason = "The field cannot be safely read.";
+            return false;
+        }
+
+        if (field.IsStatic)
+        {
+            if (field.IsLiteral)
+            {
+                memberExpression = Expression.Constant(StaticMemberSafety.GetRawConstantValue(field), field.FieldType);
+                return true;
+            }
+
+            if (!StaticMemberSafety.CanReadStaticMember(field))
+            {
+                reason = "Static member access is skipped because it could trigger the declaring type initializer.";
+                return false;
+            }
+
+            memberExpression = Expression.Field(null, field);
+            return true;
+        }
+
+        var declaringType = field.DeclaringType;
+        if (declaringType == null || !declaringType.IsAssignableFrom(source.Type))
+        {
+            reason = "The field cannot be safely read.";
+            return false;
+        }
+
+        memberExpression = Expression.Field(source, field);
+        return true;
+    }
+
     private Expression IsInstanceOf(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         var value = ParseTree(reader, parameters, itParameter);
@@ -316,10 +475,13 @@ internal partial class ProbeExpressionParser<T>
                 return RedactedValue();
             }
 
-            var argOrLocal = parameters.FirstOrDefault(p => p.Name == constantValue);
-            if (argOrLocal != null)
+            for (var i = 0; i < parameters.Count; i++)
             {
-                return argOrLocal;
+                var parameter = parameters[i];
+                if (parameter.Name == constantValue)
+                {
+                    return parameter;
+                }
             }
 
             // will return an instance field\property or an UndefinedValue
@@ -360,41 +522,13 @@ internal partial class ProbeExpressionParser<T>
                 return RedactedDictionaryValueMember(redactedDictionaryValue, propertyOrFieldValue);
             }
 
-            var memberInfo = expression.Type.GetMember(propertyOrFieldValue, GetMemberFlags).FirstOrDefault();
-
-            if (memberInfo == null)
+            if (!TryResolveSafeMemberExpression(expression, propertyOrFieldValue, out var memberExpression, out var reason))
             {
-                AddError($"{expression}.{propertyOrFieldValue}", $"The property or field does not exist in {expression.Type}");
+                AddError($"{expression}.{propertyOrFieldValue}", reason);
                 return UndefinedValue();
             }
 
-            bool isStatic = (memberInfo is PropertyInfo propertyInfo && propertyInfo.GetGetMethod(true)?.IsStatic == true) ||
-                            memberInfo is FieldInfo { IsStatic: true };
-
-            if (isStatic)
-            {
-                if (memberInfo is FieldInfo { IsLiteral: true } literalField)
-                {
-                    return Expression.Constant(StaticMemberSafety.GetRawConstantValue(literalField), literalField.FieldType);
-                }
-
-                if (!StaticMemberSafety.CanReadStaticMember(memberInfo))
-                {
-                    AddError($"{expression}.{propertyOrFieldValue}", "Static member access is skipped because it could trigger the declaring type initializer.");
-                    return UndefinedValue();
-                }
-
-                return memberInfo.MemberType switch
-                {
-                    MemberTypes.Field => Expression.Field(null, (FieldInfo)memberInfo),
-                    MemberTypes.Property => Expression.Property(null, (PropertyInfo)memberInfo),
-                    _ => throw new InvalidOperationException("Unsupported member type for static member access.")
-                };
-            }
-            else
-            {
-                return Expression.PropertyOrField(expression, propertyOrFieldValue);
-            }
+            return memberExpression;
         }
         catch (Exception e)
         {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -2404,6 +2404,264 @@ namespace Datadog.Trace.Tests.Debugger
             Assert.True(publicCompiled.Errors == null || publicCompiled.Errors.Length == 0);
         }
 
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorEntry_CanUseExplicitKeyMemberInPredicate()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, string>),
+                new Dictionary<string, string>
+                {
+                    { "hello", "world" },
+                    { "goodbye", "moon" },
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "any": [
+                                    {
+                                      "ref": "SafeDictionaryLocal"
+                                    },
+                                    {
+                                      "eq": [
+                                        {
+                                          "getmember": [
+                                            {
+                                              "ref": "@it"
+                                            },
+                                            "Key"
+                                          ]
+                                        },
+                                        "missing"
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.False(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorEntry_CanUseExplicitKeyMemberAfterIndex()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, string>),
+                new Dictionary<string, string>
+                {
+                    { "hello", "world" },
+                    { "goodbye", "moon" },
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "index": [
+                                        {
+                                          "filter": [
+                                            { "ref": "SafeDictionaryLocal" },
+                                            { "eq": [ { "ref": "@key" }, "goodbye" ] }
+                                          ]
+                                        },
+                                        0
+                                      ]
+                                    },
+                                    "Key"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<string>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Equal("goodbye", result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValueMember_RedactsUnsafeMemberAccess()
+        {
+            var scopeMembers = CreateScopeMembers();
+            const string secret = "TOP_SECRET_VALUE";
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, SideEffectingValueHolder>),
+                new Dictionary<string, SideEffectingValueHolder>
+                {
+                    { "password", new SideEffectingValueHolder(secret) },
+                },
+                ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "getmember": [
+                                        {
+                                          "index": [
+                                            {
+                                              "filter": [
+                                                { "ref": "SafeDictionaryLocal" },
+                                                { "eq": [ { "ref": "@key" }, "password" ] }
+                                              ]
+                                            },
+                                            0
+                                          ]
+                                        },
+                                        "Value"
+                                      ]
+                                    },
+                                    "UnsafeData"
+                                  ]
+                                }
+                                """;
+
+            SideEffectingValueHolder.Reset();
+            var objectCompiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var objectResult = objectCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            var stringCompiled = ProbeExpressionParser<string>.ParseExpression(json, scopeMembers);
+            var stringResult = stringCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Equal("{REDACTED}", objectResult);
+            Assert.Equal("{REDACTED}", stringResult);
+            Assert.Equal(0, SideEffectingValueHolder.GetterCalls);
+            var objectError = Assert.Single(objectCompiled.Errors);
+            Assert.Contains("cannot be safely read", objectError.Message);
+            var stringError = Assert.Single(stringCompiled.Errors);
+            Assert.Contains("cannot be safely read", stringError.Message);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValueMember_SuppressesUnsafeMemberConditionForSensitiveKey()
+        {
+            var scopeMembers = CreateScopeMembers();
+            const string secret = "TOP_SECRET_VALUE";
+            const string publicValue = "hello";
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, SideEffectingValueHolder>),
+                new Dictionary<string, SideEffectingValueHolder>
+                {
+                    { "password", new SideEffectingValueHolder(secret) },
+                    { "public", new SideEffectingValueHolder(publicValue) },
+                },
+                ScopeMemberKind.Local));
+
+            const string sensitiveJson = """
+                                         {
+                                           "eq": [
+                                             {
+                                               "getmember": [
+                                                 {
+                                                   "getmember": [
+                                                     {
+                                                       "index": [
+                                                         {
+                                                           "filter": [
+                                                             { "ref": "SafeDictionaryLocal" },
+                                                             { "eq": [ { "ref": "@key" }, "password" ] }
+                                                           ]
+                                                         },
+                                                         0
+                                                       ]
+                                                     },
+                                                     "Value"
+                                                   ]
+                                                 },
+                                                 "UnsafeData"
+                                               ]
+                                             },
+                                             "TOP_SECRET_VALUE"
+                                           ]
+                                         }
+                                         """;
+
+            const string publicJson = """
+                                      {
+                                        "eq": [
+                                          {
+                                            "getmember": [
+                                              {
+                                                "getmember": [
+                                                  {
+                                                    "index": [
+                                                      {
+                                                        "filter": [
+                                                          { "ref": "SafeDictionaryLocal" },
+                                                          { "eq": [ { "ref": "@key" }, "public" ] }
+                                                        ]
+                                                      },
+                                                      0
+                                                    ]
+                                                  },
+                                                  "Value"
+                                                ]
+                                              },
+                                              "UnsafeData"
+                                            ]
+                                          },
+                                          "hello"
+                                        ]
+                                      }
+                                      """;
+
+            SideEffectingValueHolder.Reset();
+            var sensitiveCompiled = ProbeExpressionParser<bool>.ParseExpression(sensitiveJson, scopeMembers);
+            var sensitiveResult = sensitiveCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            var publicCompiled = ProbeExpressionParser<bool>.ParseExpression(publicJson, scopeMembers);
+            var publicResult = publicCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.False(sensitiveResult);
+            Assert.True(publicResult);
+            Assert.Equal(0, SideEffectingValueHolder.GetterCalls);
+            var sensitiveError = Assert.Single(sensitiveCompiled.Errors);
+            Assert.Contains("cannot be safely read", sensitiveError.Message);
+            var publicError = Assert.Single(publicCompiled.Errors);
+            Assert.Contains("cannot be safely read", publicError.Message);
+        }
+
         [Theory]
         [MemberData(nameof(SensitiveDictionaryValueOperations))]
         public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeysBeforeDerivedOperations(string operationJson)
@@ -2740,6 +2998,53 @@ namespace Datadog.Trace.Tests.Debugger
                 scopeMembers.Members);
 
             Assert.True(result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_NonGenericDictionaryPredicates_CanUseExplicitKeyMember()
+        {
+            var hashtable = new Hashtable
+            {
+                { "hello", "world" },
+                { "goodbye", "moon" },
+            };
+
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember("HashtableLocal", typeof(Hashtable), hashtable, ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "any": [
+                                    {
+                                      "ref": "HashtableLocal"
+                                    },
+                                    {
+                                      "eq": [
+                                        {
+                                          "getmember": [
+                                            {
+                                              "ref": "@it"
+                                            },
+                                            "Key"
+                                          ]
+                                        },
+                                        "missing"
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<bool>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.False(result);
             Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -2153,6 +2153,257 @@ namespace Datadog.Trace.Tests.Debugger
             Assert.Equal(publicValue, publicResult);
         }
 
+        [Fact]
+        public void ProbeExpressionParser_PrivateAutoPropertyBackingFieldExpression_CompilesAndExecutes()
+        {
+            var target = new AutoPropertyTarget { Value = "hello" };
+            var backingField = typeof(AutoPropertyTarget).GetField("<Value>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+            backingField.Should().NotBeNull();
+
+            var source = System.Linq.Expressions.Expression.Parameter(typeof(AutoPropertyTarget), "source");
+            var field = System.Linq.Expressions.Expression.Field(source, backingField);
+            var compiled = System.Linq.Expressions.Expression.Lambda<Func<AutoPropertyTarget, string>>(field, source).Compile();
+
+            compiled(target).Should().Be("hello");
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_GetMember_AutoPropertyReadsBackingField()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember("TargetLocal", typeof(AutoPropertyTarget), new AutoPropertyTarget { Value = "hello" }, ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "ref": "TargetLocal"
+                                    },
+                                    "Value"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<string>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Equal("hello", result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_GetMember_InheritedAutoPropertyReadsBaseBackingField()
+        {
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember("TargetLocal", typeof(DerivedAutoPropertyTarget), new DerivedAutoPropertyTarget { BaseValue = "base-value" }, ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "ref": "TargetLocal"
+                                    },
+                                    "BaseValue"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<string>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Equal("base-value", result);
+            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_GetMember_DoesNotInvokeSideEffectingPropertyGetter()
+        {
+            SideEffectingPropertyTarget.Reset();
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.AddMember(new ScopeMember("TargetLocal", typeof(SideEffectingPropertyTarget), new SideEffectingPropertyTarget(), ScopeMemberKind.Local));
+
+            const string json = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "ref": "TargetLocal"
+                                    },
+                                    "UnsafeValue"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Same(UndefinedValue.Instance, result);
+            Assert.Equal(0, SideEffectingPropertyTarget.GetterCalls);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Contains("cannot be safely read", error.Message);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_GetReference_DoesNotInvokeThisPropertyGetter()
+        {
+            SideEffectingPropertyTarget.Reset();
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.InvocationTarget = new ScopeMember("this", typeof(SideEffectingPropertyTarget), new SideEffectingPropertyTarget(), ScopeMemberKind.This);
+
+            const string json = """
+                                {
+                                  "ref": "UnsafeValue"
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Same(UndefinedValue.Instance, result);
+            Assert.Equal(0, SideEffectingPropertyTarget.GetterCalls);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Contains("cannot be safely read", error.Message);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_GetMember_StaticAutoPropertyDoesNotInvokeGetterOnTypeWithCctor()
+        {
+            _staticExpressionInitializedCount = 0;
+            var scopeMembers = CreateScopeMembers();
+            scopeMembers.InvocationTarget = new ScopeMember("this", typeof(StaticExpressionWithCctor), null, ScopeMemberKind.This);
+
+            const string json = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "ref": "this"
+                                    },
+                                    "StaticProperty"
+                                  ]
+                                }
+                                """;
+
+            var compiled = ProbeExpressionParser<object>.ParseExpression(json, scopeMembers);
+            var result = compiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Same(UndefinedValue.Instance, result);
+            Assert.Equal(0, _staticExpressionInitializedCount);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Contains("could trigger the declaring type initializer", error.Message);
+        }
+
+        [Fact]
+        public void ProbeExpressionParser_DictionaryIteratorValueMember_UsesSafeResolverAndPreservesRedaction()
+        {
+            var scopeMembers = CreateScopeMembers();
+            const string secret = "TOP_SECRET_VALUE";
+            const string publicValue = "hello";
+            scopeMembers.AddMember(new ScopeMember(
+                "SafeDictionaryLocal",
+                typeof(Dictionary<string, SideEffectingValueHolder>),
+                new Dictionary<string, SideEffectingValueHolder>
+                {
+                    { "password", new SideEffectingValueHolder(secret) },
+                    { "public", new SideEffectingValueHolder(publicValue) },
+                },
+                ScopeMemberKind.Local));
+
+            const string sensitiveJson = """
+                                {
+                                  "getmember": [
+                                    {
+                                      "getmember": [
+                                        {
+                                          "index": [
+                                            {
+                                              "filter": [
+                                                { "ref": "SafeDictionaryLocal" },
+                                                { "eq": [ { "ref": "@key" }, "password" ] }
+                                              ]
+                                            },
+                                            0
+                                          ]
+                                        },
+                                        "Value"
+                                      ]
+                                    },
+                                    "Data"
+                                  ]
+                                }
+                                """;
+
+            const string publicJson = """
+                                      {
+                                        "getmember": [
+                                          {
+                                            "getmember": [
+                                              {
+                                                "index": [
+                                                  {
+                                                    "filter": [
+                                                      { "ref": "SafeDictionaryLocal" },
+                                                      { "eq": [ { "ref": "@key" }, "public" ] }
+                                                    ]
+                                                  },
+                                                  0
+                                                ]
+                                              },
+                                              "Value"
+                                            ]
+                                          },
+                                          "Data"
+                                        ]
+                                      }
+                                      """;
+
+            SideEffectingValueHolder.Reset();
+            var sensitiveCompiled = ProbeExpressionParser<object>.ParseExpression(sensitiveJson, scopeMembers);
+            var sensitiveResult = sensitiveCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            var publicCompiled = ProbeExpressionParser<object>.ParseExpression(publicJson, scopeMembers);
+            var publicResult = publicCompiled.Delegate(
+                scopeMembers.InvocationTarget,
+                scopeMembers.Return,
+                scopeMembers.Duration,
+                scopeMembers.Exception,
+                scopeMembers.Members);
+
+            Assert.Equal("{REDACTED}", sensitiveResult);
+            Assert.Equal(publicValue, publicResult);
+            Assert.Equal(0, SideEffectingValueHolder.GetterCalls);
+            Assert.True(sensitiveCompiled.Errors == null || sensitiveCompiled.Errors.Length == 0);
+            Assert.True(publicCompiled.Errors == null || publicCompiled.Errors.Length == 0);
+        }
+
         [Theory]
         [MemberData(nameof(SensitiveDictionaryValueOperations))]
         public void ProbeExpressionParser_DictionaryIteratorValue_RedactsSensitiveKeysBeforeDerivedOperations(string operationJson)
@@ -2518,7 +2769,7 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
-        public void ProbeExpressionParser_StaticMemberOnCctorFreeType_StillEvaluates()
+        public void ProbeExpressionParser_StaticPropertyOnCctorFreeType_IsUndefinedWithoutInvokingGetter()
         {
             var scopeMembers = CreateScopeMembers();
             scopeMembers.InvocationTarget = new ScopeMember("this", typeof(StaticExpressionWithoutCctor), new StaticExpressionWithoutCctor(), ScopeMemberKind.This);
@@ -2542,8 +2793,9 @@ namespace Datadog.Trace.Tests.Debugger
                 scopeMembers.Exception,
                 scopeMembers.Members);
 
-            Assert.Equal("safe-property", result);
-            Assert.True(compiled.Errors == null || compiled.Errors.Length == 0);
+            Assert.Equal(nameof(UndefinedValue), result);
+            var error = Assert.Single(compiled.Errors);
+            Assert.Contains("cannot be safely read", error.Message);
         }
 
         [Fact]
@@ -3207,6 +3459,69 @@ namespace Datadog.Trace.Tests.Debugger
         private class SensitiveValueHolder
         {
             public string Data { get; set; }
+        }
+
+        private class AutoPropertyTarget
+        {
+            public string Value { get; set; }
+        }
+
+        private class BaseAutoPropertyTarget
+        {
+            public string BaseValue { get; set; }
+        }
+
+        private class DerivedAutoPropertyTarget : BaseAutoPropertyTarget
+        {
+        }
+
+        private class SideEffectingPropertyTarget
+        {
+            private static int _getterCalls;
+
+            public static int GetterCalls => _getterCalls;
+
+            public string UnsafeValue
+            {
+                get
+                {
+                    _getterCalls++;
+                    return "unsafe";
+                }
+            }
+
+            public static void Reset()
+            {
+                _getterCalls = 0;
+            }
+        }
+
+        private class SideEffectingValueHolder
+        {
+            private static int _getterCalls;
+
+            public SideEffectingValueHolder(string data)
+            {
+                Data = data;
+            }
+
+            public static int GetterCalls => _getterCalls;
+
+            public string Data { get; }
+
+            public string UnsafeData
+            {
+                get
+                {
+                    _getterCalls++;
+                    return Data;
+                }
+            }
+
+            public static void Reset()
+            {
+                _getterCalls = 0;
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
@@ -1,4 +1,4 @@
-Template:
+﻿Template:
 Segments: 
 
 {
@@ -44,10 +44,10 @@ Expressions:
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = this.Null.NestedString;
+    var $dd_el_result = this.Null.<NestedString>k__BackingField;
 
     return $dd_el_result;
 }
 Result: The result of the expression is: 
 Errors:
-EvaluationError { Expression = this.Null.NestedString), Message = Object reference not set to an instance of an object. }
+EvaluationError { Expression = this.Null.<NestedString>k__BackingField), Message = Object reference not set to an instance of an object. }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
@@ -1,4 +1,4 @@
-﻿Template:
+Template:
 Segments: 
 
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AllGt.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AllGt.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "all": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CustomArrayAtIndex.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CustomArrayAtIndex.verified.txt
@@ -1,4 +1,4 @@
-﻿Template:
+Template:
 Segments: 
 
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAnyCustomObject.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAnyCustomObject.verified.txt
@@ -54,7 +54,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = CustomArrayLocal.Any(nestedObject => nestedObject.NestedString == "hello");
+    var $dd_el_result = CustomArrayLocal.Any(nestedObject => nestedObject.<NestedString>k__BackingField == "hello");
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAnyCustomObject.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAnyCustomObject.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "any": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAnyGt.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAnyGt.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "any": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashAnyKeyValueAnd.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashAnyKeyValueAnd.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "any": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashFilterKeyValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HashFilterKeyValue.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "any": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.InvalidJson.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.InvalidJson.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:{
     "dsl": "SomeLocal > 2",
     "json": {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "isEmpty": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
@@ -1,4 +1,4 @@
-Condition:
+﻿Condition:
 Json:
 {
   "isEmpty": [
@@ -41,7 +41,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = string.IsNullOrEmpty(this.EmptyString);
+    var $dd_el_result = string.IsNullOrEmpty(this.<EmptyString>k__BackingField);
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "gt": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
@@ -1,4 +1,4 @@
-Condition:
+﻿Condition:
 Json:
 {
   "gt": [
@@ -51,7 +51,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = this.Nested.NestedString.Length > 2;
+    var $dd_el_result = this.Nested.<NestedString>k__BackingField.Length > 2;
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "or": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
@@ -1,4 +1,4 @@
-Condition:
+﻿Condition:
 Json:
 {
   "or": [
@@ -65,7 +65,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = (this.Nested.NestedString == "dd") || !(this.Nested.NestedString == null);
+    var $dd_el_result = (this.Nested.<NestedString>k__BackingField == "dd") || !(this.Nested.<NestedString>k__BackingField == null);
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
@@ -1,4 +1,4 @@
-﻿Template:
+Template:
 Segments: 
 
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
@@ -1,4 +1,4 @@
-Template:
+﻿Template:
 Segments: 
 
 {
@@ -22,7 +22,6 @@ Expressions:
     exception,
     scopeMemberArray) =>
 {
-    string $dd_el_result;
     var this = (scopeMember.Value == null)
         ? default(DebuggerExpressionLanguageTests.TestStruct)
         : (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
@@ -50,9 +49,8 @@ Expressions:
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
+    var $dd_el_result = (this.ChildNested._parentPrivateMember == "Hello from parent private member").ToString();
 
-    return "UndefinedValue";
+    return $dd_el_result;
 }
-Result: The result of the expression is: UndefinedValue
-Errors:
-EvaluationError { Expression = this.ChildNested._parentPrivateMember, Message = The property or field does not exist in Datadog.Trace.Tests.Debugger.DebuggerExpressionLanguageTests+TestStruct+ChildNestedObject }
+Result: The result of the expression is: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
     "eq": [

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
@@ -1,4 +1,4 @@
-Condition:
+﻿Condition:
 Json:
 {
     "eq": [
@@ -47,7 +47,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = this.Nested.NestedString == "Hello from nested object";
+    var $dd_el_result = this.Nested.<NestedString>k__BackingField == "Hello from nested object";
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
@@ -1,4 +1,4 @@
-Condition:
+﻿Condition:
 Json:
 {
   "eq": [
@@ -52,7 +52,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[18].Value;
     var CollectionArg = (List<string>)scopeMemberArray[19].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[20].Value;
-    var $dd_el_result = this.Nested.Nested.NestedString == "Hello from another nested object";
+    var $dd_el_result = this.Nested.<Nested>k__BackingField.<NestedString>k__BackingField == "Hello from another nested object";
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
@@ -1,4 +1,4 @@
-﻿Condition:
+Condition:
 Json:
 {
   "eq": [


### PR DESCRIPTION
## Summary

- Prevent Live Debugger expression member access from invoking customer property getters.
- Resolve `getmember` / `ref` member access to fields or verified compiler-generated auto-property backing fields, failing closed to `UndefinedValue` for unsafe or uncertain property shapes.
- Preserve dictionary redaction behavior and keep dictionary iterator getter access limited to exact BCL `Key` / `Value` members.

## Motivation

Probe expressions can run on customer hot paths. Calling arbitrary property getters from `getmember` can trigger side effects such as lazy loading, sync body reads, or customer code execution. This change keeps expression member access side-effect-safe while preserving field and C# auto-property scenarios through direct backing-field reads.

## Implementation Notes

- Replaces broad `Type.GetMember(...).FirstOrDefault()` / `Expression.PropertyOrField()` member access with a fail-closed resolver.
- Performs reflection only during expression parse/compile, not at probe-hit evaluation time.
- Avoids LINQ and emitted runtime helper calls in the resolver path.
- Leaves broader customer-code execution surfaces like collection enumeration, indexers, `Count`, `ToString`, and exception dump behavior out of scope.

## Test Plan

- Added focused regression coverage in `DebuggerExpressionLanguageTests` for:
  - private auto-property backing-field expression compilation
  - instance and inherited auto-property access
  - side-effecting getter blocking
  - `ref` fallback blocking
  - static property getter blocking
  - dictionary value redaction tracking
- Updated expression Verify snapshots to show backing-field access. 