### PR TITLE
[Debugger] Redact sensitive values in expression dumps

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Dump.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Dump.cs
@@ -20,6 +20,8 @@ namespace Datadog.Trace.Debugger.Expressions;
 internal partial class ProbeExpressionParser<T>
 {
     private const string UndefinedValueDump = nameof(Expressions.UndefinedValue);
+    private const string RedactedValueDump = "{REDACTED}";
+    private const string BackingFieldSuffix = ">k__BackingField";
 
     private static FieldInfo[] GetSafeFieldsForDump(FieldInfo[] fields)
     {
@@ -46,6 +48,35 @@ internal partial class ProbeExpressionParser<T>
     private static object GetFieldValueForDump(FieldInfo field, object source)
     {
         return field.IsLiteral ? StaticMemberSafety.GetRawConstantValue(field) : field.GetValue(field.IsStatic ? null : source);
+    }
+
+    private static bool ShouldRedactDumpValue(string name, Type type)
+    {
+        if (Redaction.Instance.ShouldRedact(name, type, out _))
+        {
+            return true;
+        }
+
+        var autoPropertyName = GetAutoPropertyOrFieldName(name);
+        return !ReferenceEquals(name, autoPropertyName) &&
+               Redaction.Instance.IsRedactedKeyword(autoPropertyName);
+    }
+
+    private static string GetAutoPropertyOrFieldName(string fieldName)
+    {
+        if (StringUtil.IsNullOrEmpty(fieldName) || fieldName[0] != '<')
+        {
+            return fieldName;
+        }
+
+        var propertyNameLength = fieldName.Length - BackingFieldSuffix.Length - 1;
+        if (propertyNameLength <= 0 ||
+            !fieldName.EndsWith(BackingFieldSuffix, StringComparison.Ordinal))
+        {
+            return fieldName;
+        }
+
+        return fieldName.Substring(1, propertyNameLength);
     }
 
     private Expression DumpExpression(Expression expression, List<ParameterExpression> scopeMembers)
@@ -239,13 +270,19 @@ internal partial class ProbeExpressionParser<T>
 
     private string DumpObject(object value, Type type, string name, int depth = 0)
     {
+        var hasName = !StringUtil.IsNullOrEmpty(name);
+        if (ShouldRedactDumpValue(name, type))
+        {
+            return hasName ? $"{name}={RedactedValueDump}" : RedactedValueDump;
+        }
+
         // only one level depth of collection
         if (depth == 0 && IsTypeSupportIndex(type, out var assignableFrom))
         {
             return DumpCollection(value, assignableFrom);
         }
 
-        if (!string.IsNullOrEmpty(name))
+        if (hasName)
         {
             name += "=";
         }
@@ -284,7 +321,7 @@ internal partial class ProbeExpressionParser<T>
                 sb.Append('[');
                 foreach (var item in (value as IList))
                 {
-                    sb.Append($"{DumpObject(item, item.GetType(), null, 1)}");
+                    sb.Append(DumpObject(item, item?.GetType(), null, 1));
                     if (++count == 3)
                     {
                         sb.Append(", ...");
@@ -302,7 +339,7 @@ internal partial class ProbeExpressionParser<T>
                 sb.Append('[');
                 foreach (var item in (value as IEnumerable))
                 {
-                    sb.Append($"{DumpObject(item, item.GetType(), null, 1)}");
+                    sb.Append(DumpObject(item, item?.GetType(), null, 1));
                     if (++count == 3)
                     {
                         sb.Append(", ...");
@@ -320,7 +357,11 @@ internal partial class ProbeExpressionParser<T>
                 sb.Append('{');
                 foreach (DictionaryEntry entry in (value as IDictionary))
                 {
-                    sb.Append($"[{DumpObject(entry.Key, entry.Key?.GetType(), null, 1)}, {DumpObject(entry.Value, entry.Value?.GetType(), null, 1)}]");
+                    sb.Append('[');
+                    sb.Append(DumpObject(entry.Key, entry.Key?.GetType(), null, 1));
+                    sb.Append(", ");
+                    sb.Append(ShouldRedactDictionaryKey(entry.Key) ? RedactedValueDump : DumpObject(entry.Value, entry.Value?.GetType(), null, 1));
+                    sb.Append(']');
                     if (++count == 3)
                     {
                         sb.Append(", ...");

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Dump.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Dump.cs
@@ -81,6 +81,11 @@ internal partial class ProbeExpressionParser<T>
 
     private Expression DumpExpression(Expression expression, List<ParameterExpression> scopeMembers)
     {
+        if (ShouldRedactDumpValue(null, expression.Type))
+        {
+            return Expression.Constant(RedactedValueDump);
+        }
+
         if (expression.Type == ProbeExpressionParserHelper.UndefinedValueType)
         {
             return Expression.Constant(UndefinedValueDump);
@@ -274,6 +279,11 @@ internal partial class ProbeExpressionParser<T>
         if (ShouldRedactDumpValue(name, type))
         {
             return hasName ? $"{name}={RedactedValueDump}" : RedactedValueDump;
+        }
+
+        if (type == null)
+        {
+            return hasName ? $"{name}=" : string.Empty;
         }
 
         // only one level depth of collection

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -3102,8 +3102,8 @@ namespace Datadog.Trace.Tests.Debugger
             var error = Assert.Single(compiled.Errors);
             Assert.Contains("cannot be safely read", error.Message);
         }
-		
-		[Fact]
+
+        [Fact]
         public void ProbeExpressionEvaluator_TemplateDump_RedactsSensitiveObjectFields()
         {
             const string passwordSecret = "DD_PASSWORD_SECRET";

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -3102,6 +3102,115 @@ namespace Datadog.Trace.Tests.Debugger
             var error = Assert.Single(compiled.Errors);
             Assert.Contains("cannot be safely read", error.Message);
         }
+		
+		[Fact]
+        public void ProbeExpressionEvaluator_TemplateDump_RedactsSensitiveObjectFields()
+        {
+            const string passwordSecret = "DD_PASSWORD_SECRET";
+            const string apiKeySecret = "DD_API_KEY_SECRET";
+            const string publicValue = "DD_PUBLIC_VALUE";
+            var scopeMembers = CreateScopeMembers();
+            var holder = new DumpRedactionObjectHolder(passwordSecret, apiKeySecret, publicValue);
+            scopeMembers.AddMember(new ScopeMember("DumpHolderLocal", typeof(DumpRedactionObjectHolder), holder, ScopeMemberKind.Local));
+
+            var evaluator = new ProbeExpressionEvaluator(
+                templates: [new DebuggerExpression(string.Empty, @"{""ref"":""DumpHolderLocal""}", null)],
+                condition: null,
+                metric: null,
+                spanDecorations: null,
+                captureExpressions: null);
+
+            var result = evaluator.Evaluate(scopeMembers);
+
+            result.Template.Should().NotContain(passwordSecret);
+            result.Template.Should().NotContain(apiKeySecret);
+            result.Template.Should().Contain("{REDACTED}");
+            result.Template.Should().Contain(publicValue);
+            result.Errors.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void ProbeExpressionEvaluator_TemplateDump_RedactsSensitiveCollectionFieldBeforeDispatch()
+        {
+            const string authorizationSecret = "Bearer DD_AUTHORIZATION_SECRET";
+            const string authorizationPublicValue = "DD_AUTHORIZATION_PUBLIC_VALUE";
+            var scopeMembers = CreateScopeMembers();
+            var holder = new DumpRedactionCollectionFieldHolder(authorizationSecret, authorizationPublicValue);
+            scopeMembers.AddMember(new ScopeMember("DumpHolderLocal", typeof(DumpRedactionCollectionFieldHolder), holder, ScopeMemberKind.Local));
+
+            var evaluator = new ProbeExpressionEvaluator(
+                templates: [new DebuggerExpression(string.Empty, @"{""ref"":""DumpHolderLocal""}", null)],
+                condition: null,
+                metric: null,
+                spanDecorations: null,
+                captureExpressions: null);
+
+            var result = evaluator.Evaluate(scopeMembers);
+
+            result.Template.Should().Contain("Authorization={REDACTED}");
+            result.Template.Should().NotContain(authorizationSecret);
+            result.Template.Should().NotContain(authorizationPublicValue);
+            result.Errors.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void ProbeExpressionEvaluator_TemplateDump_RedactsSensitiveDictionaryValues()
+        {
+            const string authorizationSecret = "Bearer DD_AUTHORIZATION_SECRET";
+            const string publicValue = "DD_PUBLIC_VALUE";
+            var scopeMembers = CreateScopeMembers();
+            var holder = new DumpRedactionDictionaryHolder(authorizationSecret, publicValue);
+            scopeMembers.AddMember(new ScopeMember("DumpHolderLocal", typeof(DumpRedactionDictionaryHolder), holder, ScopeMemberKind.Local));
+
+            var evaluator = new ProbeExpressionEvaluator(
+                templates: [new DebuggerExpression(string.Empty, @"{""ref"":""DumpHolderLocal""}", null)],
+                condition: null,
+                metric: null,
+                spanDecorations: null,
+                captureExpressions: null);
+
+            var result = evaluator.Evaluate(scopeMembers);
+
+            result.Template.Should().Contain("Authorization");
+            result.Template.Should().Contain("{REDACTED}");
+            result.Template.Should().NotContain(authorizationSecret);
+            result.Template.Should().Contain(publicValue);
+            result.Errors.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void ProbeExpressionEvaluator_SpanDecorationDump_RedactsSensitiveObjectFields()
+        {
+            const string passwordSecret = "DD_PASSWORD_SECRET";
+            const string apiKeySecret = "DD_API_KEY_SECRET";
+            const string publicValue = "DD_PUBLIC_VALUE";
+            var scopeMembers = CreateScopeMembers();
+            var holder = new DumpRedactionObjectHolder(passwordSecret, apiKeySecret, publicValue);
+            scopeMembers.AddMember(new ScopeMember("DumpHolderLocal", typeof(DumpRedactionObjectHolder), holder, ScopeMemberKind.Local));
+
+            var evaluator = new ProbeExpressionEvaluator(
+                templates: null,
+                condition: null,
+                metric: null,
+                spanDecorations:
+                [
+                    new KeyValuePair<DebuggerExpression?, KeyValuePair<string, DebuggerExpression?[]>[]>(
+                        null,
+                        [new KeyValuePair<string, DebuggerExpression?[]>("tag", [new DebuggerExpression(string.Empty, @"{""ref"":""DumpHolderLocal""}", null)])])
+                ],
+                captureExpressions: null);
+
+            var result = evaluator.Evaluate(scopeMembers);
+            var decoration = result.Decorations.Should().ContainSingle().Subject;
+
+            decoration.TagName.Should().Be("tag");
+            decoration.Value.Should().NotContain(passwordSecret);
+            decoration.Value.Should().NotContain(apiKeySecret);
+            decoration.Value.Should().Contain("{REDACTED}");
+            decoration.Value.Should().Contain(publicValue);
+            decoration.Errors.Should().BeNullOrEmpty();
+            result.Errors.Should().BeNullOrEmpty();
+        }
 
         [Fact]
         public void ProbeExpressionParser_StaticMemberOnTypeWithCctor_IsUndefinedWithoutInitializingType()
@@ -3721,6 +3830,52 @@ namespace Datadog.Trace.Tests.Debugger
             {
                 { "hello", null },
             };
+        }
+
+        private class DumpRedactionObjectHolder
+        {
+            private readonly string _password;
+
+            private readonly string publicData;
+
+            public DumpRedactionObjectHolder(string password, string apiKey, string publicData)
+            {
+                _password = password;
+                ApiKey = apiKey;
+                this.publicData = publicData;
+            }
+
+            private string ApiKey { get; }
+        }
+
+        private class DumpRedactionCollectionFieldHolder
+        {
+#pragma warning disable SA1306
+            private readonly Hashtable Authorization;
+#pragma warning restore SA1306
+
+            public DumpRedactionCollectionFieldHolder(string authorizationSecret, string authorizationPublicValue)
+            {
+                Authorization = new Hashtable
+                {
+                    { "public", authorizationPublicValue },
+                    { "header", authorizationSecret },
+                };
+            }
+        }
+
+        private class DumpRedactionDictionaryHolder
+        {
+            private readonly Hashtable headers;
+
+            public DumpRedactionDictionaryHolder(string authorizationSecret, string publicValue)
+            {
+                headers = new Hashtable
+                {
+                    { "Authorization", authorizationSecret },
+                    { "public", publicValue },
+                };
+            }
         }
 
         private sealed class ThrowingGetTypeAssembly : Assembly

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -3130,6 +3130,26 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         [Fact]
+        public void ProbeExpressionEvaluator_TemplateDump_RedactsSensitiveRootTypeBeforeDispatch()
+        {
+            var scopeMembers = CreateScopeMembers();
+            using var credential = new System.Security.SecureString();
+            scopeMembers.AddMember(new ScopeMember("CredentialLocal", typeof(System.Security.SecureString), credential, ScopeMemberKind.Local));
+
+            var evaluator = new ProbeExpressionEvaluator(
+                templates: [new DebuggerExpression(string.Empty, @"{""ref"":""CredentialLocal""}", null)],
+                condition: null,
+                metric: null,
+                spanDecorations: null,
+                captureExpressions: null);
+
+            var result = evaluator.Evaluate(scopeMembers);
+
+            result.Template.Should().Be("{REDACTED}");
+            result.Errors.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
         public void ProbeExpressionEvaluator_TemplateDump_RedactsSensitiveCollectionFieldBeforeDispatch()
         {
             const string authorizationSecret = "Bearer DD_AUTHORIZATION_SECRET";


### PR DESCRIPTION
## Summary of changes

- Redacts sensitive field/property values when Live Debugger expression dumps stringify objects for log-probe templates and span decorations.
- Normalizes compiler-generated auto-property backing field names before identifier redaction, so fields like `<Password>k__BackingField` are treated as `Password`.
- Redacts `IDictionary` values when their keys match existing dictionary-key redaction rules.
- Adds targeted expression evaluator tests for object dumps, collection-field ordering, dictionary values, and span-decoration dumps.

## Reason for change

- Log-probe templates and span decorations use a dump-to-string path separate from structured snapshot serialization.
- That dump path could emit sensitive values when a probe referenced a containing object instead of the sensitive member directly.

## Implementation details

- The redaction check runs at the top of `DumpObject`, before collection dispatch or `ToString()`, so redacted-named collection fields cannot dump their entries.
- Dictionary value redaction reuses `ShouldRedactDictionaryKey(...)` to stay aligned with existing expression dictionary redaction behavior.
- Backing-field normalization only runs after the raw field name/type redaction check misses.

## Test coverage

- `DebuggerExpressionLanguageTests`