### PR TITLE
Move TestOptimizationFeatureTests to TracerInstanceTestCollection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -185,7 +185,7 @@ Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 
 # CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
-/tracer/test/Datadog.Trace.Tests/Ci/                          @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/test/Datadog.Trace.Tests/Ci/      @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/PDBs/MethodSymbolResolver.cs        @DataDog/ci-app-libraries-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/  @DataDog/ci-app-libraries-dotnet

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
@@ -44,7 +44,7 @@ using XUnitV3TestMethod = Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.
 
 namespace Datadog.Trace.Tests.Ci;
 
-[Collection(nameof(EnvironmentVariablesTestCollection))]
+[Collection(nameof(TracerInstanceTestCollection))]
 [EnvironmentVariablesCleaner(
     ConfigurationKeys.GlobalTags,
     ConfigurationKeys.CIVisibility.TestSessionCommand,


### PR DESCRIPTION
## Summary of changes

This puts TestOptimizationFeatureTests in the same non-parallel collection as TestSessionCoverageTests, so it can no longer null the CIVisibilityItrCoverageBackfillRunFolder mid-test and cause flake in the tests.

## Reason for change

Needs to run synchronously as they mutate the `TestOptimization.Instance`.

Tests flaked for `CloseDoesNotPublishPersistedCoverageWhenPersistedCoverageIpcSnapshotIsIncomplete` with `Did not expect a value, but found 80.0.` which was caused by other tests.

## Implementation details

Moved the collection to `[Collection(nameof(TracerInstanceTestCollection))]`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

#incident-57303
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
