### PR TITLE
Avoid excessive BuggyBits exceptions in endpoint tests

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
@@ -230,6 +230,19 @@ namespace BuggyBits.Controllers
             return View("Index");
         }
 
+        // GET: Products/EndpointProfiling
+        [Route("Products/EndpointProfiling")]
+        public IActionResult EndpointProfiling()
+        {
+            var sw = Stopwatch.StartNew();
+            while (sw.ElapsedMilliseconds < 250)
+            {
+                Thread.SpinWait(1000);
+            }
+
+            return Ok("Endpoint profiling");
+        }
+
         // GET: Products/Details/BugSpray
         [Route("Products/Details/{productName}")]
         public IActionResult Details(string productName)

--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -38,6 +38,7 @@ namespace BuggyBits
         GetAwaiterGetResult = 1024, // using GetAwaiter().GetResult() instead of await
         UseResultProperty = 2048, // using Result property instead of GetAwaiter().GetResult()
         ShortLived = 4096,      // short lived threads
+        EndpointProfiling = 8192, // lightweight CPU work for endpoint profiling tests
     }
 
     public class Program

--- a/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
@@ -206,6 +206,11 @@ namespace BuggyBits
                 {
                     urls.Add($"{rootUrl}/CompanyInformation?ShortLived=true");
                 }
+
+                if ((_scenario & Scenario.EndpointProfiling) == Scenario.EndpointProfiling)
+                {
+                    urls.Add($"{rootUrl}/Products/EndpointProfiling");
+                }
             }
 
             return urls;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -23,7 +23,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
     public class CodeHotspotTest
     {
         private const string ScenarioCodeHotspot = "--scenario 256";
-        private const string ScenarioEndpoint = "--scenario 16";
+        private const string ScenarioEndpoint = "--scenario 8192";
         private static readonly Regex RuntimeIdPattern = new("runtime-id:(?<runtimeId>[A-Z0-9-]+)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
         private readonly ITestOutputHelper _output;
 
@@ -250,14 +250,11 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
 
             // The "trace endpoint" label is attached to a sample only when (a) the web root span closes (the tracer
             // then calls SetEndpointForTrace) and (b) a sample carries that span's "local root span id", both within
-            // the SAME profile generation. We use the FormatExceptions scenario (the /Products/Sales endpoint) rather
-            // than the heavy IndexSlow page: IndexSlow builds a large response (10k products, O(n^2) string concat) and,
-            // on slow/32-bit runtimes, a single request can outlive the whole test window. Its root span then closes
-            // right as the profiler is shutting down, so SetEndpointForTrace races with (and is dropped by) the final
-            // export, and no label is attached. /Products/Sales does exception-driven, on-CPU work that is linear in
-            // the number of products, so it is reliably sampled with a trace context but completes with plenty of
-            // margin before shutdown. A single export window (flushed on shutdown) keeps the samples and the endpoints
-            // in the same generation.
+            // the SAME profile generation. Use a purpose-built endpoint that burns CPU for a short bounded interval and
+            // returns a small response: it is reliably sampled with a trace context, completes with plenty of margin
+            // before shutdown, and avoids the exception storm from the BuggyBits sales endpoint that can crash Alpine
+            // CI runs while the default exception profiler is enabled. A single export window (flushed on shutdown)
+            // keeps the samples and the endpoints in the same generation.
             runner.Environment.SetVariable("DD_PROFILING_UPLOAD_PERIOD", "600");
 
             using var agent = MockDatadogAgent.CreateHttpAgent(runner.XUnitLogger);
@@ -268,7 +265,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
 
             var endpoints = GetEndpointsFromPprofFiles(runner.Environment.PprofDir);
 
-            endpoints.Distinct().Should().BeEquivalentTo("GET /products/sales");
+            endpoints.Distinct().Should().BeEquivalentTo("GET /products/endpointprofiling");
         }
 
         [TestAppFact("Samples.BuggyBits")]


### PR DESCRIPTION
## Summary of changes

Adds a dedicated BuggyBits endpoint profiling scenario and updates the CodeHotspot endpoint tests to use it instead of the sales scenario.

## Reason for change

Over the past week(ish) BuggyBits has crashed several times during CodeHotspotTests and it appears that it was caused by it re-using an endpoint (`--scenario 16`) which called the /Sales endpoint which intentially throws significant number of exceptions per request and appeared to be crashing the sample. 

## Implementation details

- Added a new endpoint/scenario
- Updated `SelfInvoker` to call that new endpoint
- Updated `CodeHotspotTests` to use that new scenario and endpoint

## Test coverage

## Other details
<!-- Fixes #{issue} -->
#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
