### PR TITLE
Forward BP_EXTERNAL_S3_URL through benchmark CI triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,9 +22,9 @@ include:
 variables:
   DOTNET_PACKAGE_VERSION:
     description: "Used by the package stage when triggered manually"
-  # Default so the benchmark triggers forward an empty value on normal runs
-  # (an unset reference would forward the literal "$BP_EXTERNAL_S3_URL"). An
-  # external orchestrator overrides it to redirect benchmark uploads.
+  # Benchmark trigger jobs forward $BP_EXTERNAL_S3_URL to downstream pipelines so
+  # an external orchestrator can override the S3 destination of benchmark results.
+  # Defaulted to empty here so an unset value forwards as "" rather than a literal.
   BP_EXTERNAL_S3_URL: ""
   REPO_NOTIFICATION_CHANNEL: "#apm-dotnet-bots"
   # GitLab org for internal cross-repo references - parameterized for org migration resilience

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,10 @@ include:
 variables:
   DOTNET_PACKAGE_VERSION:
     description: "Used by the package stage when triggered manually"
+  # Default so the benchmark triggers forward an empty value on normal runs
+  # (an unset reference would forward the literal "$BP_EXTERNAL_S3_URL"). An
+  # external orchestrator overrides it to redirect benchmark uploads.
+  BP_EXTERNAL_S3_URL: ""
   REPO_NOTIFICATION_CHANNEL: "#apm-dotnet-bots"
   # GitLab org for internal cross-repo references - parameterized for org migration resilience
   GITLAB_GROUP: DataDog

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -312,6 +312,9 @@ macrobenchmarks:
   needs: []
   trigger:
     include: .gitlab/benchmarks/macrobenchmarks.yml
+  # Forward the external S3 destination override to the benchmark child pipeline.
+  variables:
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   allow_failure: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH =~ /^hotfix/)'
@@ -326,6 +329,9 @@ microbenchmarks:
   trigger:
     include: .gitlab/benchmarks/microbenchmarks.yml
     strategy: depend
+  # Forward the external S3 destination override to the benchmark child pipeline.
+  variables:
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   allow_failure: true
   rules:
     - if: $CI_COMMIT_TAG
@@ -336,6 +342,9 @@ dsm_throughput:
   stage: benchmarks
   trigger:
     include: .gitlab/benchmarks/dsm-throughput.yml
+  # Forward the external S3 destination override to the benchmark child pipeline.
+  variables:
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   allow_failure: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,6 @@ include:
 variables:
   DOTNET_PACKAGE_VERSION:
     description: "Used by the package stage when triggered manually"
-  # Benchmark trigger jobs forward $BP_EXTERNAL_S3_URL to downstream pipelines so
-  # an external orchestrator can override the S3 destination of benchmark results.
-  # Defaulted to empty here so an unset value forwards as "" rather than a literal.
-  BP_EXTERNAL_S3_URL: ""
   REPO_NOTIFICATION_CHANNEL: "#apm-dotnet-bots"
   # GitLab org for internal cross-repo references - parameterized for org migration resilience
   GITLAB_GROUP: DataDog
@@ -316,9 +312,10 @@ macrobenchmarks:
   needs: []
   trigger:
     include: .gitlab/benchmarks/macrobenchmarks.yml
-  # Forward the external S3 destination override to the benchmark child pipeline.
-  variables:
-    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
+    # Forward pipeline variables so an external orchestrator can pass
+    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
+    forward:
+      pipeline_variables: true
   allow_failure: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH =~ /^hotfix/)'
@@ -333,9 +330,10 @@ microbenchmarks:
   trigger:
     include: .gitlab/benchmarks/microbenchmarks.yml
     strategy: depend
-  # Forward the external S3 destination override to the benchmark child pipeline.
-  variables:
-    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
+    # Forward pipeline variables so an external orchestrator can pass
+    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
+    forward:
+      pipeline_variables: true
   allow_failure: true
   rules:
     - if: $CI_COMMIT_TAG
@@ -346,9 +344,10 @@ dsm_throughput:
   stage: benchmarks
   trigger:
     include: .gitlab/benchmarks/dsm-throughput.yml
-  # Forward the external S3 destination override to the benchmark child pipeline.
-  variables:
-    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
+    # Forward pipeline variables so an external orchestrator can pass
+    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
+    forward:
+      pipeline_variables: true
   allow_failure: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"'


### PR DESCRIPTION
## Summary of changes

Forwards pipeline variables through the macrobenchmark, microbenchmark, and dsm_throughput child-pipeline triggers (`forward: pipeline_variables: true`), so an external orchestrator (benchmarking-platform-tools) can pass `BP_EXTERNAL_S3_URL` to override the S3 destination of benchmark results.

## Reason for change

GitLab _does not_ forward pipeline variables to child pipelines by default:
- https://gitlab.com/gitlab-org/gitlab/-/merge_requests/82676
- https://docs.gitlab.com/ci/yaml/#triggerforward

Needed for flaky benchmark monitoring: [APMSP-2893 Set up flaky benchmark monitoring](https://datadoghq.atlassian.net/browse/APMSP-2893).

## Implementation details

`forward: pipeline_variables: true` on each benchmark trigger. When the orchestrator does not set `BP_EXTERNAL_S3_URL`, nothing is forwarded and uploads use the default destination. Only manual and scheduled pipeline variables are forwarded (not predefined `CI_*` or top-level YAML variables).

## Test coverage

Verified on dd-trace-py: the variable set at the orchestrator arrives in a downstream microbenchmarks pipeline with the real value. https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1848086621

## Other details