### PR TITLE
make sure parent env variables are not polluting the test env

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -339,16 +339,12 @@ namespace Datadog.Trace.TestHelpers
                 },
                 MockTracerAgent.TcpUdpAgent { StatsdPort: not 0 } tcp => new Dictionary<string, string>
                 {
-                    // URL takes precedence over HOSTNAME+PORT _sometimes_ so we set both here (and below)
-                    //  to make sure this won't get "polluted" by env variables set in the parent env.
-                    { "DD_TRACE_AGENT_URL", $"http://127.0.0.1:{tcp.Port}" },
                     { "DD_TRACE_AGENT_HOSTNAME", "127.0.0.1" },
                     { "DD_TRACE_AGENT_PORT", tcp.Port.ToString() },
                     { "DD_DOGSTATSD_PORT", tcp.StatsdPort.ToString() },
                 },
                 MockTracerAgent.TcpUdpAgent tcp => new Dictionary<string, string>
                 {
-                    { "DD_TRACE_AGENT_URL", $"http://127.0.0.1:{tcp.Port}" },
                     { "DD_TRACE_AGENT_HOSTNAME", "127.0.0.1" },
                     { "DD_TRACE_AGENT_PORT", tcp.Port.ToString() },
                 },
@@ -360,6 +356,8 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables[envVar.Key] = envVar.Value;
             }
 
+            // URL can take precedence over HOSTNAME+PORT, so we remove it to ensure what we configured above gets actually used.
+            environmentVariables.Remove("DD_TRACE_AGENT_URL");
             // Remove OTEL exporter env vars that could redirect traces away from the mock agent
             environmentVariables.Remove("OTEL_TRACES_EXPORTER");
             environmentVariables.Remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -339,12 +339,16 @@ namespace Datadog.Trace.TestHelpers
                 },
                 MockTracerAgent.TcpUdpAgent { StatsdPort: not 0 } tcp => new Dictionary<string, string>
                 {
+                    // URL takes precedence over HOSTNAME+PORT _sometimes_ so we set both here (and below)
+                    //  to make sure this won't get "polluted" by env variables set in the parent env.
+                    { "DD_TRACE_AGENT_URL", $"http://127.0.0.1:{tcp.Port}" },
                     { "DD_TRACE_AGENT_HOSTNAME", "127.0.0.1" },
                     { "DD_TRACE_AGENT_PORT", tcp.Port.ToString() },
                     { "DD_DOGSTATSD_PORT", tcp.StatsdPort.ToString() },
                 },
                 MockTracerAgent.TcpUdpAgent tcp => new Dictionary<string, string>
                 {
+                    { "DD_TRACE_AGENT_URL", $"http://127.0.0.1:{tcp.Port}" },
                     { "DD_TRACE_AGENT_HOSTNAME", "127.0.0.1" },
                     { "DD_TRACE_AGENT_PORT", tcp.Port.ToString() },
                 },
@@ -355,6 +359,17 @@ namespace Datadog.Trace.TestHelpers
             {
                 environmentVariables[envVar.Key] = envVar.Value;
             }
+
+            // Remove OTEL exporter env vars that could redirect traces away from the mock agent
+            environmentVariables.Remove("OTEL_TRACES_EXPORTER");
+            environmentVariables.Remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+            environmentVariables.Remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+            environmentVariables.Remove("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
+            environmentVariables.Remove("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT");
+            environmentVariables.Remove("OTEL_METRICS_EXPORTER");
+            environmentVariables.Remove("OTEL_LOGS_EXPORTER");
+            environmentVariables.Remove("OTEL_EXPORTER_OTLP_PROTOCOL");
+            environmentVariables.Remove("OTEL_RESOURCE_ATTRIBUTES");
         }
 
         public string GetSampleApplicationPath(string packageVersion = "", string framework = "", bool usePublishWithRID = false)


### PR DESCRIPTION
## Summary of changes

Having DD_TRACE_AGENT_URL set locally makes the samples send traces away from the mock agent, and tests fail.
Some OTEL variables can also impact tests, making sure this doesn't happen.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
