### PR TITLE
Attempt to work around runtime flake for ASM

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -246,9 +246,11 @@ namespace Datadog.Trace.TestHelpers
                        returnAllOperations: true);
         }
 
-        // Returns true when a known race fingerprint was detected in the captured stderr and the
-        // caller should retry the launch (process and agent have been torn down). Returns false
-        // when no fingerprint matched. Throws if the fingerprint persisted past the retry budget.
+        // Returns true when a known race fingerprint was detected and the caller should retry the
+        // launch, false when no fingerprint matched (caller gives up and throws). Throws if the
+        // fingerprint persisted past the retry budget. In every case the process and agent are torn
+        // down before returning, so a give-up/throw never leaves the shared fixture pointing at a
+        // dead process.
         private async Task<bool> CheckRaceAndCleanupForRetryAsync(int attempt, int maxAttempts, StringBuilder capturedStderr, TestHelper helper)
         {
             // Reset HttpPort up-front: whether we retry or rethrow, the port we bound earlier
@@ -272,14 +274,26 @@ namespace Datadog.Trace.TestHelpers
                 // best-effort
             }
 
-            if (!await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput))
-            {
-                return false;
-            }
-
             try
             {
-                if (!Process.HasExited)
+                return await ErrorHelpers.HandleRuntimeSkippableErrorsAsync(attempt, maxAttempts, exitCode, capturedStderr.ToString(), helper, WriteToOutput);
+            }
+            finally
+            {
+                // Tear down the process and agent whether we retry, give up, or fail loudly.
+                // Otherwise TryStartApp throws with Process still assigned, and because the fixture
+                // is shared via IClassFixture the next test short-circuits on `Process is not null`
+                // and runs against HttpPort == 0 — turning one startup crash into a cascade of
+                // failures across every test in the class.
+                DisposeProcessAndAgent();
+            }
+        }
+
+        private void DisposeProcessAndAgent()
+        {
+            try
+            {
+                if (Process is not null && !Process.HasExited)
                 {
                     Process.Kill();
                 }
@@ -289,11 +303,10 @@ namespace Datadog.Trace.TestHelpers
                 // best-effort cleanup
             }
 
-            Process.Dispose();
+            Process?.Dispose();
             Process = null;
-            Agent.Dispose();
+            Agent?.Dispose();
             Agent = null;
-            return true;
         }
 
         private async Task EnsureServerStarted(bool sendHealthCheck)


### PR DESCRIPTION
## Summary of changes

Updates `AspNetCoreTestFixture` so failed ASP.NET Core sample startup handling always tears down the sample process and mock agent after checking for known runtime crash fingerprints.

## Reason for change

Still flake in ASM tests with `Unable to determine port application is listening on` which looking at the crash dumps in CI were still related/caused by the runtime.

When a test hits the runtime crash it was cascading and causing all other tests to fail as they were attempting to reuse teh same process. This attempts to help that somehow which should hopefully improve our test health.

## Implementation details

- wrap in a try/finally
- dispose the process and agent when we hit this

## Test coverage

## Other details
<!-- Fixes #{issue} -->

Follow up of https://github.com/DataDog/dd-trace-dotnet/pull/8729

#incident-57303

I don't think/expect this to really resolve the flake, just hopefully reduce the impact.

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
