### PR TITLE
[Debugger] Deflake instanceof assembly lookup tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -1493,11 +1493,12 @@ namespace Datadog.Trace.Tests.Debugger
 
                 Action firstLookup = () => InstanceOfHelper.ResolveType("LazyLoaded.TypeForInstanceOf");
                 firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+                var callsAfterFirstLookup = calls;
 
                 includeSecondAssembly = true;
                 InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
                 InstanceOfHelper.IsInstanceOf(instance, "LazyLoaded.TypeForInstanceOf").Should().BeTrue();
-                calls.Should().BeGreaterThan(1);
+                calls.Should().BeGreaterThan(callsAfterFirstLookup);
             }
             finally
             {
@@ -1591,13 +1592,18 @@ namespace Datadog.Trace.Tests.Debugger
 
                 Action firstLookup = () => InstanceOfHelper.ResolveType("Missing.TypeForInstanceOf");
                 firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+                var callsAfterFirstLookup = calls;
 
                 includeSecondAssembly = true;
                 InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
                 Action secondLookup = () => InstanceOfHelper.ResolveType("Missing.TypeForInstanceOf");
                 secondLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
 
-                calls.Should().BeGreaterThan(1);
+                // Assert the delta rather than an absolute count: the second lookup must rescan
+                // (re-invoke the provider) after the new assembly appears rather than serve the cached
+                // miss. Both lookups throw *unknown type*, so an unrelated retry inflating the first
+                // lookup's count must not be able to satisfy this on its own.
+                calls.Should().BeGreaterThan(callsAfterFirstLookup);
             }
             finally
             {
@@ -1635,12 +1641,13 @@ namespace Datadog.Trace.Tests.Debugger
 
                 Action firstLookup = () => InstanceOfHelper.ResolveType("LargeMissCache.ResolvedType");
                 firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
+                var callsAfterFirstLookup = calls;
 
                 includeResolvedAssembly = true;
                 InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
                 InstanceOfHelper.ResolveType("LargeMissCache.ResolvedType").Should().Be(resolvedAssembly.GetType("LargeMissCache.ResolvedType"));
 
-                calls.Should().BeGreaterThan(1);
+                calls.Should().BeGreaterThan(callsAfterFirstLookup);
             }
             finally
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -1475,14 +1475,18 @@ namespace Datadog.Trace.Tests.Debugger
             var secondAssembly = CreateDynamicAssembly(
                 "InstanceOfLazyAssembly",
                 "LazyLoaded.TypeForInstanceOf");
+            var includeSecondAssembly = false;
             var calls = 0;
 
             try
             {
+                // Gate the second assembly on an explicit flag rather than the call count: an unrelated
+                // assembly load can bump the generation and make ResolveType retry, so the provider may be
+                // invoked more than once per lookup.
                 InstanceOfHelper.SetAssemblyProviderForTests(() =>
                 {
                     calls++;
-                    return calls == 1 ? [firstAssembly] : [firstAssembly, secondAssembly];
+                    return includeSecondAssembly ? [firstAssembly, secondAssembly] : [firstAssembly];
                 });
 
                 var instance = Activator.CreateInstance(secondAssembly.GetType("LazyLoaded.TypeForInstanceOf"));
@@ -1490,9 +1494,10 @@ namespace Datadog.Trace.Tests.Debugger
                 Action firstLookup = () => InstanceOfHelper.ResolveType("LazyLoaded.TypeForInstanceOf");
                 firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
 
+                includeSecondAssembly = true;
                 InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
                 InstanceOfHelper.IsInstanceOf(instance, "LazyLoaded.TypeForInstanceOf").Should().BeTrue();
-                calls.Should().Be(2);
+                calls.Should().BeGreaterThan(1);
             }
             finally
             {
@@ -1570,24 +1575,29 @@ namespace Datadog.Trace.Tests.Debugger
         {
             var firstAssembly = typeof(string).Assembly;
             var secondAssembly = typeof(TestStruct.NestedObject).Assembly;
+            var includeSecondAssembly = false;
             var calls = 0;
 
             try
             {
+                // Gate the second assembly on an explicit flag rather than the call count: an unrelated
+                // assembly load can bump the generation and make ResolveType retry, so the provider may be
+                // invoked more than once per lookup.
                 InstanceOfHelper.SetAssemblyProviderForTests(() =>
                 {
                     calls++;
-                    return calls == 1 ? [firstAssembly] : [firstAssembly, secondAssembly];
+                    return includeSecondAssembly ? [firstAssembly, secondAssembly] : [firstAssembly];
                 });
 
                 Action firstLookup = () => InstanceOfHelper.ResolveType("Missing.TypeForInstanceOf");
                 firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
 
+                includeSecondAssembly = true;
                 InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
                 Action secondLookup = () => InstanceOfHelper.ResolveType("Missing.TypeForInstanceOf");
                 secondLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
 
-                calls.Should().Be(2);
+                calls.Should().BeGreaterThan(1);
             }
             finally
             {
@@ -1609,23 +1619,28 @@ namespace Datadog.Trace.Tests.Debugger
             var resolvedAssembly = CreateDynamicAssembly(
                 "InstanceOfLargeMissCacheResolvedAssembly",
                 "LargeMissCache.ResolvedType");
+            var includeResolvedAssembly = false;
             var calls = 0;
 
             try
             {
+                // Gate the resolved assembly on an explicit flag rather than the call count: an unrelated
+                // assembly load can bump the generation and make ResolveType retry, so the provider may be
+                // invoked more than once per lookup.
                 InstanceOfHelper.SetAssemblyProviderForTests(() =>
                 {
                     calls++;
-                    return calls == 1 ? initialAssemblies : [.. initialAssemblies, resolvedAssembly];
+                    return includeResolvedAssembly ? [.. initialAssemblies, resolvedAssembly] : initialAssemblies;
                 });
 
                 Action firstLookup = () => InstanceOfHelper.ResolveType("LargeMissCache.ResolvedType");
                 firstLookup.Should().Throw<Exception>().WithMessage("*unknown type*");
 
+                includeResolvedAssembly = true;
                 InstanceOfHelper.IncrementAssemblyLoadGenerationForTests();
                 InstanceOfHelper.ResolveType("LargeMissCache.ResolvedType").Should().Be(resolvedAssembly.GetType("LargeMissCache.ResolvedType"));
 
-                calls.Should().Be(2);
+                calls.Should().BeGreaterThan(1);
             }
             finally
             {


### PR DESCRIPTION
## Summary of changes

Attempt to fix flake in debugger `instanceof` assembly lookup tests by avoiding call-count-based assembly provider behavior.

## Reason for change

While attempting to fix other flake, this flaked so need to try and resolve it. 
ProbeExpressionParser_InstanceOf_LazyLoadedType_CanSucceedWithoutRecompile` and two sibling tests could fail when `InstanceOfHelper.ResolveType()` retried a lookup after the process-wide assembly-load generation changed.

Because the tests changed the returned assembly an unrelated parallel assembly load could trigger a retry, expose the “later” assembly too early

## Implementation details

Replaced provider call-count gates with explicit boolean flags that control when additional assemblies become visible. Relaxed exact call-count assertions to account for legitimate retry behavior

## Test coverage

## Other details
<!-- Fixes #{issue} -->


#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
