### PR TITLE
[Profiler] Process accepted named pipe connections immediately

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
@@ -414,19 +414,24 @@ namespace Datadog.Profiler.IntegrationTests
 
                     _log("Starting wait for connection " + instance);
                     var connectTask = serverStream.WaitForConnectionAsync(_cancellationTokenSource.Token).ConfigureAwait(false);
-                    stopEvent.Set();
+                    stopEvent?.Set();
 
                     _log("Awaiting connection " + instance);
                     await connectTask;
 
                     _log("Connection accepted, starting new server" + instance);
 
-                    // start a new Named pipe server to handle additional connections
-                    // Yes, this is madness, but apparently the way it's supposed to be done
-                    using var m = new ManualResetEventSlim();
-                    _tasks.Add(Task.Run(() => StartNamedPipeServer(m)));
-                    // Wait for the next instance to start listening before we handle this one
-                    m.Wait(5_000);
+                    // Start a fresh listener to accept the NEXT connection, but do not block this
+                    // one waiting for it to come up: we keep a pool of ConcurrentInstanceCount
+                    // listeners, so another is already waiting for the next client.
+                    //
+                    // The old code blocked here (m.Wait) until the replacement was listening. Under
+                    // CI CPU load (the profiled sample saturates the cores) the replacement's
+                    // Task.Run could be starved, leaving this already-accepted connection unread for
+                    // up to 5 seconds, long enough for the profiler's export to time out. The
+                    // request was then never read, so it was never counted, which is what made this
+                    // test flaky (profiles were written to disk but "not sent" to the agent).
+                    _tasks.Add(Task.Run(() => StartNamedPipeServer(null)));
                     _log("Executing read for " + instance);
 
                     await _handleReadFunc(serverStream, _cancellationTokenSource.Token);
@@ -443,11 +448,9 @@ namespace Datadog.Profiler.IntegrationTests
                 }
                 catch (Exception ex)
                 {
-                    // unexpected exception, so start another listener
+                    // unexpected exception, so start another listener (without blocking on it)
                     _log("Unexpected exception " + instance + " " + ex.ToString());
-                    using var m = new ManualResetEventSlim();
-                    _tasks.Add(Task.Run(() => StartNamedPipeServer(m)));
-                    m.Wait(5_000);
+                    _tasks.Add(Task.Run(() => StartNamedPipeServer(null)));
                 }
             }
 


### PR DESCRIPTION
## Summary of changes

Process accepted named pipe connections without waiting for a replacement listener to start.

## Reason for change

The failure log showed that the named-pipe server had already accepted profile connections, but did not begin reading them until the test started disposing the mock agent:

```text
Connection accepted ... instance 3
Waiting for PipeServer Disposal
Executing read ... instance 3
Attempt failed ... expected at least 2 calls, actual value 1
```

This occurred because each accepted connection queued a replacement listener on the thread pool and then waited up to five seconds for that listener to start. **Assumption** Under CI load, the replacement task could be delayed, which also delayed processing the connection that had already been accepted. As a result, profile requests remained unread and were not included in the agent request count before the assertion ran.

The mock server already maintains a pool of five listeners, so waiting for a replacement appears unnecessary. The change still schedules a replacement listener, but immediately processes the accepted connection.

## Implementation details

Schedule and track a replacement listener, but immediately process the accepted connection

## Test coverage

## Other details
<!-- Fixes #{issue} -->

I'm unsure if this previous code comment is accurate "Yes, this is madness, but apparently the way it's supposed to be done"

#incident-57303
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
