### PR TITLE
[Azure Functions] Stabilize isolated host lifecycle and log collection

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -138,6 +138,39 @@ public abstract class AzureFunctionsTests : TestHelper
         return logsIntake.Logs;
     }
 
+    protected async Task<IImmutableList<MockLogsIntake.Log>> WaitForLogsToStabilizeAsync(
+        MockLogsIntake logsIntake,
+        int minimumCount,
+        int quietPeriodInMilliseconds = 2_000,
+        int timeoutInMilliseconds = 20_000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
+        var quietPeriod = TimeSpan.FromMilliseconds(quietPeriodInMilliseconds);
+        var previousCount = logsIntake.Logs.Count;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var remaining = deadline - DateTime.UtcNow;
+            if (remaining < quietPeriod)
+            {
+                await Task.Delay(remaining);
+                break;
+            }
+
+            await Task.Delay(quietPeriod);
+            var logs = logsIntake.Logs;
+            if (logs.Count >= minimumCount && logs.Count == previousCount)
+            {
+                return logs;
+            }
+
+            previousCount = logs.Count;
+        }
+
+        throw new TimeoutException(
+            $"Logs did not stabilize at or above {minimumCount} entries within {timeoutInMilliseconds}ms. Last count: {logsIntake.Logs.Count}.");
+    }
+
     protected async Task<ProcessHelper> StartAzureFunction(MockTracerAgent agent, string framework)
     {
         var binFolder = EnvironmentHelper.GetSampleApplicationOutputDirectory(packageVersion: string.Empty, framework);
@@ -550,7 +583,9 @@ public abstract class AzureFunctionsTests : TestHelper
                 });
 
             // Worker logs are submitted during shutdown, but the hundreds of host logs must remain disabled.
-            var logs = await WaitForLogsAsync(logsIntake, static logs => logs.Count > 10);
+            // Wait for submissions to become quiet before checking the upper bound so a later batch cannot
+            // invalidate the assertion after the first worker-log batch satisfies the lower bound.
+            var logs = await WaitForLogsToStabilizeAsync(logsIntake, minimumCount: 11);
             logs.Should().HaveCountGreaterThan(10);
             logs.Should().HaveCountLessThanOrEqualTo(20);
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -80,7 +81,61 @@ public abstract class AzureFunctionsTests : TestHelper
 
     protected async Task<ProcessResult> RunAzureFunctionAndWaitForExit(MockTracerAgent agent, Func<Task> seedAsync = null, string framework = null, int expectedExitCode = 0)
     {
-        // run the azure function
+        using var helper = await StartAzureFunction(agent, framework);
+
+        if (seedAsync is not null)
+        {
+            await WaitForFunctionAppReadyAsync();
+            await seedAsync();
+        }
+
+        return WaitForProcessResult(helper, expectedExitCode);
+    }
+
+    protected async Task RunIsolatedAzureFunctionAsync(MockTracerAgent agent, Func<Task> testAsync, string framework = null)
+    {
+        using var helper = await StartAzureFunction(agent, framework);
+        try
+        {
+            await WaitForFunctionAppReadyAsync();
+
+            // Keep func.exe and its isolated worker alive until the test has received and asserted all
+            // expected data. Shutting down first can discard the host process's final trace batch.
+            await testAsync();
+
+            if (helper.Process.HasExited)
+            {
+                throw new InvalidOperationException("The Azure Functions host exited before the test requested shutdown.");
+            }
+        }
+        finally
+        {
+            await StopIsolatedAzureFunctionAsync(helper);
+        }
+    }
+
+    protected async Task<IImmutableList<MockLogsIntake.Log>> WaitForLogsAsync(
+        MockLogsIntake logsIntake,
+        Func<IImmutableList<MockLogsIntake.Log>, bool> predicate,
+        int timeoutInMilliseconds = 20_000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            var logs = logsIntake.Logs;
+            if (predicate(logs))
+            {
+                return logs;
+            }
+
+            await Task.Delay(250);
+        }
+
+        return logsIntake.Logs;
+    }
+
+    protected async Task<ProcessHelper> StartAzureFunction(MockTracerAgent agent, string framework)
+    {
         var binFolder = EnvironmentHelper.GetSampleApplicationOutputDirectory(packageVersion: string.Empty, framework);
         Output.WriteLine("Using binFolder: " + binFolder);
         var process = await ProfilerHelper.StartProcessWithProfiler(
@@ -92,15 +147,95 @@ public abstract class AzureFunctionsTests : TestHelper
             processToProfile: null,
             workingDirectory: binFolder); // points to the sample project
 
-        using var helper = new ProcessHelper(process);
+        return new ProcessHelper(process);
+    }
 
-        if (seedAsync is not null)
+    protected async Task StopIsolatedAzureFunctionAsync(ProcessHelper helper)
+    {
+        var process = helper.Process;
+        var childProcessIds = new List<int>();
+
+        if (!process.HasExited)
         {
-            await WaitForFunctionAppReadyAsync();
-            await seedAsync();
+            childProcessIds.AddRange(ProcessHelper.GetChildrenIds(process.Id));
+
+            try
+            {
+                using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+                using var response = await http.PostAsync("http://127.0.0.1:7071/api/shutdown", content: null);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                Output.WriteLine($"Unable to request Azure Functions worker shutdown: {ex.Message}");
+            }
+
+            // Core Tools may remain alive after the isolated worker stops. Give it a short grace period,
+            // then terminate only this test's process tree. All expected spans and logs were awaited above.
+            _ = await Task.WhenAny(helper.Task, Task.Delay(TimeSpan.FromSeconds(2)));
         }
 
-        return WaitForProcessResult(helper, expectedExitCode);
+        if (!process.HasExited)
+        {
+            foreach (var childProcessId in ProcessHelper.GetChildrenIds(process.Id))
+            {
+                if (!childProcessIds.Contains(childProcessId))
+                {
+                    childProcessIds.Add(childProcessId);
+                }
+            }
+
+            try
+            {
+                process.Kill();
+            }
+            catch (Exception ex)
+            {
+                Output.WriteLine($"Unable to stop Azure Functions host process {process.Id}: {ex.Message}");
+            }
+        }
+
+        for (var i = childProcessIds.Count - 1; i >= 0; i--)
+        {
+            try
+            {
+                using var childProcess = Process.GetProcessById(childProcessIds[i]);
+                if (!childProcess.HasExited)
+                {
+                    childProcess.Kill();
+                }
+            }
+            catch (ArgumentException)
+            {
+                // The child process has already exited.
+            }
+            catch (Exception ex)
+            {
+                Output.WriteLine($"Unable to stop Azure Functions child process {childProcessIds[i]}: {ex.Message}");
+            }
+        }
+
+        if (!process.HasExited)
+        {
+            process.WaitForExit((int)TimeSpan.FromSeconds(10).TotalMilliseconds);
+        }
+
+        helper.Drain((int)TimeSpan.FromSeconds(5).TotalMilliseconds);
+        if (!string.IsNullOrWhiteSpace(helper.StandardOutput))
+        {
+            Output.WriteLine($"StandardOutput:{Environment.NewLine}{helper.StandardOutput}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(helper.ErrorOutput))
+        {
+            Output.WriteLine($"StandardError:{Environment.NewLine}{helper.ErrorOutput}");
+        }
+
+        Output.WriteLine("ProcessId: " + process.Id);
+        if (process.HasExited)
+        {
+            Output.WriteLine("Exit Code: " + process.ExitCode);
+        }
     }
 
     protected async Task AssertInProcessSpans(IImmutableList<MockSpan> spans)
@@ -265,16 +400,17 @@ public abstract class AzureFunctionsTests : TestHelper
 
             SuppressReadinessPingSpans(agent);
 
-            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
-            {
-                const int expectedSpanCount = 21;
-                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
-                var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
+            await RunIsolatedAzureFunctionAsync(
+                agent,
+                async () =>
+                {
+                    const int expectedSpanCount = 21;
+                    var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
-                using var s = new AssertionScope();
-                filteredSpans.Should().HaveCount(expectedSpanCount);
-                await AssertIsolatedSpans(filteredSpans, $"{nameof(AzureFunctionsTests)}.Isolated.V4.Sdk1");
-            }
+                    using var s = new AssertionScope();
+                    spans.Should().HaveCount(expectedSpanCount);
+                    await AssertIsolatedSpans(spans, $"{nameof(AzureFunctionsTests)}.Isolated.V4.Sdk1");
+                });
         }
     }
 
@@ -298,17 +434,19 @@ public abstract class AzureFunctionsTests : TestHelper
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             SuppressReadinessPingSpans(agent);
 
-            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
-            {
-                const int expectedSpanCount = 31;
-                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
+            await RunIsolatedAzureFunctionAsync(
+                agent,
+                async () =>
+                {
+                    const int expectedSpanCount = 31;
+                    var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
-                var filteredSpans = FilterOutSocketsHttpHandler(spans);
+                    var filteredSpans = FilterOutSocketsHttpHandler(spans);
 
-                using var s = new AssertionScope();
-                spans.Should().HaveCount(expectedSpanCount);
-                await AssertIsolatedSpans(filteredSpans.ToImmutableList(), $"{nameof(AzureFunctionsTests)}.Isolated.V4.AspNetCore1");
-            }
+                    using var s = new AssertionScope();
+                    spans.Should().HaveCount(expectedSpanCount);
+                    await AssertIsolatedSpans(filteredSpans.ToImmutableList(), $"{nameof(AzureFunctionsTests)}.Isolated.V4.AspNetCore1");
+                });
         }
     }
 #endif
@@ -345,21 +483,24 @@ public abstract class AzureFunctionsTests : TestHelper
 
             SuppressReadinessPingSpans(agent);
 
-            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
-            {
-                const int expectedSpanCount = 21;
-                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
-                var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
+            await RunIsolatedAzureFunctionAsync(
+                agent,
+                async () =>
+                {
+                    const int expectedSpanCount = 21;
+                    var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
-                using var s = new AssertionScope();
-                filteredSpans.Should().HaveCount(expectedSpanCount);
-                await AssertIsolatedSpans(filteredSpans);
+                    using var s = new AssertionScope();
+                    spans.Should().HaveCount(expectedSpanCount);
+                    await AssertIsolatedSpans(spans);
 
-                // ~327 (ish) logs but we kill func.exe so some logs are lost
-                // and since sometimes the batch of logs can be 100+ it can be a LOT of logs that we lose
-                // so just check that we have much more than when we have host logs disabled
-                logsIntake.Logs.Should().HaveCountGreaterThanOrEqualTo(200);
-            }
+                    var logs = await WaitForLogsAsync(
+                                   logsIntake,
+                                   static logs => logs.Count >= 200 &&
+                                                  logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true));
+                    logs.Should().HaveCountGreaterThanOrEqualTo(200);
+                    logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true).Should().BeTrue();
+                });
         }
     }
 
@@ -395,23 +536,24 @@ public abstract class AzureFunctionsTests : TestHelper
 
             SuppressReadinessPingSpans(agent);
 
-            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
-            {
-                const int expectedSpanCount = 21;
-                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
-                var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
+            await RunIsolatedAzureFunctionAsync(
+                agent,
+                async () =>
+                {
+                    const int expectedSpanCount = 21;
+                    var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
-                using var s = new AssertionScope();
-                filteredSpans.Should().HaveCount(expectedSpanCount);
-                await AssertIsolatedSpans(filteredSpans, filename: $"{nameof(AzureFunctionsTests)}.Isolated.V4.HostLogsDisabled");
+                    using var s = new AssertionScope();
+                    spans.Should().HaveCount(expectedSpanCount);
+                    await AssertIsolatedSpans(spans, filename: $"{nameof(AzureFunctionsTests)}.Isolated.V4.HostLogsDisabled");
 
-                // we expect some logs still from the worker process
-                // this just seems flaky I THINK because of killing the func.exe process (even though we aren't using the host logs)
-                // commonly see 13, 14, 15, 16 logs, but IF we were logging the host logs we'd see 300+
-                var logs = logsIntake.Logs;
-                logs.Should().HaveCountGreaterThan(10);
-                logs.Should().HaveCountLessThanOrEqualTo(20);
-            }
+                    // Worker logs are still submitted, but the hundreds of host logs must remain disabled.
+                    var logs = await WaitForLogsAsync(
+                                   logsIntake,
+                                   static logs => logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true));
+                    logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true).Should().BeTrue();
+                    logs.Should().HaveCountLessThan(50);
+                });
         }
     }
 
@@ -436,25 +578,25 @@ public abstract class AzureFunctionsTests : TestHelper
 
             SuppressReadinessPingSpans(agent);
 
-            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
-            {
-                const int expectedSpanCount = 31;
-                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
+            await RunIsolatedAzureFunctionAsync(
+                agent,
+                async () =>
+                {
+                    const int expectedSpanCount = 31;
+                    var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
-                // There are _additional_ spans created for these compared to the non-AspNetCore version
-                // These are http-client-handler-type: System.Net.Http.SocketsHttpHandler that come in around
-                // the same time as some of the `azure_functions.invoke` spans
-                // because of this they cause a lot of flake in the snapshots where they shift places
-                // opting to just scrub them from the snapshots - we also don't think that the spans provide much
-                // value so they may be removed from being traced.
-                var filteredSpans = FilterOutSocketsHttpHandler(spans)
-                                   .Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase))
-                                   .ToImmutableList();
+                    // There are _additional_ spans created for these compared to the non-AspNetCore version
+                    // These are http-client-handler-type: System.Net.Http.SocketsHttpHandler that come in around
+                    // the same time as some of the `azure_functions.invoke` spans
+                    // because of this they cause a lot of flake in the snapshots where they shift places
+                    // opting to just scrub them from the snapshots - we also don't think that the spans provide much
+                    // value so they may be removed from being traced.
+                    var filteredSpans = FilterOutSocketsHttpHandler(spans).ToImmutableList();
 
-                using var s = new AssertionScope();
-                spans.Should().HaveCount(expectedSpanCount);
-                await AssertIsolatedSpans(filteredSpans, $"{nameof(AzureFunctionsTests)}.Isolated.V4.AspNetCore");
-            }
+                    using var s = new AssertionScope();
+                    spans.Should().HaveCount(expectedSpanCount);
+                    await AssertIsolatedSpans(filteredSpans, $"{nameof(AzureFunctionsTests)}.Isolated.V4.AspNetCore");
+                });
         }
     }
 
@@ -482,41 +624,42 @@ public abstract class AzureFunctionsTests : TestHelper
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             SuppressReadinessPingSpans(agent);
 
-            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
-            {
-                // 6 spans: Timer TriggerAllTimer, http.request, azure.apim, host span (GET /api/simple),
-                // worker span (Http SimpleHttpTrigger), Manual inside Simple.
-                const int expectedSpanCount = 6;
-                var spans = await agent.WaitForSpansAsync(expectedSpanCount);
-                var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
+            await RunIsolatedAzureFunctionAsync(
+                agent,
+                async () =>
+                {
+                    // 6 spans: Timer TriggerAllTimer, http.request, azure.apim, host span (GET /api/simple),
+                    // worker span (Http SimpleHttpTrigger), Manual inside Simple.
+                    const int expectedSpanCount = 6;
+                    var spans = await agent.WaitForSpansAsync(expectedSpanCount);
 
-                using var assertionScope = new AssertionScope();
+                    using var assertionScope = new AssertionScope();
 
-                filteredSpans.Count.Should().Be(expectedSpanCount);
+                    spans.Count.Should().Be(expectedSpanCount);
 
-                filteredSpans.Should().ContainSingle(s => s.Name == "azure.apim");
+                    spans.Should().ContainSingle(s => s.Name == "azure.apim");
 
-                // Verify we have azure_functions.invoke spans: host (GET /api/simple), worker (Http SimpleHttpTrigger), Timer TriggerAllTimer
-                var functionSpans = filteredSpans.Where(s => s.Name == "azure_functions.invoke").ToList();
-                functionSpans.Should().HaveCount(3);
-                functionSpans.Should().Contain(s => s.Resource.Contains("TriggerAllTimer"));
-                functionSpans.Should().Contain(s => s.Resource.Contains("SimpleHttpTrigger"));
-                functionSpans.Should().Contain(s => s.Resource.Contains("GET /api/simple"));
+                    // Verify we have azure_functions.invoke spans: host (GET /api/simple), worker (Http SimpleHttpTrigger), Timer TriggerAllTimer
+                    var functionSpans = spans.Where(s => s.Name == "azure_functions.invoke").ToList();
+                    functionSpans.Should().HaveCount(3);
+                    functionSpans.Should().Contain(s => s.Resource.Contains("TriggerAllTimer"));
+                    functionSpans.Should().Contain(s => s.Resource.Contains("SimpleHttpTrigger"));
+                    functionSpans.Should().Contain(s => s.Resource.Contains("GET /api/simple"));
 
-                // Verify the http.request span
-                var httpSpan = filteredSpans.Should().ContainSingle(s => s.Name == "http.request").Subject;
-                httpSpan.Tags.Should().ContainKey("http.url");
+                    // Verify the http.request span
+                    var httpSpan = spans.Should().ContainSingle(s => s.Name == "http.request").Subject;
+                    httpSpan.Tags.Should().ContainKey("http.url");
 
-                var settings = VerifyHelper.GetSpanVerifierSettings();
-                settings.AddSimpleScrubber("aas.environment.runtime: .NET Core", "aas.environment.runtime: .NET");
-                settings.AddRegexScrubber(
-                    new(@"Microsoft.Azure.WebJobs.Extensions, Version=\d.\d.\d.\d"),
-                    @"Microsoft.Azure.WebJobs.Extensions, Version=0.0.0.0");
-                settings.AddRegexScrubber(new(@" in .+\.cs:line \d+"), string.Empty);
-                await VerifyHelper.VerifySpans(filteredSpans, settings)
-                                    .UseFileName($"{nameof(AzureFunctionsTests)}.Isolated.V4.AzureApim")
-                                    .DisableRequireUniquePrefix();
-            }
+                    var settings = VerifyHelper.GetSpanVerifierSettings();
+                    settings.AddSimpleScrubber("aas.environment.runtime: .NET Core", "aas.environment.runtime: .NET");
+                    settings.AddRegexScrubber(
+                        new(@"Microsoft.Azure.WebJobs.Extensions, Version=\d.\d.\d.\d"),
+                        @"Microsoft.Azure.WebJobs.Extensions, Version=0.0.0.0");
+                    settings.AddRegexScrubber(new(@" in .+\.cs:line \d+"), string.Empty);
+                    await VerifyHelper.VerifySpans(spans, settings)
+                                      .UseFileName($"{nameof(AzureFunctionsTests)}.Isolated.V4.AzureApim")
+                                      .DisableRequireUniquePrefix();
+                });
         }
     }
 #endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -28,6 +28,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 /// </summary>
 public abstract class AzureFunctionsTests : TestHelper
 {
+    // The sample waits for host readiness by probing /admin/host/ping, which the host records as one or
+    // more "GET /admin/host/ping" spans. They are not part of the traces under test, so they are excluded
+    // from the agent's span waits and results (see SuppressReadinessPingSpans).
+    protected const string ReadinessPingResource = "GET /admin/host/ping";
+
     protected AzureFunctionsTests(string sampleAppName, ITestOutputHelper output)
         : base(sampleAppName, samplePathOverrides: Path.Combine("test", "test-applications", "azure-functions"), output)
     {
@@ -46,6 +51,11 @@ public abstract class AzureFunctionsTests : TestHelper
         // as they are already covered by the existing excludes
         SetEnvironmentVariable("DD_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS", ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions + ", devstoreaccount1/azure-webjobs-hosts");
     }
+
+    // Excludes the readiness-probe spans (see ReadinessPingResource) from this agent's span waits and
+    // results, so the number of probe attempts never affects WaitForSpansAsync counts.
+    protected static void SuppressReadinessPingSpans(MockTracerAgent agent)
+        => agent.SpanFilters.Add(s => s.Resource != ReadinessPingResource);
 
     protected static IList<MockSpan> FilterOutSocketsHttpHandler(IImmutableList<MockSpan> spans)
     {
@@ -253,6 +263,8 @@ public abstract class AzureFunctionsTests : TestHelper
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 
+            SuppressReadinessPingSpans(agent);
+
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 21;
@@ -284,6 +296,8 @@ public abstract class AzureFunctionsTests : TestHelper
         public async Task SubmitsTraces()
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            SuppressReadinessPingSpans(agent);
+
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 31;
@@ -328,6 +342,8 @@ public abstract class AzureFunctionsTests : TestHelper
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.ILogger), hostName);
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+
+            SuppressReadinessPingSpans(agent);
 
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
@@ -377,6 +393,8 @@ public abstract class AzureFunctionsTests : TestHelper
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 
+            SuppressReadinessPingSpans(agent);
+
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 21;
@@ -415,6 +433,8 @@ public abstract class AzureFunctionsTests : TestHelper
         public async Task SubmitsTraces()
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+
+            SuppressReadinessPingSpans(agent);
 
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
@@ -460,6 +480,8 @@ public abstract class AzureFunctionsTests : TestHelper
             SetEnvironmentVariable("DD_TEST_APIM_ENABLED", "1");
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            SuppressReadinessPingSpans(agent);
+
             using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 // 6 spans: Timer TriggerAllTimer, http.request, azure.apim, host span (GET /api/simple),

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -94,6 +94,10 @@ public abstract class AzureFunctionsTests : TestHelper
 
     protected async Task RunIsolatedAzureFunctionAsync(MockTracerAgent agent, Func<Task> testAsync, string framework = null)
     {
+        // Timer listeners use blob singleton leases. Give every run a unique host ID so a lease
+        // left by an earlier test cannot delay this host's timer trigger for up to a minute.
+        SetEnvironmentVariable("AzureFunctionsWebHost__hostid", "aftrace" + Guid.NewGuid().ToString("N").Substring(0, 25));
+
         using var helper = await StartAzureFunction(agent, framework);
         try
         {
@@ -493,14 +497,11 @@ public abstract class AzureFunctionsTests : TestHelper
                     using var s = new AssertionScope();
                     spans.Should().HaveCount(expectedSpanCount);
                     await AssertIsolatedSpans(spans);
-
-                    var logs = await WaitForLogsAsync(
-                                   logsIntake,
-                                   static logs => logs.Count >= 200 &&
-                                                  logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true));
-                    logs.Should().HaveCountGreaterThanOrEqualTo(200);
-                    logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true).Should().BeTrue();
                 });
+
+            // The direct log submission sink can remain buffered until the worker shuts down.
+            var logs = await WaitForLogsAsync(logsIntake, static logs => logs.Count >= 200);
+            logs.Should().HaveCountGreaterThanOrEqualTo(200);
         }
     }
 
@@ -546,14 +547,12 @@ public abstract class AzureFunctionsTests : TestHelper
                     using var s = new AssertionScope();
                     spans.Should().HaveCount(expectedSpanCount);
                     await AssertIsolatedSpans(spans, filename: $"{nameof(AzureFunctionsTests)}.Isolated.V4.HostLogsDisabled");
-
-                    // Worker logs are still submitted, but the hundreds of host logs must remain disabled.
-                    var logs = await WaitForLogsAsync(
-                                   logsIntake,
-                                   static logs => logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true));
-                    logs.Any(log => log.Message?.Contains("Trigger All Timer complete") is true).Should().BeTrue();
-                    logs.Should().HaveCountLessThan(50);
                 });
+
+            // Worker logs are submitted during shutdown, but the hundreds of host logs must remain disabled.
+            var logs = await WaitForLogsAsync(logsIntake, static logs => logs.Count > 10);
+            logs.Should().HaveCountGreaterThan(10);
+            logs.Should().HaveCountLessThanOrEqualTo(20);
         }
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -29,10 +29,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 /// </summary>
 public abstract class AzureFunctionsTests : TestHelper
 {
-    // The sample waits for the HTTP listener by probing /admin/host/ping, which the host records as one or
-    // more "GET /admin/host/ping" spans. They are not part of the traces under test, so they are excluded
-    // from the agent's span waits and results (see SuppressReadinessPingSpans).
-    protected const string ReadinessPingResource = "GET /admin/host/ping";
+    private const string ReadinessPingResource = "GET /admin/host/ping";
 
     protected AzureFunctionsTests(string sampleAppName, ITestOutputHelper output)
         : base(sampleAppName, samplePathOverrides: Path.Combine("test", "test-applications", "azure-functions"), output)
@@ -53,8 +50,7 @@ public abstract class AzureFunctionsTests : TestHelper
         SetEnvironmentVariable("DD_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS", ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions + ", devstoreaccount1/azure-webjobs-hosts");
     }
 
-    // Excludes the readiness-probe spans (see ReadinessPingResource) from this agent's span waits and
-    // results, so the number of probe attempts never affects WaitForSpansAsync counts.
+    // Readiness probes create host spans that must not affect test counts or snapshots.
     protected static void SuppressReadinessPingSpans(MockTracerAgent agent)
         => agent.SpanFilters.Add(s => s.Resource != ReadinessPingResource);
 
@@ -207,8 +203,7 @@ public abstract class AzureFunctionsTests : TestHelper
                 Output.WriteLine($"Unable to request Azure Functions worker shutdown: {ex.Message}");
             }
 
-            // Core Tools may remain alive after the isolated worker stops. Give it a short grace period,
-            // then terminate only this test's process tree. All expected spans and logs were awaited above.
+            // Give the worker time to flush and stop before terminating this test's Core Tools process tree.
             _ = await Task.WhenAny(helper.Task, Task.Delay(TimeSpan.FromSeconds(2)));
         }
 
@@ -322,7 +317,7 @@ public abstract class AzureFunctionsTests : TestHelper
     {
         // This only waits for the Functions host HTTP endpoint to accept requests. The ping action itself
         // does not report whether the script host and its trigger listeners have finished initializing.
-        using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
         var pingUrl = $"http://127.0.0.1:{port}/admin/host/ping";
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
         while (DateTime.UtcNow < deadline)
@@ -337,7 +332,7 @@ public abstract class AzureFunctionsTests : TestHelper
             }
             catch
             {
-                // Host not yet listening
+                // Connection failures are expected while the host starts.
             }
 
             await Task.Delay(500);
@@ -582,9 +577,7 @@ public abstract class AzureFunctionsTests : TestHelper
                     await AssertIsolatedSpans(spans, filename: $"{nameof(AzureFunctionsTests)}.Isolated.V4.HostLogsDisabled");
                 });
 
-            // Worker logs are submitted during shutdown, but the hundreds of host logs must remain disabled.
-            // Wait for submissions to become quiet before checking the upper bound so a later batch cannot
-            // invalidate the assertion after the first worker-log batch satisfies the lower bound.
+            // Wait for shutdown logs to settle so a late host batch cannot evade the upper-bound assertion.
             var logs = await WaitForLogsToStabilizeAsync(logsIntake, minimumCount: 11);
             logs.Should().HaveCountGreaterThan(10);
             logs.Should().HaveCountLessThanOrEqualTo(20);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 /// </summary>
 public abstract class AzureFunctionsTests : TestHelper
 {
-    // The sample waits for host readiness by probing /admin/host/ping, which the host records as one or
+    // The sample waits for the HTTP listener by probing /admin/host/ping, which the host records as one or
     // more "GET /admin/host/ping" spans. They are not part of the traces under test, so they are excluded
     // from the agent's span waits and results (see SuppressReadinessPingSpans).
     protected const string ReadinessPingResource = "GET /admin/host/ping";
@@ -85,7 +85,7 @@ public abstract class AzureFunctionsTests : TestHelper
 
         if (seedAsync is not null)
         {
-            await WaitForFunctionAppReadyAsync();
+            await WaitForFunctionHostHttpEndpointAsync();
             await seedAsync();
         }
 
@@ -101,7 +101,7 @@ public abstract class AzureFunctionsTests : TestHelper
         using var helper = await StartAzureFunction(agent, framework);
         try
         {
-            await WaitForFunctionAppReadyAsync();
+            await WaitForFunctionHostHttpEndpointAsync();
 
             // Keep func.exe and its isolated worker alive until the test has received and asserted all
             // expected data. Shutting down first can discard the host process's final trace batch.
@@ -285,10 +285,10 @@ public abstract class AzureFunctionsTests : TestHelper
                           .DisableRequireUniquePrefix();
     }
 
-    private static async Task WaitForFunctionAppReadyAsync(int port = 7071, int timeoutSeconds = 60)
+    private static async Task WaitForFunctionHostHttpEndpointAsync(int port = 7071, int timeoutSeconds = 60)
     {
-        // Poll the host ping endpoint; it returns 200 only when the host is fully initialized and
-        // all function routes are registered.
+        // This only waits for the Functions host HTTP endpoint to accept requests. The ping action itself
+        // does not report whether the script host and its trigger listeners have finished initializing.
         using var http = new System.Net.Http.HttpClient { Timeout = TimeSpan.FromSeconds(2) };
         var pingUrl = $"http://127.0.0.1:{port}/admin/host/ping";
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -4,11 +4,8 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net.Sockets;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Samples
@@ -555,117 +552,6 @@ namespace Samples
         public static void RunCommand(string cmd, string? args = null)
         {
             RunCommandMethod?.Invoke(null, new object?[] { cmd, args });
-        }
-
-        // Waits for the Azure Functions host to be ready to serve function routes by polling its
-        // /admin/host/ping endpoint until it returns 200. A bare TCP connect only proves the port is
-        // open, but the host accepts connections before its function routes are registered; the ping
-        // endpoint returns 200 only once the host is fully initialized and all routes are registered,
-        // so waiting for it guarantees a subsequent self-call reaches a live route.
-        //
-        // Uses a raw socket rather than HttpClient so the readiness check isn't traced and doesn't add
-        // a stray http.request client span. (The host still records a single "GET /admin/host/ping"
-        // span for the successful probe, which the integration tests filter out.)
-        //
-        // baseUrl should be the same base the caller uses for its self-call (e.g. "http://localhost:7071")
-        // so the readiness check and the self-call always target the same host and port.
-        public static async Task WaitForFunctionHostReadyAsync(string baseUrl, int timeoutSeconds = 60)
-        {
-            var uri = new Uri(baseUrl);
-            var request = Encoding.ASCII.GetBytes(
-                $"GET /admin/host/ping HTTP/1.1\r\nHost: {uri.Authority}\r\nConnection: close\r\n\r\n");
-
-            var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
-            while (DateTime.UtcNow < deadline)
-            {
-                // Bound each attempt so a stalled connect/write/read can't hang past the overall deadline
-                // (e.g. the host accepts the socket but never sends a response). Without this the whole
-                // TriggerAllTimer could block until the test's 5-minute mutex fires, recreating the flake.
-                var remaining = deadline - DateTime.UtcNow;
-                var attemptTimeout = remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5);
-
-                if (await TryPingHostAsync(uri, request, attemptTimeout))
-                {
-                    return;
-                }
-
-                await Task.Delay(500);
-            }
-
-            throw new TimeoutException($"Azure Functions host at {baseUrl} was not ready within {timeoutSeconds}s.");
-        }
-
-        // Performs a single /admin/host/ping attempt, returning true only on a 200 response. Anything else
-        // (host not listening, connection dropped, or the attempt exceeding attemptTimeout) is reported as
-        // "not ready yet" so the caller retries. The attempt is raced against attemptTimeout: on timeout we
-        // return immediately (disposing the socket to abort the pending operation) rather than awaiting it, so
-        // a stalled connect/read cannot outlive the budget even if disposal doesn't cancel it promptly.
-        private static async Task<bool> TryPingHostAsync(Uri uri, byte[] request, TimeSpan attemptTimeout)
-        {
-            if (attemptTimeout <= TimeSpan.Zero)
-            {
-                return false;
-            }
-
-            var client = new TcpClient();
-            var pingTask = PingHostAsync(client, uri, request);
-            var completed = await Task.WhenAny(pingTask, Task.Delay(attemptTimeout));
-            if (completed != pingTask)
-            {
-                // Timed out: dispose the socket to abort the pending operation, but don't await pingTask (its
-                // completion may lag behind disposal). Observe its eventual exception out-of-band so it isn't
-                // reported as an unobserved task exception, then return so the budget is strictly enforced.
-                client.Dispose();
-                ObserveFault(pingTask);
-                return false;
-            }
-
-            // The attempt finished within budget; surface its result and dispose the socket.
-            client.Dispose();
-            try
-            {
-                return await pingTask;
-            }
-            catch (SocketException)
-            {
-                // Host is not accepting connections yet
-                return false;
-            }
-            catch (IOException)
-            {
-                // Connection dropped mid-exchange
-                return false;
-            }
-            catch (ObjectDisposedException)
-            {
-                // Socket disposed from under the attempt
-                return false;
-            }
-        }
-
-        // Observes a discarded task's exception (if any) so it doesn't surface as an unobserved task exception.
-        private static void ObserveFault(Task task)
-            => task.ContinueWith(
-                t => { _ = t.Exception; },
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
-
-        private static async Task<bool> PingHostAsync(TcpClient client, Uri uri, byte[] request)
-        {
-            await client.ConnectAsync(uri.Host, uri.Port);
-            using var stream = client.GetStream();
-            await stream.WriteAsync(request, 0, request.Length);
-
-            using var reader = new StreamReader(stream, Encoding.ASCII);
-            // The status line looks like "HTTP/1.1 200 OK"; a 200 means the host is initialized and its
-            // function routes are registered.
-            var statusLine = await reader.ReadLineAsync();
-            if (statusLine is null)
-            {
-                return false;
-            }
-
-            var parts = statusLine.Split(' ');
-            return parts.Length >= 2 && parts[1] == "200";
         }
 
         private class NoOpDisposable : IDisposable

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -4,8 +4,11 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Samples
@@ -552,6 +555,117 @@ namespace Samples
         public static void RunCommand(string cmd, string? args = null)
         {
             RunCommandMethod?.Invoke(null, new object?[] { cmd, args });
+        }
+
+        // Waits for the Azure Functions host to be ready to serve function routes by polling its
+        // /admin/host/ping endpoint until it returns 200. A bare TCP connect only proves the port is
+        // open, but the host accepts connections before its function routes are registered; the ping
+        // endpoint returns 200 only once the host is fully initialized and all routes are registered,
+        // so waiting for it guarantees a subsequent self-call reaches a live route.
+        //
+        // Uses a raw socket rather than HttpClient so the readiness check isn't traced and doesn't add
+        // a stray http.request client span. (The host still records a single "GET /admin/host/ping"
+        // span for the successful probe, which the integration tests filter out.)
+        //
+        // baseUrl should be the same base the caller uses for its self-call (e.g. "http://localhost:7071")
+        // so the readiness check and the self-call always target the same host and port.
+        public static async Task WaitForFunctionHostReadyAsync(string baseUrl, int timeoutSeconds = 60)
+        {
+            var uri = new Uri(baseUrl);
+            var request = Encoding.ASCII.GetBytes(
+                $"GET /admin/host/ping HTTP/1.1\r\nHost: {uri.Authority}\r\nConnection: close\r\n\r\n");
+
+            var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+            while (DateTime.UtcNow < deadline)
+            {
+                // Bound each attempt so a stalled connect/write/read can't hang past the overall deadline
+                // (e.g. the host accepts the socket but never sends a response). Without this the whole
+                // TriggerAllTimer could block until the test's 5-minute mutex fires, recreating the flake.
+                var remaining = deadline - DateTime.UtcNow;
+                var attemptTimeout = remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5);
+
+                if (await TryPingHostAsync(uri, request, attemptTimeout))
+                {
+                    return;
+                }
+
+                await Task.Delay(500);
+            }
+
+            throw new TimeoutException($"Azure Functions host at {baseUrl} was not ready within {timeoutSeconds}s.");
+        }
+
+        // Performs a single /admin/host/ping attempt, returning true only on a 200 response. Anything else
+        // (host not listening, connection dropped, or the attempt exceeding attemptTimeout) is reported as
+        // "not ready yet" so the caller retries. The attempt is raced against attemptTimeout: on timeout we
+        // return immediately (disposing the socket to abort the pending operation) rather than awaiting it, so
+        // a stalled connect/read cannot outlive the budget even if disposal doesn't cancel it promptly.
+        private static async Task<bool> TryPingHostAsync(Uri uri, byte[] request, TimeSpan attemptTimeout)
+        {
+            if (attemptTimeout <= TimeSpan.Zero)
+            {
+                return false;
+            }
+
+            var client = new TcpClient();
+            var pingTask = PingHostAsync(client, uri, request);
+            var completed = await Task.WhenAny(pingTask, Task.Delay(attemptTimeout));
+            if (completed != pingTask)
+            {
+                // Timed out: dispose the socket to abort the pending operation, but don't await pingTask (its
+                // completion may lag behind disposal). Observe its eventual exception out-of-band so it isn't
+                // reported as an unobserved task exception, then return so the budget is strictly enforced.
+                client.Dispose();
+                ObserveFault(pingTask);
+                return false;
+            }
+
+            // The attempt finished within budget; surface its result and dispose the socket.
+            client.Dispose();
+            try
+            {
+                return await pingTask;
+            }
+            catch (SocketException)
+            {
+                // Host is not accepting connections yet
+                return false;
+            }
+            catch (IOException)
+            {
+                // Connection dropped mid-exchange
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                // Socket disposed from under the attempt
+                return false;
+            }
+        }
+
+        // Observes a discarded task's exception (if any) so it doesn't surface as an unobserved task exception.
+        private static void ObserveFault(Task task)
+            => task.ContinueWith(
+                t => { _ = t.Exception; },
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+
+        private static async Task<bool> PingHostAsync(TcpClient client, Uri uri, byte[] request)
+        {
+            await client.ConnectAsync(uri.Host, uri.Port);
+            using var stream = client.GetStream();
+            await stream.WriteAsync(request, 0, request.Length);
+
+            using var reader = new StreamReader(stream, Encoding.ASCII);
+            // The status line looks like "HTTP/1.1 200 OK"; a 200 means the host is initialized and its
+            // function routes are registered.
+            var statusLine = await reader.ReadLineAsync();
+            if (statusLine is null)
+            {
+                return false;
+            }
+
+            var parts = statusLine.Split(' ');
+            return parts.Length >= 2 && parts[1] == "200";
         }
 
         private class NoOpDisposable : IDisposable

--- a/tracer/test/test-applications/azure-functions/AzureFunctionsTestHelpers.cs
+++ b/tracer/test/test-applications/azure-functions/AzureFunctionsTestHelpers.cs
@@ -13,24 +13,20 @@ namespace Samples.AzureFunctions;
 
 internal static class AzureFunctionsTestHelpers
 {
-    // TriggerAllTimer runs after the script host has initialized the functions and registered their routes,
-    // but it can run before the outer HTTP server accepts connections. Polling /admin/host/ping waits for
-    // that listener; a 200 response from this endpoint is a liveness signal, not a route-readiness signal.
-    //
-    // This uses a raw socket so the readiness check doesn't add an http.request client span. The host still
-    // records a "GET /admin/host/ping" span, which the integration tests filter out.
     public static async Task WaitForFunctionHostToAcceptHttpRequestsAsync(string baseUrl, int timeoutSeconds = 60)
     {
         var uri = new Uri(baseUrl);
-        var request = Encoding.ASCII.GetBytes(
-            $"GET /admin/host/ping HTTP/1.1\r\nHost: {uri.Authority}\r\nConnection: close\r\n\r\n");
+
+        // HTTP/1.1 requires a Host header; the trailing blank line terminates the headers.
+        var request = Encoding.ASCII.GetBytes($"GET /admin/host/ping HTTP/1.1\r\nHost: {uri.Authority}\r\nConnection: close\r\n\r\n");
 
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+
         while (DateTime.UtcNow < deadline)
         {
-            // Bound each attempt so a stalled connect/write/read can't hang until the test's five-minute
-            // mutex timeout. Disposing the socket aborts the pending operation if the attempt times out.
             var remaining = deadline - DateTime.UtcNow;
+
+            // Bound each socket attempt so one stalled operation cannot consume the overall timeout.
             var attemptTimeout = remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5);
 
             if (await TryPingHostAsync(uri, request, attemptTimeout))
@@ -51,30 +47,19 @@ internal static class AzureFunctionsTestHelpers
             return false;
         }
 
-        var client = new TcpClient();
-        var pingTask = PingHostAsync(client, uri, request);
-        var completed = await Task.WhenAny(pingTask, Task.Delay(attemptTimeout));
-        if (completed != pingTask)
-        {
-            client.Dispose();
-            ObserveFault(pingTask);
-            return false;
-        }
-
-        client.Dispose();
+        using var client = new TcpClient();
         try
         {
+            var pingTask = PingHostAsync(client, uri, request);
+            if (await Task.WhenAny(pingTask, Task.Delay(attemptTimeout)) != pingTask)
+            {
+                ObserveFault(pingTask);
+                return false;
+            }
+
             return await pingTask;
         }
-        catch (SocketException)
-        {
-            return false;
-        }
-        catch (IOException)
-        {
-            return false;
-        }
-        catch (ObjectDisposedException)
+        catch (Exception)
         {
             return false;
         }
@@ -87,9 +72,10 @@ internal static class AzureFunctionsTestHelpers
 
     private static async Task<bool> PingHostAsync(TcpClient client, Uri uri, byte[] request)
     {
+        // Use raw TCP to avoid creating an outgoing HttpClient span.
         await client.ConnectAsync(uri.Host, uri.Port);
         using var stream = client.GetStream();
-        await stream.WriteAsync(request, 0, request.Length);
+        await stream.WriteAsync(request);
 
         using var reader = new StreamReader(stream, Encoding.ASCII);
         var statusLine = await reader.ReadLineAsync();

--- a/tracer/test/test-applications/azure-functions/AzureFunctionsTestHelpers.cs
+++ b/tracer/test/test-applications/azure-functions/AzureFunctionsTestHelpers.cs
@@ -1,0 +1,104 @@
+// <copyright file="AzureFunctionsTestHelpers.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.AzureFunctions;
+
+internal static class AzureFunctionsTestHelpers
+{
+    // TriggerAllTimer runs after the script host has initialized the functions and registered their routes,
+    // but it can run before the outer HTTP server accepts connections. Polling /admin/host/ping waits for
+    // that listener; a 200 response from this endpoint is a liveness signal, not a route-readiness signal.
+    //
+    // This uses a raw socket so the readiness check doesn't add an http.request client span. The host still
+    // records a "GET /admin/host/ping" span, which the integration tests filter out.
+    public static async Task WaitForFunctionHostToAcceptHttpRequestsAsync(string baseUrl, int timeoutSeconds = 60)
+    {
+        var uri = new Uri(baseUrl);
+        var request = Encoding.ASCII.GetBytes(
+            $"GET /admin/host/ping HTTP/1.1\r\nHost: {uri.Authority}\r\nConnection: close\r\n\r\n");
+
+        var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            // Bound each attempt so a stalled connect/write/read can't hang until the test's five-minute
+            // mutex timeout. Disposing the socket aborts the pending operation if the attempt times out.
+            var remaining = deadline - DateTime.UtcNow;
+            var attemptTimeout = remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5);
+
+            if (await TryPingHostAsync(uri, request, attemptTimeout))
+            {
+                return;
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new TimeoutException($"Azure Functions host at {baseUrl} did not accept HTTP requests within {timeoutSeconds}s.");
+    }
+
+    private static async Task<bool> TryPingHostAsync(Uri uri, byte[] request, TimeSpan attemptTimeout)
+    {
+        if (attemptTimeout <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var client = new TcpClient();
+        var pingTask = PingHostAsync(client, uri, request);
+        var completed = await Task.WhenAny(pingTask, Task.Delay(attemptTimeout));
+        if (completed != pingTask)
+        {
+            client.Dispose();
+            ObserveFault(pingTask);
+            return false;
+        }
+
+        client.Dispose();
+        try
+        {
+            return await pingTask;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    private static void ObserveFault(Task task)
+        => task.ContinueWith(
+            t => { _ = t.Exception; },
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+
+    private static async Task<bool> PingHostAsync(TcpClient client, Uri uri, byte[] request)
+    {
+        await client.ConnectAsync(uri.Host, uri.Port);
+        using var stream = client.GetStream();
+        await stream.WriteAsync(request, 0, request.Length);
+
+        using var reader = new StreamReader(stream, Encoding.ASCII);
+        var statusLine = await reader.ReadLineAsync();
+        if (statusLine is null)
+        {
+            return false;
+        }
+
+        var parts = statusLine.Split(' ');
+        return parts.Length >= 2 && parts[1] == "200";
+    }
+}

--- a/tracer/test/test-applications/azure-functions/Directory.Build.props
+++ b/tracer/test/test-applications/azure-functions/Directory.Build.props
@@ -16,6 +16,10 @@
 
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AzureFunctionsTestHelpers.cs" />
+  </ItemGroup>
+
   <Import Project="..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
 
   <!-- Ensure that we don't reference Datadog.Trace directly (unless explicitly handled) -->

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using Microsoft.Azure.Functions.Worker;
@@ -15,7 +14,7 @@ public class AllTriggers
     private readonly IHostApplicationLifetime _lifetime;
     private const string AtMidnightOnFirstJan = "0 0 0 1 Jan *";
     private static readonly HttpClient HttpClient = new();
-    private static readonly ManualResetEventSlim _mutex = new(initialState: false, spinCount: 0);
+    private static int _shutdownStarted;
 
     // Single source of truth for the function host base URL. Both the readiness wait and the self-calls
     // derive from this so they always target the same host and port.
@@ -32,50 +31,29 @@ public class AllTriggers
     [Function("TriggerAllTimer")]
     public async Task TriggerAllTimer([TimerTrigger(AtMidnightOnFirstJan, RunOnStartup = true)] TimerInfo myTimer)
     {
-        try
-        {
-            _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
-            _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
+        _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
+        _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
 
-            var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
-            _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
+        var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
+        _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
 
-            _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+        _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
 
-            // The RunOnStartup timer can fire before the Functions host has bound its port and registered
-            // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
-            // connection-refused (or a 404) and none of the downstream spans are produced.
-            await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
-            await CallFunctionHttp("trigger");
+        // The RunOnStartup timer can fire before the Functions host has bound its port and registered
+        // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
+        // connection-refused (or a 404) and none of the downstream spans are produced.
+        await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
+        await CallFunctionHttp("trigger");
 
-            _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
-        }
-        finally
-        {
-            _mutex.Set();
-        }
+        _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
     }
 
-    [Function("ExitApp")]
-    public void ExitApp([TimerTrigger(AtMidnightOnFirstJan, RunOnStartup = true)] TimerInfo myTimer)
+    [Function("Shutdown")]
+    public HttpResponseData Shutdown(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "shutdown")] HttpRequestData req)
     {
-        _logger.LogInformation($"Waiting for mutex");
-        if (!_mutex.Wait(TimeSpan.FromMinutes(5)))
-        {
-            _logger.LogError($"Error waiting for mutex: not obtained after 5 minutes!");
-        }
-
-        _logger.LogInformation($"Pausing for 3s");
-        Thread.Sleep(3_000); // just need time for the TriggerAllTimer to finish up etc
-
-        _logger.LogInformation($"Calling StopApplication()");
-        _lifetime.StopApplication();
-        // brutally kill the host, as can't find any other way to signal it should stop
-        foreach (var process in Process.GetProcessesByName("func"))
-        {
-            _logger.LogInformation("Killing {PID} ({Name})", process.Id, process.ProcessName);
-            process.Kill();
-        }
+        ScheduleShutdown();
+        return req.CreateResponse(HttpStatusCode.Accepted);
     }
 
     [Function("SimpleHttpTrigger")]
@@ -155,6 +133,24 @@ public class AllTriggers
         _logger.LogInformation("Calling Uri {Uri}", uri);
         var simpleResponse = await HttpClient.GetStringAsync(uri);
         return simpleResponse;
+    }
+
+    private void ScheduleShutdown()
+    {
+        if (Interlocked.Exchange(ref _shutdownStarted, 1) == 1)
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            // Let the shutdown HTTP response complete before stopping the isolated worker. The test owns
+            // the func.exe lifecycle and uses targeted process-tree cleanup if Core Tools remains running.
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+            await SampleHelpers.ForceTracerFlushAsync();
+            _logger.LogInformation("Stopping Azure Functions worker");
+            _lifetime.StopApplication();
+        });
     }
 
     private async Task Attempt(string endpoint, bool expectFailure = false)

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
@@ -1,7 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
 using System.Net;
-using System.Net.Http.Headers;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Hosting;
@@ -16,8 +13,6 @@ public class AllTriggers
     private static readonly HttpClient HttpClient = new();
     private static int _shutdownStarted;
 
-    // Single source of truth for the function host base URL. Both the readiness wait and the self-calls
-    // derive from this so they always target the same host and port.
     private static readonly string FunctionBaseUrl = $"http://{Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME") ?? "localhost:7071"}";
 
     private readonly ILogger _logger;
@@ -39,9 +34,7 @@ public class AllTriggers
 
         _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
 
-        // Function routes are registered before timer listeners run, but the RunOnStartup timer can fire
-        // before the outer HTTP server accepts connections. Wait for the listener before making the traced
-        // self-call so a connection-refused error doesn't prevent the downstream spans from being produced.
+        // The startup timer can run before the HTTP listener is ready, which would lose the self-call spans.
         await AzureFunctionsTestHelpers.WaitForFunctionHostToAcceptHttpRequestsAsync(FunctionBaseUrl);
         await CallFunctionHttp("trigger");
 
@@ -127,30 +120,29 @@ public class AllTriggers
         return req.CreateResponse(HttpStatusCode.BadRequest);
     }
 
-    private async Task<string> CallFunctionHttp(string path)
+    private Task<string> CallFunctionHttp(string path)
     {
         var uri = $"{FunctionBaseUrl}/api/{path}";
         _logger.LogInformation("Calling Uri {Uri}", uri);
-        var simpleResponse = await HttpClient.GetStringAsync(uri);
-        return simpleResponse;
+        return HttpClient.GetStringAsync(uri);
     }
 
     private void ScheduleShutdown()
     {
-        if (Interlocked.Exchange(ref _shutdownStarted, 1) == 1)
+        // Concurrent shutdown requests must not race to stop the shared worker.
+        if (Interlocked.Exchange(ref _shutdownStarted, 1) == 0)
         {
-            return;
+            _ = StopWorkerAsync();
         }
+    }
 
-        _ = Task.Run(async () =>
-        {
-            // Let the shutdown HTTP response complete before stopping the isolated worker. The test owns
-            // the func.exe lifecycle and uses targeted process-tree cleanup if Core Tools remains running.
-            await Task.Delay(TimeSpan.FromMilliseconds(250));
-            await SampleHelpers.ForceTracerFlushAsync();
-            _logger.LogInformation("Stopping Azure Functions worker");
-            _lifetime.StopApplication();
-        });
+    private async Task StopWorkerAsync()
+    {
+        // Give the shutdown response time to reach the test before stopping the worker.
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+        await SampleHelpers.ForceTracerFlushAsync();
+        _logger.LogInformation("Stopping Azure Functions worker");
+        _lifetime.StopApplication();
     }
 
     private async Task Attempt(string endpoint, bool expectFailure = false)

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
@@ -17,6 +17,10 @@ public class AllTriggers
     private static readonly HttpClient HttpClient = new();
     private static readonly ManualResetEventSlim _mutex = new(initialState: false, spinCount: 0);
 
+    // Single source of truth for the function host base URL. Both the readiness wait and the self-calls
+    // derive from this so they always target the same host and port.
+    private static readonly string FunctionBaseUrl = $"http://{Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME") ?? "localhost:7071"}";
+
     private readonly ILogger _logger;
 
     public AllTriggers(ILogger<AllTriggers> logger, IHostApplicationLifetime lifetime)
@@ -28,16 +32,28 @@ public class AllTriggers
     [Function("TriggerAllTimer")]
     public async Task TriggerAllTimer([TimerTrigger(AtMidnightOnFirstJan, RunOnStartup = true)] TimerInfo myTimer)
     {
-        _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
-        _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
+        try
+        {
+            _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
+            _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
 
-        var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
-        _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
+            var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
+            _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
 
-        _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
-        await CallFunctionHttp("trigger");
-        _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
-        _mutex.Set();
+            _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+
+            // The RunOnStartup timer can fire before the Functions host has bound its port and registered
+            // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
+            // connection-refused (or a 404) and none of the downstream spans are produced.
+            await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
+            await CallFunctionHttp("trigger");
+
+            _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
+        }
+        finally
+        {
+            _mutex.Set();
+        }
     }
 
     [Function("ExitApp")]
@@ -135,8 +151,7 @@ public class AllTriggers
 
     private async Task<string> CallFunctionHttp(string path)
     {
-        var httpFunctionUrl = Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME") ?? "localhost:7071";
-        var uri = $"{$"http://{httpFunctionUrl}"}/api/{path}";
+        var uri = $"{FunctionBaseUrl}/api/{path}";
         _logger.LogInformation("Calling Uri {Uri}", uri);
         var simpleResponse = await HttpClient.GetStringAsync(uri);
         return simpleResponse;

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated.HostLogsDisabled/AllTriggers.cs
@@ -39,10 +39,10 @@ public class AllTriggers
 
         _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
 
-        // The RunOnStartup timer can fire before the Functions host has bound its port and registered
-        // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
-        // connection-refused (or a 404) and none of the downstream spans are produced.
-        await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
+        // Function routes are registered before timer listeners run, but the RunOnStartup timer can fire
+        // before the outer HTTP server accepts connections. Wait for the listener before making the traced
+        // self-call so a connection-refused error doesn't prevent the downstream spans from being produced.
+        await AzureFunctionsTestHelpers.WaitForFunctionHostToAcceptHttpRequestsAsync(FunctionBaseUrl);
         await CallFunctionHttp("trigger");
 
         _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
@@ -17,6 +17,10 @@ public class AllTriggers
     private static readonly HttpClient HttpClient = new();
     private static readonly ManualResetEventSlim _mutex = new(initialState: false, spinCount: 0);
 
+    // Single source of truth for the function host base URL. Both the readiness wait and the self-calls
+    // derive from this so they always target the same host and port.
+    private static readonly string FunctionBaseUrl = $"http://{Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME") ?? "localhost:7071"}";
+
     private readonly ILogger _logger;
 
     public AllTriggers(ILogger<AllTriggers> logger, IHostApplicationLifetime lifetime)
@@ -28,28 +32,39 @@ public class AllTriggers
     [Function("TriggerAllTimer")]
     public async Task TriggerAllTimer([TimerTrigger(AtMidnightOnFirstJan, RunOnStartup = true)] TimerInfo myTimer)
     {
-        _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
-        _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
-
-        var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
-        _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
-
-        _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
-
-        // Check if we should test APIM proxy headers
-        var testApim = Environment.GetEnvironmentVariable("DD_TEST_APIM_ENABLED");
-        if (testApim == "1" || testApim?.ToLowerInvariant() == "true")
+        try
         {
-            _logger.LogInformation("APIM test enabled, calling simple endpoint with APIM headers");
-            await CallFunctionHttpWithProxy("simple");
-        }
-        else
-        {
-            await CallFunctionHttp("trigger");
-        }
+            _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
+            _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
 
-        _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
-        _mutex.Set();
+            var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
+            _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
+
+            _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+
+            // The RunOnStartup timer can fire before the Functions host has bound its port and registered
+            // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
+            // connection-refused (or a 404) and none of the downstream spans are produced.
+            await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
+
+            // Check if we should test APIM proxy headers
+            var testApim = Environment.GetEnvironmentVariable("DD_TEST_APIM_ENABLED");
+            if (testApim == "1" || testApim?.ToLowerInvariant() == "true")
+            {
+                _logger.LogInformation("APIM test enabled, calling simple endpoint with APIM headers");
+                await CallFunctionHttpWithProxy("simple");
+            }
+            else
+            {
+                await CallFunctionHttp("trigger");
+            }
+
+            _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
+        }
+        finally
+        {
+            _mutex.Set();
+        }
     }
 
     [Function("ExitApp")]
@@ -147,8 +162,7 @@ public class AllTriggers
 
     private async Task<string> CallFunctionHttp(string path)
     {
-        var httpFunctionUrl = Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME") ?? "localhost:7071";
-        var uri = $"{$"http://{httpFunctionUrl}"}/api/{path}";
+        var uri = $"{FunctionBaseUrl}/api/{path}";
         _logger.LogInformation("Calling Uri {Uri}", uri);
         var simpleResponse = await HttpClient.GetStringAsync(uri);
         return simpleResponse;
@@ -156,8 +170,7 @@ public class AllTriggers
 
     private async Task<string> CallFunctionHttpWithProxy(string path)
     {
-        var httpFunctionUrl = Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME") ?? "localhost:7071";
-        var uri = $"http://{httpFunctionUrl}/api/{path}";
+        var uri = $"{FunctionBaseUrl}/api/{path}";
         _logger.LogInformation("Calling Uri with APIM headers: {Uri}", uri);
 
         var request = new HttpRequestMessage(HttpMethod.Get, uri);

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
@@ -1,7 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
 using System.Net;
-using System.Net.Http.Headers;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Hosting;
@@ -16,8 +13,6 @@ public class AllTriggers
     private static readonly HttpClient HttpClient = new();
     private static int _shutdownStarted;
 
-    // Single source of truth for the function host base URL. Both the readiness wait and the self-calls
-    // derive from this so they always target the same host and port.
     private static readonly string FunctionBaseUrl = $"http://{Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME") ?? "localhost:7071"}";
 
     private readonly ILogger _logger;
@@ -39,9 +34,7 @@ public class AllTriggers
 
         _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
 
-        // Function routes are registered before timer listeners run, but the RunOnStartup timer can fire
-        // before the outer HTTP server accepts connections. Wait for the listener before making the traced
-        // self-call so a connection-refused error doesn't prevent the downstream spans from being produced.
+        // The startup timer can run before the HTTP listener is ready, which would lose the self-call spans.
         await AzureFunctionsTestHelpers.WaitForFunctionHostToAcceptHttpRequestsAsync(FunctionBaseUrl);
 
         // Check if we should test APIM proxy headers
@@ -138,12 +131,11 @@ public class AllTriggers
         return req.CreateResponse(HttpStatusCode.BadRequest);
     }
 
-    private async Task<string> CallFunctionHttp(string path)
+    private Task<string> CallFunctionHttp(string path)
     {
         var uri = $"{FunctionBaseUrl}/api/{path}";
         _logger.LogInformation("Calling Uri {Uri}", uri);
-        var simpleResponse = await HttpClient.GetStringAsync(uri);
-        return simpleResponse;
+        return HttpClient.GetStringAsync(uri);
     }
 
     private async Task<string> CallFunctionHttpWithProxy(string path)
@@ -172,20 +164,20 @@ public class AllTriggers
 
     private void ScheduleShutdown()
     {
-        if (Interlocked.Exchange(ref _shutdownStarted, 1) == 1)
+        // Concurrent shutdown requests must not race to stop the shared worker.
+        if (Interlocked.Exchange(ref _shutdownStarted, 1) == 0)
         {
-            return;
+            _ = StopWorkerAsync();
         }
+    }
 
-        _ = Task.Run(async () =>
-        {
-            // Let the shutdown HTTP response complete before stopping the isolated worker. The test owns
-            // the func.exe lifecycle and uses targeted process-tree cleanup if Core Tools remains running.
-            await Task.Delay(TimeSpan.FromMilliseconds(250));
-            await SampleHelpers.ForceTracerFlushAsync();
-            _logger.LogInformation("Stopping Azure Functions worker");
-            _lifetime.StopApplication();
-        });
+    private async Task StopWorkerAsync()
+    {
+        // Give the shutdown response time to reach the test before stopping the worker.
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+        await SampleHelpers.ForceTracerFlushAsync();
+        _logger.LogInformation("Stopping Azure Functions worker");
+        _lifetime.StopApplication();
     }
 
     private async Task Attempt(string endpoint, bool expectFailure = false)

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
@@ -39,10 +39,10 @@ public class AllTriggers
 
         _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
 
-        // The RunOnStartup timer can fire before the Functions host has bound its port and registered
-        // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
-        // connection-refused (or a 404) and none of the downstream spans are produced.
-        await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
+        // Function routes are registered before timer listeners run, but the RunOnStartup timer can fire
+        // before the outer HTTP server accepts connections. Wait for the listener before making the traced
+        // self-call so a connection-refused error doesn't prevent the downstream spans from being produced.
+        await AzureFunctionsTestHelpers.WaitForFunctionHostToAcceptHttpRequestsAsync(FunctionBaseUrl);
 
         // Check if we should test APIM proxy headers
         var testApim = Environment.GetEnvironmentVariable("DD_TEST_APIM_ENABLED");

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/AllTriggers.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using Microsoft.Azure.Functions.Worker;
@@ -15,7 +14,7 @@ public class AllTriggers
     private readonly IHostApplicationLifetime _lifetime;
     private const string AtMidnightOnFirstJan = "0 0 0 1 Jan *";
     private static readonly HttpClient HttpClient = new();
-    private static readonly ManualResetEventSlim _mutex = new(initialState: false, spinCount: 0);
+    private static int _shutdownStarted;
 
     // Single source of truth for the function host base URL. Both the readiness wait and the self-calls
     // derive from this so they always target the same host and port.
@@ -32,61 +31,40 @@ public class AllTriggers
     [Function("TriggerAllTimer")]
     public async Task TriggerAllTimer([TimerTrigger(AtMidnightOnFirstJan, RunOnStartup = true)] TimerInfo myTimer)
     {
-        try
+        _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
+        _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
+
+        var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
+        _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
+
+        _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+
+        // The RunOnStartup timer can fire before the Functions host has bound its port and registered
+        // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
+        // connection-refused (or a 404) and none of the downstream spans are produced.
+        await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
+
+        // Check if we should test APIM proxy headers
+        var testApim = Environment.GetEnvironmentVariable("DD_TEST_APIM_ENABLED");
+        if (testApim == "1" || testApim?.ToLowerInvariant() == "true")
         {
-            _logger.LogInformation($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
-            _logger.LogInformation($"Profiler assembly location: {SampleHelpers.GetTracerAssemblyLocation()}");
-
-            var envVars = string.Join(", ", SampleHelpers.GetDatadogEnvironmentVariables().Select(x => $"{x.Key}={x.Value}"));
-            _logger.LogInformation("$Profiler env vars: {EnvVars}", envVars);
-
-            _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
-
-            // The RunOnStartup timer can fire before the Functions host has bound its port and registered
-            // routes, so wait for readiness before making the (traced) self-call; otherwise it fails with
-            // connection-refused (or a 404) and none of the downstream spans are produced.
-            await SampleHelpers.WaitForFunctionHostReadyAsync(FunctionBaseUrl);
-
-            // Check if we should test APIM proxy headers
-            var testApim = Environment.GetEnvironmentVariable("DD_TEST_APIM_ENABLED");
-            if (testApim == "1" || testApim?.ToLowerInvariant() == "true")
-            {
-                _logger.LogInformation("APIM test enabled, calling simple endpoint with APIM headers");
-                await CallFunctionHttpWithProxy("simple");
-            }
-            else
-            {
-                await CallFunctionHttp("trigger");
-            }
-
-            _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
+            _logger.LogInformation("APIM test enabled, calling simple endpoint with APIM headers");
+            await CallFunctionHttpWithProxy("simple");
         }
-        finally
+        else
         {
-            _mutex.Set();
+            await CallFunctionHttp("trigger");
         }
+
+        _logger.LogInformation($"Trigger All Timer complete: {DateTime.Now}");
     }
 
-    [Function("ExitApp")]
-    public void ExitApp([TimerTrigger(AtMidnightOnFirstJan, RunOnStartup = true)] TimerInfo myTimer)
+    [Function("Shutdown")]
+    public HttpResponseData Shutdown(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "shutdown")] HttpRequestData req)
     {
-        _logger.LogInformation($"Waiting for mutex");
-        if (!_mutex.Wait(TimeSpan.FromMinutes(5)))
-        {
-            _logger.LogError($"Error waiting for mutex: not obtained after 5 minutes!");
-        }
-
-        _logger.LogInformation($"Pausing for 3s");
-        Thread.Sleep(3_000); // just need time for the TriggerAllTimer to finish up etc
-
-        _logger.LogInformation($"Calling StopApplication()");
-        _lifetime.StopApplication();
-        // brutally kill the host, as can't find any other way to signal it should stop
-        foreach (var process in Process.GetProcessesByName("func"))
-        {
-            _logger.LogInformation("Killing {PID} ({Name})", process.Id, process.ProcessName);
-            process.Kill();
-        }
+        ScheduleShutdown();
+        return req.CreateResponse(HttpStatusCode.Accepted);
     }
 
     [Function("SimpleHttpTrigger")]
@@ -190,6 +168,24 @@ public class AllTriggers
         _logger.LogInformation("APIM proxy call completed with status: {StatusCode}", response.StatusCode);
 
         return content;
+    }
+
+    private void ScheduleShutdown()
+    {
+        if (Interlocked.Exchange(ref _shutdownStarted, 1) == 1)
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            // Let the shutdown HTTP response complete before stopping the isolated worker. The test owns
+            // the func.exe lifecycle and uses targeted process-tree cleanup if Core Tools remains running.
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
+            await SampleHelpers.ForceTracerFlushAsync();
+            _logger.LogInformation("Stopping Azure Functions worker");
+            _lifetime.StopApplication();
+        });
     }
 
     private async Task Attempt(string endpoint, bool expectFailure = false)


### PR DESCRIPTION
## Summary of changes

This stabilizes the isolated Azure Functions integration tests across startup, trace and log collection, and shutdown.

## Reason for change

The tests had several overlapping timing issues which are a large source of flake. The `RunOnStartup` timer could execute before the Functions HTTP listener was accepting connections, causing its self-call to fail before the downstream spans were created.

At shutdown, the sample waited for a fixed delay and then terminated every `func.exe` process. This could stop the host before its final trace batch reached the mock agent, leaving only 17 of the expected 21 spans. Reusing the same host ID could also leave timer singleton leases behind and delay later test runs.

Finally, the host-logs-disabled test asserted against the first worker-log batch without waiting for later batches, which could hide a regression that re-enabled host logs.

## Implementation details

The samples now wait for the host’s HTTP listener before making their self-calls. The readiness check uses `/admin/host/ping`, and its spans are excluded from the test results.

The tests keep the host alive until the expected spans have been received and asserted. They then call a dedicated shutdown endpoint, which allows its response to complete, flushes the worker tracer, and stops the worker. If Core Tools remains running, teardown terminates only the process tree created by that test.

Direct-submission logs can remain buffered until shutdown, so log assertions happen afterward. For the host-logs-disabled case, the test waits until the expected worker logs have arrived and the intake has remained unchanged for two seconds before checking the upper bound. It fails if the intake does not stabilize within 20 seconds.


## Test coverage

relying on CI as I had some Azurite issues locally.

## Other details

I thought first we could just slap a [Flaky] on these but I am not 100% sure if that will work with how these function tests actually spin up an additional process

#incident-57303
