### PR TITLE
[Tests] Handle UTF-16 output from ProcDump v12.01

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1716,7 +1716,7 @@ stages:
       retryCountOnTaskFailure: 3
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: true
+        enable_crash_dumps: false
         Filter: $(IntegrationTestFilter)
         SampleName: $(IntegrationTestSampleName)
 
@@ -1725,7 +1725,7 @@ stages:
       condition: ne(variables['area'], 'ASM')
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: true
+        enable_crash_dumps: false
         Filter: $(IntegrationTestFilter)
         SampleName: $(IntegrationTestSampleName)
         Area: $(area)
@@ -1736,7 +1736,7 @@ stages:
       retryCountOnTaskFailure: 2
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: true
+        enable_crash_dumps: false
         Filter: $(IntegrationTestFilter)
         SampleName: $(IntegrationTestSampleName)
         Area: $(area)
@@ -4052,7 +4052,7 @@ stages:
       displayName: Build and Test dd-dotnet
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: true
+        enable_crash_dumps: false
 
     - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1716,7 +1716,7 @@ stages:
       retryCountOnTaskFailure: 3
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: false
+        enable_crash_dumps: true
         Filter: $(IntegrationTestFilter)
         SampleName: $(IntegrationTestSampleName)
 
@@ -1725,7 +1725,7 @@ stages:
       condition: ne(variables['area'], 'ASM')
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: false
+        enable_crash_dumps: true
         Filter: $(IntegrationTestFilter)
         SampleName: $(IntegrationTestSampleName)
         Area: $(area)
@@ -1736,7 +1736,7 @@ stages:
       retryCountOnTaskFailure: 2
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: false
+        enable_crash_dumps: true
         Filter: $(IntegrationTestFilter)
         SampleName: $(IntegrationTestSampleName)
         Area: $(area)
@@ -4052,7 +4052,7 @@ stages:
       displayName: Build and Test dd-dotnet
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-        enable_crash_dumps: false
+        enable_crash_dumps: true
 
     - template: steps/make-artifacts-uploadable.yml
     - publish: artifacts/build_data

--- a/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.TestHelpers
 
                     void OnDataReceived(string output)
                     {
-                        if (output == procdumpStarted)
+                        if (output.Replace("\0", string.Empty) == procdumpStarted)
                         {
                             tcs.TrySetResult(true);
                         }
@@ -113,7 +113,7 @@ namespace Datadog.Trace.TestHelpers
 
                     // It looks like there's a small race condition where this could happen before the OnDataReceived callback is called.
                     // So redo the check before setting the task as cancelled.
-                    if (helper.StandardOutput.Contains(procdumpStarted))
+                    if (helper.StandardOutput.Replace("\0", string.Empty).Contains(procdumpStarted))
                     {
                         tcs.TrySetResult(true);
                     }

--- a/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
@@ -102,18 +102,21 @@ namespace Datadog.Trace.TestHelpers
 
                     helper.Drain();
 
-                    if (helper.StandardOutput.Contains("Dump count reached") || !helper.StandardOutput.Contains("Dump count not reached"))
+                    var standardOutput = helper.StandardOutput.Replace("\0", string.Empty);
+                    var errorOutput = helper.ErrorOutput.Replace("\0", string.Empty);
+
+                    if (standardOutput.Contains("Dump count reached") || !standardOutput.Contains("Dump count not reached"))
                     {
                         _output.Report($"[dump] procdump for process {pid} exited with code {helper.Process.ExitCode}");
                         _output.Report($"[dump] Using {_path}");
 
-                        _output.Report($"[dump][stdout] {helper.StandardOutput}");
-                        _output.Report($"[dump][stderr] {helper.ErrorOutput}");
+                        _output.Report($"[dump][stdout] {standardOutput}");
+                        _output.Report($"[dump][stderr] {errorOutput}");
                     }
 
                     // It looks like there's a small race condition where this could happen before the OnDataReceived callback is called.
                     // So redo the check before setting the task as cancelled.
-                    if (helper.StandardOutput.Replace("\0", string.Empty).Contains(procdumpStarted))
+                    if (standardOutput.Contains(procdumpStarted))
                     {
                         tcs.TrySetResult(true);
                     }


### PR DESCRIPTION

## Summary of changes

Normalize ProcDump output before evaluating its startup and shutdown messages.

## Reason for change

Windows x64 integration tests started hanging after the unversioned Microsoft download began serving ProcDump v12.01.

The test harness:

1. Starts the instrumented process in a suspended state.
2. Attaches ProcDump.
3. Waits for ProcDump’s readiness message.
4. Resumes the instrumented process.

ProcDump v12.01 emits redirected output as UTF-16. The test helper read this with embedded null characters, such as `P\0r\0e\0s\0s...`. Consequently, the exact readiness-message comparison failed and the instrumented process remained suspended indefinitely.

The same encoding change prevented the helper from recognizing the normal `"Dump count not reached"` shutdown message. It therefore treated normal shutdown as abnormal and logged ProcDump’s entire buffered exception history.

This primarily affected x64 tests because ProcDump crash monitoring is disabled for x86 tests.

## Implementation details

- Remove embedded null characters before comparing ProcDump’s readiness message.
- Normalize buffered stdout and stderr after ProcDump exits.
- Use normalized stdout for readiness and dump-count checks.
- Log normalized output only when a dump occurred or ProcDump exited unexpectedly.

Output from older ProcDump versions is unchanged because removing null characters is a no-op.

## Test coverage

Tested locally with:

`Datadog.Trace.Security.IntegrationTests.AspNetCore5BlockingTemplatesJson.TestGet`

- **ProcDump v12.0 with the original code:** Passed without excessive ProcDump logging.
- **ProcDump v12.01 with the original code:** Reproduced the hang. ProcDump attached successfully, but the target remained suspended with one thread and zero CPU.
- **ProcDump v12.01 with this change:** Passed without logging the full ProcDump exception buffer.

## Other details

This only changes test infrastructure behavior. Crash-dump monitoring remains enabled, and this change does not pin a ProcDump version.

#incident-57303

<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
