### PR TITLE
[Profiler] Mark flaky SSI tests

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/SingleStepInstrumentation/SingleStepInstrumentationTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SingleStepInstrumentation/SingleStepInstrumentationTest.cs
@@ -27,6 +27,7 @@ namespace Datadog.Profiler.IntegrationTests.SingleStepInstrumentation
             _output = output;
         }
 
+        [Flaky("Samples.Computer01 intermittently crashes with SIGSEGV; under investigation")]
         [TestAppFact("Samples.Computer01")]
         public void ManualAndProfilingEnvVarNotSet(string appName, string framework, string appAssembly)
         {
@@ -48,6 +49,7 @@ namespace Datadog.Profiler.IntegrationTests.SingleStepInstrumentation
             agent.NbCallsOnProfilingEndpoint.Should().Be(0);
         }
 
+        [Flaky("Samples.Computer01 intermittently crashes with SIGSEGV; under investigation")]
         [TestAppFact("Samples.Computer01")]
         public void ManualAndProfilingEnvVarTrue(string appName, string framework, string appAssembly)
         {
@@ -91,6 +93,7 @@ namespace Datadog.Profiler.IntegrationTests.SingleStepInstrumentation
             agent.NbCallsOnProfilingEndpoint.Should().Be(0);
         }
 
+        [Flaky("Samples.Computer01 intermittently crashes with SIGSEGV; under investigation")]
         [TestAppFact("Samples.Computer01")]
         public void SsiAndProfilingEnvVarTrue(string appName, string framework, string appAssembly)
         {
@@ -105,6 +108,7 @@ namespace Datadog.Profiler.IntegrationTests.SingleStepInstrumentation
             agent.NbCallsOnProfilingEndpoint.Should().BeGreaterThan(0);
         }
 
+        [Flaky("Samples.Computer01 intermittently crashes with SIGSEGV; under investigation")]
         [TestAppFact("Samples.Computer01")]
         public void NoMetricsWhenSsiAndProfilingEnvVarTrue(string appName, string framework, string appAssembly)
         {
@@ -124,6 +128,7 @@ namespace Datadog.Profiler.IntegrationTests.SingleStepInstrumentation
             Assert.True(parser == null, "Metrics files should not be generated");
         }
 
+        [Flaky("Samples.Computer01 intermittently crashes with SIGSEGV; under investigation")]
         [TestAppFact("Samples.Computer01")]
         public void SsiAndProfilingEnvVarFalse(string appName, string framework, string appAssembly)
         {
@@ -399,6 +404,7 @@ namespace Datadog.Profiler.IntegrationTests.SingleStepInstrumentation
             AssertProfilingLogsContains(runner.Environment.LogDir, "Profiler enabled by SSI");
         }
 
+        [Flaky("Samples.Computer01 intermittently crashes with SIGSEGV; under investigation")]
         [TestAppFact("Samples.Computer01")]
         public void StableConfigWhenKillSwitchReadsEnvVars(string appName, string framework, string appAssembly)
         {


### PR DESCRIPTION
## Summary of changes

 Marks six SSI profiler integration tests as flaky.

## Reason for change

These keep flaking, `Samples.Computer01` intermittently crashes with `SIGSEGV` during these tests

When I inspected the crash dumps I didn't see Datadog frames in them

## Implementation details

Slapped on [Flaky]

## Test coverage

## Other details

Based on the dumps I looked at initially I swapped these tests to set `ManualCpuTime` to bypass the Linux timer as it _seemed_ like it was the cause, but this seems easier.

#incident-57303
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
