### PR TITLE
[Profiler] Fix AutoResetEvent timeout overflow

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.cpp
@@ -81,7 +81,6 @@ bool AutoResetEvent::Wait(std::chrono::milliseconds timeout)
 
             if (res != 0)
             {
-                LogOnce(Debug, "AutoResetEvent::Wait: pthread_cond_timedwait failed with error code ", res);
                 isSignaled = false;
                 break;
             }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.cpp
@@ -56,6 +56,14 @@ bool AutoResetEvent::Wait(std::chrono::milliseconds timeout)
         clock_gettime(CLOCK_REALTIME, &ts);
         ts.tv_nsec += timeout.count() % 1000 * 1'000'000;
         ts.tv_sec += timeout.count() / 1000;
+
+        // pthread_cond_timedwait requires tv_nsec to be less than one second.
+        constexpr auto NanosecondsPerSecond = 1'000'000'000;
+        if (ts.tv_nsec >= NanosecondsPerSecond)
+        {
+            ts.tv_nsec -= NanosecondsPerSecond;
+            ts.tv_sec++;
+        }
     }
 
     while(!_impl->_isSet)
@@ -68,6 +76,13 @@ bool AutoResetEvent::Wait(std::chrono::milliseconds timeout)
                 // We have a race when the timeout occurs but the lock was taken
                 // before pthread_cond_timedwait acquires the lock on returned.
                 isSignaled = _impl->_isSet;
+                break;
+            }
+
+            if (res != 0)
+            {
+                LogOnce(Debug, "AutoResetEvent::Wait: pthread_cond_timedwait failed with error code ", res);
+                isSignaled = false;
                 break;
             }
         }

--- a/profiler/test/Datadog.Profiler.Native.Tests/AutoResetEventTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AutoResetEventTest.cpp
@@ -6,6 +6,8 @@
 #include "profiler/src/ProfilerEngine/Datadog.Profiler.Native/AutoResetEvent.h"
 
 #include <future>
+#include <thread>
+#include <time.h>
 
 #include "gtest/gtest.h"
 
@@ -75,6 +77,29 @@ std::shared_ptr<EventWrapper> CreateEvent(bool initialValue)
     return std::make_shared<EventWrapper>(initialValue);
 }
 
+void WaitAcrossSecondBoundary(const std::shared_ptr<EventWrapper>& event)
+{
+    struct timespec currentTime;
+    long currentMilliseconds;
+    do
+    {
+        clock_gettime(CLOCK_REALTIME, &currentTime);
+        currentMilliseconds = currentTime.tv_nsec / 1'000'000;
+        std::this_thread::sleep_for(1ms);
+    } while (currentMilliseconds < 100 || currentMilliseconds > 500);
+
+    // Force the absolute timeout calculated by AutoResetEvent::Wait to cross
+    // a second boundary while keeping the test itself short.
+    auto timeout = std::chrono::milliseconds(1'001 - currentMilliseconds);
+    auto setThread = std::thread([event] {
+        std::this_thread::sleep_for(10ms);
+        event->Set();
+    });
+
+    event->Wait(timeout);
+    setThread.join();
+}
+
 std::shared_ptr<ThreadInfo> RunInThread(std::function<void()> callback)
 {
     auto result = std::make_shared<ThreadInfo>();
@@ -138,6 +163,14 @@ TEST(AutoResetEventTest, CheckCaseWhenEventHasTimeOutButSignaledLater)
 
     ASSERT_DURATION_LE(50ms, event->Set());
     ASSERT_DURATION_LE(50ms, event->Wait(100s));
+    ASSERT_TRUE(event->IsSet());
+}
+
+TEST(AutoResetEventTest, EnsureTimeoutAcrossSecondBoundaryIsHandled)
+{
+    auto event = CreateEvent(false);
+
+    ASSERT_DURATION_LE(10s, WaitAcrossSecondBoundary(event));
     ASSERT_TRUE(event->IsSet());
 }
 #endif


### PR DESCRIPTION
## Summary of changes

Fix Linux `AutoResetEvent` waits that cross a wall-clock second boundary.

## Reason for change

A rare timing condition could produce an invalid `timespec`. `pthread_cond_timedwait()` then returned `EINVAL`, which was ignored, causing an infinite loop and a native test flake.

## Implementation details

- Normalize `tv_nsec` and carry overflow into `tv_sec`.
- Stop waiting and log unexpected pthread errors.
- Add regression coverage for waits crossing a second boundary.

## Test coverage

- Added `EnsureTimeoutAcrossSecondBoundaryIsHandled`.
- Going to rely on CI again for the actual running of the test

## Other details

#incident-57303


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
