### PR TITLE
Make DSM transaction writer test deterministic

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -71,15 +71,25 @@ public class DataStreamsWriterTests
     [Fact]
     public async Task WhenSupported_TracksTransactions()
     {
-        var bucketDurationMs = 100;
+        var bucketDurationMs = int.MaxValue;
         var api = new StubApi();
         var writer = CreateWriter(api, out var discovery, bucketDurationMs);
         TriggerSupportUpdate(discovery, isSupported: true);
 
-        writer.AddTransaction(new DataStreamsTransactionInfo("id", 1, "checkpoint"));
-        await api.WaitForCount(1, 30_000);
+        var transaction = new DataStreamsTransactionInfo("id", 1, "checkpoint");
+        writer.AddTransaction(transaction);
+        await writer.FlushAsync();
 
-        HasOneOrTwoPoints(api);
+        var sent = api.Sent.Should().ContainSingle().Subject;
+        using var compressed = new MemoryStream(sent.Array!, sent.Offset, sent.Count);
+        using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
+        using var decompressed = new MemoryStream();
+        await gzip.CopyToAsync(decompressed);
+
+        var payload = MessagePackSerializer.Deserialize<MockDataStreamsPayload>(decompressed.ToArray());
+        payload.Stats.Should().ContainSingle();
+        payload.Stats[0].Transactions.Should().Equal(transaction.GetBytes());
+
         await writer.DisposeAsync();
     }
 
@@ -252,25 +262,6 @@ public class DataStreamsWriterTests
         await writer.DisposeAsync();
 
         api.Sent.Should().ContainSingle();
-    }
-
-    [Fact]
-    public async Task FlushAsync_DrainsPendingTransactions()
-    {
-        // int.MaxValue bucket: timer will never fire and ShouldFlushTransactions
-        // won't trigger for a small payload.  FlushAsync must drain _transactionBuffer
-        // directly — it is called immediately so ProcessQueueLoop has not yet woken
-        // from its initial 10 ms sleep.
-        var bucketDuration = int.MaxValue;
-        var api = new StubApi();
-        var writer = CreateWriter(api, out var discovery, bucketDuration);
-        TriggerSupportUpdate(discovery, isSupported: true);
-
-        writer.AddTransaction(new DataStreamsTransactionInfo("tx-id", 1L, "cp"));
-        await writer.FlushAsync();
-
-        api.Sent.Should().NotBeEmpty("FlushAsync must drain the transaction buffer");
-        await writer.DisposeAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of changes

- Make `WhenSupported_TracksTransactions` explicitly flush the writer instead of waiting for the periodic background flush.
- Validate the exact transaction bytes in the gzip/messagepack payload.
- Remove the now-redundant `FlushAsync_DrainsPendingTransactions` test.

## Reason for change

`WhenSupported_TracksTransactions` flakes under heavy CI load because it polls the stub API for up to 30 seconds while relying on the periodic timer and background flush task to be scheduled.

This is similar to the flake addressed in #8872, but that change only updated the adjacent transaction threshold test. The older transaction tracking test retained the same scheduling dependency.

The failure does not indicate incorrect transaction serialization: no payload was sent before the timeout.

## Implementation details

The rewritten test disables the periodic timer, adds a transaction, and calls `FlushAsync()` directly. It then decompresses and deserializes the resulting payload and verifies that it contains the exact expected transaction bytes.

This does not remove periodic-flush coverage. Timer-driven flushing is payload-agnostic and remains covered by `WhenSupported_WritesAStatsPointAfterDelay`.

Transaction-specific paths remain covered as follows:

- `WhenSupported_TracksTransactions` verifies queue draining, payload emission, and transaction serialization.
- `WhenSupported_WritesTransaction_OnClose` verifies shutdown flushing.
- `WhenSupported_TriggersEarlyFlush_WhenTransactionsExceedThreshold` verifies threshold-triggered flushing.

`FlushAsync_DrainsPendingTransactions` was removed because the rewritten test exercises the same flush path with stronger assertions. The removed test only checked that some payload was emitted.

## Test coverage

Ran locally, all passed again

## Other details

#incident-57303

<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
