### PR TITLE
Add pagination metrics for known tests fetch

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.GetKnownTestsAsync.cs
+++ b/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.GetKnownTestsAsync.cs
@@ -6,6 +6,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci.Telemetry;
 using Datadog.Trace.Telemetry;
@@ -42,6 +43,8 @@ internal sealed partial class TestOptimizationClient
         // An explicit empty "tests": {} payload keeps known-tests enabled, so we must
         // preserve that distinction from an invalid or missing known-tests response.
         var sawExplicitTestsPayload = false;
+        var totalRequestMs = 0.0; // Accumulator for sum of per-request durations
+        var fetchStopwatch = Stopwatch.StartNew();
         string? pageState = null;
         var pageNumber = 0;
 
@@ -61,7 +64,26 @@ internal sealed partial class TestOptimizationClient
             string? queryResponse;
             try
             {
-                queryResponse = await SendJsonRequestAsync<KnownTestsCallbacks>(_knownTestsUrl, jsonQuery).ConfigureAwait(false);
+                queryResponse = await SendJsonRequestAsync(
+                    _knownTestsUrl,
+                    jsonQuery,
+                    new ActionCallbacks(
+                        onBeforeSend: () => TelemetryFactory.Metrics.RecordCountCIVisibilityKnownTestsRequest(MetricTags.CIVisibilityRequestCompressed.Uncompressed),
+                        onStatusCodeReceived: (statusCode, responseLength) =>
+                        {
+                            TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsResponseBytes(MetricTags.CIVisibilityResponseCompressed.Uncompressed, responseLength);
+                            if (TelemetryHelper.GetErrorTypeFromStatusCode(statusCode) is { } errorType)
+                            {
+                                TelemetryFactory.Metrics.RecordCountCIVisibilityKnownTestsRequestErrors(errorType);
+                            }
+                        },
+                        onError: ex => TelemetryFactory.Metrics.RecordCountCIVisibilityKnownTestsRequestErrors(MetricTags.CIVisibilityErrorType.Network),
+                        onAfterSend: totalMs =>
+                        {
+                            totalRequestMs += totalMs;
+                            TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsRequestMs(totalMs);
+                        }))
+                    .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -126,6 +148,8 @@ internal sealed partial class TestOptimizationClient
         }
         while (pageNumber < MaxKnownTestsPages);
 
+        fetchStopwatch.Stop();
+
         if (pageNumber >= MaxKnownTestsPages)
         {
             Log.Warning<int>("TestOptimizationClient: Known tests pagination exceeded maximum of {MaxPages} pages. Returning data collected so far.", MaxKnownTestsPages);
@@ -155,6 +179,9 @@ internal sealed partial class TestOptimizationClient
         }
 
         TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsResponseTests(testsCount);
+        TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsPagesFetched(pageNumber);
+        TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsTotalFetchMs(fetchStopwatch.Elapsed.TotalMilliseconds);
+        TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsTotalRequestMs(totalRequestMs);
         return finalResponse;
     }
 
@@ -206,33 +233,6 @@ internal sealed partial class TestOptimizationClient
         }
 
         return aggregate;
-    }
-
-    private readonly struct KnownTestsCallbacks : ICallbacks
-    {
-        public void OnBeforeSend()
-        {
-            TelemetryFactory.Metrics.RecordCountCIVisibilityKnownTestsRequest(MetricTags.CIVisibilityRequestCompressed.Uncompressed);
-        }
-
-        public void OnStatusCodeReceived(int statusCode, int responseLength)
-        {
-            TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsResponseBytes(MetricTags.CIVisibilityResponseCompressed.Uncompressed, responseLength);
-            if (TelemetryHelper.GetErrorTypeFromStatusCode(statusCode) is { } errorType)
-            {
-                TelemetryFactory.Metrics.RecordCountCIVisibilityKnownTestsRequestErrors(errorType);
-            }
-        }
-
-        public void OnError(Exception ex)
-        {
-            TelemetryFactory.Metrics.RecordCountCIVisibilityKnownTestsRequestErrors(MetricTags.CIVisibilityErrorType.Network);
-        }
-
-        public void OnAfterSend(double totalMs)
-        {
-            TelemetryFactory.Metrics.RecordDistributionCIVisibilityKnownTestsRequestMs(totalMs);
-        }
     }
 
     private readonly struct KnownTestsQuery

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/DistributionCIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/DistributionCIVisibility.cs
@@ -106,6 +106,24 @@ internal enum DistributionCIVisibility
     KnownTestsResponseTests,
 
     /// <summary>
+    /// The number of pages fetched during known tests pagination by CI Visibility
+    /// </summary>
+    [TelemetryMetric("known_tests.pages_fetched", isCommon: true, NS.CIVisibility)]
+    KnownTestsPagesFetched,
+
+    /// <summary>
+    /// The total wall-clock time in ms for fetching all known tests pages by CI Visibility
+    /// </summary>
+    [TelemetryMetric("known_tests.total_fetch_ms", isCommon: true, NS.CIVisibility)]
+    KnownTestsTotalFetchMs,
+
+    /// <summary>
+    /// The sum of request durations in ms across all known tests pages by CI Visibility
+    /// </summary>
+    [TelemetryMetric("known_tests.total_request_ms", isCommon: true, NS.CIVisibility)]
+    KnownTestsTotalRequestMs,
+
+    /// <summary>
     /// The time it takes to get the response of the impacted tests detection endpoint request in ms by CI Visibility
     /// </summary>
     [TelemetryMetric("impacted_tests_detection.request_ms", isCommon: true, NS.CIVisibility)] ImpactedTestsDetectionRequestMs,

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -753,4 +753,92 @@ public class MetricsTelemetryCollectorTests
             x.Points.Single().Value == 1);
         await collector.DisposeAsync();
     }
+
+    [Fact]
+    public async Task KnownTestsPaginationMetrics_AreRecordedCorrectly()
+    {
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+
+        // Record pagination metrics
+        collector.RecordDistributionCIVisibilityKnownTestsPagesFetched(3);
+        collector.RecordDistributionCIVisibilityKnownTestsTotalFetchMs(1500.5);
+        collector.RecordDistributionCIVisibilityKnownTestsTotalRequestMs(1200.25);
+
+        collector.AggregateMetrics();
+
+        var metrics = collector.GetMetrics();
+
+        using var scope = new AssertionScope();
+
+        metrics.Distributions.Should().Contain(x =>
+            x.Metric == DistributionCIVisibility.KnownTestsPagesFetched.GetName() &&
+            x.Points != null &&
+            x.Points.Single() == 3 &&
+            x.Common == true &&
+            x.Namespace == NS.CIVisibility);
+
+        metrics.Distributions.Should().Contain(x =>
+            x.Metric == DistributionCIVisibility.KnownTestsTotalFetchMs.GetName() &&
+            x.Points != null &&
+            x.Points.Single() == 1500.5 &&
+            x.Common == true &&
+            x.Namespace == NS.CIVisibility);
+
+        metrics.Distributions.Should().Contain(x =>
+            x.Metric == DistributionCIVisibility.KnownTestsTotalRequestMs.GetName() &&
+            x.Points != null &&
+            x.Points.Single() == 1200.25 &&
+            x.Common == true &&
+            x.Namespace == NS.CIVisibility);
+
+        await collector.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task KnownTestsPaginationMetrics_AggregateMultipleValues()
+    {
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+
+        // Simulate multiple fetch operations
+        collector.RecordDistributionCIVisibilityKnownTestsPagesFetched(1);
+        collector.RecordDistributionCIVisibilityKnownTestsTotalFetchMs(500.0);
+        collector.RecordDistributionCIVisibilityKnownTestsTotalRequestMs(450.0);
+
+        collector.AggregateMetrics();
+
+        // Second fetch operation
+        collector.RecordDistributionCIVisibilityKnownTestsPagesFetched(5);
+        collector.RecordDistributionCIVisibilityKnownTestsTotalFetchMs(2500.0);
+        collector.RecordDistributionCIVisibilityKnownTestsTotalRequestMs(2300.0);
+
+        collector.AggregateMetrics();
+
+        var metrics = collector.GetMetrics();
+
+        using var scope = new AssertionScope();
+
+        // Should contain both values
+        metrics.Distributions.Should().Contain(x =>
+            x.Metric == DistributionCIVisibility.KnownTestsPagesFetched.GetName() &&
+            x.Points != null &&
+            x.Points.Length == 2 &&
+            x.Points.Contains(1) &&
+            x.Points.Contains(5));
+
+        metrics.Distributions.Should().Contain(x =>
+            x.Metric == DistributionCIVisibility.KnownTestsTotalFetchMs.GetName() &&
+            x.Points != null &&
+            x.Points.Length == 2 &&
+            x.Points.Contains(500.0) &&
+            x.Points.Contains(2500.0));
+
+        metrics.Distributions.Should().Contain(x =>
+            x.Metric == DistributionCIVisibility.KnownTestsTotalRequestMs.GetName() &&
+            x.Points != null &&
+            x.Points.Length == 2 &&
+            x.Points.Contains(450.0) &&
+            x.Points.Contains(2300.0));
+
+        await collector.DisposeAsync();
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Adds three new distribution metrics to track known tests (Early Flake Detection) pagination behavior:

- `known_tests.pages_fetched` - Number of pages fetched during pagination
- `known_tests.total_fetch_ms` - Wall-clock time from first to last page request
- `known_tests.total_request_ms` - Sum of individual per-page request durations

## Motivation

Currently, only per-request timing is tracked via `known_tests.request_ms`. These new metrics provide observability into:
- How often pagination occurs (single vs multi-page responses)
- Backend pagination performance (total wall-clock time)
- Network overhead vs local processing time (total_fetch_ms vs total_request_ms)

## Implementation Details

- Added enum entries to `DistributionCIVisibility.cs` with telemetry attributes
- Refactored `GetKnownTestsAsync` to use `ActionCallbacks` with closures for accumulating request timing
- Added `Stopwatch` to track wall-clock duration across pagination loop
- Metrics are emitted **only on successful completion** after all pages are fetched
- Source generators will create extension methods on next build

## Testing

- Added 2 unit tests to `MetricsTelemetryCollectorTests.cs`:
  - `KnownTestsPaginationMetrics_AreRecordedCorrectly` - single value recording
  - `KnownTestsPaginationMetrics_AggregateMultipleValues` - aggregation across multiple fetches
- Follows existing telemetry testing pattern (direct collector testing)
- CI will run full test suite after build + source generation

## Checklist

- [x] Tests added following existing patterns
- [x] Backward compatible (no breaking changes)
- [x] Follows existing telemetry patterns
- [ ] CI build + tests (source generation required)