### PR TITLE
Attempt to fix more flake in System.Data.SqlClient

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.SqlServer/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.SqlServer/Program.cs
@@ -68,12 +68,15 @@ namespace Samples.SqlServer
                 }
 
                 await RelationalDatabaseTestHarness.RunAllAsync<SqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
+
+                // RunAllAsync produces a single large trace. Flush it before starting the next trace so
+                // it cannot be dropped while competing with the SqlCommandVb trace for the writer's buffers.
+                await SampleHelpers.ForceTracerFlushAsync();
+
                 await RelationalDatabaseTestHarness.RunSingleAsync(connection, commandFactory, commandExecutorVb, cts.Token);
             }
 
-            // Flush the first phase's traces before starting the next phase. The default-provider phase
-            // produces large traces, so draining them first stops them from competing with the next phase
-            // for the writer's buffers (a locally dropped trace here would fail the exact span-count assertion in the test).
+            // Flush the SqlCommandVb trace before starting the next phase.
             await SampleHelpers.ForceTracerFlushAsync();
 
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile


### PR DESCRIPTION
## Summary of changes

Flushes the large `RunAllAsync` trace before starting the `SqlCommandVb` trace

## Reason for change

`SystemDataSqlClientTests.SubmitsTraces` intermittently received 105 spans, consistent with the entire initial `RunAllAsync` trace being absent.

The previous mitigation flushed only after both traces had completed, leaving a timing window for the first trace.

## Implementation details

Moved the flush

## Test coverage


This is it

## Other details
<!-- Fixes #{issue} -->

Follow-up to #8871 

#incident-57303
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
