### PR TITLE
[CI] Use shallow checkouts for smoke tests

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -167,31 +167,131 @@ steps:
     displayName: clean
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-  # Git 2.25 requires partial-clone metadata before using fetch --filter
   - ${{ if eq(parameters.shallowFetch, true) }}:
-    - bash: |
-        git init "$BUILD_REPOSITORY_LOCALPATH"
-        git -C "$BUILD_REPOSITORY_LOCALPATH" config core.repositoryFormatVersion 1
-        git -C "$BUILD_REPOSITORY_LOCALPATH" config extensions.partialClone origin
-      displayName: initialize partial clone
-      condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
+    - checkout: none
 
-    - powershell: |
-        $localPath=$env:BUILD_REPOSITORY_LOCALPATH
+    - bash: |
+        set -eo pipefail
+
+        localPath="$BUILD_REPOSITORY_LOCALPATH"
+        sparseDirectories=(
+          .azure-pipelines
+          .gitlab
+          .nuke
+          tracer/build/_build
+          tracer/build/smoke_test_snapshots
+          tracer/test/test-applications/regression/AspNetCoreSmokeTest
+        )
+
         git init "$localPath"
         git -C "$localPath" config core.repositoryFormatVersion 1
         git -C "$localPath" config extensions.partialClone origin
-      displayName: initialize partial clone
+        git -C "$localPath" config gc.auto 0
+        git -C "$localPath" config http.version HTTP/1.1
+
+        if git -C "$localPath" remote get-url origin >/dev/null 2>&1; then
+          git -C "$localPath" remote set-url origin "$BUILD_REPOSITORY_URI"
+        else
+          git -C "$localPath" remote add origin "$BUILD_REPOSITORY_URI"
+        fi
+
+        git -C "$localPath" config remote.origin.promisor true
+        git -C "$localPath" config remote.origin.partialCloneFilter tree:0
+
+        git -C "$localPath" sparse-checkout init --cone
+        git -C "$localPath" sparse-checkout set "${sparseDirectories[@]}"
+
+        fetchSucceeded=false
+        for attempt in 1 2 3; do
+          echo "Fetch attempt $attempt/3"
+          if git -C "$localPath" fetch --force --no-tags --depth=1 --filter=tree:0 origin "$BUILD_SOURCEVERSION"; then
+            fetchSucceeded=true
+            break
+          fi
+
+          if [ "$attempt" -lt 3 ]; then
+            sleep $((attempt * 5))
+          fi
+        done
+
+        if [ "$fetchSucceeded" != true ]; then
+          echo "Failed to fetch $BUILD_SOURCEVERSION after 3 attempts"
+          exit 1
+        fi
+
+        git -C "$localPath" checkout --force --detach FETCH_HEAD
+        test "$(git -C "$localPath" rev-parse HEAD)" = "$BUILD_SOURCEVERSION"
+      displayName: sparse checkout
+      condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
+
+    - powershell: |
+        $ErrorActionPreference = "Stop"
+
+        function Invoke-Git {
+          & git @args
+          if ($LASTEXITCODE -ne 0) {
+            throw "git $args failed with exit code $LASTEXITCODE"
+          }
+        }
+
+        $localPath=$env:BUILD_REPOSITORY_LOCALPATH
+        $sparseDirectories = @(
+          ".azure-pipelines",
+          ".gitlab",
+          ".nuke",
+          "tracer/build/_build",
+          "tracer/build/smoke_test_snapshots",
+          "tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+        )
+
+        Invoke-Git init "$localPath"
+        Invoke-Git -C "$localPath" config core.repositoryFormatVersion 1
+        Invoke-Git -C "$localPath" config extensions.partialClone origin
+        Invoke-Git -C "$localPath" config gc.auto 0
+        Invoke-Git -C "$localPath" config http.version HTTP/1.1
+
+        $originUrl = & git -C "$localPath" config --get remote.origin.url
+        if ($LASTEXITCODE -eq 0) {
+          Invoke-Git -C "$localPath" remote set-url origin "$env:BUILD_REPOSITORY_URI"
+        } else {
+          Invoke-Git -C "$localPath" remote add origin "$env:BUILD_REPOSITORY_URI"
+        }
+
+        Invoke-Git -C "$localPath" config remote.origin.promisor true
+        Invoke-Git -C "$localPath" config remote.origin.partialCloneFilter tree:0
+
+        Invoke-Git -C "$localPath" sparse-checkout init --cone
+        & git -C "$localPath" sparse-checkout set @sparseDirectories
+        if ($LASTEXITCODE -ne 0) {
+          throw "Failed to configure sparse checkout"
+        }
+
+        $fetchSucceeded = $false
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+          Write-Host "Fetch attempt $attempt/3"
+          & git -C "$localPath" fetch --force --no-tags --depth=1 --filter=tree:0 origin "$env:BUILD_SOURCEVERSION"
+          if ($LASTEXITCODE -eq 0) {
+            $fetchSucceeded = $true
+            break
+          }
+
+          if ($attempt -lt 3) {
+            Start-Sleep -Seconds ($attempt * 5)
+          }
+        }
+
+        if (-not $fetchSucceeded) {
+          throw "Failed to fetch $env:BUILD_SOURCEVERSION after 3 attempts"
+        }
+
+        Invoke-Git -C "$localPath" checkout --force --detach FETCH_HEAD
+        $actualSha = Invoke-Git -C "$localPath" rev-parse HEAD
+        if ($actualSha.Trim() -ne $env:BUILD_SOURCEVERSION) {
+          throw "Checked out $actualSha instead of $env:BUILD_SOURCEVERSION"
+        }
+      displayName: sparse checkout
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-  - checkout: self
-    clean: true
-    ${{ if eq(parameters.shallowFetch, true) }}:
-      fetchDepth: 1
-      fetchFilter: tree:0
-      fetchTags: false
-      # Only materialize the source files used by smoke-test jobs
-      sparseCheckoutDirectories: >-
-        .azure-pipelines .gitlab .nuke
-        tracer/build/_build tracer/build/smoke_test_snapshots
-        tracer/test/test-applications/regression/AspNetCoreSmokeTest
+  - ${{ else }}:
+    - checkout: self
+      clean: true

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -168,128 +168,29 @@ steps:
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   - ${{ if eq(parameters.shallowFetch, true) }}:
-    - checkout: none
-
     - bash: |
         set -eo pipefail
 
-        localPath="$BUILD_REPOSITORY_LOCALPATH"
-        sparseDirectories=(
-          .azure-pipelines
-          .gitlab
-          .nuke
-          tracer/build/_build
-          tracer/build/smoke_test_snapshots
-          tracer/test/test-applications/regression/AspNetCoreSmokeTest
-        )
+        ref="$BUILD_SOURCEBRANCH"
+        ref="${ref#refs/heads/}"
+        ref="${ref#refs/tags/}"
 
-        git init "$localPath"
-        git -C "$localPath" config core.repositoryFormatVersion 1
-        git -C "$localPath" config extensions.partialClone origin
-        git -C "$localPath" config gc.auto 0
-        git -C "$localPath" config http.version HTTP/1.1
+        git clone --depth=1 --filter=tree:0 --sparse --no-tags --branch "$ref" "$BUILD_REPOSITORY_URI" "$BUILD_REPOSITORY_LOCALPATH"
+        git -C "$BUILD_REPOSITORY_LOCALPATH" sparse-checkout set .azure-pipelines .gitlab .nuke tracer/build/_build tracer/build/smoke_test_snapshots tracer/test/test-applications/regression/AspNetCoreSmokeTest
 
-        if git -C "$localPath" remote get-url origin >/dev/null 2>&1; then
-          git -C "$localPath" remote set-url origin "$BUILD_REPOSITORY_URI"
-        else
-          git -C "$localPath" remote add origin "$BUILD_REPOSITORY_URI"
-        fi
-
-        git -C "$localPath" config remote.origin.promisor true
-        git -C "$localPath" config remote.origin.partialCloneFilter tree:0
-
-        git -C "$localPath" sparse-checkout init --cone
-        git -C "$localPath" sparse-checkout set "${sparseDirectories[@]}"
-
-        fetchSucceeded=false
-        for attempt in 1 2 3; do
-          echo "Fetch attempt $attempt/3"
-          if git -C "$localPath" fetch --force --no-tags --depth=1 --filter=tree:0 origin "$BUILD_SOURCEVERSION"; then
-            fetchSucceeded=true
-            break
-          fi
-
-          if [ "$attempt" -lt 3 ]; then
-            sleep $((attempt * 5))
-          fi
-        done
-
-        if [ "$fetchSucceeded" != true ]; then
-          echo "Failed to fetch $BUILD_SOURCEVERSION after 3 attempts"
-          exit 1
-        fi
-
-        git -C "$localPath" checkout --force --detach FETCH_HEAD
-        test "$(git -C "$localPath" rev-parse HEAD)" = "$BUILD_SOURCEVERSION"
+        test "$(git -C "$BUILD_REPOSITORY_LOCALPATH" rev-parse HEAD)" = "$BUILD_SOURCEVERSION"
       displayName: sparse checkout
       condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
 
-    - powershell: |
-        $ErrorActionPreference = "Stop"
-
-        function Invoke-Git {
-          & git @args
-          if ($LASTEXITCODE -ne 0) {
-            throw "git $args failed with exit code $LASTEXITCODE"
-          }
-        }
-
-        $localPath=$env:BUILD_REPOSITORY_LOCALPATH
-        $sparseDirectories = @(
-          ".azure-pipelines",
-          ".gitlab",
-          ".nuke",
-          "tracer/build/_build",
-          "tracer/build/smoke_test_snapshots",
-          "tracer/test/test-applications/regression/AspNetCoreSmokeTest"
-        )
-
-        Invoke-Git init "$localPath"
-        Invoke-Git -C "$localPath" config core.repositoryFormatVersion 1
-        Invoke-Git -C "$localPath" config extensions.partialClone origin
-        Invoke-Git -C "$localPath" config gc.auto 0
-        Invoke-Git -C "$localPath" config http.version HTTP/1.1
-
-        $originUrl = & git -C "$localPath" config --get remote.origin.url
-        if ($LASTEXITCODE -eq 0) {
-          Invoke-Git -C "$localPath" remote set-url origin "$env:BUILD_REPOSITORY_URI"
-        } else {
-          Invoke-Git -C "$localPath" remote add origin "$env:BUILD_REPOSITORY_URI"
-        }
-
-        Invoke-Git -C "$localPath" config remote.origin.promisor true
-        Invoke-Git -C "$localPath" config remote.origin.partialCloneFilter tree:0
-
-        Invoke-Git -C "$localPath" sparse-checkout init --cone
-        & git -C "$localPath" sparse-checkout set @sparseDirectories
-        if ($LASTEXITCODE -ne 0) {
-          throw "Failed to configure sparse checkout"
-        }
-
-        $fetchSucceeded = $false
-        for ($attempt = 1; $attempt -le 3; $attempt++) {
-          Write-Host "Fetch attempt $attempt/3"
-          & git -C "$localPath" fetch --force --no-tags --depth=1 --filter=tree:0 origin "$env:BUILD_SOURCEVERSION"
-          if ($LASTEXITCODE -eq 0) {
-            $fetchSucceeded = $true
-            break
-          }
-
-          if ($attempt -lt 3) {
-            Start-Sleep -Seconds ($attempt * 5)
-          }
-        }
-
-        if (-not $fetchSucceeded) {
-          throw "Failed to fetch $env:BUILD_SOURCEVERSION after 3 attempts"
-        }
-
-        Invoke-Git -C "$localPath" checkout --force --detach FETCH_HEAD
-        $actualSha = Invoke-Git -C "$localPath" rev-parse HEAD
-        if ($actualSha.Trim() -ne $env:BUILD_SOURCEVERSION) {
-          throw "Checked out $actualSha instead of $env:BUILD_SOURCEVERSION"
-        }
-      displayName: sparse checkout
+    - checkout: self
+      clean: true
+      fetchDepth: 1
+      fetchFilter: tree:0
+      fetchTags: false
+      sparseCheckoutDirectories: >-
+        .azure-pipelines .gitlab .nuke
+        tracer/build/_build tracer/build/smoke_test_snapshots
+        tracer/test/test-applications/regression/AspNetCoreSmokeTest
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
   - ${{ else }}:

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -5,6 +5,10 @@ parameters:
   - name: targetBranch
     type: string
 
+  - name: shallowFetch
+    type: boolean
+    default: false
+
 steps:
 - ${{ if endsWith(variables['build.sourceBranch'], '/merge') }}:
   - checkout: none
@@ -165,3 +169,6 @@ steps:
 
   - checkout: self
     clean: true
+    ${{ if eq(parameters.shallowFetch, true) }}:
+      fetchDepth: 1
+      fetchTags: false

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -167,32 +167,8 @@ steps:
     displayName: clean
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-  - ${{ if eq(parameters.shallowFetch, true) }}:
-    - bash: |
-        set -eo pipefail
-
-        ref="$BUILD_SOURCEBRANCH"
-        ref="${ref#refs/heads/}"
-        ref="${ref#refs/tags/}"
-
-        git clone --depth=1 --filter=tree:0 --sparse --no-tags --branch "$ref" "$BUILD_REPOSITORY_URI" "$BUILD_REPOSITORY_LOCALPATH"
-        git -C "$BUILD_REPOSITORY_LOCALPATH" sparse-checkout set .azure-pipelines .gitlab .nuke tracer/build/_build tracer/build/smoke_test_snapshots tracer/test/test-applications/regression/AspNetCoreSmokeTest
-
-        test "$(git -C "$BUILD_REPOSITORY_LOCALPATH" rev-parse HEAD)" = "$BUILD_SOURCEVERSION"
-      displayName: sparse checkout
-      condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
-
-    - checkout: self
-      clean: true
+  - checkout: self
+    clean: true
+    ${{ if eq(parameters.shallowFetch, true) }}:
       fetchDepth: 1
-      fetchFilter: tree:0
       fetchTags: false
-      sparseCheckoutDirectories: >-
-        .azure-pipelines .gitlab .nuke
-        tracer/build/_build tracer/build/smoke_test_snapshots
-        tracer/test/test-applications/regression/AspNetCoreSmokeTest
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-
-  - ${{ else }}:
-    - checkout: self
-      clean: true

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -171,4 +171,5 @@ steps:
     clean: true
     ${{ if eq(parameters.shallowFetch, true) }}:
       fetchDepth: 1
+      fetchFilter: tree:0
       fetchTags: false

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -167,9 +167,31 @@ steps:
     displayName: clean
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
+  # Git 2.25 requires partial-clone metadata before using fetch --filter
+  - ${{ if eq(parameters.shallowFetch, true) }}:
+    - bash: |
+        git init "$BUILD_REPOSITORY_LOCALPATH"
+        git -C "$BUILD_REPOSITORY_LOCALPATH" config core.repositoryFormatVersion 1
+        git -C "$BUILD_REPOSITORY_LOCALPATH" config extensions.partialClone origin
+      displayName: initialize partial clone
+      condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
+
+    - powershell: |
+        $localPath=$env:BUILD_REPOSITORY_LOCALPATH
+        git init "$localPath"
+        git -C "$localPath" config core.repositoryFormatVersion 1
+        git -C "$localPath" config extensions.partialClone origin
+      displayName: initialize partial clone
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
   - checkout: self
     clean: true
     ${{ if eq(parameters.shallowFetch, true) }}:
       fetchDepth: 1
       fetchFilter: tree:0
       fetchTags: false
+      # Only materialize the source files used by smoke-test jobs
+      sparseCheckoutDirectories: >-
+        .azure-pipelines .gitlab .nuke
+        tracer/build/_build tracer/build/smoke_test_snapshots
+        tracer/test/test-applications/regression/AspNetCoreSmokeTest

--- a/.azure-pipelines/steps/run-smoke-tests-linux.yml
+++ b/.azure-pipelines/steps/run-smoke-tests-linux.yml
@@ -24,6 +24,7 @@ jobs:
     parameters:
       targetShaId: $(targetShaId)
       targetBranch: $(targetBranch)
+      shallowFetch: true
 
   # Download required artifacts. runner-standalone-* artifacts are tar.gz
   # archives that need to be extracted; all others download directly.

--- a/.azure-pipelines/steps/run-smoke-tests-windows.yml
+++ b/.azure-pipelines/steps/run-smoke-tests-windows.yml
@@ -25,6 +25,7 @@ jobs:
     parameters:
       targetShaId: $(targetShaId)
       targetBranch: $(targetBranch)
+      shallowFetch: true
 
   # Download required artifacts to the output directory
   - ${{ each artifact in parameters.artifacts }}:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5656,6 +5656,7 @@ stages:
           parameters:
             targetShaId: $(targetShaId)
             targetBranch: $(targetBranch)
+            shallowFetch: true
 
         - script: |
             if docker image inspect "$(runtimeImage)" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary of changes

Use depth-1 checkouts without tags for smoke-test jobs.

## Reason for change

Master builds intermittently time out during repository checkout before the smoke tests run. The default checkout downloads the repository history and tags, which can exceed the 20-minute job timeout when the network is seemingly slow (unsure why it only started cropping up recently)

## Implementation details

Adds an opt-in `shallowFetch` parameter to the shared checkout template. Linux and Windows smoke-test jobs enable it

- `fetchDepth: 1`
- `fetchTags: false`


## Test coverage

😬 just gonna be on CI I guess
since this won't be run on _this_ CI run I made a separate manual run of it here which I should test this out, I will verify this though

https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=205203&view=results

## Other details

#incident-57303
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
