### PR TITLE
[Tests] Fix Elasticsearch integration test span counts

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -60,6 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     {
                         "Bulk",
                         "Create",
+                        "Count",
                         "Search",
                         "DeleteByQuery",
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -61,6 +61,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     {
                         "Bulk",
                         "Create",
+                        "Create",
+                        "Count",
                         "Search",
                         "DeleteByQuery",
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -58,6 +58,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     {
                         "Bulk",
                         "Create",
+                        "Create",
+                        "Count",
                         "Search",
                         "DeleteByQuery",
 


### PR DESCRIPTION
## Summary of changes

Update the expected span counts in the Elasticsearch 5, 6, and 7 integration tests

## Reason for change

Test flaked and noticed the number of expected spans wasn't correct, essentially we had some commands that we instrument but they were missing. The asserted number was a `<=` which caused rare flake and would seemingly pass before getting all spans.

## Implementation details

- Add the missing `Count` expectation for Elasticsearch 5.
- Add the missing second `Create` and `Count` expectations for Elasticsearch 6 and 7.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
