### PR TITLE
[Profiler] Add Reader/Writer Spinning mutex

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -48,7 +48,12 @@ if (RUN_UBSAN)
 endif()
 
 if (RUN_TSAN)
-    add_compile_options(-fsanitize=thread -g -fno-omit-frame-pointer -DDD_SANITIZERS)
+    # DD_SANITIZE_THREAD (distinct from the general DD_SANITIZERS flag shared
+    # with ASAN/UBSAN) gates TSAN-only annotations (see SpinningMutex.hpp /
+    # ReaderWriterSpinningMutex.hpp) that call into libtsan's __tsan_mutex_* API.
+    # Those symbols only exist when actually linked with -fsanitize=thread, so
+    # this must NOT be defined under ASAN/UBSAN-only builds.
+    add_compile_options(-fsanitize=thread -g -fno-omit-frame-pointer -DDD_SANITIZERS -DDD_SANITIZE_THREAD)
 endif()
 
 if(ISLINUX)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ReaderWriterSpinningMutex.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ReaderWriterSpinningMutex.hpp
@@ -1,0 +1,338 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+#ifdef DD_SANITIZE_THREAD
+#include <sanitizer/tsan_interface.h>
+#define TSAN_MUTEX_CREATE __tsan_mutex_create
+#define TSAN_MUTEX_DESTROY __tsan_mutex_destroy
+#define TSAN_MUTEX_PRE_LOCK __tsan_mutex_pre_lock
+#define TSAN_MUTEX_POST_LOCK __tsan_mutex_post_lock
+#define TSAN_MUTEX_PRE_UNLOCK __tsan_mutex_pre_unlock
+#define TSAN_MUTEX_POST_UNLOCK __tsan_mutex_post_unlock
+#else
+#define TSAN_MUTEX_CREATE(...)
+#define TSAN_MUTEX_DESTROY(...)
+#define TSAN_MUTEX_PRE_LOCK(...)
+#define TSAN_MUTEX_POST_LOCK(...)
+#define TSAN_MUTEX_PRE_UNLOCK(...)
+#define TSAN_MUTEX_POST_UNLOCK(...)
+#endif
+
+// ReaderWriterSpinningMutex
+// =====================
+//
+// A reader-writer lock built entirely out of std::atomic operations: no
+// pthread mutex, no condition variable, no futex/syscall in the fast path.
+// It is meant as a signal-handler-safe alternative to std::shared_mutex /
+// std::shared_timed_mutex for code that may be read from inside a POSIX
+// signal handler (e.g. the timer_create-based CPU profiler's SIGPROF handler,
+// or the wall-time profiler's SIGUSR1 handler).
+//
+// It satisfies (a relevant subset of) the SharedMutex/SharedTimedMutex named
+// requirements, so it can be used directly with std::shared_lock<T> and
+// std::unique_lock<T>.
+//
+// Design
+// ------
+// A single state word encodes the lock:
+//   0  -> unlocked
+//   -1 -> exclusively locked (by a writer)
+//   N (N > 0) -> N concurrent readers
+//
+// A separate "waiting writer" counter is used purely for fairness: once at
+// least one writer is waiting, new readers back off instead of joining, so a
+// steady stream of readers cannot starve a writer forever. This does NOT
+// change correctness (readers already holding the lock are unaffected), only
+// how quickly a pending writer can get in.
+//
+// Safety note
+// -----------
+// This primitive only makes the *lock itself* signal-safe (bounded, no
+// blocking syscalls beyond an optional short sleep in the slow path, mirrors
+// the existing SpinningMutex.hpp). It does NOT by itself prevent the classic
+// same-thread reentrancy deadlock (writer holds the lock, gets interrupted by
+// a signal targeted at the very same thread, and the handler tries to take
+// the lock too). Bounded try_lock_for/try_lock_shared_for calls turn that
+// scenario into "handler gives up after the timeout" rather than "hang
+// forever", which is the same trade-off already made by ManagedCodeCache
+// today. If true reentrancy-proof behavior is required, combine this with
+// blocking the relevant signals for the duration of the write (see
+// ScopedProfilerSignalBlocker in ManagedCodeCache.cpp) or avoid the lock
+// entirely on the read path (we could seek for a lock-free append-only design).
+class ReaderWriterSpinningMutex
+{
+public:
+    ReaderWriterSpinningMutex() noexcept :
+        _state(0),
+        _waitingWriters(0)
+    {
+        TSAN_MUTEX_CREATE(this, __tsan_mutex_not_static);
+    }
+
+    ~ReaderWriterSpinningMutex()
+    {
+        TSAN_MUTEX_DESTROY(this, __tsan_mutex_not_static);
+    }
+
+    ReaderWriterSpinningMutex(const ReaderWriterSpinningMutex&) = delete;
+    ReaderWriterSpinningMutex& operator=(const ReaderWriterSpinningMutex&) = delete;
+    ReaderWriterSpinningMutex(ReaderWriterSpinningMutex&&) = delete;
+    ReaderWriterSpinningMutex& operator=(ReaderWriterSpinningMutex&&) = delete;
+
+    // -------------------------------------------------------------------
+    // Exclusive (writer) API
+    // -------------------------------------------------------------------
+
+    void lock() noexcept
+    {
+        // Fast path: skip the (noinline) slow path and the waiting-writer
+        // bookkeeping entirely when the lock is immediately available, which
+        // is the common case for short-lived writer critical sections.
+        if (try_lock())
+        {
+            return;
+        }
+
+        WaitingWriterGuard waitingGuard(_waitingWriters);
+        try_lock_exclusive_until_slow(std::chrono::steady_clock::time_point::max());
+    }
+
+    template <typename Rep, typename Period>
+    bool try_lock_for(std::chrono::duration<Rep, Period> timeout_duration) noexcept
+    {
+        if (try_lock())
+        {
+            return true;
+        }
+
+        WaitingWriterGuard waitingGuard(_waitingWriters);
+        return try_lock_exclusive_until_slow(std::chrono::steady_clock::now() + timeout_duration);
+    }
+
+    template <typename Clock, typename Duration>
+    bool try_lock_until(std::chrono::time_point<Clock, Duration> timeout_time) noexcept
+    {
+        return try_lock_for(timeout_time - Clock::now());
+    }
+
+    bool try_lock() noexcept
+    {
+        TSAN_MUTEX_PRE_LOCK(this, __tsan_mutex_try_lock);
+        int32_t expected = kFree;
+        bool result = _state.compare_exchange_strong(expected, kExclusive,
+                                                       std::memory_order_acquire,
+                                                       std::memory_order_relaxed);
+        TSAN_MUTEX_POST_LOCK(this, result ? __tsan_mutex_try_lock : __tsan_mutex_try_lock_failed, 0);
+        return result;
+    }
+
+    void unlock() noexcept
+    {
+        TSAN_MUTEX_PRE_UNLOCK(this, 0);
+        assert(_state.load(std::memory_order_relaxed) == kExclusive);
+        _state.store(kFree, std::memory_order_release);
+        TSAN_MUTEX_POST_UNLOCK(this, 0);
+    }
+
+    // -------------------------------------------------------------------
+    // Shared (reader) API
+    // -------------------------------------------------------------------
+
+    void lock_shared() noexcept
+    {
+        // Fast path: same rationale as lock() above.
+        if (try_lock_shared())
+        {
+            return;
+        }
+
+        try_lock_shared_until_slow(std::chrono::steady_clock::time_point::max());
+    }
+
+    template <typename Rep, typename Period>
+    bool try_lock_shared_for(std::chrono::duration<Rep, Period> timeout_duration) noexcept
+    {
+        if (try_lock_shared())
+        {
+            return true;
+        }
+        return try_lock_shared_until_slow(std::chrono::steady_clock::now() + timeout_duration);
+    }
+
+    template <typename Clock, typename Duration>
+    bool try_lock_shared_until(std::chrono::time_point<Clock, Duration> timeout_time) noexcept
+    {
+        return try_lock_shared_for(timeout_time - Clock::now());
+    }
+
+    bool try_lock_shared() noexcept
+    {
+        TSAN_MUTEX_PRE_LOCK(this, __tsan_mutex_try_lock | __tsan_mutex_read_lock);
+        // Fairness: honor the waiting-writer flag here too, not just in the
+        // slow (blocking) path below. Without this, a tight retry loop of
+        // plain try_lock_shared() calls (which is exactly what a spinning
+        // reader does) would always win the fast path and could starve a
+        // waiting writer indefinitely.
+        // relaxed is enough: _waitingWriters is purely an advisory fairness
+        // hint (it doesn't guard any other memory), so a stale read only
+        // means a reader occasionally wins one extra race before backing
+        // off - a liveness nicety, not a safety property. Correctness is
+        // fully governed by the CAS on _state in try_lock_shared_once().
+        bool result = _waitingWriters.load(std::memory_order_relaxed) == 0 && try_lock_shared_once();
+        TSAN_MUTEX_POST_LOCK(this, (result ? __tsan_mutex_try_lock : __tsan_mutex_try_lock_failed) | __tsan_mutex_read_lock, 0);
+        return result;
+    }
+
+    void unlock_shared() noexcept
+    {
+        TSAN_MUTEX_PRE_UNLOCK(this, __tsan_mutex_read_lock);
+        [[maybe_unused]] auto previous = _state.fetch_sub(1, std::memory_order_release);
+        assert(previous > kFree);
+        TSAN_MUTEX_POST_UNLOCK(this, __tsan_mutex_read_lock);
+    }
+
+    // Exposed for tests only: number of writers currently blocked in lock()/
+    // try_lock_for(). Used to assert on fairness/starvation behavior.
+    int32_t WaitingWriterCountForTest() const noexcept
+    {
+        return _waitingWriters.load(std::memory_order_relaxed);
+    }
+
+private:
+    static constexpr int32_t kFree = 0;
+    static constexpr int32_t kExclusive = -1;
+
+    static constexpr uint32_t kMaxActiveSpin = 4000;
+    static constexpr std::chrono::nanoseconds kYieldSleep = std::chrono::microseconds(500);
+
+    // RAII helper: increments the waiting-writer counter for the lifetime of
+    // a blocking lock() / try_lock_for() call, regardless of how it exits
+    // (success or timeout), so readers can see "a writer is waiting" and back
+    // off without the counter ever leaking upward.
+    struct WaitingWriterGuard
+    {
+        explicit WaitingWriterGuard(std::atomic<int32_t>& counter) noexcept : _counter(counter)
+        {
+            _counter.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        ~WaitingWriterGuard()
+        {
+            _counter.fetch_sub(1, std::memory_order_relaxed);
+        }
+
+        WaitingWriterGuard(const WaitingWriterGuard&) = delete;
+        WaitingWriterGuard& operator=(const WaitingWriterGuard&) = delete;
+
+        std::atomic<int32_t>& _counter;
+    };
+
+    bool try_lock_shared_once() noexcept
+    {
+        int32_t expected = _state.load(std::memory_order_relaxed);
+        while (expected >= kFree)
+        {
+            if (_state.compare_exchange_weak(expected, expected + 1,
+                                              std::memory_order_acquire,
+                                              std::memory_order_relaxed))
+            {
+                return true;
+            }
+            // expected has been updated by compare_exchange_weak; retry unless
+            // a writer holds the lock.
+        }
+        return false;
+    }
+
+    __attribute__((noinline)) bool try_lock_exclusive_until_slow(std::chrono::steady_clock::time_point timeoutTime) noexcept
+    {
+        uint32_t spincount = 0;
+        for (;;)
+        {
+            TSAN_MUTEX_PRE_LOCK(this, __tsan_mutex_try_lock);
+            int32_t expected = kFree;
+            if (_state.compare_exchange_weak(expected, kExclusive,
+                                              std::memory_order_acquire,
+                                              std::memory_order_relaxed))
+            {
+                TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock, 0);
+                return true;
+            }
+            TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock_failed, 0);
+
+            if (spincount < kMaxActiveSpin)
+            {
+                ++spincount;
+#ifdef __x86_64__
+                asm volatile("pause");
+#else
+                asm volatile("yield");
+#endif
+            }
+            else
+            {
+                auto now = std::chrono::steady_clock::now();
+                if (now >= timeoutTime)
+                {
+                    return false;
+                }
+                // Clamp to the remaining budget: unconditionally sleeping the
+                // full kYieldSleep here would let a short deadline (e.g. a
+                // signal handler's bounded try_lock_for) overshoot by nearly
+                // kYieldSleep, since the next deadline check only happens
+                // after waking up.
+                std::this_thread::sleep_for(std::min<std::chrono::steady_clock::duration>(kYieldSleep, timeoutTime - now));
+            }
+        }
+    }
+
+    __attribute__((noinline)) bool try_lock_shared_until_slow(std::chrono::steady_clock::time_point timeoutTime) noexcept
+    {
+        uint32_t spincount = 0;
+        for (;;)
+        {
+            TSAN_MUTEX_PRE_LOCK(this, __tsan_mutex_try_lock | __tsan_mutex_read_lock);
+            // Fairness: if a writer is already waiting, do not let new readers
+            // jump the queue; only readers already holding the lock can keep
+            // going. This bounds how long a writer can be starved.
+            // See try_lock_shared() above for why relaxed is sufficient here.
+            if (_waitingWriters.load(std::memory_order_relaxed) == 0 && try_lock_shared_once())
+            {
+                TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_read_lock, 0);
+                return true;
+            }
+            TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock_failed | __tsan_mutex_read_lock, 0);
+
+            if (spincount < kMaxActiveSpin)
+            {
+                ++spincount;
+#ifdef __x86_64__
+                asm volatile("pause");
+#else
+                asm volatile("yield");
+#endif
+            }
+            else
+            {
+                auto now = std::chrono::steady_clock::now();
+                if (now >= timeoutTime)
+                {
+                    return false;
+                }
+                // See try_lock_exclusive_until_slow() above for why this is
+                // clamped rather than an unconditional sleep_for(kYieldSleep).
+                std::this_thread::sleep_for(std::min<std::chrono::steady_clock::duration>(kYieldSleep, timeoutTime - now));
+            }
+        }
+    }
+
+    std::atomic<int32_t> _state;
+    std::atomic<int32_t> _waitingWriters;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ReaderWriterSpinningMutex.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ReaderWriterSpinningMutex.hpp
@@ -6,7 +6,9 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
-#include <thread>
+
+#include <errno.h>
+#include <time.h>
 
 #ifdef DD_SANITIZE_THREAD
 #include <sanitizer/tsan_interface.h>
@@ -54,12 +56,13 @@
 //
 // Safety note
 // -----------
-// This primitive only makes the *lock itself* signal-safe (bounded, no
-// blocking syscalls beyond an optional short sleep in the slow path, mirrors
-// the existing SpinningMutex.hpp). It does NOT by itself prevent the classic
-// same-thread reentrancy deadlock (writer holds the lock, gets interrupted by
-// a signal targeted at the very same thread, and the handler tries to take
-// the lock too). Bounded try_lock_for/try_lock_shared_for calls turn that
+// This primitive only makes the *lock itself* signal-safe (bounded; the
+// slow path's backoff sleep goes straight to ::clock_nanosleep() rather than
+// std::this_thread::sleep_for(), see BoundedSleep() below for why). It does
+// NOT by itself prevent the classic same-thread reentrancy deadlock (writer
+// holds the lock, gets interrupted by a signal targeted at the very same
+// thread, and the handler tries to take the lock too). Bounded
+// try_lock_for/try_lock_shared_for calls turn that
 // scenario into "handler gives up after the timeout" rather than "hang
 // forever", which is the same trade-off already made by ManagedCodeCache
 // today. If true reentrancy-proof behavior is required, combine this with
@@ -234,6 +237,42 @@ private:
         std::atomic<int32_t>& _counter;
     };
 
+    // Sleeps for at most `duration` without going through
+    // std::this_thread::sleep_for(): this primitive can be exercised from a
+    // POSIX signal handler (that is its whole purpose), and sleep_for() is
+    // not documented as async-signal-safe - on this toolchain it is a thin
+    // wrapper around ::nanosleep(), which POSIX explicitly does NOT put on
+    // the async-signal-safe list (see signal-safety(7); only bare sleep(3)
+    // is listed, not nanosleep(2)/clock_nanosleep(2)). Calling
+    // ::clock_nanosleep() directly is not a POSIX-certified guarantee either
+    // (no bounded-sleep primitive is), but it avoids any indirection through
+    // libstdc++'s <thread> internals (chrono conversions, its own possible
+    // lazy-init) and, unlike ::nanosleep(), reports errors via its return
+    // value rather than errno, so this call touches no thread-global state
+    // at all beyond the syscall itself.
+    static void BoundedSleep(std::chrono::steady_clock::duration duration) noexcept
+    {
+        if (duration <= std::chrono::steady_clock::duration::zero())
+        {
+            return;
+        }
+
+        auto seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+        auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration - seconds);
+
+        struct timespec ts;
+        ts.tv_sec = static_cast<time_t>(seconds.count());
+        ts.tv_nsec = static_cast<long>(nanoseconds.count());
+
+        // On EINTR, clock_nanosleep() refreshes ts in place with the
+        // remaining relative time, so re-issuing the call with the same ts
+        // resumes waiting for what is left rather than restarting the full
+        // duration.
+        while (::clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, &ts) == EINTR)
+        {
+        }
+    }
+
     bool try_lock_shared_once() noexcept
     {
         int32_t expected = _state.load(std::memory_order_relaxed);
@@ -288,7 +327,7 @@ private:
                 // signal handler's bounded try_lock_for) overshoot by nearly
                 // kYieldSleep, since the next deadline check only happens
                 // after waking up.
-                std::this_thread::sleep_for(std::min<std::chrono::steady_clock::duration>(kYieldSleep, timeoutTime - now));
+                BoundedSleep(std::min<std::chrono::steady_clock::duration>(kYieldSleep, timeoutTime - now));
             }
         }
     }
@@ -305,7 +344,12 @@ private:
             // See try_lock_shared() above for why relaxed is sufficient here.
             if (_waitingWriters.load(std::memory_order_relaxed) == 0 && try_lock_shared_once())
             {
-                TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_read_lock, 0);
+                // Must echo __tsan_mutex_try_lock here too (not just
+                // read_lock): pre_lock announced this as a try-lock attempt,
+                // and TSAN requires that flag to match on the post_lock call
+                // that reports its outcome - see try_lock_shared() above,
+                // which does the same on its success path.
+                TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock | __tsan_mutex_read_lock, 0);
                 return true;
             }
             TSAN_MUTEX_POST_LOCK(this, __tsan_mutex_try_lock_failed | __tsan_mutex_read_lock, 0);
@@ -328,7 +372,7 @@ private:
                 }
                 // See try_lock_exclusive_until_slow() above for why this is
                 // clamped rather than an unconditional sleep_for(kYieldSleep).
-                std::this_thread::sleep_for(std::min<std::chrono::steady_clock::duration>(kYieldSleep, timeoutTime - now));
+                BoundedSleep(std::min<std::chrono::steady_clock::duration>(kYieldSleep, timeoutTime - now));
             }
         }
     }

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -26,7 +26,12 @@ if (RUN_UBSAN)
 endif()
 
 if (RUN_TSAN)
-    add_compile_options(-fsanitize=thread -g -fno-omit-frame-pointer -DDD_SANITIZERS)
+    # DD_SANITIZE_THREAD (distinct from the general DD_SANITIZERS flag shared
+    # with ASAN/UBSAN) gates TSAN-only annotations (see SpinningMutex.hpp /
+    # ReaderWriterSpinningMutex.hpp) that call into libtsan's __tsan_mutex_* API.
+    # Those symbols only exist when actually linked with -fsanitize=thread, so
+    # this must NOT be defined under ASAN/UBSAN-only builds.
+    add_compile_options(-fsanitize=thread -g -fno-omit-frame-pointer -DDD_SANITIZERS -DDD_SANITIZE_THREAD)
 endif()
 
 if(ISLINUX)

--- a/profiler/test/Datadog.Profiler.Native.Tests/ReaderWriterSpinningMutexTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ReaderWriterSpinningMutexTest.cpp
@@ -1,0 +1,548 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gtest/gtest.h"
+
+#include "ReaderWriterSpinningMutex.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <mutex>
+#include <shared_mutex>
+#include <signal.h>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+// =======================================================================
+// Basic correctness
+// =======================================================================
+
+TEST(ReaderWriterSpinningMutexTest, TryLock_WhenFree_Succeeds)
+{
+    ReaderWriterSpinningMutex mutex;
+    EXPECT_TRUE(mutex.try_lock());
+    mutex.unlock();
+}
+
+TEST(ReaderWriterSpinningMutexTest, TryLock_WhenExclusivelyHeld_Fails)
+{
+    ReaderWriterSpinningMutex mutex;
+    mutex.lock();
+    EXPECT_FALSE(mutex.try_lock());
+    mutex.unlock();
+}
+
+TEST(ReaderWriterSpinningMutexTest, TryLockShared_WhenFree_Succeeds)
+{
+    ReaderWriterSpinningMutex mutex;
+    EXPECT_TRUE(mutex.try_lock_shared());
+    mutex.unlock_shared();
+}
+
+TEST(ReaderWriterSpinningMutexTest, TryLockShared_WhenExclusivelyHeld_Fails)
+{
+    ReaderWriterSpinningMutex mutex;
+    mutex.lock();
+    EXPECT_FALSE(mutex.try_lock_shared());
+    mutex.unlock();
+}
+
+TEST(ReaderWriterSpinningMutexTest, TryLock_WhenSharedHeld_Fails)
+{
+    ReaderWriterSpinningMutex mutex;
+    mutex.lock_shared();
+    EXPECT_FALSE(mutex.try_lock());
+    mutex.unlock_shared();
+}
+
+TEST(ReaderWriterSpinningMutexTest, MultipleReaders_CanHoldConcurrently)
+{
+    ReaderWriterSpinningMutex mutex;
+    EXPECT_TRUE(mutex.try_lock_shared());
+    EXPECT_TRUE(mutex.try_lock_shared());
+    EXPECT_TRUE(mutex.try_lock_shared());
+    mutex.unlock_shared();
+    mutex.unlock_shared();
+    mutex.unlock_shared();
+}
+
+TEST(ReaderWriterSpinningMutexTest, TryLockFor_WhenExclusivelyHeldByAnotherThread_TimesOutCloseToBudget)
+{
+    ReaderWriterSpinningMutex mutex;
+    std::atomic<bool> writerHoldsLock{false};
+    std::atomic<bool> releaseWriter{false};
+
+    std::thread writer([&]() {
+        mutex.lock();
+        writerHoldsLock.store(true);
+        while (!releaseWriter.load())
+        {
+            std::this_thread::sleep_for(1ms);
+        }
+        mutex.unlock();
+    });
+
+    while (!writerHoldsLock.load())
+    {
+        std::this_thread::sleep_for(1ms);
+    }
+
+    constexpr auto budget = 20ms;
+    auto start = std::chrono::steady_clock::now();
+    bool acquired = mutex.try_lock_for(budget);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_FALSE(acquired);
+    // Bounded: must not wait dramatically longer than the requested budget.
+    EXPECT_LT(elapsed, budget + 20ms);
+
+    releaseWriter.store(true);
+    writer.join();
+}
+
+TEST(ReaderWriterSpinningMutexTest, TryLockSharedFor_WhenExclusivelyHeldByAnotherThread_TimesOutCloseToBudget)
+{
+    ReaderWriterSpinningMutex mutex;
+    std::atomic<bool> writerHoldsLock{false};
+    std::atomic<bool> releaseWriter{false};
+
+    std::thread writer([&]() {
+        mutex.lock();
+        writerHoldsLock.store(true);
+        while (!releaseWriter.load())
+        {
+            std::this_thread::sleep_for(1ms);
+        }
+        mutex.unlock();
+    });
+
+    while (!writerHoldsLock.load())
+    {
+        std::this_thread::sleep_for(1ms);
+    }
+
+    constexpr auto budget = 20ms;
+    auto start = std::chrono::steady_clock::now();
+    bool acquired = mutex.try_lock_shared_for(budget);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_FALSE(acquired);
+    EXPECT_LT(elapsed, budget + 20ms);
+
+    releaseWriter.store(true);
+    writer.join();
+}
+
+// Regression test for a real bug found while benchmarking: the internal
+// sleep-based backoff (used once the active-spin budget is exhausted)
+// unconditionally slept for a fixed ~500us slice regardless of how close the
+// deadline already was, so a *short* bounded wait (exactly the
+// signal-handler use case this primitive exists for) could overshoot its
+// requested budget by nearly that full slice on every failed attempt. That
+// was invisible in millisecond-scale timeout tests (500us is noise at that
+// scale) but was an 8x+ overshoot for a budget in the tens-of-microseconds
+// range - measured via `--gtest_filter=*Benchmark*` on an optimized build.
+// Average over many attempts to smooth out one-off scheduling jitter while
+// still catching a systematic per-call overshoot.
+TEST(ReaderWriterSpinningMutexTest, TryLockSharedFor_ShortBudget_DoesNotSystematicallyOvershoot)
+{
+    ReaderWriterSpinningMutex mutex;
+    mutex.lock(); // Held for the whole test; every attempt below must fail/time out.
+
+    constexpr auto budget = 200us;
+    constexpr int iterations = 500;
+
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < iterations; i++)
+    {
+        ASSERT_FALSE(mutex.try_lock_shared_for(budget));
+    }
+    auto averagePerCall = (std::chrono::steady_clock::now() - start) / iterations;
+
+    // A regression to the old unconditional-sleep behavior would push this to
+    // budget + ~500us (or more) on essentially every call. Give headroom for
+    // scheduling jitter while staying far tighter than that.
+    EXPECT_LT(averagePerCall, budget + 300us);
+
+    mutex.unlock();
+}
+
+TEST(ReaderWriterSpinningMutexTest, TryLockFor_WhenReleasedBeforeTimeout_Succeeds)
+{
+    ReaderWriterSpinningMutex mutex;
+    std::atomic<bool> readerHoldsLock{false};
+
+    // Acquire and release the shared lock on the SAME thread. Doing it across
+    // threads (lock_shared() on the main thread, unlock_shared() on another)
+    // is legal for this atomic-counter-based design, but it confuses TSAN's
+    // built-in deadlock detector, which models mutex ownership per-thread.
+    std::thread reader([&]() {
+        mutex.lock_shared();
+        readerHoldsLock.store(true);
+        std::this_thread::sleep_for(10ms);
+        mutex.unlock_shared();
+    });
+
+    while (!readerHoldsLock.load())
+    {
+        std::this_thread::sleep_for(1ms);
+    }
+
+    EXPECT_TRUE(mutex.try_lock_for(1s));
+    mutex.unlock();
+    reader.join();
+}
+
+// =======================================================================
+// RAII wrapper compatibility (std::unique_lock / std::shared_lock)
+// =======================================================================
+
+TEST(ReaderWriterSpinningMutexTest, WorksWithStdUniqueLock)
+{
+    ReaderWriterSpinningMutex mutex;
+    {
+        std::unique_lock<ReaderWriterSpinningMutex> lock(mutex);
+        EXPECT_TRUE(lock.owns_lock());
+        EXPECT_FALSE(mutex.try_lock_shared());
+    }
+    EXPECT_TRUE(mutex.try_lock_shared());
+    mutex.unlock_shared();
+}
+
+TEST(ReaderWriterSpinningMutexTest, WorksWithStdSharedLock)
+{
+    ReaderWriterSpinningMutex mutex;
+    {
+        std::shared_lock<ReaderWriterSpinningMutex> lock(mutex);
+        EXPECT_TRUE(lock.owns_lock());
+        EXPECT_FALSE(mutex.try_lock());
+    }
+    EXPECT_TRUE(mutex.try_lock());
+    mutex.unlock();
+}
+
+TEST(ReaderWriterSpinningMutexTest, WorksWithStdSharedLock_TimedTryLock)
+{
+    ReaderWriterSpinningMutex mutex;
+    mutex.lock();
+
+    std::shared_lock<ReaderWriterSpinningMutex> lock(mutex, 10ms);
+    EXPECT_FALSE(lock.owns_lock());
+
+    mutex.unlock();
+}
+
+// =======================================================================
+// Concurrency stress: invariant must never be violated
+// =======================================================================
+
+// Writer updates two related fields under the exclusive lock; readers must
+// never observe them out of sync. This would fail under a buggy
+// implementation that lets a reader in while a writer is mid-update, or lets
+// two writers in at once.
+TEST(ReaderWriterSpinningMutexTest, ConcurrentReadersAndWriters_NeverObserveTornState)
+{
+    ReaderWriterSpinningMutex mutex;
+    long long canaryA = 0;
+    long long canaryB = 0;
+    std::atomic<bool> stop{false};
+    std::atomic<int> tornObservations{0};
+    std::atomic<int> readCount{0};
+
+    constexpr int numReaders = 8;
+    constexpr int numWriters = 2;
+    constexpr auto testDuration = 300ms;
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < numReaders; i++)
+    {
+        threads.emplace_back([&]() {
+            while (!stop.load(std::memory_order_relaxed))
+            {
+                std::shared_lock<ReaderWriterSpinningMutex> lock(mutex);
+                if (canaryA != canaryB)
+                {
+                    tornObservations.fetch_add(1);
+                }
+                readCount.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    for (int i = 0; i < numWriters; i++)
+    {
+        threads.emplace_back([&]() {
+            long long value = 0;
+            while (!stop.load(std::memory_order_relaxed))
+            {
+                std::unique_lock<ReaderWriterSpinningMutex> lock(mutex);
+                value++;
+                canaryA = value;
+                // Small window where, if the lock were broken, a reader could
+                // slip in and observe canaryA != canaryB.
+                std::this_thread::yield();
+                canaryB = value;
+            }
+        });
+    }
+
+    std::this_thread::sleep_for(testDuration);
+    stop.store(true, std::memory_order_relaxed);
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    EXPECT_EQ(0, tornObservations.load());
+    EXPECT_GT(readCount.load(), 0);
+}
+
+// =======================================================================
+// Writer fairness: a steady stream of readers must not starve a writer.
+// =======================================================================
+
+TEST(ReaderWriterSpinningMutexTest, SustainedReaders_DoNotStarveWaitingWriter)
+{
+    ReaderWriterSpinningMutex mutex;
+    std::atomic<bool> stop{false};
+
+    constexpr int numReaders = 8;
+    std::vector<std::thread> readers;
+    for (int i = 0; i < numReaders; i++)
+    {
+        readers.emplace_back([&]() {
+            while (!stop.load(std::memory_order_relaxed))
+            {
+                if (mutex.try_lock_shared_for(1ms))
+                {
+                    // Simulate a tiny bit of read work.
+                    std::this_thread::yield();
+                    mutex.unlock_shared();
+                }
+            }
+        });
+    }
+
+    // Give the readers a head start so there is real contention.
+    std::this_thread::sleep_for(20ms);
+
+    auto start = std::chrono::steady_clock::now();
+    mutex.lock();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    mutex.unlock();
+
+    stop.store(true, std::memory_order_relaxed);
+    for (auto& t : readers)
+    {
+        t.join();
+    }
+
+    // With the "waiting writer" fairness flag, the writer must not be starved
+    // indefinitely by a continuous stream of short-lived readers.
+    EXPECT_LT(elapsed, 2s);
+}
+
+// =======================================================================
+// Real-signal reentrancy: the scenario this primitive exists for.
+// =======================================================================
+// A thread takes the exclusive lock, then raises a real SIGUSR1 against
+// itself while still holding it (mirroring the CPU/wall-time profiler
+// delivering its sampling signal to the very thread being sampled). The
+// signal handler tries to take the shared lock with a bounded timeout.
+// This must never hang: try_lock_shared_for must return promptly (it will
+// return false, since this lock is not reentrant), and control must return
+// to the interrupted writer, which then completes normally.
+
+namespace
+{
+ReaderWriterSpinningMutex* g_signalTestMutex = nullptr;
+std::atomic<bool> g_handlerRan{false};
+std::atomic<bool> g_handlerAcquiredSharedLock{false};
+
+void SelfSignalReentrancyHandler(int)
+{
+    g_handlerRan.store(true, std::memory_order_relaxed);
+    bool acquired = g_signalTestMutex->try_lock_shared_for(std::chrono::milliseconds(50));
+    if (acquired)
+    {
+        g_signalTestMutex->unlock_shared();
+    }
+    g_handlerAcquiredSharedLock.store(acquired, std::memory_order_relaxed);
+}
+} // namespace
+
+TEST(ReaderWriterSpinningMutexTest, WriterInterruptedBySelfSignal_DoesNotDeadlock)
+{
+    ReaderWriterSpinningMutex mutex;
+    g_signalTestMutex = &mutex;
+    g_handlerRan.store(false);
+    g_handlerAcquiredSharedLock.store(false);
+
+    struct sigaction action{};
+    action.sa_handler = SelfSignalReentrancyHandler;
+    sigemptyset(&action.sa_mask);
+    action.sa_flags = 0;
+
+    struct sigaction previousAction{};
+    ASSERT_EQ(0, sigaction(SIGUSR1, &action, &previousAction));
+
+    // Run the actual reentrancy scenario on a worker thread so the test can
+    // apply a watchdog timeout around it: if a regression ever turns this
+    // primitive into something that can truly hang on self-reentrancy, the
+    // test fails loudly instead of hanging CI silently.
+    auto future = std::async(std::launch::async, [&]() {
+        mutex.lock();
+        // Deliver SIGUSR1 to this very thread while still holding the
+        // exclusive lock - this is the exact hazard the design doc calls
+        // out (a profiler signal targeted at the thread that is currently
+        // writing to the cache).
+        pthread_kill(pthread_self(), SIGUSR1);
+        mutex.unlock();
+    });
+
+    auto status = future.wait_for(5s);
+    sigaction(SIGUSR1, &previousAction, nullptr);
+
+    ASSERT_EQ(std::future_status::ready, status) << "writer thread appears stuck: self-signal reentrancy caused a hang";
+    EXPECT_TRUE(g_handlerRan.load());
+    // The lock is not reentrant, so the handler must have backed off rather
+    // than acquiring it while the same thread holds the exclusive lock.
+    EXPECT_FALSE(g_handlerAcquiredSharedLock.load());
+
+    // The mutex must be left in a clean, reusable state afterwards.
+    EXPECT_TRUE(mutex.try_lock());
+    mutex.unlock();
+
+    g_signalTestMutex = nullptr;
+}
+
+// =======================================================================
+// Micro-benchmarks (disabled by default - run explicitly with
+// --gtest_also_run_disabled_tests --gtest_filter=*Benchmark*)
+// =======================================================================
+// Not a substitute for a real benchmark harness, but enough to sanity-check
+// that ReaderWriterSpinningMutex is in the right ballpark versus the
+// std::shared_timed_mutex baseline it is meant to replace, both uncontended
+// (dominated by the primitive's own overhead) and under writer contention
+// (where std::shared_timed_mutex's try_lock_for goes through libstdc++'s
+// internal condition-variable wait, while ReaderWriterSpinningMutex spins/sleeps
+// on plain atomics).
+//
+// IMPORTANT - build configuration matters a lot here: this repo's local
+// CMake dev build defaults to CMAKE_BUILD_TYPE=Debug (effectively -O0). At
+// -O0, ReaderWriterSpinningMutex's header-only call chain (lock_shared() ->
+// try_lock_shared() -> try_lock_shared_once(), etc.) is NOT inlined and pays
+// real function-call overhead on every operation, whereas
+// std::shared_timed_mutex's pthread_rwlock_* implementation is already
+// compiled into libstdc++.so at full optimization regardless of how this
+// test binary is built. That asymmetry alone was measured to make the
+// uncontended benchmark look ~1.4-1.8x slower for ReaderWriterSpinningMutex at
+// -O0. Build with -DCMAKE_BUILD_TYPE=Release (or any -O1/-O2/-O3) to get a
+// representative comparison: with real inlining, ReaderWriterSpinningMutex is
+// measured to be ~25-30% FASTER than std::shared_timed_mutex uncontended,
+// and roughly on par under writer contention with a short timeout budget.
+
+namespace
+{
+template <typename Func>
+double MeasureNanosPerOp(int iterations, Func&& func)
+{
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < iterations; i++)
+    {
+        func();
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    return static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(elapsed).count()) / iterations;
+}
+} // namespace
+
+TEST(ReaderWriterSpinningMutexTest, DISABLED_Benchmark_UncontendedSharedLockUnlock)
+{
+    constexpr int iterations = 2'000'000;
+
+    ReaderWriterSpinningMutex spinMutex;
+    auto spinNs = MeasureNanosPerOp(iterations, [&]() {
+        spinMutex.lock_shared();
+        spinMutex.unlock_shared();
+    });
+
+    std::shared_timed_mutex stdMutex;
+    auto stdNs = MeasureNanosPerOp(iterations, [&]() {
+        stdMutex.lock_shared();
+        stdMutex.unlock_shared();
+    });
+
+    std::cout << "[benchmark] uncontended lock_shared+unlock_shared: "
+              << "ReaderWriterSpinningMutex=" << spinNs << " ns/op, "
+              << "std::shared_timed_mutex=" << stdNs << " ns/op" << std::endl;
+}
+
+TEST(ReaderWriterSpinningMutexTest, DISABLED_Benchmark_ReaderLatencyUnderWriterContention)
+{
+    // A writer holds the exclusive lock for a short window in a tight loop;
+    // meanwhile a reader repeatedly tries a bounded try_lock_shared_for and
+    // we measure how long each *failing* attempt takes to give up - this is
+    // exactly the ManagedCodeCache signal-handler scenario (bounded wait,
+    // give up cleanly rather than block forever).
+    constexpr auto perAttemptBudget = 50us;
+    constexpr int iterations = 2000;
+
+    auto benchmarkSpin = [&]() {
+        ReaderWriterSpinningMutex mutex;
+        std::atomic<bool> stop{false};
+        std::thread writer([&]() {
+            while (!stop.load(std::memory_order_relaxed))
+            {
+                mutex.lock();
+                std::this_thread::sleep_for(10us);
+                mutex.unlock();
+            }
+        });
+
+        auto ns = MeasureNanosPerOp(iterations, [&]() {
+            if (mutex.try_lock_shared_for(perAttemptBudget))
+            {
+                mutex.unlock_shared();
+            }
+        });
+
+        stop.store(true, std::memory_order_relaxed);
+        writer.join();
+        return ns;
+    };
+
+    auto benchmarkStd = [&]() {
+        std::shared_timed_mutex mutex;
+        std::atomic<bool> stop{false};
+        std::thread writer([&]() {
+            while (!stop.load(std::memory_order_relaxed))
+            {
+                mutex.lock();
+                std::this_thread::sleep_for(10us);
+                mutex.unlock();
+            }
+        });
+
+        auto ns = MeasureNanosPerOp(iterations, [&]() {
+            if (mutex.try_lock_shared_for(perAttemptBudget))
+            {
+                mutex.unlock_shared();
+            }
+        });
+
+        stop.store(true, std::memory_order_relaxed);
+        writer.join();
+        return ns;
+    };
+
+    auto spinNs = benchmarkSpin();
+    auto stdNs = benchmarkStd();
+
+    std::cout << "[benchmark] try_lock_shared_for(" << perAttemptBudget.count() << "us) under writer contention: "
+              << "ReaderWriterSpinningMutex=" << spinNs << " ns/op, "
+              << "std::shared_timed_mutex=" << stdNs << " ns/op" << std::endl;
+}


### PR DESCRIPTION
## Summary of changes

Implement `ReaderWriterSpinningMutex`.

## Reason for change

The goal is to replace the `std::shared_timed_mutex` to make `ManagedCodeCache::IsManaged` signal-safe.

## Implementation details

- Add new class `ReaderWriterSpinningMutex`

## Test coverage
- Add unit test
- + TSAN
- + Benchmark tests

## Other details
<!-- Fixes #{issue} -->

<html>
<body>

Scenario | Build config | ReaderWriterSpinningMutex | std::shared_timed_mutex | Result
-- | -- | -- | -- | --
Uncontended lock_shared/unlock_shared | Release (optimized) | 15.3 ns/op | 20.6–21.7 ns/op | ~1.35x faster
try_lock_shared_for(50µs) under writer contention | Release (optimized) | ~70.0 µs/op | ~71.5 µs/op | on par (~2% faster)


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
