### PR TITLE
[IAST] Exclude FSharp.* assemblies from dataflow

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -89,7 +89,7 @@ static std::vector<WSTRING> _assemblyExcludeFilters = {
     WStr("AWSSDK.Core"),
     WStr("MailKit"),
     WStr("MimeKit"),
-    WStr("FSharp*"),
+    WStr("FSharp.*"),
 };
 static std::vector<WSTRING> _methodIncludeFilters = {
     WStr("System.Web.Mvc.ControllerActionInvoker::InvokeAction*"),

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -89,6 +89,7 @@ static std::vector<WSTRING> _assemblyExcludeFilters = {
     WStr("AWSSDK.Core"),
     WStr("MailKit"),
     WStr("MimeKit"),
+    WStr("FSharp*"),
 };
 static std::vector<WSTRING> _methodIncludeFilters = {
     WStr("System.Web.Mvc.ControllerActionInvoker::InvokeAction*"),


### PR DESCRIPTION
## Summary of changes
Add `FSharp*` to the dataflow assembly exclude list so these framework assemblies are never instrumented. Customer F# code (non-FSharp* assemblies) is unaffected.

## Reason for change
FSharp.Core's printf/quotation/reflection code (e.g. Microsoft.FSharp.Quotations.PatternsModule, Microsoft.FSharp.Reflection) calls String.Format and other aspected APIs. With IAST enabled, the dataflow rewriter instruments these methods, which triggers a runaway ReJIT cascade that can hang startup of F# applications.
