### PR TITLE
Forward BP_EXTERNAL_S3_URL explicitly on benchmark triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -312,10 +312,12 @@ macrobenchmarks:
   needs: []
   trigger:
     include: .gitlab/benchmarks/macrobenchmarks.yml
-    # Forward pipeline variables so an external orchestrator can pass
-    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
-    forward:
-      pipeline_variables: true
+  variables:
+    # Forward BP_EXTERNAL_S3_URL so an external orchestrator can override the S3 destination.
+    # This avoids 'forward: pipeline_variables: true', which forwards every parent variable and may be unsafe.
+    # When the orchestrator leaves it unset, GitLab forwards the literal '$BP_EXTERNAL_S3_URL' (not empty),
+    # so downstream code must treat that literal as unset.
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   allow_failure: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push" && ($CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH =~ /^hotfix/)'
@@ -330,10 +332,12 @@ microbenchmarks:
   trigger:
     include: .gitlab/benchmarks/microbenchmarks.yml
     strategy: depend
-    # Forward pipeline variables so an external orchestrator can pass
-    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
-    forward:
-      pipeline_variables: true
+  variables:
+    # Forward BP_EXTERNAL_S3_URL so an external orchestrator can override the S3 destination.
+    # This avoids 'forward: pipeline_variables: true', which forwards every parent variable and may be unsafe.
+    # When the orchestrator leaves it unset, GitLab forwards the literal '$BP_EXTERNAL_S3_URL' (not empty),
+    # so downstream code must treat that literal as unset.
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   allow_failure: true
   rules:
     - if: $CI_COMMIT_TAG
@@ -344,10 +348,12 @@ dsm_throughput:
   stage: benchmarks
   trigger:
     include: .gitlab/benchmarks/dsm-throughput.yml
-    # Forward pipeline variables so an external orchestrator can pass
-    # BP_EXTERNAL_S3_URL down to override the S3 destination of benchmark results.
-    forward:
-      pipeline_variables: true
+  variables:
+    # Forward BP_EXTERNAL_S3_URL so an external orchestrator can override the S3 destination.
+    # This avoids 'forward: pipeline_variables: true', which forwards every parent variable and may be unsafe.
+    # When the orchestrator leaves it unset, GitLab forwards the literal '$BP_EXTERNAL_S3_URL' (not empty),
+    # so downstream code must treat that literal as unset.
+    BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL
   allow_failure: true
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"'


### PR DESCRIPTION
## Summary of changes

Replace `forward: pipeline_variables: true` on the macrobenchmark, microbenchmark, and dsm_throughput child-pipeline triggers with an explicit `BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL` passthrough.

## Reason for change

`forward: pipeline_variables: true` was cleaner but passed every parent variable down to the child pipeline, which is unsafe (a caller could override sensitive child settings such as the clone target, branch, region, or cleanup): https://chatgpt.com/codex/cloud/security/findings/f09758651f888191be4662de57d130a6?repo=https%3A%2F%2Fgithub.com%2FDataDog%2Fdd-trace-dotnet&sev=medium%2Ccritical%2Chigh

## Implementation details

Only `BP_EXTERNAL_S3_URL` is forwarded now, via the trigger job's `variables:` block (forwarded by the default `yaml_variables`). When an orchestrator leaves it unset, GitLab forwards the unexpanded literal `$BP_EXTERNAL_S3_URL`, which downstream code treats as unset.

## Test coverage

This was tested when authoring https://github.com/DataDog/dd-trace-py/pull/18955 on dd-trace-py. On that work, I tested the `BP_EXTERNAL_S3_URL: $BP_EXTERNAL_S3_URL` explicit forwarding behavior before switching to `forward: pipeline_variables`.

- CI job used for testing, echoing the substituted env var passed down from an orchestrator: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1844147454
    - The "orchestrator" is a benchmark stability monitoring pipeline triggered from benchmarking-platform-tools: https://github.com/DataDog/benchmarking-platform-tools/blob/main/scripts/stability/.gitlab/monitor-stability.yml
- Line of code setting the explicit forwarding on that commit: https://github.com/DataDog/dd-trace-py/blob/92dc737fa2a14745f4ab7453b402bfe149c6022f/.gitlab-ci.yml#L189-L190

## Other details