### PR TITLE
[Tracer] (Event Grid 5/5) Enable integration and add support metadata

### DIFF
--- a/docs/span_attribute_schema/v0.md
+++ b/docs/span_attribute_schema/v0.md
@@ -642,6 +642,44 @@ peer.address | No
 server.address | Yes
 span.kind | `consumer`
 
+## AzureEventGridOutbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `azure_eventgrid.send`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+component | `AzureEventGrid`
+messaging.batch.message_count | No
+messaging.message_id | No
+messaging.operation | `send`
+messaging.system | Optional: `eventgrid`
+net.peer.name | No
+network.destination.name | Yes
+network.destination.port | No
+peer.address | No
+span.kind | `producer`
+
+## AzureEventGridInbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `azure_eventgrid.receive`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+component | `AzureEventGrid`
+messaging.batch.message_count | No
+messaging.message_id | No
+messaging.operation | `receive`
+messaging.system | Optional: `eventgrid`
+span.kind | `consumer`
+
 ## CosmosDb
 ### Span properties
 Name | Required |

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -401,6 +401,47 @@ peer.address | No
 server.address | Yes
 span.kind | `consumer`
 
+## AzureEventGridOutbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `azure_eventgrid.send`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+_dd.peer.service.source | No
+component | `AzureEventGrid`
+messaging.batch.message_count | No
+messaging.message_id | No
+messaging.operation | `send`
+messaging.system | Optional: `eventgrid`
+net.peer.name | No
+network.destination.name | Yes
+network.destination.port | No
+peer.address | No
+peer.service | No
+peer.service.remapped_from | No
+span.kind | `producer`
+
+## AzureEventGridInbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `azure_eventgrid.receive`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.base_service | No
+component | `AzureEventGrid`
+messaging.batch.message_count | No
+messaging.message_id | No
+messaging.operation | `receive`
+messaging.system | Optional: `eventgrid`
+span.kind | `consumer`
+
 ## CosmosDb
 ### Span properties
 Name | Required |

--- a/tracer/build/supported_versions.json
+++ b/tracer/build/supported_versions.json
@@ -409,6 +409,40 @@
     ]
   },
   {
+    "integrationName": "AzureEventGrid",
+    "assemblyName": "Azure.Messaging.EventGrid",
+    "minAssemblyVersionInclusive": "4.0.0",
+    "maxAssemblyVersionInclusive": "5.65535.65535",
+    "packages": [
+      {
+        "name": "Azure.Messaging.EventGrid",
+        "minVersionAvailableInclusive": "4.0.0",
+        "minVersionSupportedInclusive": "4.0.0",
+        "minVersionTestedInclusive": "4.0.0",
+        "maxVersionSupportedInclusive": "5.0.0",
+        "maxVersionAvailableInclusive": "5.0.0",
+        "maxVersionTestedInclusive": "5.0.0"
+      }
+    ]
+  },
+  {
+    "integrationName": "AzureEventGrid",
+    "assemblyName": "Azure.Messaging.EventGrid.Namespaces",
+    "minAssemblyVersionInclusive": "1.0.0",
+    "maxAssemblyVersionInclusive": "1.65535.65535",
+    "packages": [
+      {
+        "name": "Azure.Messaging.EventGrid.Namespaces",
+        "minVersionAvailableInclusive": "1.0.0",
+        "minVersionSupportedInclusive": "1.0.0",
+        "minVersionTestedInclusive": "1.0.0",
+        "maxVersionSupportedInclusive": "1.1.0",
+        "maxVersionAvailableInclusive": "1.1.0",
+        "maxVersionTestedInclusive": "1.1.0"
+      }
+    ]
+  },
+  {
     "integrationName": "AzureEventHubs",
     "assemblyName": "Azure.Messaging.EventHubs",
     "minAssemblyVersionInclusive": "5.9.2",

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/EventGrid/EventGridCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/EventGrid/EventGridCommon.cs
@@ -26,7 +26,7 @@ internal static class EventGridCommon
     internal static CallTargetState CreateProducerSpan<TTarget, TEvents>(TTarget instance, ref TEvents events, bool injectContext)
     {
         var tracer = Tracer.Instance;
-        if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid, defaultValue: false))
+        if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid))
         {
             return CallTargetState.GetDefault();
         }
@@ -50,7 +50,7 @@ internal static class EventGridCommon
         where TTarget : IEventGridSenderClient
     {
         var tracer = Tracer.Instance;
-        if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid, defaultValue: false))
+        if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid))
         {
             return CallTargetState.GetDefault();
         }
@@ -63,7 +63,7 @@ internal static class EventGridCommon
         where TTarget : IEventGridSenderClient
     {
         var tracer = Tracer.Instance;
-        if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid, defaultValue: false))
+        if (!tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid))
         {
             return CallTargetState.GetDefault();
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -311,7 +311,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                             extractedContext = ExtractPropagatedContextFromMessaging(functionContext, "Properties", "PropertiesArray").MergeBaggageInto(Baggage.Current);
                             break;
 
-                        case "EventGrid" when tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid, defaultValue: false):
+                        case "EventGrid" when tracer.CurrentTraceSettings.Settings.IsIntegrationEnabled(IntegrationId.AzureEventGrid):
                         {
                             extractedContext = EventGridFunctionsCommon.CreateReceiveSpanContext(tracer, functionContext, entry.Key as string, Baggage.Current);
                             break;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventGridNamespacesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventGridNamespacesTests.cs
@@ -23,7 +23,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         public AzureEventGridNamespacesTests(ITestOutputHelper output)
             : base("AzureEventGridNamespaces", output)
         {
-            SetEnvironmentVariable("DD_TRACE_AZUREEVENTGRID_ENABLED", "true");
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventGridTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventGridTests.cs
@@ -53,7 +53,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
         public AzureEventGridTests(ITestOutputHelper output)
             : base("AzureEventGrid", output)
         {
-            SetEnvironmentVariable("DD_TRACE_AZUREEVENTGRID_ENABLED", "true");
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsMessagingTriggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsMessagingTriggerTests.cs
@@ -55,7 +55,6 @@ public class AzureFunctionsMessagingTriggerTests : AzureFunctionsTests
         SetEnvironmentVariable("EVENTHUBS_CONNECTION_STRING", GetEventHubsConnectionString());
         SetEnvironmentVariable("EVENTGRID_TOPIC_ENDPOINT", GetEventGridTopicEndpoint());
         SetEnvironmentVariable("EVENTGRID_TOPIC_KEY", "test-key");
-        SetEnvironmentVariable("DD_TRACE_AZUREEVENTGRID_ENABLED", "true");
         SetEnvironmentVariable("AzureWebJobsStorage", GetAzuriteConnectionString());
         // Exclude the Event Grid emulator endpoint from HTTP client tracing to avoid an extra http.request span.
         SetEnvironmentVariable(


### PR DESCRIPTION
## Summary of changes

Enable Azure Event Grid tracing by default and add its support metadata.

## Reason for change

Activate the integration introduced by the preceding PRs in this Graphite stack.

## Implementation details

- Enable outbound SDK and Azure Functions Event Grid tracing by default.
- Register supported versions for `Azure.Messaging.EventGrid` and `Azure.Messaging.EventGrid.Namespaces`.
- Document inbound and outbound spans in the v0 and v1 span attribute schemas.

## Test coverage

Existing Event Grid SDK, Namespaces, and Azure Functions integration tests now validate the default-enabled behavior without an explicit opt-in setting.

## Other details

This PR is the final activation step in the Azure Event Grid Graphite stack.
