### PR TITLE
Share agent skills between Codex and Claude Code via symlink

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,14 @@ Debugger code runs inside customer processes while inspecting live customer obje
 - Commits: imperative mood, optional `[Area]` prefix (e.g. `[Debugger]`, `[SymDB]`). Keep messages concise — avoid full diffs or extensive explanation.
 - PRs: follow [`.github/pull_request_template.md`](.github/pull_request_template.md). Keep descriptions concise — focus on "what" and "why", brief "how" only when complex.
 
+## Agent skills
+
+Shared agent skills are maintained under `.claude/skills`.
+
+`.agents/skills` is a symbolic link to that directory so that Codex and
+Claude Code use the same skill definitions. Do not edit or duplicate skills
+under `.agents/skills`; update the canonical files under `.claude/skills`.
+
 ## Documentation References
 
 **Core docs:**


### PR DESCRIPTION
## Summary of changes
Add `.agents/skills` as a symbolic link to `.claude/skills`, and document the convention in `AGENTS.md`.

## Reason for change
Codex and Claude Code should read the same skill definitions instead of maintaining duplicate copies.

## Implementation details
- Added `.agents/skills` as a symlink pointing to `.claude/skills`.
- Updated `AGENTS.md` to note that `.agents/skills` is a symlink and skills should be edited only under the canonical `.claude/skills` directory.

## Test coverage
N/A — no code change, just a symlink and doc update.

## Other details