### PR TITLE
clean env variables in the correct place

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -176,7 +176,19 @@ namespace Datadog.Trace.TestHelpers
                 "DD_VERSION",
                 "DD_TAGS",
                 "DD_APPSEC_ENABLED",
-                "DD_WRITE_INSTRUMENTATION_TO_DISK"
+                "DD_WRITE_INSTRUMENTATION_TO_DISK",
+                "DD_TRACE_AGENT_URL",
+
+                // OpenTelemetry
+                "OTEL_TRACES_EXPORTER",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+                "OTEL_METRICS_EXPORTER",
+                "OTEL_LOGS_EXPORTER",
+                "OTEL_EXPORTER_OTLP_PROTOCOL",
+                "OTEL_RESOURCE_ATTRIBUTES"
             };
 
             foreach (string variable in environmentVariables)
@@ -355,19 +367,6 @@ namespace Datadog.Trace.TestHelpers
             {
                 environmentVariables[envVar.Key] = envVar.Value;
             }
-
-            // URL can take precedence over HOSTNAME+PORT, so we remove it to ensure what we configured above gets actually used.
-            environmentVariables.Remove("DD_TRACE_AGENT_URL");
-            // Remove OTEL exporter env vars that could redirect traces away from the mock agent
-            environmentVariables.Remove("OTEL_TRACES_EXPORTER");
-            environmentVariables.Remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
-            environmentVariables.Remove("OTEL_EXPORTER_OTLP_ENDPOINT");
-            environmentVariables.Remove("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
-            environmentVariables.Remove("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT");
-            environmentVariables.Remove("OTEL_METRICS_EXPORTER");
-            environmentVariables.Remove("OTEL_LOGS_EXPORTER");
-            environmentVariables.Remove("OTEL_EXPORTER_OTLP_PROTOCOL");
-            environmentVariables.Remove("OTEL_RESOURCE_ATTRIBUTES");
         }
 
         public string GetSampleApplicationPath(string packageVersion = "", string framework = "", bool usePublishWithRID = false)


### PR DESCRIPTION
## Summary of changes

follow up on #8883 where a discussion after the change was merged made me realize we cleaned too late (after the process start, i.e. we'd override test set variables), and also that there was a specific place to clean env variables already.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
