### PR TITLE
[OTLP] Removing the path with OtelTracesSpanMetricsEnabled

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
+++ b/tracer/src/Datadog.Trace/Agent/ApiOtlp.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Agent
         private readonly SendCallback<SendStatsState> _sendStats;
         private readonly SendCallback<SendTracesState> _sendTraces;
 
-        public ApiOtlp(IApiRequestFactory apiRequestFactory, TracerSettings settings, ExporterSettings exporterSettings, IDatadogLogger log = null)
+        public ApiOtlp(IApiRequestFactory tracesRequestFactory, IApiRequestFactory metricsRequestFactory, TracerSettings settings, ExporterSettings exporterSettings, IDatadogLogger log = null)
         {
             // optionally injecting a log instance in here for testing purposes
             _log = log ?? StaticLog;
@@ -46,8 +46,8 @@ namespace Datadog.Trace.Agent
             _sendStats = SendStatsAsyncImpl;
             _sendTraces = SendTracesAsyncImpl;
 
-            _apiRequestFactory = apiRequestFactory;
-            _metricsRequestFactory = OtlpTransportStrategy.GetMetrics(exporterSettings);
+            _apiRequestFactory = tracesRequestFactory;
+            _metricsRequestFactory = metricsRequestFactory;
             _tracesEncoding = exporterSettings.TracesEncoding;
             _tracesEndpoint = _apiRequestFactory.GetEndpoint(null); // The base endpoint for OTLP traces already includes the path component
             _statsEndpoint = exporterSettings.OtlpMetricsEndpoint;

--- a/tracer/src/Datadog.Trace/Agent/ManagedApiOtlp.cs
+++ b/tracer/src/Datadog.Trace/Agent/ManagedApiOtlp.cs
@@ -33,7 +33,8 @@ internal sealed class ManagedApiOtlp : IApi
         void UpdateApi(TracerSettings settings, ExporterSettings exporterSettings)
         {
             var apiRequestFactory = OtlpTransportStrategy.GetTraces(exporterSettings);
-            var api = new ApiOtlp(apiRequestFactory, settings, exporterSettings);
+            var metricsRequestFactory = OtlpTransportStrategy.GetMetrics(exporterSettings);
+            var api = new ApiOtlp(apiRequestFactory, metricsRequestFactory, settings, exporterSettings);
             Interlocked.Exchange(ref _api!, api);
         }
     }

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -257,6 +257,11 @@ namespace Datadog.Trace.Configuration
         internal TracesEncoding TracesEncoding { get; }
 
         /// <summary>
+        /// Gets a value indicating whether traces are exported using OTLP encoding. Depends on OTEL_TRACES_EXPORTER=otlp.
+        /// </summary>
+        internal bool IsOtlpTraceExport => TracesEncoding is TracesEncoding.OtlpProtobuf or TracesEncoding.OtlpJson;
+
+        /// <summary>
         /// Gets the transport used to send traces to the Agent.
         /// </summary>
         internal TracesTransportType TracesTransport { get; }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -870,6 +870,22 @@ namespace Datadog.Trace.Configuration
             _fallbackApplicationName = new(() => ApplicationNameHelpers.GetFallbackApplicationName(this));
 
             Manager = new(source, this, telemetry, errorLog);
+
+            // OTLP span metrics require OTLP trace export (see TracerManagerFactory.GetAgentWriter).
+            // Force to false otherwise, even if explicitly requested.
+            if (OtelTracesSpanMetricsEnabled && !Manager.InitialExporterSettings.IsOtlpTraceExport)
+            {
+                if (explicitSpanMetrics == true)
+                {
+                    Log.Warning(
+                        "{ConfigurationKey} is set to true, but traces are not being exported using OTLP encoding (OTEL_TRACES_EXPORTER={OtelTracesExporter}). OTLP span metrics require OTLP trace export, so this setting has been disabled.",
+                        ConfigurationKeys.OpenTelemetry.TracesSpanMetricsEnabled,
+                        otelTracesExporter);
+                }
+
+                OtelTracesSpanMetricsEnabled = false;
+                telemetry.Record(ConfigurationKeys.OpenTelemetry.TracesSpanMetricsEnabled, false, ConfigurationOrigins.Calculated);
+            }
         }
 
         internal bool IsRunningInCiVisibility { get; }

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -3963,7 +3963,10 @@ supportedConfigurations:
     documentation: |-
       Tri-state gate for OTLP span metrics export (traces.span.sdk.metrics.duration).
       When unset, auto-enables iff OTEL_TRACES_EXPORTER=otlp and DD_METRICS_OTEL_ENABLED=true.
-      When true, always enables span metrics export regardless of other settings.
+      When true, enables span metrics export, unless traces aren't actually exported using
+      OTLP encoding, in which case the setting is forced back to false (with a warning
+      logged and the calculated value reported in telemetry), since OTLP span metrics
+      require OTLP trace export.
       When false, always disables span metrics export.
   _DD_EXTENSION_ENDPOINT:
   - implementation: A

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
@@ -237,7 +237,10 @@ internal static partial class ConfigurationKeys
         /// <summary>
         /// Tri-state gate for OTLP span metrics export (traces.span.sdk.metrics.duration).
         /// When unset, auto-enables iff OTEL_TRACES_EXPORTER=otlp and DD_METRICS_OTEL_ENABLED=true.
-        /// When true, always enables span metrics export regardless of other settings.
+        /// When true, enables span metrics export, unless traces aren't actually exported using
+        /// OTLP encoding, in which case the setting is forced back to false (with a warning
+        /// logged and the calculated value reported in telemetry), since OTLP span metrics
+        /// require OTLP trace export.
         /// When false, always disables span metrics export.
         /// </summary>
         public const string TracesSpanMetricsEnabled = "OTEL_TRACES_SPAN_METRICS_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
@@ -237,7 +237,10 @@ internal static partial class ConfigurationKeys
         /// <summary>
         /// Tri-state gate for OTLP span metrics export (traces.span.sdk.metrics.duration).
         /// When unset, auto-enables iff OTEL_TRACES_EXPORTER=otlp and DD_METRICS_OTEL_ENABLED=true.
-        /// When true, always enables span metrics export regardless of other settings.
+        /// When true, enables span metrics export, unless traces aren't actually exported using
+        /// OTLP encoding, in which case the setting is forced back to false (with a warning
+        /// logged and the calculated value reported in telemetry), since OTLP span metrics
+        /// require OTLP trace export.
         /// When false, always disables span metrics export.
         /// </summary>
         public const string TracesSpanMetricsEnabled = "OTEL_TRACES_SPAN_METRICS_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
@@ -237,7 +237,10 @@ internal static partial class ConfigurationKeys
         /// <summary>
         /// Tri-state gate for OTLP span metrics export (traces.span.sdk.metrics.duration).
         /// When unset, auto-enables iff OTEL_TRACES_EXPORTER=otlp and DD_METRICS_OTEL_ENABLED=true.
-        /// When true, always enables span metrics export regardless of other settings.
+        /// When true, enables span metrics export, unless traces aren't actually exported using
+        /// OTLP encoding, in which case the setting is forced back to false (with a warning
+        /// logged and the calculated value reported in telemetry), since OTLP span metrics
+        /// require OTLP trace export.
         /// When false, always disables span metrics export.
         /// </summary>
         public const string TracesSpanMetricsEnabled = "OTEL_TRACES_SPAN_METRICS_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.OpenTelemetry.g.cs
@@ -237,7 +237,10 @@ internal static partial class ConfigurationKeys
         /// <summary>
         /// Tri-state gate for OTLP span metrics export (traces.span.sdk.metrics.duration).
         /// When unset, auto-enables iff OTEL_TRACES_EXPORTER=otlp and DD_METRICS_OTEL_ENABLED=true.
-        /// When true, always enables span metrics export regardless of other settings.
+        /// When true, enables span metrics export, unless traces aren't actually exported using
+        /// OTLP encoding, in which case the setting is forced back to false (with a warning
+        /// logged and the calculated value reported in telemetry), since OTLP span metrics
+        /// require OTLP trace export.
         /// When false, always disables span metrics export.
         /// </summary>
         public const string TracesSpanMetricsEnabled = "OTEL_TRACES_SPAN_METRICS_ENABLED";

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -294,13 +294,6 @@ namespace Datadog.Trace
 
             var api = new ManagedApi(settings.Manager, statsd, updateSampleRates, updateConfigHash, settings.PartialFlushEnabled);
 
-            if (settings.OtelTracesSpanMetricsEnabled)
-            {
-                var otlpMetricsApi = new ManagedApiOtlp(settings);
-                var otlpSpanMetricsAggregator = StatsAggregator.Create(otlpMetricsApi, settings, discoveryService, statsd, isOtlp: true);
-                return new AgentWriter(api, otlpSpanMetricsAggregator, statsd, settings);
-            }
-
             var statsAggregator = StatsAggregator.Create(api, settings, discoveryService, statsd, isOtlp: false);
 
             return new AgentWriter(api, statsAggregator, statsd, settings);

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -285,7 +285,7 @@ namespace Datadog.Trace
 
         protected virtual IAgentWriter GetAgentWriter(TracerSettings settings, IStatsdManager statsd, Action<Dictionary<string, float>> updateSampleRates, Action<string> updateConfigHash, IDiscoveryService discoveryService, TelemetrySettings telemetrySettings)
         {
-            if (settings.Manager.InitialExporterSettings.TracesEncoding is TracesEncoding.OtlpProtobuf or TracesEncoding.OtlpJson)
+            if (settings.Manager.InitialExporterSettings.IsOtlpTraceExport)
             {
                 var otlpApi = new ManagedApiOtlp(settings);
                 var otlpStatsAggregator = StatsAggregator.Create(otlpApi, settings, discoveryService, statsd, isOtlp: true);

--- a/tracer/test/Datadog.Trace.Tests/Agent/ApiOtlpTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ApiOtlpTests.cs
@@ -1,0 +1,123 @@
+// <copyright file="ApiOtlpTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Specialized;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Agent;
+
+public class ApiOtlpTests
+{
+    [Fact]
+    public async Task SendStatsAsync_WhenSpanMetricsDisabled_DoesNotPostToMetricsEndpoint()
+    {
+        var source = BuildSource(
+            "OTEL_TRACES_EXPORTER:otlp",
+            "OTEL_TRACES_SPAN_METRICS_ENABLED:false");
+
+        var settings = new TracerSettings(source);
+        settings.OtelTracesSpanMetricsEnabled.Should().BeFalse();
+
+        var exporterSettings = new ExporterSettings(source, _ => false, NullConfigurationTelemetry.Instance);
+
+        var mockTracesFactory = new Mock<IApiRequestFactory>();
+        mockTracesFactory.Setup(f => f.GetEndpoint(null)).Returns(new Uri("http://localhost:4317"));
+
+        var mockMetricsRequest = new Mock<IApiRequest>();
+        var mockMetricsFactory = new Mock<IApiRequestFactory>();
+        mockMetricsFactory.Setup(f => f.Create(It.IsAny<Uri>())).Returns(mockMetricsRequest.Object);
+
+        var api = new ApiOtlp(mockTracesFactory.Object, mockMetricsFactory.Object, settings, exporterSettings);
+
+        var result = await api.SendStatsAsync(stats: null, bucketDuration: 0, tracerObfuscationVersion: 0);
+        result.Should().BeTrue();
+        mockMetricsRequest.Verify(r => r.PostAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendStatsAsync_WhenSpanMetricsEnabled_PostsToMetricsEndpoint()
+    {
+        var source = BuildSource(
+            "OTEL_TRACES_EXPORTER:otlp",
+            "OTEL_TRACES_SPAN_METRICS_ENABLED:true");
+
+        var settings = new TracerSettings(source);
+        settings.OtelTracesSpanMetricsEnabled.Should().BeTrue();
+
+        var exporterSettings = new ExporterSettings(source, _ => false, NullConfigurationTelemetry.Instance);
+
+        var mockResponse = new Mock<IApiResponse>();
+        mockResponse.Setup(r => r.StatusCode).Returns(200);
+
+        var mockMetricsRequest = new Mock<IApiRequest>();
+        mockMetricsRequest
+            .Setup(r => r.PostAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<string>()))
+            .ReturnsAsync(mockResponse.Object);
+
+        var mockTracesFactory = new Mock<IApiRequestFactory>();
+        mockTracesFactory.Setup(f => f.GetEndpoint(null)).Returns(new Uri("http://localhost:4317"));
+
+        var mockMetricsFactory = new Mock<IApiRequestFactory>();
+        mockMetricsFactory.Setup(f => f.Create(It.IsAny<Uri>())).Returns(mockMetricsRequest.Object);
+
+        var api = new ApiOtlp(mockTracesFactory.Object, mockMetricsFactory.Object, settings, exporterSettings);
+
+        var result = await api.SendStatsAsync(CreateBufferWithOneHit(), bucketDuration: 10_000_000_000L, tracerObfuscationVersion: 0);
+
+        result.Should().BeTrue();
+        mockMetricsRequest.Verify(r => r.PostAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<string>()), Times.Once);
+    }
+
+    private static StatsBuffer CreateBufferWithOneHit()
+    {
+        var buffer = new StatsBuffer(
+            new ClientStatsPayload(MutableSettings.CreateForTesting(new(), [])),
+            new StatsCardinalityLimiter(new TracerSettings()),
+            new StatsCardinalityReporter(NullMetricsTelemetryCollector.Instance));
+
+        var key = new StatsAggregationKey(
+            resource: "GET /",
+            service: "test-service",
+            operationName: "http.request",
+            type: "web",
+            httpStatusCode: 200,
+            isSyntheticsRequest: false,
+            spanKind: "server",
+            isError: false,
+            isTopLevel: true,
+            isTraceRoot: true,
+            httpMethod: "GET",
+            httpEndpoint: "/",
+            grpcStatusCode: string.Empty,
+            serviceSource: string.Empty,
+            peerTagsHash: 0,
+            additionalMetricTagsHash: 0,
+            truncatedFields: StatsCardinalityTruncatedFields.None);
+
+        buffer.Buckets.Add(key, new StatsBucket(key, [], []) { Hits = 1, Duration = 5_000_000 });
+        return buffer;
+    }
+
+    private static NameValueConfigurationSource BuildSource(params string[] config)
+    {
+        var configNameValues = new NameValueCollection();
+
+        foreach (var item in config)
+        {
+            var separatorIndex = item.IndexOf(':');
+            configNameValues.Add(item.Substring(0, separatorIndex), item.Substring(separatorIndex + 1));
+        }
+
+        return new NameValueConfigurationSource(configNameValues);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Agent/ApiOtlpTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ApiOtlpTests.cs
@@ -34,12 +34,15 @@ public class ApiOtlpTests
         mockTracesFactory.Setup(f => f.GetEndpoint(null)).Returns(new Uri("http://localhost:4317"));
 
         var mockMetricsRequest = new Mock<IApiRequest>();
+        mockMetricsRequest
+            .Setup(r => r.PostAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<string>()))
+            .Throws(new InvalidOperationException("PostAsync should not be called when span metrics are disabled."));
         var mockMetricsFactory = new Mock<IApiRequestFactory>();
         mockMetricsFactory.Setup(f => f.Create(It.IsAny<Uri>())).Returns(mockMetricsRequest.Object);
 
         var api = new ApiOtlp(mockTracesFactory.Object, mockMetricsFactory.Object, settings, exporterSettings);
 
-        var result = await api.SendStatsAsync(stats: null, bucketDuration: 0, tracerObfuscationVersion: 0);
+        var result = await api.SendStatsAsync(CreateBufferWithOneHit(), bucketDuration: 10_000_000_000L, tracerObfuscationVersion: 0);
         result.Should().BeTrue();
         mockMetricsRequest.Verify(r => r.PostAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<string>()), Times.Never);
     }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1055,6 +1055,33 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
+        [InlineData("otlp", true, true)] // OTLP export: explicit true is honored
+        [InlineData(null, true, false)] // non-OTLP export: explicit true is forced back to false
+        [InlineData(null, false, false)] // non-OTLP export: explicit false stays false
+        public void OtelTracesSpanMetricsEnabled_ForcedFalseWhenNotOtlpTraceExport(string tracesExporter, bool explicitValue, bool expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.OpenTelemetry.TracesExporter, tracesExporter),
+                (ConfigurationKeys.OpenTelemetry.TracesSpanMetricsEnabled, explicitValue.ToString()));
+            var telemetry = new ConfigurationTelemetry();
+            var settings = new TracerSettings(source, telemetry, new());
+
+            settings.OtelTracesSpanMetricsEnabled.Should().Be(expected);
+
+            var entries = telemetry.GetQueueForTesting()
+                                   .Where(e => e is { Key: ConfigurationKeys.OpenTelemetry.TracesSpanMetricsEnabled })
+                                   .OrderByDescending(e => e.SeqId)
+                                   .ToList();
+
+            // the originally-configured value, before the override is applied
+            entries.Should().ContainSingle(e => e.Origin == ConfigurationOrigins.Code)
+                   .Which.BoolValue.Should().Be(explicitValue);
+
+            var forcedFalse = explicitValue && !expected;
+            entries.Any(e => e.Origin == ConfigurationOrigins.Calculated && e.BoolValue == false).Should().Be(forcedFalse);
+        }
+
+        [Theory]
         [InlineData(null, 10000)]
         [InlineData("5000", 5000)]  // User custom value
         [InlineData("60000", 60000)]  // OTel spec default


### PR DESCRIPTION
## Summary of changes

Following https://github.com/DataDog/dd-trace-dotnet/pull/8826 a bug got introduced where OTLP sampling rules end up applying the Datadog traces as well

## Reason for change

fix wrong sampling for dd traces

## Implementation details

## Test coverage

Some new unit test 
Testing in https://github.com/DataDog/system-tests/pull/7361/changes

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
