### PR TITLE
[Tests] Skip MySQL and Npgsql tests on database timeouts

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -83,12 +83,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             string packageVersion = PackageVersions.MySqlConnector.First()[0] as string;
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
+            try
+            {
+                using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+                var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
-            Assert.NotEmpty(spans);
-            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
-            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.MySql);
+                Assert.NotEmpty(spans);
+                spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.MySql);
+            }
+            catch (ExitCodeException ex) when (ex.Message.Contains("Connection timed out"))
+            {
+                throw new SkipException("The MySQL test dependency timed out.");
+            }
         }
 
         private static int GetSpanCount(string packageVersionString)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -107,12 +107,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             string packageVersion = PackageVersions.Npgsql.First()[0] as string;
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
-            var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
+            try
+            {
+                using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+                var spans = await agent.WaitForSpansAsync(totalSpanCount, returnAllOperations: true);
 
-            Assert.NotEmpty(spans);
-            spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
-            await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Npgsql);
+                Assert.NotEmpty(spans);
+                spans.Where(s => s.Name.Equals(expectedOperationName)).Should().BeEmpty();
+                await telemetry.AssertIntegrationDisabledAsync(IntegrationId.Npgsql);
+            }
+            catch (ExitCodeException ex) when (ex.Message.Contains("Connection timed out"))
+            {
+                throw new SkipException("The PostgreSQL test dependency timed out.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
Skip the MySqlConnector and Npgsql disabled-integration tests when the database dependency times out.

## Reason for change
Avoid transient CI failures caused by database [connection timeouts](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/205246/logs/8769)

## Implementation details

## Test coverage

#incident-57303