### PR TITLE
[APM] Set _dd.apm.enabled:0 on all spans

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -879,10 +879,9 @@ namespace Datadog.Trace.Agent.MessagePack
                 }
             }
 
-            // add the "apm.enabled" tag with a value of 0 to every service-entry (aka top-level) span
-            // when APM tracing is disabled, so the backend flags each service in the trace correctly
-            // (not just the local root span).
-            if (!model.TraceChunk.IsApmEnabled && span.IsTopLevel)
+            // add the "apm.enabled" tag with a value of 0 to every span when APM tracing is disabled,
+            // so the backend flags every span in the trace as APM-disabled (not just service-entry spans).
+            if (!model.TraceChunk.IsApmEnabled)
             {
                 count++;
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ApmEnabledNameBytes);

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -879,9 +879,10 @@ namespace Datadog.Trace.Agent.MessagePack
                 }
             }
 
-            // add the "apm.enabled" tag with a value of 0
-            // to the first span in the chunk when APM is disabled
-            if (!model.TraceChunk.IsApmEnabled && model.IsLocalRoot)
+            // add the "apm.enabled" tag with a value of 0 to every service-entry (aka top-level) span
+            // when APM tracing is disabled, so the backend flags each service in the trace correctly
+            // (not just the local root span).
+            if (!model.TraceChunk.IsApmEnabled && span.IsTopLevel)
             {
                 count++;
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, ApmEnabledNameBytes);

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
@@ -683,10 +683,10 @@ public class SpanMessagePackFormatterTests
     }
 
     [Fact]
-    public async Task ApmDisabled_WritesApmEnabledZero_OnAllServiceEntrySpans()
+    public async Task ApmDisabled_WritesApmEnabledZero_OnAllSpans()
     {
-        // When APM tracing is disabled, "_dd.apm.enabled":0 must be written to EVERY service-entry
-        // (top-level) span, not just the local root span, so the backend flags each service correctly.
+        // When APM tracing is disabled, "_dd.apm.enabled":0 must be written to EVERY span
+        // (not just service-entry spans), so the backend flags every span in the trace correctly.
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.ApmTracingEnabled, false } });
         await using var tracer = TracerHelper.Create(settings);
         var traceContext = new TraceContext(tracer);
@@ -696,7 +696,7 @@ public class SpanMessagePackFormatterTests
         var root = new Span(rootContext, DateTimeOffset.UtcNow);
         root.OperationName = "root";
 
-        // child in the SAME service A -> NOT a service-entry span
+        // child in the SAME service A -> not a service-entry span
         var sameServiceContext = new SpanContext(rootContext, traceContext, "service-A");
         var sameService = new Span(sameServiceContext, DateTimeOffset.UtcNow);
         sameService.OperationName = "same-service-child";
@@ -719,16 +719,12 @@ public class SpanMessagePackFormatterTests
         var result = global::MessagePack.MessagePackSerializer.Deserialize<MockSpan[]>(new ArraySegment<byte>(bytes, 0, length));
 
         result.Should().HaveCount(3);
-        var rootSpan = result.Single(s => s.Name == "root");
-        var sameServiceSpan = result.Single(s => s.Name == "same-service-child");
-        var otherServiceSpan = result.Single(s => s.Name == "other-service-child");
 
-        // service-entry spans (local root AND the different-service child) get the tag
-        rootSpan.GetMetric("_dd.apm.enabled").Should().Be(0d);
-        otherServiceSpan.GetMetric("_dd.apm.enabled").Should().Be(0d);
-
-        // same-service child is not a service-entry span, so it must NOT get the tag
-        sameServiceSpan.GetMetric("_dd.apm.enabled").Should().BeNull();
+        // every span gets the tag, regardless of whether it is a service-entry span
+        foreach (var span in result)
+        {
+            span.GetMetric("_dd.apm.enabled").Should().Be(0d);
+        }
     }
 
     private readonly struct TagsProcessor<T> : IItemProcessor<T>

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
@@ -682,6 +682,55 @@ public class SpanMessagePackFormatterTests
         }
     }
 
+    [Fact]
+    public async Task ApmDisabled_WritesApmEnabledZero_OnAllServiceEntrySpans()
+    {
+        // When APM tracing is disabled, "_dd.apm.enabled":0 must be written to EVERY service-entry
+        // (top-level) span, not just the local root span, so the backend flags each service correctly.
+        var settings = TracerSettings.Create(new() { { ConfigurationKeys.ApmTracingEnabled, false } });
+        await using var tracer = TracerHelper.Create(settings);
+        var traceContext = new TraceContext(tracer);
+
+        // local root, service A -> service-entry span
+        var rootContext = new SpanContext(null, traceContext, "service-A");
+        var root = new Span(rootContext, DateTimeOffset.UtcNow);
+        root.OperationName = "root";
+
+        // child in the SAME service A -> NOT a service-entry span
+        var sameServiceContext = new SpanContext(rootContext, traceContext, "service-A");
+        var sameService = new Span(sameServiceContext, DateTimeOffset.UtcNow);
+        sameService.OperationName = "same-service-child";
+
+        // child in a DIFFERENT service B -> service-entry span
+        var otherServiceContext = new SpanContext(rootContext, traceContext, "service-B");
+        var otherService = new Span(otherServiceContext, DateTimeOffset.UtcNow);
+        otherService.OperationName = "other-service-child";
+
+        foreach (var span in new[] { root, sameService, otherService })
+        {
+            span.SetDuration(TimeSpan.FromSeconds(1));
+        }
+
+        var traceChunk = new TraceChunkModel(new SpanCollection(new[] { root, sameService, otherService }));
+        var formatter = SpanFormatterResolver.Instance.GetFormatter<TraceChunkModel>();
+        byte[] bytes = [];
+
+        var length = formatter.Serialize(ref bytes, 0, traceChunk, SpanFormatterResolver.Instance);
+        var result = global::MessagePack.MessagePackSerializer.Deserialize<MockSpan[]>(new ArraySegment<byte>(bytes, 0, length));
+
+        result.Should().HaveCount(3);
+        var rootSpan = result.Single(s => s.Name == "root");
+        var sameServiceSpan = result.Single(s => s.Name == "same-service-child");
+        var otherServiceSpan = result.Single(s => s.Name == "other-service-child");
+
+        // service-entry spans (local root AND the different-service child) get the tag
+        rootSpan.GetMetric("_dd.apm.enabled").Should().Be(0d);
+        otherServiceSpan.GetMetric("_dd.apm.enabled").Should().Be(0d);
+
+        // same-service child is not a service-entry span, so it must NOT get the tag
+        sameServiceSpan.GetMetric("_dd.apm.enabled").Should().BeNull();
+    }
+
     private readonly struct TagsProcessor<T> : IItemProcessor<T>
     {
         private readonly Dictionary<string, T> _expectedTags;

--- a/tracer/test/snapshots/Iast.StandaloneBilling.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StandaloneBilling.AspNetCore5.IastEnabled.verified.txt
@@ -79,6 +79,9 @@
       env: integration_tests,
       language: dotnet,
       span.kind: server
+    },
+    Metrics: {
+      _dd.apm.enabled: 0.0
     }
   }
 ]


### PR DESCRIPTION
## Summary of changes
When APM tracing is disabled, the "_dd.apm.enabled":0 metric was written only to the local root span. It must be written to **every span** in the trace so the backend flags all of them as APM-disabled.

The `span.IsTopLevel` condition is removed, so the metric is now added to every span (not just service-entry spans) whenever APM tracing is disabled.

## Reason for change
_dd.apm.enabled was added only to the local root span, but the backend needs it on all spans of the trace.

## Implementation details
Dropped the `span.IsTopLevel` guard around the `_dd.apm.enabled` metric in `SpanMessagePackFormatter`, leaving only the `!IsApmEnabled` check.

## Test coverage
- Updated the `SpanMessagePackFormatter` unit test to assert every span (local root, same-service child, and different-service child) receives `_dd.apm.enabled:0`.
- Updated the `Iast.StandaloneBilling` integration snapshot so the non-service-entry child span also carries the metric.

## Other details
<!-- Fixes #{issue} -->
