### PR TITLE
[CI] Speed up GitLab Windows build with parallel C++ compilation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,12 +108,12 @@ build:
         exit 1
       }
     - |
-      # Enable MSVC /MP, but cap it at two compiler processes to limit peak memory usage.
+      # Enable MSVC /MP, but cap it at three compiler processes to limit peak memory usage.
       docker run --rm -m 10240M `
         -v "$(Get-Location):c:\mnt" `
         -e CI_JOB_ID=${CI_JOB_ID} `
         -e ENABLE_MULTIPROCESSOR_COMPILATION=true `
-        -e CL_MPCount=2 `
+        -e CL_MPCount=3 `
         -e WINDOWS_BUILDER=true `
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,10 +108,12 @@ build:
         exit 1
       }
     - |
+      # Enable MSVC /MP, but cap it at two compiler processes to limit peak memory usage.
       docker run --rm -m 10240M `
         -v "$(Get-Location):c:\mnt" `
         -e CI_JOB_ID=${CI_JOB_ID} `
-        -e ENABLE_MULTIPROCESSOR_COMPILATION=false `
+        -e ENABLE_MULTIPROCESSOR_COMPILATION=true `
+        -e CL_MPCount=2 `
         -e WINDOWS_BUILDER=true `
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,12 +108,20 @@ build:
         exit 1
       }
     - |
-      # Enable MSVC /MP, but cap it at three compiler processes to limit peak memory usage.
-      docker run --rm -m 10240M `
+      try {
+        $computerSystem = Get-CimInstance Win32_ComputerSystem
+        $operatingSystem = Get-CimInstance Win32_OperatingSystem
+        Write-Output ("Runner memory: {0:N1} GB total, {1:N1} GB free" -f ($computerSystem.TotalPhysicalMemory / 1GB), ($operatingSystem.FreePhysicalMemory * 1KB / 1GB))
+      } catch {
+        Write-Warning "Unable to retrieve runner memory information: $_"
+      }
+
+      # Enable MSVC /MP, but cap it at four compiler processes to limit peak memory usage.
+      docker run --rm -m 16384M `
         -v "$(Get-Location):c:\mnt" `
         -e CI_JOB_ID=${CI_JOB_ID} `
         -e ENABLE_MULTIPROCESSOR_COMPILATION=true `
-        -e CL_MPCount=3 `
+        -e CL_MPCount=4 `
         -e WINDOWS_BUILDER=true `
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,12 +168,12 @@ build:
         Write-Output ("Peak container memory: {0} ({1:N1}% of limit)" -f $peakUsage, $peakPercent)
       }
 
-      # Enable MSVC /MP, but cap it at eight compiler processes to limit peak memory usage.
+      # Enable MSVC /MP, capped at the runner's logical processor count.
       docker run --name $containerName --rm -m 20480M `
         -v "$(Get-Location):c:\mnt" `
         -e CI_JOB_ID=${CI_JOB_ID} `
         -e ENABLE_MULTIPROCESSOR_COMPILATION=true `
-        -e CL_MPCount=8 `
+        -e CL_MPCount=16 `
         -e WINDOWS_BUILDER=true `
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,16 +112,47 @@ build:
         $computerSystem = Get-CimInstance Win32_ComputerSystem
         $operatingSystem = Get-CimInstance Win32_OperatingSystem
         Write-Output ("Runner memory: {0:N1} GB total, {1:N1} GB free" -f ($computerSystem.TotalPhysicalMemory / 1GB), ($operatingSystem.FreePhysicalMemory * 1KB / 1GB))
+        Write-Output "Runner logical processors: $($computerSystem.NumberOfLogicalProcessors)"
       } catch {
-        Write-Warning "Unable to retrieve runner memory information: $_"
+        Write-Warning "Unable to retrieve runner information: $_"
       }
 
-      # Enable MSVC /MP, but cap it at four compiler processes to limit peak memory usage.
-      docker run --rm -m 16384M `
+      $containerName = "dd-trace-build-$env:CI_JOB_ID"
+      $statsJob = Start-Job -ArgumentList $containerName -ScriptBlock {
+        param($name)
+
+        $containerSeen = $false
+        $peakPercent = 0.0
+        $peakUsage = "unknown"
+
+        while ($true) {
+          $stats = docker stats $name --no-stream --format "{{.MemPerc}}|{{.MemUsage}}" 2>$null
+          if ($LASTEXITCODE -eq 0 -and $stats) {
+            $containerSeen = $true
+            $parts = $stats -split '\|', 2
+            $percent = 0.0
+            if ($parts.Count -eq 2 -and
+                [double]::TryParse($parts[0].Trim().TrimEnd('%'), [Globalization.NumberStyles]::Float, [Globalization.CultureInfo]::InvariantCulture, [ref]$percent) -and
+                $percent -gt $peakPercent) {
+              $peakPercent = $percent
+              $peakUsage = $parts[1].Trim()
+            }
+          } elseif ($containerSeen) {
+            break
+          }
+
+          Start-Sleep -Seconds 5
+        }
+
+        Write-Output ("Peak container memory: {0} ({1:N1}% of limit)" -f $peakUsage, $peakPercent)
+      }
+
+      # Enable MSVC /MP, but cap it at eight compiler processes to limit peak memory usage.
+      docker run --name $containerName --rm -m 20480M `
         -v "$(Get-Location):c:\mnt" `
         -e CI_JOB_ID=${CI_JOB_ID} `
         -e ENABLE_MULTIPROCESSOR_COMPILATION=true `
-        -e CL_MPCount=4 `
+        -e CL_MPCount=8 `
         -e WINDOWS_BUILDER=true `
         -e AWS_NETWORKING=true `
         -e SIGN_WINDOWS=true `
@@ -131,6 +162,19 @@ build:
         -e CI_JOB_NAME_SLUG `
         $env:WINDOWS_BUILD_IMAGE `
         Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader BuildDdDotnet PublishFleetInstaller PackageTracerHome ZipSymbols SignDlls SignMsi DownloadWinSsiTelemetryForwarder
+      $buildExitCode = $LASTEXITCODE
+
+      Wait-Job $statsJob -Timeout 15 | Out-Null
+      if ($statsJob.State -eq 'Running') {
+        Stop-Job $statsJob
+      }
+
+      Receive-Job $statsJob
+      Remove-Job $statsJob -Force
+
+      if ($buildExitCode -ne 0) {
+        throw "Docker build container exited with code $buildExitCode"
+      }
     - mkdir artifacts-out
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out
     - remove-item -recurse -force build-out\${CI_JOB_ID}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,24 +118,44 @@ build:
       }
 
       $containerName = "dd-trace-build-$env:CI_JOB_ID"
-      $statsJob = Start-Job -ArgumentList $containerName -ScriptBlock {
-        param($name)
+      $containerMemoryLimit = 20GB
+      $dockerPath = (Get-Command docker).Source
+      $statsJob = Start-Job -ArgumentList $containerName, $containerMemoryLimit, $dockerPath -ScriptBlock {
+        param($name, $memoryLimit, $docker)
+
+        function ConvertTo-Bytes([string] $value) {
+          if ($value -notmatch '^\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGT]?i?B)\s*$') {
+            return $null
+          }
+
+          $factors = @{
+            B   = 1
+            KB  = 1KB
+            KiB = 1KB
+            MB  = 1MB
+            MiB = 1MB
+            GB  = 1GB
+            GiB = 1GB
+            TB  = 1TB
+            TiB = 1TB
+          }
+
+          return [double]$Matches[1] * $factors[$Matches[2]]
+        }
 
         $containerSeen = $false
-        $peakPercent = 0.0
+        $peakBytes = 0.0
         $peakUsage = "unknown"
 
         while ($true) {
-          $stats = docker stats $name --no-stream --format "{{.MemPerc}}|{{.MemUsage}}" 2>$null
+          $stats = & $docker stats $name --no-stream --format "{{.MemUsage}}" 2>$null
           if ($LASTEXITCODE -eq 0 -and $stats) {
             $containerSeen = $true
-            $parts = $stats -split '\|', 2
-            $percent = 0.0
-            if ($parts.Count -eq 2 -and
-                [double]::TryParse($parts[0].Trim().TrimEnd('%'), [Globalization.NumberStyles]::Float, [Globalization.CultureInfo]::InvariantCulture, [ref]$percent) -and
-                $percent -gt $peakPercent) {
-              $peakPercent = $percent
-              $peakUsage = $parts[1].Trim()
+            $usage = ($stats -split '/', 2)[0].Trim()
+            $usageBytes = ConvertTo-Bytes $usage
+            if ($null -ne $usageBytes -and $usageBytes -gt $peakBytes) {
+              $peakBytes = $usageBytes
+              $peakUsage = $usage
             }
           } elseif ($containerSeen) {
             break
@@ -144,6 +164,7 @@ build:
           Start-Sleep -Seconds 5
         }
 
+        $peakPercent = 100 * $peakBytes / $memoryLimit
         Write-Output ("Peak container memory: {0} ({1:N1}% of limit)" -f $peakUsage, $peakPercent)
       }
 


### PR DESCRIPTION
## Summary of changes

Enable MSVC multiprocessor compilation for the GitLab Windows build, capped at the runner's 16 logical processors. Increase the container memory limit from 10 GB to 20 GB and log runner and peak container memory.

## Reason for change

The Windows GitLab build took around 40 minutes. Native compilation accounted for 24:52 of the 31:45 NUKE execution.

## Implementation details

Set `ENABLE_MULTIPROCESSOR_COMPILATION=true` and `CL_MPCount=16`. The runner has 16 logical processors and approximately 31 GB of RAM. Peak container usage with MP16 was 9.105 GiB.

## Test coverage

| Configuration | NUKE | Native compilation | End-to-end | Peak container memory |
| --- | ---: | ---: | ---: | ---: |
| Baseline, MP disabled / 10 GB | 31:45 | 24:52 | ~40 min | Not measured |
| MP2 / 10 GB | 22:27 | 14:40 | ~29–31 min | Not measured |
| MP3 / 10 GB | Not measured | Not measured | ~24–28 min | Not measured |
| MP4 / 16 GB | 15:00–15:54 | Not measured | ~17–23 min | Not measured |
| MP8 / 16 GB | 13:50 | 6:01 | 23:27 | Not measured |
| MP8 / 20 GB | 13:11 | 5:44 | 21:31 | 8.686 GiB |
| MP16 / 20 GB | 11:37 | 4:37 | 19:54 | 9.105 GiB |

| Configuration | Tracer | Loader | Profiler |
| --- | ---: | ---: | ---: |
| Baseline | 8:38 | 2:46 | 13:28 |
| MP2 / 10 GB | 5:15 | 1:40 | 7:45 |
| MP8 / 16 GB | 2:21 | 0:42 | 2:58 |
| MP8 / 20 GB | 2:13 | 0:41 | 2:50 |
| MP16 / 20 GB | 1:50 | 0:33 | 2:14 |

MP16 reduced NUKE time by approximately 63% and cold end-to-end time by approximately 50% compared with `master`. All runs completed without OOM or compiler failures. End-to-end variance was mostly caused by the 7–9 minute Docker image pull.