### PR TITLE
[ADO.NET] Fix flaky Microsoft.Data.SqlClient test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -54,10 +54,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             SetEnvironmentVariable("DD_DBM_PROPAGATION_MODE", propagation);
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
-            // The sample creates two large traces. Flush them in smaller chunks so a trace that is too
-            // large for the writer's active buffer is not dropped before the sample can force a flush.
-            SetEnvironmentVariable("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true");
-            SetEnvironmentVariable("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "20");
             var isExternalSpan = metadataSchemaVersion == "v0";
             var clientSpanServiceName = isExternalSpan ? $"{EnvironmentHelper.FullSampleName}-{dbType}" : EnvironmentHelper.FullSampleName;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -54,6 +54,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             SetEnvironmentVariable("DD_DBM_PROPAGATION_MODE", propagation);
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
+            // The sample creates two large traces. Flush them in smaller chunks so a trace that is too
+            // large for the writer's active buffer is not dropped before the sample can force a flush.
+            SetEnvironmentVariable("DD_TRACE_PARTIAL_FLUSH_ENABLED", "true");
+            SetEnvironmentVariable("DD_TRACE_PARTIAL_FLUSH_MIN_SPANS", "20");
             var isExternalSpan = metadataSchemaVersion == "v0";
             var clientSpanServiceName = isExternalSpan ? $"{EnvironmentHelper.FullSampleName}-{dbType}" : EnvironmentHelper.FullSampleName;
 

--- a/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
@@ -24,12 +24,10 @@ namespace Samples.Microsoft.Data.SqlClient
                     return 13;
                 }
 
-                await RelationalDatabaseTestHarness.RunAllAsync<SqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunAllAsync<SqlCommand>(connection, commandFactory, commandExecutor, cts.Token, flushAfterEachExecutor: true);
             }
 
-            // Flush the first phase's trace before starting the next phase. Each phase produces a single
-            // large trace, so draining this one first stops the two from competing for the writer's buffers
-            // (a locally dropped trace here would fail the exact span-count assertion in the test).
+            // Flush any spans created while disposing the first connection before starting the next phase.
             await SampleHelpers.ForceTracerFlushAsync();
 
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
@@ -46,10 +44,10 @@ namespace Samples.Microsoft.Data.SqlClient
                 }
 
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
-                await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
+                await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token, flushAfterEachExecutor: true);
             }
 
-            // Flush before exit so all spans are delivered (deterministic, unlike a fixed delay).
+            // Flush any spans created while disposing the second connection before exit.
             await SampleHelpers.ForceTracerFlushAsync();
             return 0;
         }

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -20,6 +20,7 @@ namespace Samples.DatabaseHelper
         /// <param name="providerSpecificCommandExecutor">A <see cref="IDbCommandExecutor"/> specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand, used to call DbCommand methods.</param>
         /// <param name="cancellationToken">A cancellation token passed into downstream async methods.</param>
         /// <param name="useTransactionScope">Whether or not a Transcation Scope should be created.</param>
+        /// <param name="flushAfterEachExecutor">Whether each executor should use a separate trace that is flushed before the next executor starts.</param>
         /// <typeparam name="TCommand">The DbCommand implementation specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand.</typeparam>
         /// <returns>A task representing the asynchronous operation.</returns>
         public static async Task RunAllAsync<TCommand>(
@@ -27,7 +28,8 @@ namespace Samples.DatabaseHelper
             DbCommandFactory commandFactory,
             IDbCommandExecutor providerSpecificCommandExecutor,
             CancellationToken cancellationToken,
-            bool useTransactionScope = true)
+            bool useTransactionScope = true,
+            bool flushAfterEachExecutor = false)
             where TCommand : IDbCommand
         {
             var executors = new List<IDbCommandExecutor>
@@ -54,13 +56,7 @@ namespace Samples.DatabaseHelper
                                 new DbCommandNetStandardInterfaceGenericExecutor<TCommand>(),
                             };
 
-            using (var root = SampleHelpers.CreateScope("RunAllAsync<TCommand>"))
-            {
-                foreach (var executor in executors)
-                {
-                    await RunAsync(connection, commandFactory, executor, cancellationToken, useTransactionScope);
-                }
-            }
+            await RunExecutorsAsync(connection, commandFactory, executors, cancellationToken, useTransactionScope, "RunAllAsync<TCommand>", flushAfterEachExecutor);
         }
 
         /// <summary>
@@ -70,12 +66,14 @@ namespace Samples.DatabaseHelper
         /// <param name="commandFactory">A <see cref="DbCommandFactory"/> implementation specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand.</param>
         /// <param name="cancellationToken">A cancellation token passed into downstream async methods.</param>
         /// <param name="useTransactionScope">Whether or not a Transcation Scope should be created.</param>
+        /// <param name="flushAfterEachExecutor">Whether each executor should use a separate trace that is flushed before the next executor starts.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         public static async Task RunBaseClassesAsync(
             IDbConnection connection,
             DbCommandFactory commandFactory,
             CancellationToken cancellationToken,
-            bool useTransactionScope = true)
+            bool useTransactionScope = true,
+            bool flushAfterEachExecutor = false)
         {
             var executors = new List<IDbCommandExecutor>
                             {
@@ -92,13 +90,7 @@ namespace Samples.DatabaseHelper
                                 new DbCommandNetStandardInterfaceExecutor(),
                             };
 
-            using (var root = SampleHelpers.CreateScope("RunBaseClassesAsync"))
-            {
-                foreach (var executor in executors)
-                {
-                    await RunAsync(connection, commandFactory, executor, cancellationToken, useTransactionScope);
-                }
-            }
+            await RunExecutorsAsync(connection, commandFactory, executors, cancellationToken, useTransactionScope, "RunBaseClassesAsync", flushAfterEachExecutor);
         }
 
         public static async Task RunSingleAsync(
@@ -144,6 +136,39 @@ namespace Samples.DatabaseHelper
                 {
                     await RunAsync(connection, commandFactory, executor, cancellationToken, useTransactionScope);
                 }
+            }
+        }
+
+        private static async Task RunExecutorsAsync(
+            IDbConnection connection,
+            DbCommandFactory commandFactory,
+            List<IDbCommandExecutor> executors,
+            CancellationToken cancellationToken,
+            bool useTransactionScope,
+            string rootScopeName,
+            bool flushAfterEachExecutor)
+        {
+            if (!flushAfterEachExecutor)
+            {
+                using (SampleHelpers.CreateScope(rootScopeName))
+                {
+                    foreach (var executor in executors)
+                    {
+                        await RunAsync(connection, commandFactory, executor, cancellationToken, useTransactionScope);
+                    }
+                }
+
+                return;
+            }
+
+            foreach (var executor in executors)
+            {
+                using (SampleHelpers.CreateScope(rootScopeName))
+                {
+                    await RunAsync(connection, commandFactory, executor, cancellationToken, useTransactionScope);
+                }
+
+                await SampleHelpers.ForceTracerFlushAsync();
             }
         }
 


### PR DESCRIPTION
## Summary of changes

Update the `Microsoft.Data.SqlClient` sample to complete and flush each command executor trace before starting the next one. The shared database harness exposes this as opt-in behavior, preserving the existing behavior for other database samples.

## Reason for change

The test has been [detected as flaky](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/205258/logs/5973) when the first large trace is dropped before reaching the mock agent.

```
2026-07-21T11:51:00.1449146Z 11:51:00 [DBG]   Failed Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet.MicrosoftDataSqlClientTests.SubmitsTraces(packageVersion: "1.1.4", metadataSchemaVersion: "v1", propagation: "full") [22 s]
2026-07-21T11:51:00.1450474Z 11:51:00 [DBG]   Error Message:
2026-07-21T11:51:00.1467490Z 11:51:00 [DBG]    Expected relevantSpans to contain at least 147 item(s) because we want to ensure that we don't timeout while waiting for spans from the mock tracer agent, but found 69
```

Splitting the workload into smaller completed traces and flushing each one makes delivery deterministic without changing the tracer configuration used by the test. Only the sample detected as flaky opts into this behavior.

## Test coverage
