### PR TITLE
Mark Debugger MethodProbeTest_NamedPipes as Flaky

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -552,6 +552,7 @@ public class ProbesTests : TestHelper
     [Trait("Category", "ArmUnsupported")]
     [Trait("Category", "LinuxUnsupported")]
     [Trait("RunOnWindows", "True")]
+    [Flaky("Named pipes is flaky", maxRetries: 3)]
     public async Task MethodProbeTest_NamedPipes()
     {
         if (!EnvironmentTools.IsWindows())


### PR DESCRIPTION
## Summary of changes

Marks Debugger MethodProbeTest_NamedPipes as Flaky

## Reason for change

Named pipes are a common source of flake in CI and they flaked here so marking them as flaky.

## Implementation details

Added [Flaky]

## Test coverage

Same, but will re-run if they flake

## Other details
<!-- Fixes #{issue} -->

#incident-57303
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
