### PR TITLE
[IAST] Add Class field to vulnerability Location and repurpose Path to source file

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rasp/MetaStructHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/MetaStructHelper.cs
@@ -114,6 +114,11 @@ internal static class MetaStructHelper
                         locationDict["path"] = location.Path;
                     }
 
+                    if (location.Class is { Length: > 0 })
+                    {
+                        locationDict["class"] = location.Class;
+                    }
+
                     if (location.Method is { Length: > 0 })
                     {
                         locationDict["method"] = location.Method;

--- a/tracer/src/Datadog.Trace/Iast/Location.cs
+++ b/tracer/src/Datadog.Trace/Iast/Location.cs
@@ -23,7 +23,7 @@ internal readonly struct Location
         var index = method.LastIndexOf("::", StringComparison.Ordinal);
         if (index >= 0)
         {
-            Path = method.Substring(0, length: index);
+            Class = method.Substring(0, length: index);
             var bracketIndex = method.IndexOf("(", startIndex: index + 2, StringComparison.Ordinal);
             Method = bracketIndex > 0
                          ? method.Substring(index + 2, length: bracketIndex - index - 2)
@@ -38,10 +38,12 @@ internal readonly struct Location
     public Location(StackFrame? stackFrame, StackTrace? stack, string? stackId, ulong? spanId)
     {
         var method = stackFrame?.GetMethod();
-        Path = method?.DeclaringType?.FullName;
+        Class = method?.DeclaringType?.FullName;
         Method = method?.Name;
         var line = stackFrame?.GetFileLineNumber();
         Line = line > 0 ? line : null;
+        var fileName = stackFrame?.GetFileName();
+        Path = string.IsNullOrEmpty(fileName) ? null : System.IO.Path.GetFileName(fileName);
 
         SpanId = spanId == 0 ? null : spanId;
 
@@ -51,7 +53,7 @@ internal readonly struct Location
 
     internal Location(string? typeName, string? methodName, int? line, ulong? spanId) // For testing purposes only
     {
-        this.Path = typeName;
+        this.Class = typeName;
         this.Method = methodName;
         Line = line > 0 ? line : null;
 
@@ -62,6 +64,8 @@ internal readonly struct Location
 
     public string? Path { get; }
 
+    public string? Class { get; }
+
     public string? Method { get; }
 
     public int? Line { get; }
@@ -71,7 +75,7 @@ internal readonly struct Location
     public override int GetHashCode()
     {
         // We do not calculate the hash including the spanId nor the line
-        return IastUtils.GetHashCode(Path, Method);
+        return IastUtils.GetHashCode(Class, Method);
     }
 
     internal void ReportStack(Span? span)

--- a/tracer/src/Datadog.Trace/Iast/Location.cs
+++ b/tracer/src/Datadog.Trace/Iast/Location.cs
@@ -16,6 +16,9 @@ namespace Datadog.Trace.Iast;
 
 internal readonly struct Location
 {
+    // Both Windows ('\') and Unix ('/') separators, because PDBs produced on one OS may be read on another.
+    private static readonly char[] PathSeparators = ['/', '\\'];
+
     internal readonly StackTrace? _stack = null;
 
     public Location(string method)
@@ -42,8 +45,7 @@ internal readonly struct Location
         Method = method?.Name;
         var line = stackFrame?.GetFileLineNumber();
         Line = line > 0 ? line : null;
-        var fileName = stackFrame?.GetFileName();
-        Path = string.IsNullOrEmpty(fileName) ? null : System.IO.Path.GetFileName(fileName);
+        Path = GetFileName(stackFrame?.GetFileName());
 
         SpanId = spanId == 0 ? null : spanId;
 
@@ -76,6 +78,20 @@ internal readonly struct Location
     {
         // We do not calculate the hash including the spanId nor the line
         return IastUtils.GetHashCode(Class, Method);
+    }
+
+    // Extracts the file name from a path, handling both Windows ('\') and Unix ('/') separators.
+    // We can't rely on System.IO.Path.GetFileName here because it only recognizes the current OS
+    // separator, so a Windows path read on Unix (from a Windows-built PDB) would leak the full path.
+    private static string? GetFileName(string? filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return null;
+        }
+
+        var separatorIndex = filePath!.LastIndexOfAny(PathSeparators);
+        return separatorIndex >= 0 ? filePath.Substring(separatorIndex + 1) : filePath;
     }
 
     internal void ReportStack(Span? span)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -375,7 +375,7 @@ public class AspNetCore5IastTestsStackTraces : AspNetCore5IastTests
         var settings = VerifyHelper.GetSpanVerifierSettings();
         settings.AddIastScrubbing();
         var hashRegex = (new Regex(@"""hash"": -?\d+"), @"""hash"": XXX");
-        var pathRegex = (new Regex(@"""path"": ""AspNetCore.*\."), @"""path"": ""AspNetCore.");
+        var pathRegex = (new Regex(@"""class"": ""AspNetCore.*\."), @"""class"": ""AspNetCore.");
 
         settings.AddRegexScrubber(hashRegex);
         settings.AddRegexScrubber(pathRegex);
@@ -658,8 +658,8 @@ public class AspNetCore5IastTestsRestartedSampleIastEnabled : AspNetCore5IastTes
         (Regex RegexPattern, string Replacement) sessionIdleTimeoutRegex = (new Regex(@"Session idle timeout is configured with: options.IdleTimeout, with a value of \d+ minutes"), "Session idle timeout is configured with: options.IdleTimeout, with a value of XXX minutes");
         (Regex RegexPattern, string Replacement) hashRegex = (new Regex(@"""hash"": -?\d+"), @"""hash"": XXX");
 
-        // Only for net5.0: path and method are different
-        (Regex RegexPattern, string Replacement) pathRegex = (new Regex(@"""path"": ""Samples.Security.AspNetCore5.Program"""), @"""path"": ""Samples.Security.AspNetCore5.Startup+<>c__DisplayClass4_0""");
+        // Only for net5.0: class and method are different
+        (Regex RegexPattern, string Replacement) pathRegex = (new Regex(@"""class"": ""Samples.Security.AspNetCore5.Program"""), @"""class"": ""Samples.Security.AspNetCore5.Startup+<>c__DisplayClass4_0""");
         (Regex RegexPattern, string Replacement) methodRegex = (new Regex(@"""method"": ""Main"""), @"""method"": ""<ConfigureServices>b__0""");
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
@@ -895,7 +895,7 @@ public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
         settings.AddIastScrubbing()
-            .AddRegexScrubber((new Regex("\"path\": \"Samples.Security.AspNetCore5.Controllers.IastController\\+.*"), "\"path\": \"Samples.Security.AspNetCore5.Controllers.IastController+\""))
+            .AddRegexScrubber((new Regex("\"class\": \"Samples.Security.AspNetCore5.Controllers.IastController\\+.*"), "\"class\": \"Samples.Security.AspNetCore5.Controllers.IastController+\""))
             .AddRegexScrubber((new Regex("\"hash\": .*"), "\"hash\": 9515978"))
             .AddRegexScrubber((new Regex("\"method\": \"<Ldap>g__PerformLdapQuery\\|.\""), "\"method\": \"<Ldap>g__PerformLdapQuery|0\""));
         await VerifySpans(spansFiltered, settings, fileNameOverride: filename);
@@ -1208,7 +1208,7 @@ public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
 public abstract class AspNetCore5IastTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
 #pragma warning disable SA1311 // Static readonly fields should begin with upper-case letter
-    protected static readonly (Regex RegexPattern, string Replacement) aspNetCorePathScrubber = (new Regex("\"path\": \"AspNetCore[^\\.]+\\."), "\"path\": \"AspNetCore.");
+    protected static readonly (Regex RegexPattern, string Replacement) aspNetCorePathScrubber = (new Regex("\"class\": \"AspNetCore[^\\.]+\\."), "\"class\": \"AspNetCore.");
     protected static readonly (Regex RegexPattern, string Replacement) hashScrubber = (new Regex("\"hash\": .+,"), "\"hash\": XXX,");
 #pragma warning restore SA1311 // Static readonly fields should begin with upper-case letter
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Grpc/GrpcDotNetTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Grpc/GrpcDotNetTests.cs
@@ -60,7 +60,7 @@ public class GrpcDotNetTests : TestHelper
         var settings = VerifyHelper.GetSpanVerifierSettings();
 
         // Add scrub for the location data, as using APM sample, we won't disable symbols on their sample
-        (Regex RegexPattern, string Replacement) locationMsgRegex = (new Regex(@"(\S)*""location"": {(\r|\n){1,2}(.*(\r|\n){1,2}){0,4}(\s)*},"), string.Empty);
+        (Regex RegexPattern, string Replacement) locationMsgRegex = (new Regex(@"(\S)*""location"": {(\r|\n){1,2}(.*(\r|\n){1,2}){0,6}(\s)*},"), string.Empty);
         settings.AddRegexScrubber(locationMsgRegex);
 
         settings.AddIastScrubbing();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/LocationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/LocationTests.cs
@@ -18,7 +18,7 @@ public class LocationTests
         var method = "GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable";
         var typeName = "Samples.InstrumentedTests.Iast.Vulnerabilities.CommandInjectionTests";
         var location = new Location(typeName, method, 23, 4);
-        location.Path.Should().Be(typeName);
+        location.Class.Should().Be(typeName);
         location.Method.Should().Be(method);
     }
 
@@ -27,7 +27,7 @@ public class LocationTests
     {
         var method = "GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable";
         var location = new Location(null, method, null, 4);
-        location.Path.Should().BeNull();
+        location.Class.Should().BeNull();
         location.Method.Should().Be("GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable");
     }
 
@@ -36,7 +36,7 @@ public class LocationTests
     {
         var method = "Samples.InstrumentedTests.Iast.Vulnerabilities.CommandInjectionTests.GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable";
         var location = new Location(null, method, 23, 4);
-        location.Path.Should().BeNull();
+        location.Class.Should().BeNull();
         location.Method.Should().Be("Samples.InstrumentedTests.Iast.Vulnerabilities.CommandInjectionTests.GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable");
     }
 
@@ -44,17 +44,18 @@ public class LocationTests
     public void GivenALocation_WhenCreatedFromNull_NothingIsStored()
     {
         var location = new Location(null, null, 23, 4);
-        location.Path.Should().BeNull();
+        location.Class.Should().BeNull();
         location.Method.Should().BeNull();
     }
 
     [Fact]
     public void GivenALocation_WhenCreatedFromStackFrame_ValueIsExpected()
     {
-        var stack = new StackTrace();
+        var stack = new StackTrace(fNeedFileInfo: true);
         var frame = stack.GetFrame(0);
         var location = new Location(frame, stack, null, null);
-        location.Path.Should().Be("Datadog.Trace.Security.Unit.Tests.IAST.LocationTests");
+        location.Class.Should().Be("Datadog.Trace.Security.Unit.Tests.IAST.LocationTests");
         location.Method.Should().Be("GivenALocation_WhenCreatedFromStackFrame_ValueIsExpected");
+        location.Path.Should().Be("LocationTests.cs");
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
@@ -513,7 +513,7 @@ public partial class VulnerabilityBatchTests
                     "spanId": 123456,
                     "line": 1,
                     "method": "fooMethod",
-                    "path": "foo"
+                    "class": "foo"
                   }
                 }
               ]
@@ -548,7 +548,7 @@ public partial class VulnerabilityBatchTests
                     "spanId": 123456,
                     "line": 1,
                     "method": "fooMethod",
-                    "path": "foo"
+                    "class": "foo"
                   },
                   "type": "WEAK_HASH"
                 },
@@ -561,7 +561,7 @@ public partial class VulnerabilityBatchTests
                     "spanId": 123456,
                     "line": 1,
                     "method": "fooMethod",
-                    "path": "foo"
+                    "class": "foo"
                   },
                   "type": "WEAK_HASH"
                 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/vulnerability_schema.json
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/vulnerability_schema.json
@@ -86,7 +86,11 @@
                 "type": "integer"
               },
               "path": {
-                "description": "The name of the file containing the vulnerability or class name",
+                "description": "The name of the source file containing the vulnerability (only available with debug info)",
+                "type": "string"
+              },
+              "class": {
+                "description": "The name of the class (declaring type) where this location points to",
                 "type": "string"
               },
               "line": {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 469656765,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TestCookieName"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CustomAttribute.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CustomAttribute.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -2017497883,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetCustomString"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CustomAttribute.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CustomAttribute.AspNetCore5.IastEnabled.verified.txt
@@ -29,7 +29,7 @@
       "hash": -2017497883,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetCustomString"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CustomManual.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CustomManual.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1292214103,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "CustomManual"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.CustomManual.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CustomManual.AspNetCore5.IastEnabled.verified.txt
@@ -29,7 +29,7 @@
       "hash": -1292214103,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "CustomManual"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.DatabaseSourceInjection.AspNetCore5.Mixed.verified.txt
+++ b/tracer/test/snapshots/Iast.DatabaseSourceInjection.AspNetCore5.Mixed.verified.txt
@@ -33,7 +33,7 @@
       "hash": 760067032,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "DatabaseSourceInjection"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.DirectoryListingLeak.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.DirectoryListingLeak.AspNetCore5.IastEnabled.verified.txt
@@ -18,7 +18,7 @@
       "type": "DIRECTORY_LISTING_LEAK",
       "hash": 758800904,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Startup",
+        "class": "Samples.Security.AspNetCore5.Startup",
         "method": "Configure"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.EmailHtmlInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.EmailHtmlInjection.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -543813396,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SendMailAux"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.EmailHtmlInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.EmailHtmlInjection.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 799617955,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Helpers.EmailHelper",
+        "class": "Samples.Security.AspNetCore5.Helpers.EmailHelper",
         "method": "SendEmailSystemLib"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.EmailHtmlInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.EmailHtmlInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -543813396,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SendMailAux"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -70,7 +70,7 @@
       "type": "HARDCODED_SECRET",
       "hash": -956844721,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {
@@ -106,7 +106,7 @@
       "type": "HARDCODED_SECRET",
       "hash": 1765594085,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {
@@ -142,7 +142,7 @@
       "type": "HARDCODED_SECRET",
       "hash": 1916343769,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {
@@ -178,7 +178,7 @@
       "type": "HARDCODED_SECRET",
       "hash": 465913083,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.verified.txt
@@ -70,7 +70,7 @@
       "type": "HARDCODED_SECRET",
       "hash": -956844721,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {
@@ -106,7 +106,7 @@
       "type": "HARDCODED_SECRET",
       "hash": 1765594085,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {
@@ -142,7 +142,7 @@
       "type": "HARDCODED_SECRET",
       "hash": 1916343769,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {
@@ -178,7 +178,7 @@
       "type": "HARDCODED_SECRET",
       "hash": 465913083,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.JavaScriptSerializerDeserializeObject.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.JavaScriptSerializerDeserializeObject.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.JsonTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.JsonTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
@@ -36,7 +36,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -48,7 +48,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -60,7 +60,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -72,7 +72,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -84,7 +84,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -96,7 +96,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -108,7 +108,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -120,7 +120,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -132,7 +132,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -144,7 +144,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -156,7 +156,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -168,7 +168,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -180,7 +180,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -192,7 +192,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -204,7 +204,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -216,7 +216,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -228,7 +228,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -240,7 +240,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -252,7 +252,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -264,7 +264,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -276,7 +276,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -288,7 +288,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -300,7 +300,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -312,7 +312,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -324,7 +324,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -336,7 +336,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -348,7 +348,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -360,7 +360,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -372,7 +372,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -384,7 +384,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -396,7 +396,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -408,7 +408,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -420,7 +420,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -432,7 +432,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     },
@@ -444,7 +444,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       }
     }

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 941004385,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "Ldap"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 941004385,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "Ldap"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 9515978
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController+"
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController+"
         "method": "<Ldap>g__PerformLdapQuery|0"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 9515978
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController+"
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController+"
         "method": "<Ldap>g__PerformLdapQuery|0"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": 9515978,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController+<>c__DisplayClass28_0",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController+<>c__DisplayClass28_0",
         "method": "<Ldap>g__PerformLdapQuery|0"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.10.10.verified.txt
+++ b/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.10.10.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1779576281,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "MaxRanges"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.10.15.verified.txt
+++ b/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.10.15.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1779576281,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "MaxRanges"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.15.15.verified.txt
+++ b/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.15.15.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1779576281,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "MaxRanges"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.5.15.verified.txt
+++ b/tracer/test/snapshots/Iast.MaxRanges.AspNetCore5.IastEnabled.5.15.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1779576281,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "MaxRanges"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.MetaStruct.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.MetaStruct.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1084027092,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TypeReflectionInjection"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.MetaStructTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.MetaStructTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -45,7 +45,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -57,7 +57,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -69,7 +69,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -81,7 +81,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -93,7 +93,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -105,7 +105,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -117,7 +117,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -129,7 +129,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -141,7 +141,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -153,7 +153,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -165,7 +165,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -177,7 +177,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -189,7 +189,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -201,7 +201,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -213,7 +213,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -225,7 +225,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -237,7 +237,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -249,7 +249,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -261,7 +261,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -273,7 +273,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -285,7 +285,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -297,7 +297,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -309,7 +309,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -321,7 +321,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -333,7 +333,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -345,7 +345,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -357,7 +357,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -369,7 +369,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -381,7 +381,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -393,7 +393,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -405,7 +405,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -417,7 +417,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -429,7 +429,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {
@@ -441,7 +441,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.NHibernateSqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.NHibernateSqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1532278957,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.Data.NHibernateHelper",
+        "class": "Samples.Security.Data.NHibernateHelper",
         "method": "CreateSqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.NHibernateSqlInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.NHibernateSqlInjection.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1532278957,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.Data.NHibernateHelper",
+        "class": "Samples.Security.Data.NHibernateHelper",
         "method": "CreateSqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.NewtonsoftJsonParseTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.NewtonsoftJsonParseTainting.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.NoSqlMongoDbInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.NoSqlMongoDbInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 254412174,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "NoSqlQueryMongoDb"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.NoSqlMongoDbInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.NoSqlMongoDbInjection.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 254412174,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "NoSqlQueryMongoDb"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.TelemetryEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.TelemetryEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.QueryParameterName.AspNetCore5.verified.txt
+++ b/tracer/test/snapshots/Iast.QueryParameterName.AspNetCore5.verified.txt
@@ -33,7 +33,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.QueryParameterName.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.QueryParameterName.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectedXss.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.ReflectedXss.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectedXss.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,8 @@
       "hash": -2097573301,
       "location": {
         "spanId": XXX,
-        "path": "ASP._Page_Views_Iast_ReflectedXss_cshtml",
+        "path": "ReflectedXss.cshtml",
+        "class": "ASP._Page_Views_Iast_ReflectedXss_cshtml",
         "method": "Execute",
         "line": XXX
       },

--- a/tracer/test/snapshots/Iast.ReflectionInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectionInjection.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1084027092,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TypeReflectionInjection"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 1200051503,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore2.Pages.DataRazorIastPageModel",
+        "class": "Samples.Security.AspNetCore2.Pages.DataRazorIastPageModel",
         "method": "OnPost"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 1200051503,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore2.Pages.DataRazorIastPageModel",
+        "class": "Samples.Security.AspNetCore2.Pages.DataRazorIastPageModel",
         "method": "OnPost"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1750686827,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.DataRazorIastPageModel",
+        "class": "Samples.Security.AspNetCore5.DataRazorIastPageModel",
         "method": "OnPost"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 1750686827,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.DataRazorIastPageModel",
+        "class": "Samples.Security.AspNetCore5.DataRazorIastPageModel",
         "method": "OnPost"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -1044426696,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "Ssrf"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -1044426696,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "Ssrf"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1044426696,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "Ssrf"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1044426696,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "Ssrf"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -1044426696,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "Ssrf"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SessionIdleTimeout.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SessionIdleTimeout.AspNetCore5.IastEnabled.verified.txt
@@ -18,7 +18,7 @@
       "type": "SESSION_TIMEOUT",
       "hash": XXX,
       "location": {
-        "path": "Samples.Security.AspNetCore5.Startup+<>c__DisplayClass4_0",
+        "class": "Samples.Security.AspNetCore5.Startup+<>c__DisplayClass4_0",
         "method": "<ConfigureServices>b__0"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -1673193954,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -1673193954,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1673193954,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1673193954,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -1673193954,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SqliInterpolatedString.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqliInterpolatedString.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -41956447,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "InterpolatedSqlString"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore2.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore2.verified.txt
@@ -34,7 +34,7 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
       "hash": 1099366274,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "StackTraceLeak"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore5.NotVulnerable.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore5.NotVulnerable.verified.txt
@@ -39,7 +39,7 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
       "hash": 1099366274,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "StackTraceLeak"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore5.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore5.verified.txt
@@ -39,7 +39,7 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
       "hash": 1099366274,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "StackTraceLeak"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetMvc5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
       "hash": 1099366274,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "StackTraceLeak"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.Stacks.Vulnerability.InFunction.verified.txt
+++ b/tracer/test/snapshots/Iast.Stacks.Vulnerability.InFunction.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/Iast.Stacks.Vulnerability.LocatedDeeper.verified.txt
+++ b/tracer/test/snapshots/Iast.Stacks.Vulnerability.LocatedDeeper.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing",
         "stackId": "1"
       },
@@ -46,7 +46,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing",
         "stackId": "2"
       },

--- a/tracer/test/snapshots/Iast.Stacks.Vulnerability.LocatedInFunction.verified.txt
+++ b/tracer/test/snapshots/Iast.Stacks.Vulnerability.LocatedInFunction.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/Iast.Stacks.Vulnerability.LocatedInRenderPipeline.verified.txt
+++ b/tracer/test/snapshots/Iast.Stacks.Vulnerability.LocatedInRenderPipeline.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/Iast.StandaloneBilling.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StandaloneBilling.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1084027092,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TypeReflectionInjection"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StoredSqli.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StoredSqli.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "StoredSqli"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StoredXss.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StoredXss.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StoredXss.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StoredXss.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StoredXss.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StoredXss.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StoredXss.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StoredXss.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": XXX,
       "location": {
         "spanId": XXX,
-        "path": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
+        "class": "AspNetCore.Views_Iast_Xss+<<ExecuteAsync>b__8_1>d",
         "method": "MoveNext"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.SystemTextJsonParseTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SystemTextJsonParseTainting.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {
@@ -50,7 +50,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {
@@ -67,7 +67,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {
@@ -50,7 +50,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {
@@ -67,7 +67,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {
@@ -44,7 +44,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {
@@ -61,7 +61,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {
@@ -78,7 +78,7 @@
       "hash": -1696363463,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "TrustBoundaryViolation"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -85,7 +85,7 @@
       "hash": 403854644,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "UnvalidatedRedirect"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.verified.txt
@@ -85,7 +85,7 @@
       "hash": 403854644,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "UnvalidatedRedirect"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": 403854644,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "UnvalidatedRedirect"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.VulnerabilitySampling.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -45,7 +45,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -57,7 +57,7 @@
       "hash": -1130147155,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakRandomness"
       },
       "evidence": {
@@ -142,7 +142,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -154,7 +154,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -166,7 +166,7 @@
       "hash": -1130147155,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakRandomness"
       },
       "evidence": {
@@ -217,7 +217,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -229,7 +229,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -241,7 +241,7 @@
       "hash": -1130147155,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakRandomness"
       },
       "evidence": {
@@ -326,7 +326,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -338,7 +338,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -350,7 +350,7 @@
       "hash": -1130147155,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakRandomness"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.SingleVulnerability.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.SingleVulnerability.verified.txt
@@ -28,7 +28,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -40,7 +40,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.SingleVulnerability.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.SingleVulnerability.verified.txt
@@ -33,7 +33,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {
@@ -45,7 +45,7 @@
       "hash": 414128505,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakHashing"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": -1130147155,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakRandomness"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": -1130147155,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakRandomness"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": -1130147155,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "WeakRandomness"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.XpathInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.XpathInjection.AspNetCore2.IastEnabled.verified.txt
@@ -28,7 +28,7 @@
       "hash": 874141243,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "XpathInjection"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.XpathInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.XpathInjection.AspNetCore5.IastEnabled.verified.txt
@@ -33,7 +33,7 @@
       "hash": 874141243,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "XpathInjection"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.XpathInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.XpathInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -27,7 +27,7 @@
       "hash": 874141243,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "XpathInjection"
       },
       "evidence": {

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
@@ -60,7 +60,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
@@ -60,7 +60,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -60,7 +60,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
@@ -46,7 +46,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -60,7 +60,7 @@
       "hash": -782610048,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SsrfAttack",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
@@ -61,7 +61,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
@@ -65,7 +65,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
@@ -65,7 +65,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -65,7 +65,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
@@ -53,7 +53,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -65,7 +65,7 @@
       "hash": -782610048,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SsrfAttack",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
@@ -66,7 +66,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
@@ -38,7 +38,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
@@ -38,7 +38,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -62,7 +62,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
@@ -50,7 +50,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -62,7 +62,7 @@
       "hash": -782610048,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SsrfAttack",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -38,7 +38,7 @@
       "hash": -903370233,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SsrfAttackNoCatch",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
@@ -39,7 +39,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.CmdI_url=-Iast-ExecuteCommand-file=-bin-rebootCommand&argumentLine=-f&fromShell=false_exploit=CmdI.verified.txt
@@ -39,7 +39,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },
@@ -64,7 +64,7 @@
       "hash": 1198423289,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "2"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.CmdI_url=-Iast-ExecuteCommand-file=ls&argumentLine=;evilCommand&fromShell=true_exploit=CmdI.verified.txt
@@ -39,7 +39,7 @@
       "hash": -430498668,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "1"
       },
@@ -64,7 +64,7 @@
       "hash": 1198423289,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteCommandInternal",
         "stackId": "2"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -63,7 +63,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=filename_exploit=Lfi.verified.txt
@@ -51,7 +51,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -63,7 +63,7 @@
       "hash": -782610048,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SsrfAttack",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -39,7 +39,7 @@
       "hash": -903370233,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SsrfAttackNoCatch",
         "stackId": "1"
       },
@@ -63,7 +63,7 @@
       "hash": 799633597,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SsrfAttackNoCatch",
         "stackId": "2"
       },

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SqlI_url=-Iast-ExecuteQueryFromBodyQueryData_exploit=SqlI_body={-UserName-- -' or '1'='1-}.verified.txt
@@ -40,7 +40,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery",
         "stackId": "1"
       },
@@ -64,7 +64,7 @@
       "hash": -518319264,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery",
         "stackId": "2"
       },

--- a/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
@@ -39,7 +39,7 @@
       "hash": -209503571,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery",
         "stackId": "1"
       },

--- a/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
@@ -27,7 +27,7 @@
       "hash": 2114125236,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "GetFileContent"
       },
       "evidence": {

--- a/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_QueryOwnUrl.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_QueryOwnUrl.verified.txt
@@ -27,7 +27,7 @@
       "hash": -1673193954,
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "class": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "SqlQuery"
       },
       "evidence": {

--- a/tracer/test/snapshots/Security.AspNetWebForms.Classic.enableSecurity=True.__test=TestQueryParameterNameVulnerability.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebForms.Classic.enableSecurity=True.__test=TestQueryParameterNameVulnerability.verified.txt
@@ -26,7 +26,8 @@
       "hash": -1368908679,
       "location": {
         "spanId": XXX,
-        "path": "Iast_Print",
+        "path": "print.aspx.cs",
+        "class": "Iast_Print",
         "method": "Page_Load",
         "line": XXX
       },

--- a/tracer/test/snapshots/Security.AspNetWebForms.Integrated.enableSecurity=True.__test=TestQueryParameterNameVulnerability.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetWebForms.Integrated.enableSecurity=True.__test=TestQueryParameterNameVulnerability.verified.txt
@@ -26,7 +26,8 @@
       "hash": -1368908679,
       "location": {
         "spanId": XXX,
-        "path": "Iast_Print",
+        "path": "print.aspx.cs",
+        "class": "Iast_Print",
         "method": "Page_Load",
         "line": XXX
       },

--- a/tracer/test/snapshots/WeakCipherTests.SubmitsTraces.verified.txt
+++ b/tracer/test/snapshots/WeakCipherTests.SubmitsTraces.verified.txt
@@ -19,7 +19,7 @@
       "type": "WEAK_CIPHER",
       "hash": 1966097305,
       "location": {
-        "path": "Samples.WeakCipher.Program",
+        "class": "Samples.WeakCipher.Program",
         "method": "VulnerableSection"
       },
       "evidence": {
@@ -56,7 +56,7 @@
       "type": "WEAK_CIPHER",
       "hash": 1966097305,
       "location": {
-        "path": "Samples.WeakCipher.Program",
+        "class": "Samples.WeakCipher.Program",
         "method": "VulnerableSection"
       },
       "evidence": {
@@ -93,7 +93,7 @@
       "type": "WEAK_CIPHER",
       "hash": 1966097305,
       "location": {
-        "path": "Samples.WeakCipher.Program",
+        "class": "Samples.WeakCipher.Program",
         "method": "VulnerableSection"
       },
       "evidence": {
@@ -130,7 +130,7 @@
       "type": "WEAK_CIPHER",
       "hash": 1966097305,
       "location": {
-        "path": "Samples.WeakCipher.Program",
+        "class": "Samples.WeakCipher.Program",
         "method": "VulnerableSection"
       },
       "evidence": {
@@ -167,7 +167,7 @@
       "type": "WEAK_CIPHER",
       "hash": 1966097305,
       "location": {
-        "path": "Samples.WeakCipher.Program",
+        "class": "Samples.WeakCipher.Program",
         "method": "VulnerableSection"
       },
       "evidence": {
@@ -204,7 +204,7 @@
       "type": "WEAK_CIPHER",
       "hash": 1966097305,
       "location": {
-        "path": "Samples.WeakCipher.Program",
+        "class": "Samples.WeakCipher.Program",
         "method": "VulnerableSection"
       },
       "evidence": {

--- a/tracer/test/snapshots/iast.deduplication.deduplicated.All.verified.txt
+++ b/tracer/test/snapshots/iast.deduplication.deduplicated.All.verified.txt
@@ -19,7 +19,7 @@
       "type": "WEAK_HASH",
       "hash": -788071420,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {
@@ -56,7 +56,7 @@
       "type": "WEAK_RANDOMNESS",
       "hash": -605200023,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {

--- a/tracer/test/snapshots/iast.deduplication.deduplicated.verified.txt
+++ b/tracer/test/snapshots/iast.deduplication.deduplicated.verified.txt
@@ -19,7 +19,7 @@
       "type": "WEAK_HASH",
       "hash": -788071420,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {

--- a/tracer/test/snapshots/iast.deduplication.duplicated.verified.txt
+++ b/tracer/test/snapshots/iast.deduplication.duplicated.verified.txt
@@ -19,7 +19,7 @@
       "type": "WEAK_HASH",
       "hash": -788071420,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {
@@ -56,7 +56,7 @@
       "type": "WEAK_HASH",
       "hash": -788071420,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {
@@ -93,7 +93,7 @@
       "type": "WEAK_HASH",
       "hash": -788071420,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {
@@ -130,7 +130,7 @@
       "type": "WEAK_HASH",
       "hash": -788071420,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {
@@ -167,7 +167,7 @@
       "type": "WEAK_HASH",
       "hash": -788071420,
       "location": {
-        "path": "Samples.Deduplication.Program",
+        "class": "Samples.Deduplication.Program",
         "method": "ComputeHashNTimes"
       },
       "evidence": {

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/InstrumentationTestsBase.cs
@@ -53,7 +53,7 @@ public class InstrumentationTestsBase : IDisposable
     private static MethodInfo _vulnerabilityTypeProperty = _vulnerabilityType.GetProperty("Type", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _evidenceProperty = _vulnerabilityType.GetProperty("Evidence", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _locationProperty = _vulnerabilityType.GetProperty("Location", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
-    private static MethodInfo _pathProperty = _locationType.GetProperty("Path", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
+    private static MethodInfo _classProperty = _locationType.GetProperty("Class", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _lineProperty = _locationType.GetProperty("Line", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _taintMethod = _taintedObjectsType.GetMethod("Taint", BindingFlags.Instance | BindingFlags.Public);
     private static MethodInfo _enableIastInRequestMethod = _traceContextType.GetMethod("EnableIastInRequest", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -215,7 +215,7 @@ public class InstrumentationTestsBase : IDisposable
         foreach (var vulnerability in vulnerabilities)
         {
             var locationProperty = _locationProperty.Invoke(vulnerability, Array.Empty<object>());
-            var path = _pathProperty.Invoke(locationProperty, Array.Empty<object>());
+            var className = _classProperty.Invoke(locationProperty, Array.Empty<object>());
             var line = _lineProperty.Invoke(locationProperty, Array.Empty<object>());
 
             if (line != null)
@@ -223,11 +223,11 @@ public class InstrumentationTestsBase : IDisposable
                 ((int)line).Should().BeGreaterThan(0);
             }
 
-            locations?.Add(path.ToString());
+            locations?.Add(className?.ToString());
 
-            if (!string.IsNullOrEmpty(path as string))
+            if (!string.IsNullOrEmpty(className as string))
             {
-                if (!path.ToString().Contains(location))
+                if (!className.ToString().Contains(location))
                 {
                     return false;
                 }


### PR DESCRIPTION
## Summary of changes

Resemantizes the IAST vulnerability `Location` so the declaring type and the source file are reported in distinct fields:

- **New `class` field** always carries the declaring type (`DeclaringType.FullName`) — this is what `path` used to hold.
- **`method`** continues to carry the method name (unchanged).
- **`path`** is repurposed to hold the **source file name** (basename of `StackFrame.GetFileName()`), present **only when debug info (PDBs)** is available.
- **`line`** remains present only with debug info (as before).

## Reason for change

Previously `path` conflated two concepts: it held the *type name*, never the actual source file, and left file/line information (which depends on PDBs) unused. This split makes `class` a stable, always-present identifier and lets `path` carry genuinely useful source-file information when PDBs are present.

## Implementation details

- `Iast/Location.cs`: added `Class` property; runtime ctor now sets `Class = method?.DeclaringType?.FullName` and `Path = Path.GetFileName(stackFrame?.GetFileName())` (filename only, matching `StackReporter` and avoiding leaking build-machine paths). String and test ctors updated accordingly.
- `Location.GetHashCode()` now hashes `Class`+`Method` (previously `Path`+`Method`, where `Path` was the type). **Deduplication is unchanged** — same inputs, same hash — and is now independent of PDB availability.
- `AppSec/Rasp/MetaStructHelper.cs`: emits `class` in the MessagePack meta-struct. The `_dd.iast.json` span tag emits `class` automatically via the reflection-based camelCase serializer (`NullValueHandling.Ignore`).
- `vulnerability_schema.json`: added `class`; `path` re-documented as "source file name (only available with debug info)".

## Test coverage

- Updated `LocationTests` and `VulnerabilityBatchTests` unit tests.
- Regenerated the IAST integration snapshots (144 files): most are a deterministic `path`→`class` rename (the normal integration environment does not expose PDBs for sample code).
- The **3 snapshots with debug info** (Razor/WebForms compiled types) were regenerated by **running the IIS integration tests locally in Release (net48)** to capture the real runtime source-file `path`:
  - `Iast.ReflectedXss.AspNetMvc5.IastEnabled` → `path: "ReflectedXss.cshtml"`
  - `Security.AspNetWebForms.Classic/Integrated…TestQueryParameterNameVulnerability` → `path: "print.aspx.cs"`
  - All 3 verified green locally.

## Other details

⚠️ **Backend coordination required**: please confirm the wire/backend accepts the new `class` field and the resemantized `path` before merging.