### PR TITLE
Mark CheckProfilesSentThroughNamedPipe Flaky

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/NamedPipeTestcs.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/NamedPipeTestcs.cs
@@ -6,6 +6,7 @@
 using System.IO;
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.IntegrationTests.Xunit;
 using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
 using Xunit;
@@ -28,6 +29,7 @@ namespace Datadog.Profiler.IntegrationTests.WindowsOnly
         //       to connect to the Agent using namedpipe. Since the Agent does not exist in CI,
         //       the ETW support is disabled in the tests for .NET Framework.
 
+        [Flaky("Named pipes seem to be flaky in CI")]
         [TestAppFact("Samples.Computer01")]
         public void CheckProfilesSentThroughNamedPipe(string appName, string framework, string appAssembly)
         {


### PR DESCRIPTION
## Summary of changes

Marks CheckProfilesSentThroughNamedPipe as flaky as they use named pipes and the thought process is those are flaky in CI

## Reason for change

This test flaked I see no obvious reason why so I am blaming Named Pipes

## Implementation details

Mark as flaky

## Test coverage

They will run more, these tests did seem to run for a _while_  (but the AzDo logs for these look so different than the logs for other tests so I don't know if there were tests that ran inbetween these🤷 ) so I wonder if this will be okay but we can always see if the CI agents then start timing out due to running to long.

## Other details
<!-- Fixes #{issue} -->

#incident-57303
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
