### PR TITLE
Fix Azure Service Bus sample restore

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.AzureServiceBus.APM/Samples.AzureServiceBus.APM.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AzureServiceBus.APM/Samples.AzureServiceBus.APM.csproj
@@ -5,15 +5,18 @@
     <RequiresDockerDependency>All</RequiresDockerDependency>
 
     <!-- NU1510: System.Diagnostics.DiagnosticSource below is flagged as framework-provided, but it's retained
-         to deploy the 8.0.0.0 assembly that Azure.Core (transitive of Azure.Messaging.ServiceBus) hard-binds
-         against. Without it, runtimes whose shared framework ships a different version (e.g. 10.0.0.0 on
-         net10.0) fail with FileNotFoundException at load time. -->
+         to deploy the assembly version that Azure.Core (transitive of Azure.Messaging.ServiceBus) hard-binds
+         against. Azure.Messaging.ServiceBus 7.20.2 requires DiagnosticSource 10.0.9, while earlier versions
+         require 8.0.1. Without an explicit reference, runtimes whose shared framework ships a different version
+         can fail with FileNotFoundException at load time. -->
     <NoWarn>$(NoWarn);NU1510</NoWarn>
+    <DiagnosticSourceVersion>8.0.1</DiagnosticSourceVersion>
+    <DiagnosticSourceVersion Condition="$([MSBuild]::VersionGreaterThanOrEquals($(ApiVersion), '7.20.2'))">10.0.9</DiagnosticSourceVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="$(ApiVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(DiagnosticSourceVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary of changes

This pins the DiagnosticSourceVersion and fixes the sample app as it broke in the version bump / was changed

## Reason for change

Make the samples build again

## Implementation details

If 7.20.2+ it needs the newer version
## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
