### PR TITLE
Remove timestamp from crashdump file in CI for smoke.dotnet-tool.dockerfile

### DIFF
--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -41,7 +41,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%d
 ENV DOTNET_EnableCrashReport=1
 
 ## SSI variables


### PR DESCRIPTION
## Summary of changes

Strips `%t.%p` (timestamp & PID) from the crashdump file name and replaces with just a `%d` (PID)

## Reason for change

CI flaked, we got a 2.1 crash on the smoke tests on Alpine (here https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=205438&view=logs&s=143773f2-6887-5cc8-5ee0-3c891c9227cc&j=4055512d-4af5-506f-f458-b6ae156ad112) 

In the log file when I was searching for the dump it said:

`Writing full dump to file `
`Could not open output : No such file or directory`

It appears that you cannot set the timestamp/PID on the dumps for these older runtimes.

## Implementation details

## Test coverage

Reproduced locally (the fact that you can't use %t.%p` ) using the same alpine images for 2.1

  - `%t.%p` no dump
  - `%d` dump

## Other details
<!-- Fixes #{issue} -->

I appears that this is something only supported in later versions, the one from the 2.1 image `createdump --help` output: `--name - dump path and file name. The pid can be placed in the name with %d. The default is '/tmp/coredump.%d'`

Output from a modern one:

```
-f, --name - dump path and file name. The default is '%TEMP%\dump.%p.dmp'. These specifiers are substituted with following values:
   %p  PID of dumped process.
   %e  The process executable filename.
   %h  Hostname return by gethostname().
   %t  Time of dump, expressed as seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
```

Granted this also means that we may overwrite dumps as the timestamp helped keep them unique.
Also this will impact other runtimes that get run here, can amend this _somehow_ I bet to support this change only there.

No idea what crashed

#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
