### PR TITLE
Report OTLP export status in tracer startup log

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -403,7 +403,7 @@ namespace Datadog.Trace.ClrProfiler
 #if NET6_0_OR_GREATER
             try
             {
-                if (Tracer.Instance.Settings.OpenTelemetryMetricsEnabled is true && Tracer.Instance.Settings.OtelMetricsExporterEnabled is true)
+                if (Tracer.Instance.Settings.OtlpMetricsExportEnabled)
                 {
                     Log.Debug("Initializing Opentelemetry Protocol Metrics collection.");
                     OpenTelemetry.Metrics.MetricsRuntime.Start(Tracer.Instance.Settings);

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -373,7 +373,11 @@ namespace Datadog.Trace.Configuration
                                     .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryLogsEnabled)
                                     .AsBool(defaultValue: false);
 
+#if NETCOREAPP3_1_OR_GREATER
             OpenTelemetryLogsEnabled = OpenTelemetryLogsEnabled && OtelLogsExporterEnabled;
+#else
+            OpenTelemetryLogsEnabled = false;
+#endif
 
             // We should also be writing telemetry for OTEL_LOGS_EXPORTER similar to OTEL_METRICS_EXPORTER, but we don't have a corresponding Datadog config
             // When we do, we can insert that here
@@ -801,11 +805,11 @@ namespace Datadog.Trace.Configuration
                                     .AsInt32(2000, value => value > 0).Value;
 
 #if NET6_0_OR_GREATER
-            OtlpRuntimeMetricsEnabled = OpenTelemetryMetricsEnabled && OtelMetricsExporterEnabled && RuntimeMetricsEnabled;
+            OtlpMetricsExportEnabled = OpenTelemetryMetricsEnabled && OtelMetricsExporterEnabled;
 #else
-            // Default to false on unsupported TFMs so the StatsD RuntimeMetricsWriter runs as expected.
-            OtlpRuntimeMetricsEnabled = false;
+            OtlpMetricsExportEnabled = false;
 #endif
+            OtlpRuntimeMetricsEnabled = OtlpMetricsExportEnabled && RuntimeMetricsEnabled;
 
             // OTEL_TRACES_SPAN_METRICS_ENABLED is a tri-state: explicit true/false overrides auto-detection.
             // When unset, span metrics are auto-enabled iff OTEL_TRACES_EXPORTER=otlp AND DD_METRICS_OTEL_ENABLED=true.
@@ -1270,6 +1274,11 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.RuntimeMetricsDiagnosticsMetricsApiEnabled"/>
         internal bool RuntimeMetricsDiagnosticsMetricsApiEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the OTLP metrics pipeline is enabled on this target framework.
+        /// </summary>
+        internal bool OtlpMetricsExportEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether runtime metrics should be collected in OTEL format and exported via OTLP.

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -555,6 +555,15 @@ namespace Datadog.Trace
                     writer.WritePropertyName("activity_listener_enabled");
                     writer.WriteValue(instanceSettings.IsActivityListenerEnabled);
 
+                    writer.WritePropertyName("otlp_traces_export_enabled");
+                    writer.WriteValue(exporterSettings.TracesEncoding is TracesEncoding.OtlpProtobuf or TracesEncoding.OtlpJson);
+
+                    writer.WritePropertyName("otlp_metrics_export_enabled");
+                    writer.WriteValue(instanceSettings.OtlpRuntimeMetricsEnabled);
+
+                    writer.WritePropertyName("otlp_logs_export_enabled");
+                    writer.WriteValue(instanceSettings.OpenTelemetryLogsEnabled && instanceSettings.OtelLogsExporterEnabled);
+
                     writer.WritePropertyName("profiler_enabled");
                     writer.WriteValue(Profiler.Instance.Status.IsProfilerReady);
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -555,14 +555,7 @@ namespace Datadog.Trace
                     writer.WritePropertyName("activity_listener_enabled");
                     writer.WriteValue(instanceSettings.IsActivityListenerEnabled);
 
-                    writer.WritePropertyName("otlp_traces_export_enabled");
-                    writer.WriteValue(exporterSettings.IsOtlpTraceExport);
-
-                    writer.WritePropertyName("otlp_metrics_export_enabled");
-                    writer.WriteValue(instanceSettings.OtlpMetricsExportEnabled);
-
-                    writer.WritePropertyName("otlp_logs_export_enabled");
-                    writer.WriteValue(instanceSettings.OpenTelemetryLogsEnabled);
+                    WriteOtlpExportSettings(writer, instanceSettings, exporterSettings);
 
                     writer.WritePropertyName("profiler_enabled");
                     writer.WriteValue(Profiler.Instance.Status.IsProfilerReady);
@@ -645,6 +638,19 @@ namespace Datadog.Trace
             {
                 Log.Warning(ex, "DATADOG TRACER DIAGNOSTICS - Error fetching configuration");
             }
+        }
+
+        [TestingAndPrivateOnly]
+        internal static void WriteOtlpExportSettings(JsonTextWriter writer, TracerSettings instanceSettings, ExporterSettings exporterSettings)
+        {
+            writer.WritePropertyName("otlp_traces_export_enabled");
+            writer.WriteValue(exporterSettings.IsOtlpTraceExport);
+
+            writer.WritePropertyName("otlp_metrics_export_enabled");
+            writer.WriteValue(instanceSettings.OtlpMetricsExportEnabled);
+
+            writer.WritePropertyName("otlp_logs_export_enabled");
+            writer.WriteValue(instanceSettings.OpenTelemetryLogsEnabled);
         }
 
         private static void WriteAsmInfo(JsonTextWriter writer)

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -556,13 +556,13 @@ namespace Datadog.Trace
                     writer.WriteValue(instanceSettings.IsActivityListenerEnabled);
 
                     writer.WritePropertyName("otlp_traces_export_enabled");
-                    writer.WriteValue(exporterSettings.TracesEncoding is TracesEncoding.OtlpProtobuf or TracesEncoding.OtlpJson);
+                    writer.WriteValue(exporterSettings.IsOtlpTraceExport);
 
                     writer.WritePropertyName("otlp_metrics_export_enabled");
-                    writer.WriteValue(instanceSettings.OtlpRuntimeMetricsEnabled);
+                    writer.WriteValue(instanceSettings.OtlpMetricsExportEnabled);
 
                     writer.WritePropertyName("otlp_logs_export_enabled");
-                    writer.WriteValue(instanceSettings.OpenTelemetryLogsEnabled && instanceSettings.OtelLogsExporterEnabled);
+                    writer.WriteValue(instanceSettings.OpenTelemetryLogsEnabled);
 
                     writer.WritePropertyName("profiler_enabled");
                     writer.WriteValue(Profiler.Instance.Status.IsProfilerReady);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
@@ -3,10 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -41,38 +39,4 @@ public class TracerTests : TestHelper
         agent.Spans.Should().BeEmpty();
         await agent.AssertConfigurationAsync("DD_TRACE_ENABLED", false);
     }
-
-#if NET6_0_OR_GREATER
-    [SkippableTheory]
-    [Trait("RunOnWindows", "True")]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task ReportsOtlpExportStateInStartupLog(bool enabled)
-    {
-        SetEnvironmentVariable("OTEL_TRACES_EXPORTER", enabled ? "otlp" : "none");
-        SetEnvironmentVariable("DD_METRICS_OTEL_ENABLED", enabled ? "true" : "false");
-        SetEnvironmentVariable("DD_LOGS_OTEL_ENABLED", enabled ? "true" : "false");
-
-        using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
-        var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory, Output);
-        using var processResult = await RunSampleAndWaitForExit(agent, "traces 1");
-
-        var entry = await logEntryWatcher.WaitForLogEntry(DiagnosticLog);
-        var match = Regex.Match(entry, @".+ (?<diagnosticLog>\{.+\})\s+\{.+\}");
-        match.Success.Should().BeTrue();
-
-        var json = JObject.Parse(match.Groups["diagnosticLog"].Value);
-        foreach (var field in new[]
-                 {
-                     "otlp_traces_export_enabled",
-                     "otlp_metrics_export_enabled",
-                     "otlp_logs_export_enabled",
-                 })
-        {
-            json[field]?.Type.Should().Be(JTokenType.Boolean);
-            json[field]?.Value<bool>().Should().Be(enabled);
-        }
-    }
-#endif
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
@@ -3,8 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -39,4 +41,41 @@ public class TracerTests : TestHelper
         agent.Spans.Should().BeEmpty();
         await agent.AssertConfigurationAsync("DD_TRACE_ENABLED", false);
     }
+
+#if NET6_0_OR_GREATER
+    [SkippableTheory]
+    [Trait("RunOnWindows", "True")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReportsOtlpExportStateInStartupLog(bool enabled)
+    {
+        if (enabled)
+        {
+            SetEnvironmentVariable("OTEL_TRACES_EXPORTER", "otlp");
+            SetEnvironmentVariable("DD_METRICS_OTEL_ENABLED", "true");
+            SetEnvironmentVariable("DD_LOGS_OTEL_ENABLED", "true");
+        }
+
+        using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+        var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
+        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory, Output);
+        using var processResult = await RunSampleAndWaitForExit(agent, "traces 1");
+
+        var entry = await logEntryWatcher.WaitForLogEntry(DiagnosticLog);
+        var match = Regex.Match(entry, @".+ (?<diagnosticLog>\{.+\})\s+\{.+\}");
+        match.Success.Should().BeTrue();
+
+        var json = JObject.Parse(match.Groups["diagnosticLog"].Value);
+        foreach (var field in new[]
+                 {
+                     "otlp_traces_export_enabled",
+                     "otlp_metrics_export_enabled",
+                     "otlp_logs_export_enabled",
+                 })
+        {
+            json[field]?.Type.Should().Be(JTokenType.Boolean);
+            json[field]?.Value<bool>().Should().Be(enabled);
+        }
+    }
+#endif
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerTests.cs
@@ -49,12 +49,9 @@ public class TracerTests : TestHelper
     [InlineData(true)]
     public async Task ReportsOtlpExportStateInStartupLog(bool enabled)
     {
-        if (enabled)
-        {
-            SetEnvironmentVariable("OTEL_TRACES_EXPORTER", "otlp");
-            SetEnvironmentVariable("DD_METRICS_OTEL_ENABLED", "true");
-            SetEnvironmentVariable("DD_LOGS_OTEL_ENABLED", "true");
-        }
+        SetEnvironmentVariable("OTEL_TRACES_EXPORTER", enabled ? "otlp" : "none");
+        SetEnvironmentVariable("DD_METRICS_OTEL_ENABLED", enabled ? "true" : "false");
+        SetEnvironmentVariable("DD_LOGS_OTEL_ENABLED", enabled ? "true" : "false");
 
         using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1061,6 +1061,9 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("false", "otlp", false)]
         public void OtlpMetricsExportEnabled(string metricsEnabled, string exporter, bool expected)
         {
+#if !NET6_0_OR_GREATER
+            expected = false;
+#endif
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.FeatureFlags.OpenTelemetryMetricsEnabled, metricsEnabled),
                 (ConfigurationKeys.OpenTelemetry.MetricsExporter, exporter));
@@ -1076,6 +1079,9 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("false", "otlp", false)]
         public void OpenTelemetryLogsEnabled(string logsEnabled, string exporter, bool expected)
         {
+#if !NETCOREAPP3_1_OR_GREATER
+            expected = false;
+#endif
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.FeatureFlags.OpenTelemetryLogsEnabled, logsEnabled),
                 (ConfigurationKeys.OpenTelemetry.LogsExporter, exporter));

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1055,15 +1055,17 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
+#if NET6_0_OR_GREATER
         [InlineData("true", null, true)]
         [InlineData("true", "otlp", true)]
+#else
+        [InlineData("true", null, false)]
+        [InlineData("true", "otlp", false)]
+#endif
         [InlineData("true", "none", false)]
         [InlineData("false", "otlp", false)]
         public void OtlpMetricsExportEnabled(string metricsEnabled, string exporter, bool expected)
         {
-#if !NET6_0_OR_GREATER
-            expected = false;
-#endif
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.FeatureFlags.OpenTelemetryMetricsEnabled, metricsEnabled),
                 (ConfigurationKeys.OpenTelemetry.MetricsExporter, exporter));
@@ -1073,15 +1075,17 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
+#if NETCOREAPP3_1_OR_GREATER
         [InlineData("true", null, true)]
         [InlineData("true", "otlp", true)]
+#else
+        [InlineData("true", null, false)]
+        [InlineData("true", "otlp", false)]
+#endif
         [InlineData("true", "none", false)]
         [InlineData("false", "otlp", false)]
         public void OpenTelemetryLogsEnabled(string logsEnabled, string exporter, bool expected)
         {
-#if !NETCOREAPP3_1_OR_GREATER
-            expected = false;
-#endif
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.FeatureFlags.OpenTelemetryLogsEnabled, logsEnabled),
                 (ConfigurationKeys.OpenTelemetry.LogsExporter, exporter));

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -1055,6 +1055,36 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
+        [InlineData("true", null, true)]
+        [InlineData("true", "otlp", true)]
+        [InlineData("true", "none", false)]
+        [InlineData("false", "otlp", false)]
+        public void OtlpMetricsExportEnabled(string metricsEnabled, string exporter, bool expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.FeatureFlags.OpenTelemetryMetricsEnabled, metricsEnabled),
+                (ConfigurationKeys.OpenTelemetry.MetricsExporter, exporter));
+            var settings = new TracerSettings(source);
+
+            settings.OtlpMetricsExportEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("true", null, true)]
+        [InlineData("true", "otlp", true)]
+        [InlineData("true", "none", false)]
+        [InlineData("false", "otlp", false)]
+        public void OpenTelemetryLogsEnabled(string logsEnabled, string exporter, bool expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.FeatureFlags.OpenTelemetryLogsEnabled, logsEnabled),
+                (ConfigurationKeys.OpenTelemetry.LogsExporter, exporter));
+            var settings = new TracerSettings(source);
+
+            settings.OpenTelemetryLogsEnabled.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData("otlp", true, true)] // OTLP export: explicit true is honored
         [InlineData(null, true, false)] // non-OTLP export: explicit true is forced back to false
         [InlineData(null, false, false)] // non-OTLP export: explicit false stays false

--- a/tracer/test/Datadog.Trace.Tests/TracerManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerManagerTests.cs
@@ -1,0 +1,54 @@
+// <copyright file="TracerManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+
+using System.IO;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests;
+
+public class TracerManagerTests
+{
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void WriteOtlpExportSettingsWritesConfiguredStates(bool tracesEnabled, bool metricsEnabled, bool logsEnabled)
+    {
+        var settings = TracerSettings.Create(
+            new()
+            {
+                { ConfigurationKeys.OpenTelemetry.TracesExporter, tracesEnabled ? "otlp" : "none" },
+                { ConfigurationKeys.FeatureFlags.OpenTelemetryMetricsEnabled, metricsEnabled },
+                { ConfigurationKeys.OpenTelemetry.MetricsExporter, metricsEnabled ? "otlp" : "none" },
+                { ConfigurationKeys.FeatureFlags.OpenTelemetryLogsEnabled, logsEnabled },
+                { ConfigurationKeys.OpenTelemetry.LogsExporter, logsEnabled ? "otlp" : "none" },
+            });
+
+        using var stringWriter = new StringWriter();
+        using (var jsonWriter = new JsonTextWriter(stringWriter))
+        {
+            jsonWriter.WriteStartObject();
+            TracerManager.WriteOtlpExportSettings(jsonWriter, settings, settings.Manager.InitialExporterSettings);
+            jsonWriter.WriteEndObject();
+        }
+
+        var json = JObject.Parse(stringWriter.ToString());
+        json["otlp_traces_export_enabled"]?.Type.Should().Be(JTokenType.Boolean);
+        json["otlp_traces_export_enabled"]?.Value<bool>().Should().Be(tracesEnabled);
+        json["otlp_metrics_export_enabled"]?.Type.Should().Be(JTokenType.Boolean);
+        json["otlp_metrics_export_enabled"]?.Value<bool>().Should().Be(metricsEnabled);
+        json["otlp_logs_export_enabled"]?.Type.Should().Be(JTokenType.Boolean);
+        json["otlp_logs_export_enabled"]?.Value<bool>().Should().Be(logsEnabled);
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes

Adds `otlp_traces_export_enabled`, `otlp_metrics_export_enabled`, and `otlp_logs_export_enabled` to the `DATADOG TRACER CONFIGURATION` startup log.

## Reason for change

The cross-tracer startup-log schema now reports whether each signal is exported with OTLP.

## Implementation details

The trace field uses `ExporterSettings.IsOtlpTraceExport`. Metrics use a shared, target-aware `OtlpMetricsExportEnabled` setting for both pipeline startup and diagnostics. Logs use the effective `OpenTelemetryLogsEnabled` setting and report `false` on unsupported target frameworks.

## Test coverage

- Added target-aware unit tests for the effective metrics and logs exporter settings.
- Added a focused diagnostic JSON writer test with each signal independently enabled. The test does not initialize the exporters.
- Ran the affected unit tests on .NET 10: 418 passed.

## Other details

Related system-tests coverage: https://github.com/DataDog/system-tests/pull/7376
