### PR TITLE
[Smoke Tests] Collect crash dumps from Windows containers

### DIFF
--- a/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
+++ b/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
@@ -247,6 +247,14 @@ public static partial class SmokeTestRunner
             $"DD_TRACE_AGENT_URL=http://{TestAgentAlias}:8126",
             $"dockerTag={imageTag}",
         };
+
+        if (isWindowsScenario)
+        {
+            AddIfNotConfigured("COMPlus_DbgEnableMiniDump", "1");
+            AddIfNotConfigured("COMPlus_DbgMiniDumpType", "4");
+            AddIfNotConfigured("DOTNET_DbgMiniDumpName", @"C:\dumps\coredump.%t.%p.dmp");
+        }
+
         env.AddRange(environment.Select(kvp => $"{kvp.Key}={kvp.Value}"));
 
         return new CreateContainerParameters
@@ -262,6 +270,7 @@ public static partial class SmokeTestRunner
                     ? new List<string>
                     {
                         $"{logsDir}:c:/logs",
+                        $"{dumpsDir}:c:/dumps",
                     }
                     : new List<string>
                     {
@@ -277,6 +286,14 @@ public static partial class SmokeTestRunner
                 },
             },
         };
+
+        void AddIfNotConfigured(string key, string value)
+        {
+            if (!environment.ContainsKey(key))
+            {
+                env.Add($"{key}={value}");
+            }
+        }
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
+++ b/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
@@ -253,6 +253,13 @@ public static partial class SmokeTestRunner
             AddIfNotConfigured("COMPlus_DbgEnableMiniDump", "1");
             AddIfNotConfigured("COMPlus_DbgMiniDumpType", "4");
             AddIfNotConfigured("DOTNET_DbgMiniDumpName", @"C:\dumps\coredump.%t.%p.dmp");
+
+            // TEMPORARY: Force the failing Windows x86/.NET 6 scenario to crash so CI dump collection can be verified.
+            // Remove this before requesting review.
+            if (imageTag == "dd-trace-dotnet/x86_6_0-windowsservercore-ltsc2022-tester")
+            {
+                AddIfNotConfigured("CRASH_APP_ON_STARTUP", "1");
+            }
         }
 
         env.AddRange(environment.Select(kvp => $"{kvp.Key}={kvp.Value}"));

--- a/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
+++ b/tracer/build/_build/SmokeTests/SmokeTestRunner.cs
@@ -253,13 +253,6 @@ public static partial class SmokeTestRunner
             AddIfNotConfigured("COMPlus_DbgEnableMiniDump", "1");
             AddIfNotConfigured("COMPlus_DbgMiniDumpType", "4");
             AddIfNotConfigured("DOTNET_DbgMiniDumpName", @"C:\dumps\coredump.%t.%p.dmp");
-
-            // TEMPORARY: Force the failing Windows x86/.NET 6 scenario to crash so CI dump collection can be verified.
-            // Remove this before requesting review.
-            if (imageTag == "dd-trace-dotnet/x86_6_0-windowsservercore-ltsc2022-tester")
-            {
-                AddIfNotConfigured("CRASH_APP_ON_STARTUP", "1");
-            }
         }
 
         env.AddRange(environment.Select(kvp => $"{kvp.Key}={kvp.Value}"));


### PR DESCRIPTION
## Summary of changes

Enable crash dump collection for Windows artifact smoke-test containers.

## Reason for change

When a Windows smoke-test container crashed, CI reported only the process exit code. Any dump written inside the container was lost when the container was removed, which made native crash investigation difficult.

## Implementation details

- Enable full CLR crash dumps for Windows smoke-test containers.
- Write dumps to `C:\dumps` using a timestamp- and process-specific filename.
- Bind-mount `C:\dumps` to the existing host-side dump artifact directory.
- Preserve scenario-specific dump configuration overrides.

## Test coverage

- Temporarily forced the Windows x86/.NET 6 NuGet smoke-test application to throw an unhandled exception.
- Confirmed that CI generated the dump and published it in the smoke-test artifact.
- Removed the intentional crash trigger after validating dump collection.

## Other details
#incident-57303
