### PR TITLE
Attempt to delete Kinesis stream before running tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
@@ -21,6 +21,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
     [UsesVerify]
     public class AwsKinesisTests : TracingIntegrationTest
     {
+        // Keep in sync with Samples.AWS.Kinesis
+        private const string PreTestCleanupOperationName = "KINESIS-CLEAN-UP-SHOULD-NOT-BE-IN-SNAPSHOT";
+
         public AwsKinesisTests(ITestOutputHelper output)
             : base("AWS.Kinesis", output)
         {
@@ -81,10 +84,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 settings.DisableRequireUniquePrefix();
 
-                await VerifyHelper.VerifySpans(spans, settings);
+                await VerifyHelper.VerifySpans(ExcludePreTestCleanupSpans(spans), settings);
 
                 await telemetry.AssertIntegrationEnabledAsync(IntegrationId.AwsKinesis);
             }
+        }
+
+        private static IReadOnlyCollection<MockSpan> ExcludePreTestCleanupSpans(IEnumerable<MockSpan> spans)
+        {
+            var spanList = spans.ToList();
+            var excludedTraceIds = spanList.Where(s => s.Name == PreTestCleanupOperationName)
+                                           .Select(s => s.TraceId)
+                                           .ToHashSet();
+
+            return spanList.Where(s => !excludedTraceIds.Contains(s.TraceId)).ToList();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
@@ -52,10 +52,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
 #if NETFRAMEWORK
-                var expectedCount = 10;
+                var expectedCount = 12;
                 var frameworkName = "NetFramework";
 #else
-                var expectedCount = 5;
+                var expectedCount = 7;
                 var frameworkName = "NetCore";
 #endif
                 var spans = await agent.WaitForSpansAsync(expectedCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
@@ -54,10 +54,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
             using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
 #if NETFRAMEWORK
-                var expectedCount = 10;
+                var expectedCount = 12;
                 var frameworkName = "NetFramework";
 #else
-                var expectedCount = 5;
+                var expectedCount = 7;
                 var frameworkName = "NetCore";
 #endif
                 var spans = await agent.WaitForSpansAsync(expectedCount);

--- a/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/Program.cs
@@ -8,15 +8,38 @@ namespace Samples.AWS.Kinesis
 {
     public class Program
     {
+        // Keep in sync with the name in KinesisTests - this is used to be able to remove the trace/spans associated with this
+        private const string PreTestCleanupOperationName = "KINESIS-CLEAN-UP-SHOULD-NOT-BE-IN-SNAPSHOT";
+
         private static async Task Main(string[] args)
         {
             // Set up AmazonSQSConfig and redirect to the local message queue instance
             var kinesisClient = GetAmazonKinesisClient();
+            await TryDeleteStreamBeforeRunningTests(kinesisClient);
 
 #if NETFRAMEWORK
             SyncHelpers.StartKinesisTasks(kinesisClient);
 #endif
             await AsyncHelpers.StartKinesisTasks(kinesisClient);
+        }
+
+        private static async Task TryDeleteStreamBeforeRunningTests(AmazonKinesisClient kinesisClient)
+        {
+            using (SampleHelpers.CreateScope(PreTestCleanupOperationName))
+            {
+                try
+                {
+                    await AsyncHelpers.DeleteStreamAsync(kinesisClient);
+                }
+                catch
+                {
+                    // Saw flake in CI where the stream from the prior test wasn't deleted (they are re-used)
+                    // we can't easily change the stream names to be unique as the DSM hashes use it
+                    // So this is a best effort to try
+                }
+
+                await Task.Delay(1000);
+            }
         }
 
         private static AmazonKinesisClient GetAmazonKinesisClient()


### PR DESCRIPTION
## Summary of changes

Does a best (minimal) effort attempt at deleting the stream before running Kinesis tests.

## Reason for change

The Kinesis tests all use the same stream name, they are supposed to each create and delete the stream (run synchronously) but it seems that the deletion can fail. When it failed, it cascaded to every other Kinesis test that ran after it, which they then all failed.

## Implementation details

Basic attempt at just blindly calling DeleteStream prior to running the tests, wraps it in a manual span that we then exclude out of the snapshots

## Test coverage

Similar, ran this locally, tests ran fine without a stream, then ran with a stream (of the same name) created before running and it was deleted and the the tests passed.

## Other details
<!-- Fixes #{issue} -->

We can't change the stream names to be unique -> I tried this but found out that DSM hashes use the stream name, so snapshots would change.

I did think about polling for it, but decided to just do this single attempt as I have only seen this once I think a minimal best effort here is reasonable - I'm not super sure either how the deletion works, it seems the `localstack` container has a timer on it so I think it takes time to delete. Maybe if this flakes again we bump the sleeps by ~500ms or so.

#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
