### PR TITLE
[AWS] Fix flaky Kinesis integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -21,6 +22,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
     [UsesVerify]
     public class AwsKinesisTests : TracingIntegrationTest
     {
+        private static readonly Regex StreamNameRegex = new(@"MyStreamName-[a-f0-9]{32}", VerifyHelper.RegOptions);
+
         public AwsKinesisTests(ITestOutputHelper output)
             : base("AWS.Kinesis", output)
         {
@@ -72,6 +75,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_kinesis");
                 settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_kinesis");
                 settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_kinesis");
+                settings.AddRegexScrubber(StreamNameRegex, "MyStreamName");
                 // V4 uses the sockets handler by default where possible instead of the httpclienthandler
                 settings.AddSimpleScrubber("http-client-handler-type: System.Net.Http.SocketsHttpHandler", "http-client-handler-type: System.Net.Http.HttpClientHandler");
                 if (!string.IsNullOrWhiteSpace(host))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -22,6 +23,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
     [UsesVerify]
     public class DataStreamsMonitoringAwsKinesisTests : TracingIntegrationTest
     {
+        private static readonly Regex StreamNameRegex = new(@"MyStreamName-[a-f0-9]{32}", VerifyHelper.RegOptions);
+        private static readonly Regex PathwayHashRegex = new(@"Hash: \d+", VerifyHelper.RegOptions);
+
         public DataStreamsMonitoringAwsKinesisTests(ITestOutputHelper output)
             : base("AWS.Kinesis", output)
         {
@@ -76,6 +80,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 settings.UseFileName($"{nameof(DataStreamsMonitoringAwsKinesisTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
                 settings.AddDataStreamsScrubber();
+                settings.AddRegexScrubber(StreamNameRegex, "MyStreamName");
+                settings.AddRegexScrubber(PathwayHashRegex, "Hash: <Hash>");
                 if (!string.IsNullOrWhiteSpace(host))
                 {
                     settings.AddSimpleScrubber(host, "localhost:00000");

--- a/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetCore.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetCore.SchemaV0.verified.txt
@@ -14,7 +14,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,
@@ -32,7 +32,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,

--- a/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetCore.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetCore.SchemaV1.verified.txt
@@ -14,7 +14,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,
@@ -32,7 +32,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,

--- a/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetFramework.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetFramework.SchemaV0.verified.txt
@@ -14,7 +14,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,
@@ -32,7 +32,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,

--- a/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetFramework.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringAwsKinesisTests.NetFramework.SchemaV1.verified.txt
@@ -14,7 +14,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,
@@ -32,7 +32,7 @@
             topic:MyStreamName,
             type:kinesis
           ],
-          Hash: 488941857031791118,
+          Hash: <Hash>,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
           PayloadSize: /w==,

--- a/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/AsyncHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/AsyncHelpers.cs
@@ -12,9 +12,6 @@ namespace Samples.AWS.Kinesis
 {
     static class AsyncHelpers
     {
-
-        private const string StreamName = "MyStreamName";
-
         public static async Task StartKinesisTasks(AmazonKinesisClient kinesisClient)
         {
             Console.WriteLine("Beginning Async methods");
@@ -37,7 +34,7 @@ namespace Samples.AWS.Kinesis
 
         public static async Task CreateStreamAsync(AmazonKinesisClient kinesisClient)
         {
-            var createStreamRequest = new CreateStreamRequest { StreamName = StreamName };
+            var createStreamRequest = new CreateStreamRequest { StreamName = Common.StreamName };
 
             var response = await kinesisClient.CreateStreamAsync(createStreamRequest);
             Console.WriteLine($"CreateStreamAsync(CreateStreamRequest) HTTP status code: {response.HttpStatusCode}");
@@ -45,7 +42,7 @@ namespace Samples.AWS.Kinesis
         
         public static async Task DeleteStreamAsync(AmazonKinesisClient kinesisClient)
         {
-            var deleteStreamRequest = new DeleteStreamRequest { StreamName = StreamName };
+            var deleteStreamRequest = new DeleteStreamRequest { StreamName = Common.StreamName };
 
             var response = await kinesisClient.DeleteStreamAsync(deleteStreamRequest);
             Console.WriteLine($"DeleteStreamAsync(DeleteStreamRequest) HTTP status code: {response.HttpStatusCode}");
@@ -55,7 +52,7 @@ namespace Samples.AWS.Kinesis
         {
             var putRecordRequest = new PutRecordRequest
             {
-                StreamName = StreamName,
+                StreamName = Common.StreamName,
                 PartitionKey = Guid.NewGuid().ToString(),
             };
 
@@ -72,7 +69,7 @@ namespace Samples.AWS.Kinesis
             var pokemon = new Dictionary<string, object> { { "id", "393" }, { "name", "Piplup" }, { "type", "water" } };
             var putRecordsRequest = new PutRecordsRequest
             {
-                StreamName = StreamName,
+                StreamName = Common.StreamName,
                 Records = new List<PutRecordsRequestEntry>
                 {
                     new PutRecordsRequestEntry

--- a/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/Common.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/Common.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -7,6 +8,8 @@ namespace Samples.AWS.Kinesis;
 
 public class Common
 {
+    public static readonly string StreamName = $"MyStreamName-{Guid.NewGuid():N}";
+
     public static MemoryStream DictionaryToMemoryStream(Dictionary<string, object> dictionary)
     {
         var jsonString = JsonConvert.SerializeObject(dictionary);

--- a/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/SyncHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Kinesis/SyncHelpers.cs
@@ -10,9 +10,6 @@ namespace Samples.AWS.Kinesis
 {
     static class SyncHelpers
     {
-
-        private const string StreamName = "MyStreamName";
-
         public static void StartKinesisTasks(AmazonKinesisClient kinesisClient)
         {
             Console.WriteLine("Beginning Synchronous methods");
@@ -35,7 +32,7 @@ namespace Samples.AWS.Kinesis
 
         public static void CreateStream(AmazonKinesisClient kinesisClient)
         {
-            var createStreamRequest = new CreateStreamRequest { StreamName = StreamName };
+            var createStreamRequest = new CreateStreamRequest { StreamName = Common.StreamName };
 
             var response = kinesisClient.CreateStream(createStreamRequest);
             Console.WriteLine($"CreateStream(CreateStreamRequest) HTTP status code: {response.HttpStatusCode}");
@@ -43,7 +40,7 @@ namespace Samples.AWS.Kinesis
 
         public static void DeleteStream(AmazonKinesisClient kinesisClient)
         {
-            var deleteStreamRequest = new DeleteStreamRequest { StreamName = StreamName };
+            var deleteStreamRequest = new DeleteStreamRequest { StreamName = Common.StreamName };
 
             var response = kinesisClient.DeleteStream(deleteStreamRequest);
             Console.WriteLine($"DeleteStream(DeleteStreamRequest) HTTP status code: {response.HttpStatusCode}");
@@ -53,7 +50,7 @@ namespace Samples.AWS.Kinesis
         {
             var putRecordRequest = new PutRecordRequest
             {
-                StreamName = StreamName,
+                StreamName = Common.StreamName,
                 PartitionKey = Guid.NewGuid().ToString(),
             };
 
@@ -70,7 +67,7 @@ namespace Samples.AWS.Kinesis
             var pokemon = new Dictionary<string, object> { { "id", "393" }, { "name", "Piplup" }, { "type", "water" } };
             var putRecordsRequest = new PutRecordsRequest
             {
-                StreamName = StreamName,
+                StreamName = Common.StreamName,
                 Records = new List<PutRecordsRequestEntry>
                 {
                     new PutRecordsRequestEntry


### PR DESCRIPTION
## Summary of changes

- Give each AWS Kinesis sample process a unique stream name.
- Normalize the dynamic stream name and DSM pathway hash in snapshots.

## Reason for change

Kinesis integration tests share LocalStack, so reusing `MyStreamName` could cause cascading `ResourceInUseException` failures across test cases.

## Test coverage

- Built the Kinesis sample on .NET 10 with AWSSDK.Kinesis 3.3.101.1.
- Built the .NET 10 integration test project.