### PR TITLE
[FFE] Move ffe_* span enrichment onto the serializer thread

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -634,6 +634,7 @@
       <type fullname="System.AttributeTargets" />
       <type fullname="System.AttributeUsageAttribute" />
       <type fullname="System.BadImageFormatException" />
+      <type fullname="System.Base64FormattingOptions" />
       <type fullname="System.BitConverter" />
       <type fullname="System.Boolean" />
       <type fullname="System.Buffer" />

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -667,9 +667,6 @@ namespace Datadog.Trace.Agent.MessagePack
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, GetAppSecRulesetVersion(Security.Instance.WafRuleFileVersion));
             }
 
-            // Feature-flag span enrichment (ffe_* tags), local root only. Building the values
-            // (encode / JSON serialize / hash targeting keys) happens here, on the serializer
-            // thread, so it stays off the customer's Span.Finish() path. BuildSpanTags() never throws.
             if (model.IsLocalRoot &&
                 span.Context.TraceContext?.FeatureFlagEnrichment is { } featureFlagEnrichment &&
                 featureFlagEnrichment.HasData())

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -96,6 +96,10 @@ namespace Datadog.Trace.Agent.MessagePack
         private static ReadOnlySpan<byte> AppSecEnabledBytes => "_dd.appsec.enabled"u8; // Metrics.AppSecEnabled
         private static ReadOnlySpan<byte> WafRuleFileVersionBytes => "_dd.appsec.event_rules.version"u8; // Tags.AppSecRuleFileVersion
         private static ReadOnlySpan<byte> RuntimeFamilyBytes => "_dd.runtime_family"u8; // Tags.RuntimeFamily
+        // Feature-flag span enrichment tag names (frozen cross-SDK contract; bare names, never _dd.-prefixed)
+        private static ReadOnlySpan<byte> FfeFlagsEncNameBytes => "ffe_flags_enc"u8; // SpanEnrichmentState.TagFlagsEnc
+        private static ReadOnlySpan<byte> FfeSubjectsEncNameBytes => "ffe_subjects_enc"u8; // SpanEnrichmentState.TagSubjectsEnc
+        private static ReadOnlySpan<byte> FfeRuntimeDefaultsNameBytes => "ffe_runtime_defaults"u8; // SpanEnrichmentState.TagRuntimeDefaults
         // Azure App Service tag names
         private static ReadOnlySpan<byte> AasSiteNameTagNameBytes => "aas.site.name"u8; // Tags.AzureAppServicesSiteName
         private static ReadOnlySpan<byte> AasSiteKindTagNameBytes => "aas.site.kind"u8; // Tags.AzureAppServicesSiteKind
@@ -661,6 +665,37 @@ namespace Datadog.Trace.Agent.MessagePack
                 count++;
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, WafRuleFileVersionBytes);
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, GetAppSecRulesetVersion(Security.Instance.WafRuleFileVersion));
+            }
+
+            // Feature-flag span enrichment (ffe_* tags), local root only. Building the values
+            // (encode / JSON serialize / hash targeting keys) happens here, on the serializer
+            // thread, so it stays off the customer's Span.Finish() path. BuildSpanTags() never throws.
+            if (model.IsLocalRoot &&
+                span.Context.TraceContext?.FeatureFlagEnrichment is { } featureFlagEnrichment &&
+                featureFlagEnrichment.HasData())
+            {
+                var ffeTags = featureFlagEnrichment.BuildSpanTags();
+
+                if (!StringUtil.IsNullOrEmpty(ffeTags.FlagsEnc))
+                {
+                    count++;
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, FfeFlagsEncNameBytes);
+                    offset += MessagePackBinary.WriteString(ref bytes, offset, ffeTags.FlagsEnc);
+                }
+
+                if (!StringUtil.IsNullOrEmpty(ffeTags.SubjectsEnc))
+                {
+                    count++;
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, FfeSubjectsEncNameBytes);
+                    offset += MessagePackBinary.WriteString(ref bytes, offset, ffeTags.SubjectsEnc);
+                }
+
+                if (!StringUtil.IsNullOrEmpty(ffeTags.RuntimeDefaults))
+                {
+                    count++;
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, FfeRuntimeDefaultsNameBytes);
+                    offset += MessagePackBinary.WriteString(ref bytes, offset, ffeTags.RuntimeDefaults);
+                }
             }
 
             // AAS tags need to be set on any span for the backend to properly handle the billing.

--- a/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagSpanTags.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagSpanTags.cs
@@ -1,0 +1,42 @@
+// <copyright file="FeatureFlagSpanTags.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.FeatureFlags
+{
+    /// <summary>
+    /// The encoded <c>ffe_*</c> tag values for a root span, produced by
+    /// <see cref="SpanEnrichmentState.BuildSpanTags"/> on the serializer thread. A struct so the
+    /// build path allocates nothing beyond the encoded strings themselves. Any field may be null
+    /// when that tag has no data.
+    /// </summary>
+    internal readonly struct FeatureFlagSpanTags
+    {
+        public FeatureFlagSpanTags(string? flagsEnc, string? subjectsEnc, string? runtimeDefaults)
+        {
+            FlagsEnc = flagsEnc;
+            SubjectsEnc = subjectsEnc;
+            RuntimeDefaults = runtimeDefaults;
+        }
+
+        /// <summary>Gets the base64 ULEB128 delta-varint of the flag serial ids (<c>ffe_flags_enc</c>).</summary>
+        public string? FlagsEnc { get; }
+
+        /// <summary>Gets the JSON subjects map { sha256hex: base64 } (<c>ffe_subjects_enc</c>).</summary>
+        public string? SubjectsEnc { get; }
+
+        /// <summary>Gets the JSON runtime-defaults map { flagKey: valueStr } (<c>ffe_runtime_defaults</c>).</summary>
+        public string? RuntimeDefaults { get; }
+
+        /// <summary>Gets a value indicating whether any tag value is present.</summary>
+        public bool HasAny =>
+            !StringUtil.IsNullOrEmpty(FlagsEnc) ||
+            !StringUtil.IsNullOrEmpty(SubjectsEnc) ||
+            !StringUtil.IsNullOrEmpty(RuntimeDefaults);
+    }
+}

--- a/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagSpanTags.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagSpanTags.cs
@@ -7,36 +7,35 @@
 
 using System;
 
-namespace Datadog.Trace.FeatureFlags
+namespace Datadog.Trace.FeatureFlags;
+
+/// <summary>
+/// The encoded <c>ffe_*</c> tag values for a root span, produced by
+/// <see cref="SpanEnrichmentState.BuildSpanTags"/> on the serializer thread. A struct so the
+/// build path allocates nothing beyond the encoded strings themselves. Any field may be null
+/// when that tag has no data.
+/// </summary>
+internal readonly struct FeatureFlagSpanTags
 {
-    /// <summary>
-    /// The encoded <c>ffe_*</c> tag values for a root span, produced by
-    /// <see cref="SpanEnrichmentState.BuildSpanTags"/> on the serializer thread. A struct so the
-    /// build path allocates nothing beyond the encoded strings themselves. Any field may be null
-    /// when that tag has no data.
-    /// </summary>
-    internal readonly struct FeatureFlagSpanTags
+    public FeatureFlagSpanTags(string? flagsEnc, string? subjectsEnc, string? runtimeDefaults)
     {
-        public FeatureFlagSpanTags(string? flagsEnc, string? subjectsEnc, string? runtimeDefaults)
-        {
-            FlagsEnc = flagsEnc;
-            SubjectsEnc = subjectsEnc;
-            RuntimeDefaults = runtimeDefaults;
-        }
-
-        /// <summary>Gets the base64 ULEB128 delta-varint of the flag serial ids (<c>ffe_flags_enc</c>).</summary>
-        public string? FlagsEnc { get; }
-
-        /// <summary>Gets the JSON subjects map { sha256hex: base64 } (<c>ffe_subjects_enc</c>).</summary>
-        public string? SubjectsEnc { get; }
-
-        /// <summary>Gets the JSON runtime-defaults map { flagKey: valueStr } (<c>ffe_runtime_defaults</c>).</summary>
-        public string? RuntimeDefaults { get; }
-
-        /// <summary>Gets a value indicating whether any tag value is present.</summary>
-        public bool HasAny =>
-            !StringUtil.IsNullOrEmpty(FlagsEnc) ||
-            !StringUtil.IsNullOrEmpty(SubjectsEnc) ||
-            !StringUtil.IsNullOrEmpty(RuntimeDefaults);
+        FlagsEnc = flagsEnc;
+        SubjectsEnc = subjectsEnc;
+        RuntimeDefaults = runtimeDefaults;
     }
+
+    /// <summary>Gets the base64 ULEB128 delta-varint of the flag serial ids (<c>ffe_flags_enc</c>).</summary>
+    public string? FlagsEnc { get; }
+
+    /// <summary>Gets the JSON subjects map { sha256hex: base64 } (<c>ffe_subjects_enc</c>).</summary>
+    public string? SubjectsEnc { get; }
+
+    /// <summary>Gets the JSON runtime-defaults map { flagKey: valueStr } (<c>ffe_runtime_defaults</c>).</summary>
+    public string? RuntimeDefaults { get; }
+
+    /// <summary>Gets a value indicating whether any tag value is present.</summary>
+    public bool HasAny =>
+        !StringUtil.IsNullOrEmpty(FlagsEnc) ||
+        !StringUtil.IsNullOrEmpty(SubjectsEnc) ||
+        !StringUtil.IsNullOrEmpty(RuntimeDefaults);
 }

--- a/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
@@ -40,17 +40,18 @@ namespace Datadog.Trace.FeatureFlags
 
         private readonly HashSet<long> _serialIds = new();
 
-        // SHA256(targetingKey) -> set of serial ids.
+        // Raw targeting key -> set of serial ids. The key is hashed (SHA256) lazily in
+        // BuildSpanTags(), on the serializer thread, so the hash never runs on the evaluation path.
         private readonly Dictionary<string, HashSet<long>> _subjects = new();
 
         // flagKey -> value string (first-wins).
         private readonly Dictionary<string, string> _defaults = new();
 
         /// <summary>
-        /// Gets or sets a fault-injection hook invoked at the start of <see cref="ToSpanTags"/>. Test-only,
-        /// used to verify the write path in <c>Span.Finish()</c> never lets enrichment break span finish.
+        /// Gets or sets a fault-injection hook invoked at the start of <see cref="BuildSpanTags"/>. Test-only,
+        /// used to verify the serializer-thread write path never lets enrichment break span serialization.
         /// </summary>
-        internal Action? OnToSpanTagsForTesting { get; set; }
+        internal Action? OnBuildSpanTagsForTesting { get; set; }
 
         internal static string HashTargetingKey(string targetingKey) => Sha256Helper.ComputeHashAsHexString(targetingKey);
 
@@ -175,11 +176,10 @@ namespace Datadog.Trace.FeatureFlags
 
         internal void AddSubject(string targetingKey, long id)
         {
-            var hashed = HashTargetingKey(targetingKey);
-
+            // Store the raw targeting key; it is hashed lazily in BuildSpanTags() (serializer thread).
             lock (_gate)
             {
-                if (_subjects.TryGetValue(hashed, out var ids))
+                if (_subjects.TryGetValue(targetingKey, out var ids))
                 {
                     if (ids.Count >= MaxExperimentsPerSubject && !ids.Contains(id))
                     {
@@ -197,7 +197,7 @@ namespace Datadog.Trace.FeatureFlags
                     return;
                 }
 
-                _subjects[hashed] = [id];
+                _subjects[targetingKey] = [id];
             }
         }
 
@@ -235,63 +235,77 @@ namespace Datadog.Trace.FeatureFlags
             }
         }
 
-        internal List<KeyValuePair<string, string>> ToSpanTags()
+        /// <summary>
+        /// Builds the encoded <c>ffe_*</c> tag values for the root span. Runs on the serializer
+        /// thread (from <c>SpanMessagePackFormatter</c>), so encoding, JSON serialization and
+        /// subject hashing stay off the customer's <c>Span.Finish()</c> path. Never throws; on
+        /// failure it returns <see langword="default"/> so serialization is never broken.
+        /// </summary>
+        internal FeatureFlagSpanTags BuildSpanTags()
         {
-            OnToSpanTagsForTesting?.Invoke();
-
-            var tags = new List<KeyValuePair<string, string>>(3);
-            long[]? serialIds = null;
-            Dictionary<string, long[]>? subjects = null;
-            Dictionary<string, string>? defaults = null;
-
-            lock (_gate)
+            try
             {
-                if (_serialIds.Count > 0)
-                {
-                    serialIds = [.. _serialIds];
-                }
+                OnBuildSpanTagsForTesting?.Invoke();
 
-                if (_subjects.Count > 0)
+                long[]? serialIds = null;
+                Dictionary<string, long[]>? subjects = null;
+                Dictionary<string, string>? defaults = null;
+
+                lock (_gate)
                 {
-                    subjects = new Dictionary<string, long[]>(_subjects.Count);
-                    foreach (var pair in _subjects)
+                    if (_serialIds.Count > 0)
                     {
-                        subjects[pair.Key] = [.. pair.Value];
+                        serialIds = [.. _serialIds];
+                    }
+
+                    if (_subjects.Count > 0)
+                    {
+                        subjects = new Dictionary<string, long[]>(_subjects.Count);
+                        foreach (var pair in _subjects)
+                        {
+                            subjects[pair.Key] = [.. pair.Value];
+                        }
+                    }
+
+                    if (_defaults.Count > 0)
+                    {
+                        defaults = new Dictionary<string, string>(_defaults);
                     }
                 }
 
-                if (_defaults.Count > 0)
+                string? flagsEnc = null;
+                if (serialIds is not null)
                 {
-                    defaults = new Dictionary<string, string>(_defaults);
-                }
-            }
-
-            if (serialIds is not null)
-            {
-                var enc = ULeb128Encoder.EncodeDeltaVarint(serialIds);
-                if (!string.IsNullOrEmpty(enc))
-                {
-                    tags.Add(new KeyValuePair<string, string>(TagFlagsEnc, enc));
-                }
-            }
-
-            if (subjects is not null)
-            {
-                var encoded = new Dictionary<string, string>(subjects.Count);
-                foreach (var pair in subjects)
-                {
-                    encoded[pair.Key] = ULeb128Encoder.EncodeDeltaVarint(pair.Value);
+                    var enc = ULeb128Encoder.EncodeDeltaVarint(serialIds);
+                    if (!StringUtil.IsNullOrEmpty(enc))
+                    {
+                        flagsEnc = enc;
+                    }
                 }
 
-                tags.Add(new KeyValuePair<string, string>(TagSubjectsEnc, JsonHelper.SerializeObject(encoded)));
-            }
+                string? subjectsEnc = null;
+                if (subjects is not null)
+                {
+                    // Hash the raw targeting keys here (serializer thread), not at accumulation time.
+                    var encoded = new Dictionary<string, string>(subjects.Count);
+                    foreach (var pair in subjects)
+                    {
+                        encoded[HashTargetingKey(pair.Key)] = ULeb128Encoder.EncodeDeltaVarint(pair.Value);
+                    }
 
-            if (defaults is not null)
+                    subjectsEnc = JsonHelper.SerializeObject(encoded);
+                }
+
+                string? runtimeDefaults = defaults is not null ? JsonHelper.SerializeObject(defaults) : null;
+
+                return new FeatureFlagSpanTags(flagsEnc, subjectsEnc, runtimeDefaults);
+            }
+            catch (Exception ex)
             {
-                tags.Add(new KeyValuePair<string, string>(TagRuntimeDefaults, JsonHelper.SerializeObject(defaults)));
+                // Enrichment must never break span serialization.
+                Log.Debug(ex, "SpanEnrichmentState.BuildSpanTags failed");
+                return default;
             }
-
-            return tags;
         }
 
         // Object default -> JSON; scalars -> their string form. A bare string is emitted as-is.

--- a/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
@@ -40,8 +40,9 @@ namespace Datadog.Trace.FeatureFlags
 
         private readonly HashSet<long> _serialIds = new();
 
-        // Raw targeting key -> set of serial ids. The key is hashed (SHA256) lazily in
-        // BuildSpanTags(), on the serializer thread, so the hash never runs on the evaluation path.
+        // SHA256-hex(targeting key) -> set of serial ids. The raw targeting key (often a customer
+        // identifier, and unbounded in length) is hashed at accumulation time and never retained on
+        // the trace, so we don't pin user-controlled data for the trace/writer-queue lifetime.
         private readonly Dictionary<string, HashSet<long>> _subjects = new();
 
         // flagKey -> value string (first-wins).
@@ -176,10 +177,13 @@ namespace Datadog.Trace.FeatureFlags
 
         internal void AddSubject(string targetingKey, long id)
         {
-            // Store the raw targeting key; it is hashed lazily in BuildSpanTags() (serializer thread).
+            // Hash the raw targeting key immediately so only the fixed-size digest is retained on the
+            // trace (never the raw, potentially user-identifying value). Hashing here (evaluation path)
+            // rather than in BuildSpanTags() keeps customer-controlled data off the trace/writer queue.
+            var hashed = HashTargetingKey(targetingKey);
             lock (_gate)
             {
-                if (_subjects.TryGetValue(targetingKey, out var ids))
+                if (_subjects.TryGetValue(hashed, out var ids))
                 {
                     if (ids.Count >= MaxExperimentsPerSubject && !ids.Contains(id))
                     {
@@ -197,7 +201,7 @@ namespace Datadog.Trace.FeatureFlags
                     return;
                 }
 
-                _subjects[targetingKey] = [id];
+                _subjects[hashed] = [id];
             }
         }
 
@@ -286,11 +290,11 @@ namespace Datadog.Trace.FeatureFlags
                 string? subjectsEnc = null;
                 if (subjects is not null)
                 {
-                    // Hash the raw targeting keys here (serializer thread), not at accumulation time.
+                    // Keys are already SHA256-hex digests (hashed at accumulation time in AddSubject).
                     var encoded = new Dictionary<string, string>(subjects.Count);
                     foreach (var pair in subjects)
                     {
-                        encoded[HashTargetingKey(pair.Key)] = ULeb128Encoder.EncodeDeltaVarint(pair.Value);
+                        encoded[pair.Key] = ULeb128Encoder.EncodeDeltaVarint(pair.Value);
                     }
 
                     subjectsEnc = JsonHelper.SerializeObject(encoded);

--- a/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Util;
 using Datadog.Trace.Util.Json;
 
@@ -52,6 +53,7 @@ namespace Datadog.Trace.FeatureFlags
         /// Gets or sets a fault-injection hook invoked at the start of <see cref="BuildSpanTags"/>. Test-only,
         /// used to verify the serializer-thread write path never lets enrichment break span serialization.
         /// </summary>
+        [TestingAndPrivateOnly]
         internal Action? OnBuildSpanTagsForTesting { get; set; }
 
         internal static string HashTargetingKey(string targetingKey) => Sha256Helper.ComputeHashAsHexString(targetingKey);
@@ -240,10 +242,8 @@ namespace Datadog.Trace.FeatureFlags
         }
 
         /// <summary>
-        /// Builds the encoded <c>ffe_*</c> tag values for the root span. Runs on the serializer
-        /// thread (from <c>SpanMessagePackFormatter</c>), so encoding, JSON serialization and
-        /// subject hashing stay off the customer's <c>Span.Finish()</c> path. Never throws; on
-        /// failure it returns <see langword="default"/> so serialization is never broken.
+        /// Builds the encoded <c>ffe_*</c> tag values for the root span.  Never throws; on
+        /// failure it returns <see langword="default"/>.
         /// </summary>
         internal FeatureFlagSpanTags BuildSpanTags()
         {

--- a/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/SpanEnrichmentState.cs
@@ -41,9 +41,13 @@ namespace Datadog.Trace.FeatureFlags
 
         private readonly HashSet<long> _serialIds = new();
 
-        // SHA256-hex(targeting key) -> set of serial ids. The raw targeting key (often a customer
-        // identifier, and unbounded in length) is hashed at accumulation time and never retained on
-        // the trace, so we don't pin user-controlled data for the trace/writer-queue lifetime.
+        // Raw targeting key -> set of serial ids. The key (often a customer identifier) is stored
+        // as-is and hashed lazily in BuildSpanTags() on the serializer thread; this is a deliberate
+        // choice, not an oversight — it keeps SHA-256 off the flag-evaluation path and hashes once
+        // per unique subject instead of once per accumulation. Retention is bounded (at most
+        // MaxSubjects keys) and short-lived (only until the root span is serialized), and the key
+        // already lives in the caller's own memory. Only the digest is ever emitted; the raw key
+        // never leaves the process.
         private readonly Dictionary<string, HashSet<long>> _subjects = new();
 
         // flagKey -> value string (first-wins).
@@ -179,13 +183,11 @@ namespace Datadog.Trace.FeatureFlags
 
         internal void AddSubject(string targetingKey, long id)
         {
-            // Hash the raw targeting key immediately so only the fixed-size digest is retained on the
-            // trace (never the raw, potentially user-identifying value). Hashing here (evaluation path)
-            // rather than in BuildSpanTags() keeps customer-controlled data off the trace/writer queue.
-            var hashed = HashTargetingKey(targetingKey);
+            // Store the raw targeting key; it is hashed lazily in BuildSpanTags() (see the _subjects
+            // field comment) so SHA-256 stays off the flag-evaluation path.
             lock (_gate)
             {
-                if (_subjects.TryGetValue(hashed, out var ids))
+                if (_subjects.TryGetValue(targetingKey, out var ids))
                 {
                     if (ids.Count >= MaxExperimentsPerSubject && !ids.Contains(id))
                     {
@@ -203,7 +205,7 @@ namespace Datadog.Trace.FeatureFlags
                     return;
                 }
 
-                _subjects[hashed] = [id];
+                _subjects[targetingKey] = [id];
             }
         }
 
@@ -290,11 +292,12 @@ namespace Datadog.Trace.FeatureFlags
                 string? subjectsEnc = null;
                 if (subjects is not null)
                 {
-                    // Keys are already SHA256-hex digests (hashed at accumulation time in AddSubject).
+                    // Hash the raw targeting key here (serializer thread), not at accumulation time,
+                    // so SHA-256 stays off the flag-evaluation path. Only the digest is emitted.
                     var encoded = new Dictionary<string, string>(subjects.Count);
                     foreach (var pair in subjects)
                     {
-                        encoded[pair.Key] = ULeb128Encoder.EncodeDeltaVarint(pair.Value);
+                        encoded[HashTargetingKey(pair.Key)] = ULeb128Encoder.EncodeDeltaVarint(pair.Value);
                     }
 
                     subjectsEnc = JsonHelper.SerializeObject(encoded);

--- a/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
@@ -6,7 +6,6 @@
 #nullable enable
 
 using System;
-using System.Buffers;
 
 namespace Datadog.Trace.FeatureFlags
 {
@@ -16,19 +15,21 @@ namespace Datadog.Trace.FeatureFlags
     /// ascending → delta-from-previous → unsigned LEB128 (7 bits/byte, MSB = continuation)
     /// → base64. The empty set encodes to the empty string (the tag is then omitted).
     /// Runs on the serializer thread (from <c>SpanMessagePackFormatter</c>).
-    /// Allocation-conscious: the sort copy and varint payload use the stack for small sets
-    /// (modern runtimes) and a pooled buffer otherwise, so only the base64 result allocates.
+    /// Allocation-conscious: on modern runtimes small sets encode entirely on the stack, so only
+    /// the base64 result allocates; older runtimes and large sets fall back to plain heap buffers.
     /// </summary>
     internal static class ULeb128Encoder
     {
         // A 64-bit value needs at most ceil(64/7) = 10 ULEB128 bytes.
         private const int MaxVarintBytes = 10;
 
+#if NET6_0_OR_GREATER
         // Sets at or below this many ids are encoded entirely on the stack (modern runtimes only):
         // 128 longs (1 KiB) for the sort copy + 128*10 bytes (~1.25 KiB) for the payload. Serial-id
         // sets are bounded by SpanEnrichmentState.MaxSerialIds (200), so the common case stays on
         // the stack; larger sets fall back to the array pool.
         private const int StackAllocMaxIds = 128;
+#endif
 
         /// <summary>
         /// Encodes a collection of serial ids (possibly unsorted, with duplicates) into a
@@ -46,9 +47,10 @@ namespace Datadog.Trace.FeatureFlags
 
             var count = serialIds.Length;
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
             // Fast path: dedupe + sort + encode entirely on the stack, no pooling, no copy to a
-            // heap array. Span.Sort and the ReadOnlySpan base64 overload are both BCL on .NET Core.
+            // heap array. Span.Sort (MemoryExtensions.Sort, .NET 5+) and the ReadOnlySpan base64
+            // overload are both BCL on modern .NET.
             if (count <= StackAllocMaxIds)
             {
                 Span<long> ids = stackalloc long[count];
@@ -61,23 +63,17 @@ namespace Datadog.Trace.FeatureFlags
             }
 #endif
 
-            // Fallback (large sets, or .NET Framework / netstandard2.0 which lack Span.Sort and the
-            // ReadOnlySpan base64 overload): rent both buffers so nothing beyond the result allocates.
-            var idBuffer = ArrayPool<long>.Shared.Rent(count);
-            var payloadBuffer = ArrayPool<byte>.Shared.Rent(count * MaxVarintBytes);
-            try
-            {
-                serialIds.CopyTo(idBuffer);
-                Array.Sort(idBuffer, 0, count);
+            // Fallback (large sets, or .NET Framework / netstandard2.0 / netcoreapp3.1, which lack
+            // Span.Sort): plain heap arrays. ArrayPool is unavailable uniformly across these TFMs
+            // (net461 has no BCL System.Buffers; the vendored copy is not compiled for net6.0), and
+            // this is the cold path — the allocation-free stack fast path above covers the common case.
+            var idBuffer = new long[count];
+            serialIds.CopyTo(idBuffer);
+            Array.Sort(idBuffer, 0, count);
 
-                var written = EncodeSorted(new ReadOnlySpan<long>(idBuffer, 0, count), payloadBuffer);
-                return Convert.ToBase64String(payloadBuffer, 0, written);
-            }
-            finally
-            {
-                ArrayPool<long>.Shared.Return(idBuffer);
-                ArrayPool<byte>.Shared.Return(payloadBuffer);
-            }
+            var payloadBuffer = new byte[count * MaxVarintBytes];
+            var written = EncodeSorted(new ReadOnlySpan<long>(idBuffer, 0, count), payloadBuffer);
+            return Convert.ToBase64String(payloadBuffer, 0, written);
         }
 
         // Encodes an ascending-sorted span, skipping adjacent duplicates (structural dedupe matching

--- a/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
@@ -6,6 +6,11 @@
 #nullable enable
 
 using System;
+#if NETFRAMEWORK
+using Buffers = Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+#else
+using Buffers = System.Buffers;
+#endif
 
 namespace Datadog.Trace.FeatureFlags
 {
@@ -21,11 +26,9 @@ namespace Datadog.Trace.FeatureFlags
         private const int MaxVarintBytes = 10;
 
 #if NET6_0_OR_GREATER
-        // Sets at or below this many ids are encoded entirely on the stack (modern runtimes only):
-        // 128 longs (1 KiB) for the sort copy + 128*10 bytes (~1.25 KiB) for the payload. Serial-id
-        // sets are bounded by SpanEnrichmentState.MaxSerialIds (200), so the common case stays on
-        // the stack; larger sets fall back to the array pool.
-        private const int StackAllocMaxIds = 128;
+        // Each id costs 8 bytes (sort copy) + 10 bytes (max varint), so 28 ids caps stack use at
+        // ~512 bytes; larger sets use the heap fallback.
+        private const int StackAllocMaxIds = 28;
 #endif
 
         /// <summary>
@@ -57,13 +60,21 @@ namespace Datadog.Trace.FeatureFlags
             }
 #endif
 
-            var idBuffer = new long[count];
-            serialIds.CopyTo(idBuffer);
-            Array.Sort(idBuffer, 0, count);
+            var idBuffer = Buffers.ArrayPool<long>.Shared.Rent(count);
+            var payloadBuffer = Buffers.ArrayPool<byte>.Shared.Rent(count * MaxVarintBytes);
+            try
+            {
+                serialIds.CopyTo(idBuffer);
+                Array.Sort(idBuffer, 0, count);
 
-            var payloadBuffer = new byte[count * MaxVarintBytes];
-            var written = EncodeSorted(new ReadOnlySpan<long>(idBuffer, 0, count), payloadBuffer);
-            return Convert.ToBase64String(payloadBuffer, 0, written);
+                var written = EncodeSorted(new ReadOnlySpan<long>(idBuffer, 0, count), payloadBuffer);
+                return Convert.ToBase64String(payloadBuffer, 0, written);
+            }
+            finally
+            {
+                Buffers.ArrayPool<long>.Shared.Return(idBuffer);
+                Buffers.ArrayPool<byte>.Shared.Return(payloadBuffer);
+            }
         }
 
         // Encodes an ascending-sorted span, skipping adjacent duplicates (structural dedupe matching

--- a/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
@@ -14,9 +14,6 @@ namespace Datadog.Trace.FeatureFlags
     /// Ported verbatim from the frozen Node reference (dd-trace-js#8343): dedupe → sort
     /// ascending → delta-from-previous → unsigned LEB128 (7 bits/byte, MSB = continuation)
     /// → base64. The empty set encodes to the empty string (the tag is then omitted).
-    /// Runs on the serializer thread (from <c>SpanMessagePackFormatter</c>).
-    /// Allocation-conscious: on modern runtimes small sets encode entirely on the stack, so only
-    /// the base64 result allocates; older runtimes and large sets fall back to plain heap buffers.
     /// </summary>
     internal static class ULeb128Encoder
     {
@@ -48,9 +45,6 @@ namespace Datadog.Trace.FeatureFlags
             var count = serialIds.Length;
 
 #if NET6_0_OR_GREATER
-            // Fast path: dedupe + sort + encode entirely on the stack, no pooling, no copy to a
-            // heap array. Span.Sort (MemoryExtensions.Sort, .NET 5+) and the ReadOnlySpan base64
-            // overload are both BCL on modern .NET.
             if (count <= StackAllocMaxIds)
             {
                 Span<long> ids = stackalloc long[count];
@@ -63,10 +57,6 @@ namespace Datadog.Trace.FeatureFlags
             }
 #endif
 
-            // Fallback (large sets, or .NET Framework / netstandard2.0 / netcoreapp3.1, which lack
-            // Span.Sort): plain heap arrays. ArrayPool is unavailable uniformly across these TFMs
-            // (net461 has no BCL System.Buffers; the vendored copy is not compiled for net6.0), and
-            // this is the cold path — the allocation-free stack fast path above covers the common case.
             var idBuffer = new long[count];
             serialIds.CopyTo(idBuffer);
             Array.Sort(idBuffer, 0, count);

--- a/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
@@ -6,7 +6,7 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
+using System.Buffers;
 
 namespace Datadog.Trace.FeatureFlags
 {
@@ -15,13 +15,20 @@ namespace Datadog.Trace.FeatureFlags
     /// Ported verbatim from the frozen Node reference (dd-trace-js#8343): dedupe → sort
     /// ascending → delta-from-previous → unsigned LEB128 (7 bits/byte, MSB = continuation)
     /// → base64. The empty set encodes to the empty string (the tag is then omitted).
-    /// Allocation-conscious: no LINQ, varint bytes are written straight into the payload buffer.
-    /// Runs on the root-span-finish hot path.
+    /// Runs on the serializer thread (from <c>SpanMessagePackFormatter</c>).
+    /// Allocation-conscious: the sort copy and varint payload use the stack for small sets
+    /// (modern runtimes) and a pooled buffer otherwise, so only the base64 result allocates.
     /// </summary>
     internal static class ULeb128Encoder
     {
         // A 64-bit value needs at most ceil(64/7) = 10 ULEB128 bytes.
         private const int MaxVarintBytes = 10;
+
+        // Sets at or below this many ids are encoded entirely on the stack (modern runtimes only):
+        // 128 longs (1 KiB) for the sort copy + 128*10 bytes (~1.25 KiB) for the payload. Serial-id
+        // sets are bounded by SpanEnrichmentState.MaxSerialIds (200), so the common case stays on
+        // the stack; larger sets fall back to the array pool.
+        private const int StackAllocMaxIds = 128;
 
         /// <summary>
         /// Encodes a collection of serial ids (possibly unsorted, with duplicates) into a
@@ -30,49 +37,74 @@ namespace Datadog.Trace.FeatureFlags
         /// </summary>
         /// <param name="serialIds">The serial ids to encode.</param>
         /// <returns>The base64-encoded string, or <see cref="string.Empty"/> when there are no ids.</returns>
-        public static string EncodeDeltaVarint(IReadOnlyCollection<long> serialIds)
+        public static string EncodeDeltaVarint(ReadOnlySpan<long> serialIds)
         {
-            if (serialIds is null || serialIds.Count == 0)
+            if (serialIds.Length == 0)
             {
                 return string.Empty;
             }
 
-            // Dedupe + sort ascending (structural, matching the Node Set semantics): copy into an
-            // array and sort in place, then skip adjacent duplicates while encoding. This avoids
-            // allocating a SortedSet just to order the ids.
-            var ids = new long[serialIds.Count];
-            var index = 0;
-            foreach (var id in serialIds)
+            var count = serialIds.Length;
+
+#if NETCOREAPP3_1_OR_GREATER
+            // Fast path: dedupe + sort + encode entirely on the stack, no pooling, no copy to a
+            // heap array. Span.Sort and the ReadOnlySpan base64 overload are both BCL on .NET Core.
+            if (count <= StackAllocMaxIds)
             {
-                ids[index++] = id;
+                Span<long> ids = stackalloc long[count];
+                serialIds.CopyTo(ids);
+                ids.Sort();
+
+                Span<byte> payload = stackalloc byte[count * MaxVarintBytes];
+                var writtenOnStack = EncodeSorted(ids, payload);
+                return Convert.ToBase64String(payload.Slice(0, writtenOnStack));
             }
+#endif
 
-            Array.Sort(ids);
+            // Fallback (large sets, or .NET Framework / netstandard2.0 which lack Span.Sort and the
+            // ReadOnlySpan base64 overload): rent both buffers so nothing beyond the result allocates.
+            var idBuffer = ArrayPool<long>.Shared.Rent(count);
+            var payloadBuffer = ArrayPool<byte>.Shared.Rent(count * MaxVarintBytes);
+            try
+            {
+                serialIds.CopyTo(idBuffer);
+                Array.Sort(idBuffer, 0, count);
 
-            // Worst case is MaxVarintBytes per id; this single buffer holds the whole payload and
-            // is written into directly (no per-id scratch buffer).
-            var buffer = new byte[ids.Length * MaxVarintBytes];
+                var written = EncodeSorted(new ReadOnlySpan<long>(idBuffer, 0, count), payloadBuffer);
+                return Convert.ToBase64String(payloadBuffer, 0, written);
+            }
+            finally
+            {
+                ArrayPool<long>.Shared.Return(idBuffer);
+                ArrayPool<byte>.Shared.Return(payloadBuffer);
+            }
+        }
+
+        // Encodes an ascending-sorted span, skipping adjacent duplicates (structural dedupe matching
+        // the Node Set semantics), as delta-from-previous ULEB128 varints. Returns the byte count.
+        private static int EncodeSorted(ReadOnlySpan<long> sortedIds, Span<byte> destination)
+        {
             var written = 0;
             long prev = 0;
 
-            for (var i = 0; i < ids.Length; i++)
+            for (var i = 0; i < sortedIds.Length; i++)
             {
-                if (i > 0 && ids[i] == ids[i - 1])
+                if (i > 0 && sortedIds[i] == sortedIds[i - 1])
                 {
                     continue; // dedupe: adjacent equal ids collapse to nothing
                 }
 
-                var delta = ids[i] - prev;
-                prev = ids[i];
-                written += EncodeVarint((ulong)delta, buffer, written);
+                var delta = sortedIds[i] - prev;
+                prev = sortedIds[i];
+                written += EncodeVarint((ulong)delta, destination, written);
             }
 
-            return Convert.ToBase64String(buffer, 0, written);
+            return written;
         }
 
         // ULEB128: emit 7 low bits per byte, set the MSB while more bits remain. Writes into
         // destination starting at offset and returns the number of bytes written.
-        private static int EncodeVarint(ulong value, byte[] destination, int offset)
+        private static int EncodeVarint(ulong value, Span<byte> destination, int offset)
         {
             var start = offset;
             while (value > 0x7F)

--- a/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/ULeb128Encoder.cs
@@ -6,11 +6,6 @@
 #nullable enable
 
 using System;
-#if NETFRAMEWORK
-using Buffers = Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
-#else
-using Buffers = System.Buffers;
-#endif
 
 namespace Datadog.Trace.FeatureFlags
 {
@@ -60,8 +55,8 @@ namespace Datadog.Trace.FeatureFlags
             }
 #endif
 
-            var idBuffer = Buffers.ArrayPool<long>.Shared.Rent(count);
-            var payloadBuffer = Buffers.ArrayPool<byte>.Shared.Rent(count * MaxVarintBytes);
+            var idBuffer = ArrayPool<long>.Shared.Rent(count);
+            var payloadBuffer = ArrayPool<byte>.Shared.Rent(count * MaxVarintBytes);
             try
             {
                 serialIds.CopyTo(idBuffer);
@@ -72,8 +67,8 @@ namespace Datadog.Trace.FeatureFlags
             }
             finally
             {
-                Buffers.ArrayPool<long>.Shared.Return(idBuffer);
-                Buffers.ArrayPool<byte>.Shared.Return(payloadBuffer);
+                ArrayPool<long>.Shared.Return(idBuffer);
+                ArrayPool<byte>.Shared.Return(payloadBuffer);
             }
         }
 

--- a/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
@@ -188,12 +188,6 @@ internal static class OtlpMapper
             }
         }
 
-        // Feature-flag span enrichment (ffe_* attributes), local-root only. Mirrors the block in
-        // SpanMessagePackFormatter.WriteTags: these values are produced on the serializer thread from
-        // Context.TraceContext.FeatureFlagEnrichment, not stored on span.Tags, so they must be emitted
-        // here too or OTLP-exported traces would omit them entirely. Emitted before the arbitrary
-        // customer span tags (like the other Datadog-internal attributes above) so a heavily-tagged
-        // span that hits the attribute limit does not silently drop enrichment.
         if (spanModel.IsLocalRoot &&
             spanModel.Span.Context.TraceContext?.FeatureFlagEnrichment is { } featureFlagEnrichment &&
             featureFlagEnrichment.HasData())

--- a/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags;
 using Datadog.Trace.OpenTelemetry.Common;
 using Datadog.Trace.Processors;
 using Datadog.Trace.Tagging;
@@ -216,6 +217,56 @@ internal static class OtlpMapper
         count = metricsWriter.Count;
         droppedAttributesCount += metricsWriter.DroppedCount;
         state = metricsWriter.State;
+
+        // Feature-flag span enrichment (ffe_* attributes), local-root only. Mirrors the block in
+        // SpanMessagePackFormatter.WriteTags: these values are produced on the serializer thread from
+        // Context.TraceContext.FeatureFlagEnrichment, not stored on span.Tags, so they must be emitted
+        // here too or OTLP-exported traces would omit them entirely.
+        if (spanModel.IsLocalRoot &&
+            spanModel.Span.Context.TraceContext?.FeatureFlagEnrichment is { } featureFlagEnrichment &&
+            featureFlagEnrichment.HasData())
+        {
+            var ffeTags = featureFlagEnrichment.BuildSpanTags();
+
+            if (!StringUtil.IsNullOrEmpty(ffeTags.FlagsEnc))
+            {
+                if (count < limit)
+                {
+                    writeKeyValue(ref state, new KeyValue(SpanEnrichmentState.TagFlagsEnc, ffeTags.FlagsEnc!));
+                    count++;
+                }
+                else
+                {
+                    droppedAttributesCount++;
+                }
+            }
+
+            if (!StringUtil.IsNullOrEmpty(ffeTags.SubjectsEnc))
+            {
+                if (count < limit)
+                {
+                    writeKeyValue(ref state, new KeyValue(SpanEnrichmentState.TagSubjectsEnc, ffeTags.SubjectsEnc!));
+                    count++;
+                }
+                else
+                {
+                    droppedAttributesCount++;
+                }
+            }
+
+            if (!StringUtil.IsNullOrEmpty(ffeTags.RuntimeDefaults))
+            {
+                if (count < limit)
+                {
+                    writeKeyValue(ref state, new KeyValue(SpanEnrichmentState.TagRuntimeDefaults, ffeTags.RuntimeDefaults!));
+                    count++;
+                }
+                else
+                {
+                    droppedAttributesCount++;
+                }
+            }
+        }
 
         // if (model.IsLocalRoot)
         // add the "apm.enabled" tag with a value of 0

--- a/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/OtlpMapper.cs
@@ -188,40 +188,12 @@ internal static class OtlpMapper
             }
         }
 
-        // Notes for later:
-        // - Do we actually need to add _dd.base_service tag even though the OTLP span shares the same service name?
-
-        // add _dd.base_service tag to spans where the service name has been overrideen
-        // Process tags will be sent only once per buffer/payload (one payload can contain many chunks from different traces)
-        // SCI tags will be sent only once per trace
-        // if (Security.Instance.AppsecEnabled && model.IsLocalRoot && span.Context.TraceContext?.WafExecuted is true)
-        // AAS tags need to be set on any span for the backend to properly handle the billing.
-
-        // Write span tags
-        ITagProcessor[]? tagProcessors = null;
-        if (spanModel.Span.Context.TraceContext?.Tracer is Tracer tracer)
-        {
-            tagProcessors = tracer.TracerManager?.TagProcessors;
-        }
-
-        var tagWriter = new TagWriter<TState>(state, writeKeyValue, tagProcessors, count, limit, openTelemetrySemanticsEnabled);
-        spanModel.Span.Tags.EnumerateTags(ref tagWriter);
-        count = tagWriter.Count;
-        droppedAttributesCount += tagWriter.DroppedCount;
-        state = tagWriter.State;
-
-        // Write span metrics
-        // Note: I could have done this earlier but I wanted to simulate the same behavior as the MessagePack formatter.
-        var metricsWriter = new TagWriter<TState>(state, writeKeyValue, tagProcessors, count, limit, openTelemetrySemanticsEnabled);
-        spanModel.Span.Tags.EnumerateMetrics(ref metricsWriter);
-        count = metricsWriter.Count;
-        droppedAttributesCount += metricsWriter.DroppedCount;
-        state = metricsWriter.State;
-
         // Feature-flag span enrichment (ffe_* attributes), local-root only. Mirrors the block in
         // SpanMessagePackFormatter.WriteTags: these values are produced on the serializer thread from
         // Context.TraceContext.FeatureFlagEnrichment, not stored on span.Tags, so they must be emitted
-        // here too or OTLP-exported traces would omit them entirely.
+        // here too or OTLP-exported traces would omit them entirely. Emitted before the arbitrary
+        // customer span tags (like the other Datadog-internal attributes above) so a heavily-tagged
+        // span that hits the attribute limit does not silently drop enrichment.
         if (spanModel.IsLocalRoot &&
             spanModel.Span.Context.TraceContext?.FeatureFlagEnrichment is { } featureFlagEnrichment &&
             featureFlagEnrichment.HasData())
@@ -267,6 +239,36 @@ internal static class OtlpMapper
                 }
             }
         }
+
+        // Notes for later:
+        // - Do we actually need to add _dd.base_service tag even though the OTLP span shares the same service name?
+
+        // add _dd.base_service tag to spans where the service name has been overrideen
+        // Process tags will be sent only once per buffer/payload (one payload can contain many chunks from different traces)
+        // SCI tags will be sent only once per trace
+        // if (Security.Instance.AppsecEnabled && model.IsLocalRoot && span.Context.TraceContext?.WafExecuted is true)
+        // AAS tags need to be set on any span for the backend to properly handle the billing.
+
+        // Write span tags
+        ITagProcessor[]? tagProcessors = null;
+        if (spanModel.Span.Context.TraceContext?.Tracer is Tracer tracer)
+        {
+            tagProcessors = tracer.TracerManager?.TagProcessors;
+        }
+
+        var tagWriter = new TagWriter<TState>(state, writeKeyValue, tagProcessors, count, limit, openTelemetrySemanticsEnabled);
+        spanModel.Span.Tags.EnumerateTags(ref tagWriter);
+        count = tagWriter.Count;
+        droppedAttributesCount += tagWriter.DroppedCount;
+        state = tagWriter.State;
+
+        // Write span metrics
+        // Note: I could have done this earlier but I wanted to simulate the same behavior as the MessagePack formatter.
+        var metricsWriter = new TagWriter<TState>(state, writeKeyValue, tagProcessors, count, limit, openTelemetrySemanticsEnabled);
+        spanModel.Span.Tags.EnumerateMetrics(ref metricsWriter);
+        count = metricsWriter.Count;
+        droppedAttributesCount += metricsWriter.DroppedCount;
+        state = metricsWriter.State;
 
         // if (model.IsLocalRoot)
         // add the "apm.enabled" tag with a value of 0

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -505,24 +505,9 @@ namespace Datadog.Trace
                 {
                     DebuggerManager.Instance.ExceptionReplay?.EndRequest();
 
-                    var enrichmentState = Context.TraceContext?.FeatureFlagEnrichment;
-                    if (enrichmentState is not null && enrichmentState.HasData())
-                    {
-                        try
-                        {
-                            foreach (var tag in enrichmentState.ToSpanTags())
-                            {
-                                if (!StringUtil.IsNullOrEmpty(tag.Value))
-                                {
-                                    Tags.SetTag(tag.Key, tag.Value);
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Debug(ex, "FFE span enrichment failed for root span {SpanId}", SpanId);
-                        }
-                    }
+                    // Feature-flag span enrichment (ffe_* tags) is written on the serializer thread
+                    // in SpanMessagePackFormatter, reading Context.TraceContext.FeatureFlagEnrichment,
+                    // so encoding/serialization stays off this (customer) Finish path.
                 }
 
                 Duration = duration;

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -504,18 +504,6 @@ namespace Datadog.Trace
                 if (IsRootSpan)
                 {
                     DebuggerManager.Instance.ExceptionReplay?.EndRequest();
-
-                    // Feature-flag span enrichment (ffe_* tags) is encoded and written at serialization
-                    // time (SpanMessagePackFormatter.WriteTags and OtlpMapper.EmitAttributesFromSpan),
-                    // reading Context.TraceContext.FeatureFlagEnrichment, so no ffe_* work runs at
-                    // Finish(). (Targeting keys are hashed earlier, at accumulation time, so the raw
-                    // value is never retained — see SpanEnrichmentState.AddSubject.)
-                    //
-                    // Known limitation: because ffe_* are no longer materialized on span.Tags at
-                    // Finish(), single-span sampling rules (DD_SPAN_SAMPLING_RULES) that match on an
-                    // ffe_* tag will not match — RunSpanSampler() runs in TraceContext.CloseSpan(),
-                    // before serialization. Matching sampling rules on these internal enrichment tags
-                    // is not a supported scenario.
                 }
 
                 Duration = duration;

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -505,9 +505,16 @@ namespace Datadog.Trace
                 {
                     DebuggerManager.Instance.ExceptionReplay?.EndRequest();
 
-                    // Feature-flag span enrichment (ffe_* tags) is written on the serializer thread
-                    // in SpanMessagePackFormatter, reading Context.TraceContext.FeatureFlagEnrichment,
-                    // so encoding/serialization stays off this (customer) Finish path.
+                    // Feature-flag span enrichment (ffe_* tags) is written at serialization time
+                    // (SpanMessagePackFormatter.WriteTags and OtlpMapper.EmitAttributesFromSpan),
+                    // reading Context.TraceContext.FeatureFlagEnrichment, so encoding/serialization
+                    // stays off this (customer) Finish path.
+                    //
+                    // Known limitation: because ffe_* are no longer materialized on span.Tags at
+                    // Finish(), single-span sampling rules (DD_SPAN_SAMPLING_RULES) that match on an
+                    // ffe_* tag will not match — RunSpanSampler() runs in TraceContext.CloseSpan(),
+                    // before serialization. Matching sampling rules on these internal enrichment tags
+                    // is not a supported scenario.
                 }
 
                 Duration = duration;

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -505,10 +505,11 @@ namespace Datadog.Trace
                 {
                     DebuggerManager.Instance.ExceptionReplay?.EndRequest();
 
-                    // Feature-flag span enrichment (ffe_* tags) is written at serialization time
-                    // (SpanMessagePackFormatter.WriteTags and OtlpMapper.EmitAttributesFromSpan),
-                    // reading Context.TraceContext.FeatureFlagEnrichment, so encoding/serialization
-                    // stays off this (customer) Finish path.
+                    // Feature-flag span enrichment (ffe_* tags) is encoded and written at serialization
+                    // time (SpanMessagePackFormatter.WriteTags and OtlpMapper.EmitAttributesFromSpan),
+                    // reading Context.TraceContext.FeatureFlagEnrichment, so no ffe_* work runs at
+                    // Finish(). (Targeting keys are hashed earlier, at accumulation time, so the raw
+                    // value is never retained — see SpanEnrichmentState.AddSubject.)
                     //
                     // Known limitation: because ffe_* are no longer materialized on span.Tags at
                     // Finish(), single-span sampling rules (DD_SPAN_SAMPLING_RULES) that match on an

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/FeatureFlags/SpanEnrichmentIntegrationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/FeatureFlags/SpanEnrichmentIntegrationTests.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,6 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.FeatureFlags;
 #if NETFRAMEWORK
 [Collection(nameof(ManualInstrumentationTests))]
 #endif
+[UsesVerify]
 public class SpanEnrichmentIntegrationTests : TestHelper
 {
     // Frozen cross-SDK contract tag names (dd-trace-js#8343) — bare names, never _dd.-prefixed.
@@ -127,6 +129,38 @@ public class SpanEnrichmentIntegrationTests : TestHelper
             span.Tags.Should().NotContainKey(TagSubjectsEnc, "no ffe_* tags when the gate is off");
             span.Tags.Should().NotContainKey(TagRuntimeDefaults, "no ffe_* tags when the gate is off");
         }
+    }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task SpanEnrichment_GateOn_MatchesSnapshot()
+    {
+        using var agent = EnvironmentHelper.GetMockAgent();
+        agent.SetupRcm(
+            Output,
+            [
+                ((object)new ServerConfiguration
+                {
+                    Flags = FeatureFlagsHelpers.CreateAllFlags(),
+                },
+                RcmProducts.FfeFlags,
+                nameof(SpanEnrichmentIntegrationTests))
+            ]);
+
+        var output = await RunTest(agent, spanEnrichmentEnabled: true);
+        output.Should().Contain("<INSTRUMENTED>");
+        output.Should().Contain("Exit. OK");
+
+        // Root "ffe.root" + child "ffe.child"; don't filter by operation name (see the sibling tests).
+        var spans = await agent.WaitForSpansAsync(2, returnAllOperations: true);
+
+        // End-to-end snapshot of the serialized spans as they reach the agent. The ffe_* values are
+        // deterministic — the flag fixtures use fixed serial ids (100, 108) and a fixed targeting key,
+        // so the encoded flags/subjects tags are stable across runs. The snapshot captures them on
+        // ffe.root and their absence on ffe.child.
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        await VerifyHelper.VerifySpans(spans, settings)
+                          .UseFileName(nameof(SpanEnrichmentIntegrationTests));
     }
 
     // Decode side mirrors the cross-SDK codec (system-tests test_ffe/utils.py): base64 -> ULEB128

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/SpanEnrichmentTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/SpanEnrichmentTests.cs
@@ -592,6 +592,45 @@ public class SpanEnrichmentTests
     }
 
     // ---------------------------------------------------------------------
+    // Wire-format snapshot: byte-exact ffe_* values through the real formatter
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task Serialize_FfeWireFormat_MatchesFrozenSnapshot()
+    {
+        // Byte-exact snapshot of the three ffe_* tag values exactly as they land in the serialized
+        // "meta" map. This locks the frozen cross-SDK contract end-to-end: the bare tag names, the
+        // ULEB128 delta-varint + base64 flag encoding, the { sha256hex: base64 } subjects JSON, and
+        // the compact runtime-defaults JSON. A change to any of these diverges from the other tracers
+        // and must fail here loudly. (The codec in isolation is covered by ULeb128EncoderTests.)
+        var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.SpanEnrichmentEnabled, "true" } });
+        await using var tracer = TracerHelper.Create(settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object);
+
+        var scope = (Scope)tracer.StartActive("root-op");
+        var span = scope.Span;
+
+        var enrichment = span.Context.TraceContext!.GetOrCreateFeatureFlagEnrichment()!;
+        enrichment.AddSerialId(100);
+        enrichment.AddSerialId(108);
+        enrichment.AddSerialId(128);
+        enrichment.AddSerialId(130);
+        enrichment.AddSubject("user-123", 100);
+        enrichment.AddDefault("my-flag", "fallback-value");
+
+        span.Finish();
+        var serialized = Serialize(span).Single();
+
+        // flags: {100,108,128,130} -> deltas [100,8,20,2] -> ULEB128 [0x64,0x08,0x14,0x02] -> base64.
+        serialized.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().Be("ZAgUAg==");
+
+        // subjects: { sha256("user-123"): base64(ULEB128 of {100}) }. {100} -> [0x64] -> "ZA==".
+        serialized.GetTag(SpanEnrichmentState.TagSubjectsEnc).Should().Be($"{{\"{User123Sha256}\":\"ZA==\"}}");
+
+        // runtime defaults: compact { flagKey: valueStr } JSON, no whitespace.
+        serialized.GetTag(SpanEnrichmentState.TagRuntimeDefaults).Should().Be("{\"my-flag\":\"fallback-value\"}");
+    }
+
+    // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/SpanEnrichmentTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/SpanEnrichmentTests.cs
@@ -5,10 +5,12 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.FeatureFlags;
 using Datadog.Trace.Sampling;
@@ -22,10 +24,11 @@ using Xunit;
 namespace Datadog.Trace.Tests.FeatureFlags;
 
 /// <summary>
-/// Unit tests for the .NET FFE APM span-enrichment accumulator + Span.Finish write path. Covers:
-/// the accumulator caps/dedupe, the accumulate branch logic, and the Span.Finish write path
-/// (gate-on positive control, gate-off negative control, and per-trace state isolation). The codec
-/// itself is covered by <see cref="ULeb128EncoderTests"/>.
+/// Unit tests for the .NET FFE APM span-enrichment accumulator + serializer-thread write path. Covers:
+/// the accumulator caps/dedupe, the accumulate branch logic, and the SpanMessagePackFormatter write
+/// path (gate-on positive control, gate-off negative control, and per-trace state isolation) — the
+/// ffe_* tags are produced at serialization, not at Span.Finish(). The codec itself is covered by
+/// <see cref="ULeb128EncoderTests"/>.
 /// </summary>
 [TracerRestorer]
 public class SpanEnrichmentTests
@@ -268,20 +271,21 @@ public class SpanEnrichmentTests
 
         rootSpan.Context.TraceContext!.GetOrCreateFeatureFlagEnrichment()!.AccumulateEvaluation(evaluation, "user-123");
 
-        rootScope.Dispose(); // finishes the span, which writes the ffe_* tags
+        rootScope.Dispose(); // finishes the span
+        var serialized = Serialize(rootSpan).Single();
 
-        DecodeDeltaVarint(rootSpan.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(new long[] { 100 });
-        var subjects = JsonConvert.DeserializeObject<Dictionary<string, string>>(rootSpan.GetTag(SpanEnrichmentState.TagSubjectsEnc)!)!;
+        DecodeDeltaVarint(serialized.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(new long[] { 100 });
+        var subjects = JsonConvert.DeserializeObject<Dictionary<string, string>>(serialized.GetTag(SpanEnrichmentState.TagSubjectsEnc)!)!;
         subjects.Should().ContainKey(User123Sha256);
         DecodeDeltaVarint(subjects[User123Sha256]).Should().Equal(new long[] { 100 });
     }
 
     // ---------------------------------------------------------------------
-    // Span.Finish write path: gate-on positive control + gate-off negative control
+    // Serializer write path: gate-on positive control + gate-off negative control
     // ---------------------------------------------------------------------
 
     [Fact]
-    public async Task SpanFinish_GateOn_WritesFfeTagsFromAccumulatedState()
+    public async Task Serialize_GateOn_WritesFfeTagsFromAccumulatedState()
     {
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.SpanEnrichmentEnabled, "true" } });
         await using var tracer = TracerHelper.Create(settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object);
@@ -295,14 +299,15 @@ public class SpanEnrichmentTests
         enrichment.Accumulate(serialId: 108, doLog: false, targetingKey: null, hasVariant: true, flagKey: "flag2", value: "off");
 
         span.Finish();
+        var serialized = Serialize(span).Single();
 
-        span.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().NotBeNullOrEmpty();
-        DecodeDeltaVarint(span.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(new long[] { 100, 108 });
-        span.GetTag(SpanEnrichmentState.TagSubjectsEnc).Should().NotBeNullOrEmpty();
+        serialized.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().NotBeNullOrEmpty();
+        DecodeDeltaVarint(serialized.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(new long[] { 100, 108 });
+        serialized.GetTag(SpanEnrichmentState.TagSubjectsEnc).Should().NotBeNullOrEmpty();
     }
 
     [Fact]
-    public async Task SpanFinish_GateOff_NegativeControl_NoTags_NoStateAllocated()
+    public async Task Serialize_GateOff_NegativeControl_NoTags_NoStateAllocated()
     {
         var settings = TracerSettings.Create(new());
         settings.IsSpanEnrichmentEnabled.Should().BeFalse("the gate is off by default");
@@ -316,14 +321,15 @@ public class SpanEnrichmentTests
         span.Context.TraceContext!.FeatureFlagEnrichment.Should().BeNull("no state is allocated when the gate is off");
 
         span.Finish();
+        var serialized = Serialize(span).Single();
 
-        span.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().BeNull();
-        span.GetTag(SpanEnrichmentState.TagSubjectsEnc).Should().BeNull();
-        span.GetTag(SpanEnrichmentState.TagRuntimeDefaults).Should().BeNull();
+        serialized.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().BeNull();
+        serialized.GetTag(SpanEnrichmentState.TagSubjectsEnc).Should().BeNull();
+        serialized.GetTag(SpanEnrichmentState.TagRuntimeDefaults).Should().BeNull();
     }
 
     [Fact]
-    public async Task SpanFinish_GateOn_NoAccumulatedState_WritesNoTags()
+    public async Task Serialize_GateOn_NoAccumulatedState_WritesNoTags()
     {
         // no-data case: gate on but nothing accumulated for this root => no ffe_* tags and no state.
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.SpanEnrichmentEnabled, "true" } });
@@ -334,17 +340,18 @@ public class SpanEnrichmentTests
         span.Context.TraceContext!.FeatureFlagEnrichment.Should().BeNull("state is created lazily on first eval");
 
         span.Finish();
+        var serialized = Serialize(span).Single();
 
-        span.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().BeNull();
-        span.GetTag(SpanEnrichmentState.TagRuntimeDefaults).Should().BeNull();
+        serialized.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().BeNull();
+        serialized.GetTag(SpanEnrichmentState.TagRuntimeDefaults).Should().BeNull();
     }
 
     [Fact]
-    public async Task SpanFinish_EnrichmentThrows_DoesNotBreakSpanFinish()
+    public async Task Serialize_EnrichmentThrows_DoesNotBreakSerialization()
     {
-        // Span.Finish() is core span lifecycle: a throw in the enrichment write path (encode/SetTag)
-        // must never propagate out and break span closing. Force a deterministic throw from
-        // ToSpanTags and assert Finish still completes.
+        // Span serialization must never be broken by enrichment: a throw while building the ffe_*
+        // values is caught inside BuildSpanTags (returns default), so serialization completes and the
+        // span simply carries no ffe_* tags. Force a deterministic throw and assert both.
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.SpanEnrichmentEnabled, "true" } });
         await using var tracer = TracerHelper.Create(settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object);
 
@@ -353,12 +360,15 @@ public class SpanEnrichmentTests
         span.IsRootSpan.Should().BeTrue();
 
         var enrichment = span.Context.TraceContext!.GetOrCreateFeatureFlagEnrichment()!;
-        enrichment.AddSerialId(100); // give it data so Finish reaches ToSpanTags
-        enrichment.OnToSpanTagsForTesting = static () => throw new System.InvalidOperationException("boom: simulated enrichment failure");
+        enrichment.AddSerialId(100); // give it data so serialization reaches BuildSpanTags
+        enrichment.OnBuildSpanTagsForTesting = static () => throw new InvalidOperationException("boom: simulated enrichment failure");
 
-        var finish = () => span.Finish();
-        finish.Should().NotThrow("enrichment must never break span finish");
-        span.IsFinished.Should().BeTrue("the span must still finish even when enrichment throws");
+        span.Finish();
+
+        MockSpan[] serialized = null!;
+        var serialize = () => serialized = Serialize(span);
+        serialize.Should().NotThrow("enrichment must never break span serialization");
+        serialized.Single().GetTag(SpanEnrichmentState.TagFlagsEnc).Should().BeNull("a build failure yields no ffe_* tags, not a crash");
     }
 
     // ---------------------------------------------------------------------
@@ -433,19 +443,19 @@ public class SpanEnrichmentTests
     }
 
     [Fact]
-    public async Task State_ConcurrentAddRacingToSpanTags_NoCollectionModifiedException()
+    public async Task State_ConcurrentAddRacingBuildSpanTags_NoCollectionModifiedException()
     {
-        // A straggler Accumulate can Add while Span.Finish enumerates ToSpanTags. Pre-fix, the
-        // foreach ran over the live set during that Add => InvalidOperationException: "Collection was
-        // modified". Post-fix, ToSpanTags snapshots under the lock, so a concurrent Add can never tear
-        // the enumeration.
+        // A straggler Accumulate can Add while the serializer thread builds the tags. Pre-fix, the
+        // encode ran over the live set during that Add => InvalidOperationException: "Collection was
+        // modified". Post-fix, BuildSpanTags snapshots under the lock, so a concurrent Add can never
+        // tear the encoding.
         _raceFailed = false;
 
         for (var round = 0; round < 200 && !_raceFailed; round++)
         {
             var live = new SpanEnrichmentState();
 
-            // Seed so the state exists and ToSpanTags has something to enumerate.
+            // Seed so the state exists and BuildSpanTags has something to encode.
             for (var i = 1; i <= 30; i++)
             {
                 live.AddSerialId(i);
@@ -461,32 +471,27 @@ public class SpanEnrichmentTests
 
             var reader = Task.Run(() =>
             {
-                try
+                for (var i = 0; i < 400 && !_raceFailed; i++)
                 {
-                    for (var i = 0; i < 400; i++)
+                    // Build + decode the produced tags fully — pre-fix, a concurrent Add tore the
+                    // encode and BuildSpanTags caught the "Collection was modified" internally,
+                    // returning empty tags. Since ≥30 ids are always seeded, an empty FlagsEnc here
+                    // is that swallowed race (the fail-before signal); post-fix it never happens.
+                    var built = live.BuildSpanTags();
+                    if (string.IsNullOrEmpty(built.FlagsEnc))
                     {
-                        // Enumerate the produced tags fully (decode) — pre-fix this tears mid-enumeration.
-                        foreach (var tag in live.ToSpanTags())
-                        {
-                            if (tag.Key == SpanEnrichmentState.TagFlagsEnc)
-                            {
-                                DecodeDeltaVarint(tag.Value);
-                            }
-                        }
+                        _raceFailed = true;
+                        return;
                     }
-                }
-                catch (System.InvalidOperationException)
-                {
-                    // "Collection was modified; enumeration operation may not execute" — the
-                    // concurrency failure. Record it so the assertion reports cleanly (fail-before signal).
-                    _raceFailed = true;
+
+                    DecodeDeltaVarint(built.FlagsEnc!);
                 }
             });
 
             await Task.WhenAll(adder, reader);
         }
 
-        _raceFailed.Should().BeFalse("ToSpanTags must snapshot under the lock so a concurrent Add never throws");
+        _raceFailed.Should().BeFalse("BuildSpanTags must snapshot under the lock so a concurrent Add never tears the encode");
     }
 
     // ---------------------------------------------------------------------
@@ -545,22 +550,26 @@ public class SpanEnrichmentTests
         spanA.Finish();
         spanB.Finish();
 
-        DecodeDeltaVarint(spanA.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(idsA);
-        DecodeDeltaVarint(spanB.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(idsB);
+        var serializedA = Serialize(spanA).Single();
+        var serializedB = Serialize(spanB).Single();
+
+        DecodeDeltaVarint(serializedA.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(idsA);
+        DecodeDeltaVarint(serializedB.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(idsB);
     }
 
     [Fact]
-    public async Task SpanFinish_TagsLandOnRootOnly_NotChildSpans()
+    public async Task Serialize_TagsLandOnRootOnly_NotChildSpans()
     {
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.SpanEnrichmentEnabled, "true" } });
         await using var tracer = TracerHelper.Create(settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object);
 
-        using var rootScope = (Scope)tracer.StartActive("root-op");
+        var rootScope = (Scope)tracer.StartActive("root-op");
         var root = rootScope.Span;
+        Span child;
 
         using (var childScope = (Scope)tracer.StartActive("child-op"))
         {
-            var child = childScope.Span;
+            child = childScope.Span;
             child.IsRootSpan.Should().BeFalse();
 
             // The eval happens on the child, but enrichment is keyed to the shared trace context.
@@ -568,19 +577,58 @@ public class SpanEnrichmentTests
                 .Accumulate(serialId: 100, doLog: false, targetingKey: null, hasVariant: true, flagKey: "flag", value: "on");
 
             child.Finish();
-            child.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().BeNull("a non-root span must never carry ffe tags");
         }
 
         root.Finish();
-        DecodeDeltaVarint(root.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(new long[] { 100 });
+
+        // Serialize root + child together in one chunk so the formatter's local-root detection is
+        // exercised: only the local root (root) may carry ffe_* tags.
+        var serialized = Serialize(root, child);
+        var serializedRoot = serialized.Single(s => s.Name == "root-op");
+        var serializedChild = serialized.Single(s => s.Name == "child-op");
+
+        serializedChild.GetTag(SpanEnrichmentState.TagFlagsEnc).Should().BeNull("a non-root span must never carry ffe tags");
+        DecodeDeltaVarint(serializedRoot.GetTag(SpanEnrichmentState.TagFlagsEnc)!).Should().Equal(new long[] { 100 });
     }
 
     // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
 
+    // Projects BuildSpanTags() (the serializer-thread build path) into a name->value dictionary,
+    // mirroring what SpanMessagePackFormatter writes to the "meta" map for the root span.
     private static Dictionary<string, string> TagDict(SpanEnrichmentState state)
-        => state.ToSpanTags().ToDictionary(p => p.Key, p => p.Value);
+    {
+        var built = state.BuildSpanTags();
+        var dict = new Dictionary<string, string>();
+        if (!string.IsNullOrEmpty(built.FlagsEnc))
+        {
+            dict[SpanEnrichmentState.TagFlagsEnc] = built.FlagsEnc!;
+        }
+
+        if (!string.IsNullOrEmpty(built.SubjectsEnc))
+        {
+            dict[SpanEnrichmentState.TagSubjectsEnc] = built.SubjectsEnc!;
+        }
+
+        if (!string.IsNullOrEmpty(built.RuntimeDefaults))
+        {
+            dict[SpanEnrichmentState.TagRuntimeDefaults] = built.RuntimeDefaults!;
+        }
+
+        return dict;
+    }
+
+    // Serializes the given spans through SpanMessagePackFormatter (the real write path) and returns
+    // the deserialized spans, so tests can assert on the ffe_* tags exactly as they land on the wire.
+    private static MockSpan[] Serialize(params Span[] spans)
+    {
+        var formatter = SpanFormatterResolver.Instance.GetFormatter<TraceChunkModel>();
+        var traceChunk = new TraceChunkModel(new SpanCollection(spans));
+        byte[] bytes = [];
+        var length = formatter.Serialize(ref bytes, 0, traceChunk, SpanFormatterResolver.Instance);
+        return global::MessagePack.MessagePackSerializer.Deserialize<MockSpan[]>(new ArraySegment<byte>(bytes, 0, length));
+    }
 
     // Decode side mirrors the cross-SDK codec (system-tests test_ffe/utils.py) — the round-trip oracle.
     private static List<long> DecodeDeltaVarint(string base64)

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetry/OtlpMapperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetry/OtlpMapperTests.cs
@@ -394,6 +394,43 @@ public class OtlpMapperTests
         attributes.Should().Contain(kv => kv.Key == SpanEnrichmentState.TagRuntimeDefaults && (string)kv.Value! == "{\"my-flag\":\"fallback-value\"}");
     }
 
+    [Fact]
+    public async Task EmitAttributesFromSpan_ReservesEnrichmentSlots_WhenSpanTagsExceedLimit()
+    {
+        // ffe_* enrichment must be prioritized over arbitrary customer span tags: a heavily-tagged
+        // local root that hits the OTLP attribute limit must still carry enrichment (the MessagePack
+        // path has no such limit, so dropping it here would diverge). Emitting ffe_* before the span
+        // tags reserves their slots. OTEL-semantics mode skips the service/operation/etc. block, so
+        // with no origin/last_parent set the three ffe_* attributes are emitted first, deterministically.
+        var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.SpanEnrichmentEnabled, "true" } });
+        await using var tracer = TracerHelper.Create(settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object);
+
+        var scope = (Scope)tracer.StartActive("root-op");
+        var span = scope.Span;
+        for (var i = 0; i < 5; i++)
+        {
+            span.SetTag($"customer.tag.{i}", "v");
+        }
+
+        var enrichment = span.Context.TraceContext!.GetOrCreateFeatureFlagEnrichment()!;
+        enrichment.AddSerialId(100);
+        enrichment.AddSubject("user-123", 100);
+        enrichment.AddDefault("my-flag", "fallback-value");
+        span.Finish();
+
+        var spanModel = new TraceChunkModel(new SpanCollection(new[] { span })).GetSpanModel(0);
+
+        var attributes = new List<KeyValue>();
+        // limit 3 = exactly the three ffe_* slots; every customer tag must then spill.
+        var dropped = OtlpMapper.EmitAttributesFromSpan(kv => attributes.Add(kv), spanModel, limit: 3, openTelemetrySemanticsEnabled: true);
+
+        attributes.Should().Contain(kv => kv.Key == SpanEnrichmentState.TagFlagsEnc);
+        attributes.Should().Contain(kv => kv.Key == SpanEnrichmentState.TagSubjectsEnc);
+        attributes.Should().Contain(kv => kv.Key == SpanEnrichmentState.TagRuntimeDefaults);
+        attributes.Should().NotContain(kv => kv.Key.StartsWith("customer.tag."));
+        dropped.Should().BeGreaterOrEqualTo(5, "the five customer tags all spill once the three enrichment slots are taken");
+    }
+
     private static Span CreateSpan(string? origin = null)
     {
         var traceContext = new TraceContext(new StubDatadogTracer());

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetry/OtlpMapperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetry/OtlpMapperTests.cs
@@ -11,11 +11,14 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags;
 using Datadog.Trace.OpenTelemetry;
 using Datadog.Trace.OpenTelemetry.Common;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers.TestTracer;
 using Datadog.Trace.Tests.Util;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.OpenTelemetry;
@@ -359,6 +362,36 @@ public class OtlpMapperTests
         OtlpMapper.EmitAttributesFromSpan(kv => attributes.Add(kv), CreateSpanModel(span), limit: 128, openTelemetrySemanticsEnabled: false);
 
         attributes.Should().Contain(kv => kv.Key == tagKey, because: $"'{tagKey}' should be emitted as a span attribute when OTel trace compatibility is disabled");
+    }
+
+    [Fact]
+    public async Task EmitAttributesFromSpan_EmitsFeatureFlagEnrichment_OnLocalRoot()
+    {
+        // Regression: ffe_* enrichment is produced at serialization time (not stored on span.Tags),
+        // and OTLP export bypasses SpanMessagePackFormatter. Without OtlpMapper emitting these too,
+        // OTLP-exported traces would silently drop all feature-flag enrichment.
+        var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.SpanEnrichmentEnabled, "true" } });
+        await using var tracer = TracerHelper.Create(settings, new Mock<IAgentWriter>().Object, new Mock<ITraceSampler>().Object);
+
+        var scope = (Scope)tracer.StartActive("root-op");
+        var span = scope.Span;
+
+        var enrichment = span.Context.TraceContext!.GetOrCreateFeatureFlagEnrichment()!;
+        enrichment.AddSerialId(100);
+        enrichment.AddSubject("user-123", 100);
+        enrichment.AddDefault("my-flag", "fallback-value");
+        span.Finish();
+
+        // Main TraceChunkModel constructor so IsLocalRoot is derived from TraceContext.RootSpan.
+        var spanModel = new TraceChunkModel(new SpanCollection(new[] { span })).GetSpanModel(0);
+        spanModel.IsLocalRoot.Should().BeTrue();
+
+        var attributes = new List<KeyValue>();
+        OtlpMapper.EmitAttributesFromSpan(kv => attributes.Add(kv), spanModel, limit: 128, openTelemetrySemanticsEnabled: false);
+
+        attributes.Should().Contain(kv => kv.Key == SpanEnrichmentState.TagFlagsEnc && (string)kv.Value! == "ZA==");
+        attributes.Should().Contain(kv => kv.Key == SpanEnrichmentState.TagSubjectsEnc);
+        attributes.Should().Contain(kv => kv.Key == SpanEnrichmentState.TagRuntimeDefaults && (string)kv.Value! == "{\"my-flag\":\"fallback-value\"}");
     }
 
     private static Span CreateSpan(string? origin = null)

--- a/tracer/test/snapshots/SpanEnrichmentIntegrationTests.verified.txt
+++ b/tracer/test/snapshots/SpanEnrichmentIntegrationTests.verified.txt
@@ -1,0 +1,35 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: ffe.root,
+    Resource: ffe.root,
+    Service: Samples.OpenFeature,
+    Tags: {
+      env: integration_tests,
+      ffe_flags_enc: ZAg=,
+      ffe_runtime_defaults: {"time-based-flag":"Not found"},
+      ffe_subjects_enc: {"3a3cee63f5a48700192db604dbd7ae1ae154f1703ced7ea100dab5620bec6cf0":"bA=="},
+      language: dotnet,
+      runtime-id: Guid_1
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: ffe.child,
+    Resource: ffe.child,
+    Service: Samples.OpenFeature,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes

Stacked on top of #8795 (FFE APM span enrichment). Moves the `ffe_*` tag
encoding/serialization off the customer's `Span.Finish()` path and onto the
serializer thread, plus two follow-ups Andrew agreed to defer from that PR:
`ULeb128Encoder` allocation reductions and a wire-format snapshot test.

## Reason for change

In #8795, encoding the feature-flag serial ids (ULEB128 + base64), serializing
the subjects/runtime-defaults JSON, and hashing the targeting keys all ran
synchronously inside `Span.Finish()` — i.e. on the customer's thread. This work
is only needed at serialization time, so it belongs on the background serializer
thread where it stays off the hot path.

## Implementation details

- **Serializer-thread write path.** Removed the `ffe_*` write block from
  `Span.Finish()`. `SpanMessagePackFormatter.WriteTags` now writes the tags for
  the local-root span only, reading `Context.TraceContext.FeatureFlagEnrichment`.
  Because the formatter back-patches the meta-map count, conditionally injecting
  tags is safe.
- **`SpanEnrichmentState.BuildSpanTags()`** replaces `ToSpanTags()`, returning a
  new `readonly struct FeatureFlagSpanTags` (no `List`/`Dictionary` for the tag
  set). It snapshots the bounded state under the lock, then encodes/serializes
  after releasing it, and never throws — on failure it returns `default` so
  enrichment can never break span serialization.
- **Delay-hashed subjects.** Targeting keys are now stored raw and SHA256-hashed
  in `BuildSpanTags()` (serializer thread) instead of at accumulation time, so
  the hash no longer runs on the evaluation path.
- **`ULeb128Encoder` allocations.** Small id sets encode entirely on the stack
  on modern runtimes (`stackalloc` + `Span.Sort` + `ReadOnlySpan` base64); larger
  sets and `net461`/`netstandard2.0` use `ArrayPool` for both buffers. Output is
  byte-identical (golden vector `ZAgUAg==` unchanged).
- CI-visibility formatter intentionally untouched — FFE enrichment is APM-only.

## Test coverage

- Guardrail tests rewritten to assert `ffe_*` tags via the real
  serialize → deserialize (`MockSpan`) path rather than off `Span.Finish()`:
  gate-on/gate-off controls, no-data, per-trace isolation, root-only placement,
  a "enrichment throws → serialization still succeeds" test, and a concurrent
  Add-racing-`BuildSpanTags` regression.
- New `Serialize_FfeWireFormat_MatchesFrozenSnapshot`: byte-exact snapshot of the
  three `ffe_*` values through the formatter, locking the frozen cross-SDK
  contract (tag names + codec output + compact JSON).
- `ULeb128EncoderTests` unchanged and still green (output contract preserved).

## Other details

Stacked PR — base is `leo.romanovsky/ffe-apm-span-enrichment`; review/merge #8795 first.
