### PR TITLE
Expands test ownership out to support CI Vis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,6 +120,41 @@
 /tracer/src/**/*GCP*.cs                                                         @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 /tracer/test/**/*GCP*.cs                                                        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
 
+## START - CI Visibility test ownership compatibility
+# Our current version of DatadogTestLogger 0.0.54 does not support expanding ** patterns for our tests
+# So to get this working well and get the correct teams to be reported we are expanding these out manually
+# Note: these all already have ** patterns that do what the following are doing so no _real_ changes to CODEOWNERs
+# TODO: Remove these explicit entries when the logger supports ** patterns
+
+### Data Streams Monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs      @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSnsTests.cs          @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSqsTests.cs          @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringHttpClientTests.cs          @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringKafkaTests.cs               @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringManualApiTest.cs            @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs            @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
+
+### Serverless (AWS Lambda)
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs    @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsAwsLambdaTests.cs  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs                           @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs                   @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
+
+### Serverless (Azure)
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsMessagingTriggerTests.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs  @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/Datadog.Trace.Tests/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommonTests.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsAzureFunctionsPipeTests.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableAzureAppServiceSettingsTests.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsAzureAppServiceTests.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs        @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+
+### Serverless (GCP)
+/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableGCPFunctionSettingsTests.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
+## END - CI Visibility test ownership compatibility
+
 # ASM
 /tracer/src/Datadog.Trace/AppSec/         @DataDog/asm-dotnet
 /tracer/src/Datadog.Tracer.Native/iast/    @DataDog/asm-dotnet


### PR DESCRIPTION
## Summary of changes

Expands out `CODEOWNERS` (specifically tests) so that Serverless/DSM tests don't incorrectly get reported to different teams.

## Reason for change

The current DatadogTestLogger that we use in tests doesn't support expanding ** patterns. Not entirely sure on the effort of updating it to support this, so this seems like a simple solution/workaround.

Several of these tests / related tests have flaked in the past several weeks but since they are covered by ** they just get pinged to the generic team in CI Vis.

## Implementation details

FWIW it is the expansion of the following:
```
- /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/**/DataStreamsMonitoring* @DataDog/tracing-dotnet @DataDog/data-streams-monitoring
- /tracer/test/**/*Lambda* @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-aws
- /tracer/test/**/*AzureAppService*.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
- /tracer/test/**/*AzureFunctions*.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
- /tracer/test/**/*GCP*.cs @DataDog/tracing-dotnet @DataDog/apm-serverless @DataDog/serverless-azure-and-gcp
```
## Test coverage

N/A (also not sure how to test this 😛)
The expected outcome is that the `@test.codeowners` is properly resolved.

## Other details
<!-- Fixes #{issue} -->

#incident-57303


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
