### PR TITLE
[OTLP] Exclude non-top-level, non-measured spans from OTLP trace metrics

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -728,9 +728,16 @@ namespace Datadog.Trace.Agent
             var spanKind = (span.Tags is InstrumentationTags t ? t.SpanKind : span.GetTag(Tags.SpanKind));
             var isSpanKindEligible = spanKind is SpanKinds.Client or SpanKinds.Server or SpanKinds.Consumer or SpanKinds.Producer;
 
-            if (!_isOtlp // If we are using OTLP, we include both top-level and non-top-level spans
-                && (!(span.IsTopLevel || isSpanKindEligible || span.GetMetric(Tags.Measured) == 1.0)
-                 || span.GetMetric(Tags.PartialSnapshot) >= 0))
+            if (_isOtlp)
+            {
+                // OTLP span metrics (SEMCON-1093 FR04): only service-entry (top-level) or explicitly measured spans.
+                if (!span.IsTopLevel && span.GetMetric(Tags.Measured) != 1.0)
+                {
+                    return;
+                }
+            }
+            else if (!(span.IsTopLevel || isSpanKindEligible || span.GetMetric(Tags.Measured) == 1.0)
+                     || span.GetMetric(Tags.PartialSnapshot) >= 0)
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -728,16 +728,16 @@ namespace Datadog.Trace.Agent
             var spanKind = (span.Tags is InstrumentationTags t ? t.SpanKind : span.GetTag(Tags.SpanKind));
             var isSpanKindEligible = spanKind is SpanKinds.Client or SpanKinds.Server or SpanKinds.Consumer or SpanKinds.Producer;
 
-            if (_isOtlp)
-            {
-                // OTLP span metrics (SEMCON-1093 FR04): only service-entry (top-level) or explicitly measured spans.
-                if (!span.IsTopLevel && span.GetMetric(Tags.Measured) != 1.0)
-                {
-                    return;
-                }
-            }
-            else if (!(span.IsTopLevel || isSpanKindEligible || span.GetMetric(Tags.Measured) == 1.0)
-                     || span.GetMetric(Tags.PartialSnapshot) >= 0)
+            // SEMCON-1093 FR04: OTLP span metrics only for service-entry (top-level) or explicitly measured spans.
+            // Non-OTLP: also includes span-kind-eligible spans, and excludes partial snapshots.
+            // Note: !(x >= 0) is intentionally used instead of x < 0 because GetMetric returns double?,
+            // and null < 0 is false while !(null >= 0) is true — we want null (unset) to pass through.
+            var isEligible = _isOtlp
+                ? span.IsTopLevel || span.GetMetric(Tags.Measured) == 1.0
+                : (span.IsTopLevel || isSpanKindEligible || span.GetMetric(Tags.Measured) == 1.0)
+                  && !(span.GetMetric(Tags.PartialSnapshot) >= 0);
+
+            if (!isEligible)
             {
                 return;
             }

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -549,8 +549,8 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public async Task Otlp_UnmeasuredChildSpan_ExcludedFromStats()
         {
-            // SEMCON-1093: only service-entry (top-level), span-kind-eligible, or Measured=1 spans
-            // should generate OTLP trace metrics — unmeasured child spans must be excluded.
+// SEMCON-1093 FR04: only service-entry (top-level) or explicitly measured (_dd.measured=1) spans
+// should generate OTLP trace metrics — unmeasured child spans must be excluded.
             var start = DateTimeOffset.UtcNow;
             await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), NullDiscoveryService.Instance, Mock.Of<IStatsdManager>(), isOtlp: true);
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -547,6 +547,80 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public async Task Otlp_UnmeasuredChildSpan_ExcludedFromStats()
+        {
+            // SEMCON-1093: only service-entry (top-level), span-kind-eligible, or Measured=1 spans
+            // should generate OTLP trace metrics — unmeasured child spans must be excluded.
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), NullDiscoveryService.Instance, Mock.Of<IStatsdManager>(), isOtlp: true);
+
+            var parentSpan = CreateTopLevelSpan(start, "service");
+            parentSpan.OperationName = "web.request";
+            parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+            // Non-top-level, non-measured child — must not produce a stats bucket
+            var childSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(new StubDatadogTracer()), "service"), start);
+            childSpan.OperationName = "child.op";
+            childSpan.SetDuration(TimeSpan.FromMilliseconds(50));
+
+            aggregator.Add(parentSpan, childSpan);
+
+            var buffer = aggregator.CurrentBuffer;
+            buffer.Buckets.Should().HaveCount(1);
+            buffer.Buckets.Should().ContainKey(aggregator.BuildKey(parentSpan));
+            buffer.Buckets.Should().NotContainKey(aggregator.BuildKey(childSpan));
+        }
+
+        [Fact]
+        public async Task Otlp_MeasuredChildSpan_IncludedInStats()
+        {
+            // FR04: spans with _dd.measured=1 should be included in OTLP mode even when non-top-level.
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), NullDiscoveryService.Instance, Mock.Of<IStatsdManager>(), isOtlp: true);
+
+            var parentSpan = CreateTopLevelSpan(start, "service");
+            parentSpan.OperationName = "web.request";
+            parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+            var measuredChild = new Span(new SpanContext(parentSpan.Context, new TraceContext(new StubDatadogTracer()), "service"), start);
+            measuredChild.OperationName = "measured.child";
+            measuredChild.SetTag(Tags.Measured, "1");
+            measuredChild.SetDuration(TimeSpan.FromMilliseconds(50));
+
+            aggregator.Add(parentSpan, measuredChild);
+
+            var buffer = aggregator.CurrentBuffer;
+            buffer.Buckets.Should().HaveCount(2);
+            buffer.Buckets.Should().ContainKey(aggregator.BuildKey(parentSpan));
+            buffer.Buckets.Should().ContainKey(aggregator.BuildKey(measuredChild));
+        }
+
+        [Fact]
+        public async Task Otlp_SpanKindEligibleChildSpan_ExcludedFromStats()
+        {
+            // FR04: span-kind-eligible (client/server) is a Datadog stats concept; for OTLP only
+            // top-level and _dd.measured=1 spans are included — span kind alone is not enough.
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), NullDiscoveryService.Instance, Mock.Of<IStatsdManager>(), isOtlp: true);
+
+            var parentSpan = CreateTopLevelSpan(start, "service");
+            parentSpan.OperationName = "web.request";
+            parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+            var clientChild = new Span(new SpanContext(parentSpan.Context, new TraceContext(new StubDatadogTracer()), "service"), start);
+            clientChild.OperationName = "http.client";
+            clientChild.SetTag(Tags.SpanKind, SpanKinds.Client);
+            clientChild.SetDuration(TimeSpan.FromMilliseconds(50));
+
+            aggregator.Add(parentSpan, clientChild);
+
+            var buffer = aggregator.CurrentBuffer;
+            buffer.Buckets.Should().HaveCount(1);
+            buffer.Buckets.Should().ContainKey(aggregator.BuildKey(parentSpan));
+            buffer.Buckets.Should().NotContainKey(aggregator.BuildKey(clientChild));
+        }
+
+        [Fact]
         public async Task ProcessTrace_WhenSampled_ReturnsAggregateAndExport()
         {
             var discoveryService = new StubDiscoveryService(obfuscationVersion: 1);


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where all spans (including child spans) were generating OTLP trace metrics data points. Per the [SEMCON-1093 FR04 spec](https://dd.slack.com/archives/CC7Q58YRG/p1784888745827229?thread_ts=1784627500.558219), only service-entry (top-level) or explicitly measured (`_dd.measured=1`) spans should be selected by the OTLP span metrics pipeline.

The `!_isOtlp` guard in `AddToBuffer` was bypassing span selection entirely in OTLP mode, causing every child span to generate spurious stats — a significant source of metric volume inflation in apps with deep call trees.

## Changes

- **`StatsAggregator.AddToBuffer`**: Split the filter into two explicit paths:
  - **OTLP** (FR04): skip if `!IsTopLevel && Measured != 1` — only top-level and `_dd.measured=1` spans included. Span kind is not a selection criterion for OTLP metrics.
  - **Datadog stats**: unchanged — keeps the existing `span_concentrator.go` logic (span-kind-eligible, `PartialSnapshot` checks).
- **`StatsAggregatorTests`**: Added 3 tests covering the OTLP cases: unmeasured child excluded, measured child included, span-kind-eligible child excluded in OTLP mode.

## Motivation

This unblocks the `test_fr04_2_unmeasured_child_excluded` system test in [system-tests#7361](https://github.com/DataDog/system-tests/pull/7361).

See https://github.com/DataDog/system-tests/pull/7390, running on branch, is working

## Checklist

- [x] Follows coding guidelines
- [x] Unit tests added
- [ ] Integration/system tests activated (pending system-tests PR)