### PR TITLE
Bump DatadogTestCollector and DatadogTestLogger to 0.0.55

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -92,6 +92,6 @@
     <ProjectReference Include="..\..\src\Tools\ReferenceChainExplorer\ReferenceChainModel\ReferenceChainModel.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.54" ExcludeAssets="compile" />
+    <PackageReference Include="DatadogTestLogger" Version="0.0.55" ExcludeAssets="compile" />
   </ItemGroup>
 </Project>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -59,8 +59,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestCollector" Version="0.0.54" ExcludeAssets="compile"/>
-    <PackageReference Include="DatadogTestLogger" Version="0.0.54" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestCollector" Version="0.0.55" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.55" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
## Summary of changes

Bumps the `DatadogTestCollector` and `DatadogTestLogger` package references from `0.0.54` to `0.0.55` in the tracer and profiler test projects.

## Reason for change

Consume version `0.0.55` of the Datadog test tooling.

## Implementation details

- Update the shared tracer test package references.
- Update the profiler integration test logger reference.

## Test coverage

- `git diff --check` passes.
- `dotnet restore tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj --disable-parallel --force-evaluate` currently fails with `NU1102` because `DatadogTestLogger 0.0.55` was not yet available from the configured NuGet or Azure feeds at validation time. `DatadogTestCollector 0.0.55` is available.
- No test suite was run because restore could not complete.

## Other details

#incident-57303