### PR TITLE
Avoid Microsoft.Data.SqlClient transport flakes

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Data.Common;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -11,6 +10,20 @@ namespace Samples.Microsoft.Data.SqlClient
     internal static class Program
     {
         private static async Task<int> Main()
+        {
+            try
+            {
+                return await RunAsync();
+            }
+            catch (SqlException ex) when (IsRetryableConnectionError(ex))
+            {
+                Console.WriteLine("Transport-level SQL error, skipping test");
+                Console.WriteLine(ex.ToString());
+                return 13;
+            }
+        }
+
+        private static async Task<int> RunAsync()
         {
             var commandFactory = new DbCommandFactory($"[Microsoft-Data-SqlClient-Test-{Guid.NewGuid():N}]");
             var commandExecutor = new MicrosoftSqlCommandExecutor();
@@ -123,8 +136,9 @@ namespace Samples.Microsoft.Data.SqlClient
                 return true;
             }
 
-            // Number=0 with SocketException indicates network issue
-            if (ex.Number == 0 && ex.InnerException is SocketException)
+            // Number=0 indicates a driver-level transport error. Microsoft.Data.SqlClient does not
+            // always include the underlying SocketException when the connection is lost mid-command.
+            if (ex.Number == 0)
             {
                 return true;
             }

--- a/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
@@ -15,7 +15,7 @@ namespace Samples.Microsoft.Data.SqlClient
             {
                 return await RunAsync();
             }
-            catch (SqlException ex) when (IsRetryableConnectionError(ex))
+            catch (Exception ex) when (IsTransportError(ex))
             {
                 Console.WriteLine("Transport-level SQL error, skipping test");
                 Console.WriteLine(ex.ToString());
@@ -122,28 +122,27 @@ namespace Samples.Microsoft.Data.SqlClient
         }
 
         static bool IsRetryableConnectionError(SqlException ex)
+            => IsTransportError(ex) ||
+               ex.Number == -2 ||  // Connection timeout
+               ex.Number == 258;   // Connection timeout
+
+        static bool IsTransportError(Exception ex)
         {
-            // Known retryable error codes
-            if (ex.Number == -1 ||      // Generic network error
-                ex.Number == -2 ||      // Connection timeout
-                ex.Number == 53 ||      // SQL Server not found
-                ex.Number == 258 ||     // Connection timeout
-                ex.Number == 10053 ||   // Connection aborted
-                ex.Number == 10054 ||   // Connection reset
-                ex.Number == 10060 ||   // Connection timeout
-                ex.Number == 11001)     // DNS failure
+            // Assembly.LoadFile creates a distinct SqlException type identity, so use the full name
+            // and reflection instead of casting to the compile-time Microsoft.Data.SqlClient type.
+            if (ex.GetType().FullName != typeof(SqlException).FullName ||
+                ex.GetType().GetProperty(nameof(SqlException.Number))?.GetValue(ex) is not int errorNumber)
             {
-                return true;
+                return false;
             }
 
-            // Number=0 indicates a driver-level transport error. Microsoft.Data.SqlClient does not
-            // always include the underlying SocketException when the connection is lost mid-command.
-            if (ex.Number == 0)
-            {
-                return true;
-            }
-
-            return false;
+            return errorNumber == -1 ||      // Generic network error
+                   errorNumber == 0 ||       // Driver-level transport error
+                   errorNumber == 53 ||      // SQL Server not found
+                   errorNumber == 10053 ||   // Connection aborted
+                   errorNumber == 10054 ||   // Connection reset
+                   errorNumber == 10060 ||   // Connection timeout
+                   errorNumber == 11001;     // DNS failure
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Handle transient Microsoft.Data.SqlClient transport errors during the full sample run and return skip exit code 13.

## Reason for change

SQL Server connections [can occasionally drop mid-command in CI](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/205732/logs/15386), causing unrelated integration test flakes.

```
Datadog.Trace.TestHelpers.ExitCodeException+SIGABRTExitCodeException: Expected exit code: 0, actual exit code: 134. Message: Unhandled exception. Microsoft.Data.SqlClient.SqlException (0x80131904): A transport-level error has occurred when receiving results from the server. (provider: TCP Provider, error: 0 - No error information)
   at Microsoft.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
   at Microsoft.Data.SqlClient.SqlInternalConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction)
   at Microsoft.Data.SqlClient.TdsParser.ThrowExceptionAndWarning(TdsParserStateObject stateObj, SqlCommand command, Boolean callerHasConnectionLock, Boolean asyncClose)
   at Microsoft.Data.SqlClient.TdsParserStateObject.ThrowExceptionAndWarning(Boolean callerHasConnectionLock, Boolean asyncClose)
   at Microsoft.Data.SqlClient.TdsParserStateObject.ReadSniError(TdsParserStateObject stateObj, UInt32 error)
   at Microsoft.Data.SqlClient.TdsParserStateObject.ReadSniSyncOverAsync()
   at Microsoft.Data.SqlClient.TdsParserStateObject.TryReadNetworkPacket()
   at Microsoft.Data.SqlClient.TdsParserStateObject.TryPrepareBuffer()
   at Microsoft.Data.SqlClient.TdsParserStateObject.TryReadByte(Byte& value)
   at Microsoft.Data.SqlClient.TdsParser.TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, Boolean& dataReady)
   at Microsoft.Data.SqlClient.SqlDataReader.TryConsumeMetaData()
   at Microsoft.Data.SqlClient.SqlDataReader.get_MetaData()
   at Microsoft.Data.SqlClient.SqlCommand.FinishExecuteReader(SqlDataReader ds, RunBehavior runBehavior, String resetOptionsString, Boolean isInternal, Boolean forDescribeParameterEncryption, Boolean shouldCacheForAlwaysEncrypted)
   at Microsoft.Data.SqlClient.SqlCommand.RunExecuteReaderTds(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, Boolean isAsync, Int32 timeout, Task& task, Boolean asyncWrite, Boolean inRetry, SqlDataReader ds, Boolean describeParameterEncryptionRequest)
   at Microsoft.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, TaskCompletionSource`1 completion, Int32 timeout, Task& task, Boolean& usedCache, Boolean asyncWrite, Boolean inRetry, String method)
   at Microsoft.Data.SqlClient.SqlCommand.RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, Boolean returnStream, String method)
   at Microsoft.Data.SqlClient.SqlCommand.ExecuteReader(CommandBehavior behavior)
   at Microsoft.Data.SqlClient.SqlCommand.ExecuteDbDataReader(CommandBehavior behavior)
   at Samples.DatabaseHelper.DbCommandInterfaceExecutor.ExecuteReader(IDbCommand command, CommandBehavior behavior) in D:\a\_work\1\s\tracer\test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper\DbCommandInterfaceExecutor.cs:line 32
   at Samples.DatabaseHelper.DbCommandExecutor`1.Samples.DatabaseHelper.IDbCommandExecutor.ExecuteReader(IDbCommand command, CommandBehavior behavior) in D:\a\_work\1\s\tracer\test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper.netstandard\DbCommandExecutor.cs:line 54
   at Samples.DatabaseHelper.RelationalDatabaseTestHarness.RunAsync(IDbConnection connection, DbCommandFactory commandFactory, IDbCommandExecutor commandExecutor, CancellationToken cancellationToken, Boolean useTransactionScope) in D:\a\_work\1\s\tracer\test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper\RelationalDatabaseTestHarness.cs:line 198
   at Samples.DatabaseHelper.RelationalDatabaseTestHarness.RunAllAsync[TCommand](IDbConnection connection, DbCommandFactory commandFactory, IDbCommandExecutor providerSpecificCommandExecutor, CancellationToken cancellationToken, Boolean useTransactionScope) in D:\a\_work\1\s\tracer\test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper\RelationalDatabaseTestHarness.cs:line 61
   at Samples.Microsoft.Data.SqlClient.Program.Main() in D:\a\_work\1\s\tracer\test\test-applications\integrations\Samples.Microsoft.Data.SqlClient\Program.cs:line 27
   at Samples.Microsoft.Data.SqlClient.Program.<Main>()
ClientConnectionId:d7cf9feb-8c6b-4258-8167-189047fba237
```

## Test coverage

Built Samples.Microsoft.Data.SqlClient across all configured target frameworks.
#incident-57303