### PR TITLE
Handle duplicate keys in ASM `DecodeMap`

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafObjectStruct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafObjectStruct.cs
@@ -17,7 +17,6 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
     internal struct DdwafObjectStruct
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DdwafObjectStruct>();
-        private static int _duplicateKeyWarningLogged;
 
         [FieldOffset(0)]
         public IntPtr ParameterName;
@@ -109,18 +108,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                             var array = (DdwafObjectStruct*)arrayPtr;
                             var key = Marshal.PtrToStringAnsi(array->ParameterName, (int)array->ParameterNameLength);
                             var value = array->Decode();
-#if NETCOREAPP
-                            if (!res.TryAdd(key, value) && Interlocked.Exchange(ref _duplicateKeyWarningLogged, 1) == 0)
-#else
-                            if (!res.ContainsKey(key))
-                            {
-                                res.Add(key, value);
-                            }
-                            else if (Interlocked.Exchange(ref _duplicateKeyWarningLogged, 1) == 0)
-#endif
-                            {
-                                Log.Warning("Unexpected duplicate key {Key} while decoding a WAF map, ignoring entry", key);
-                            }
+                            res[key] = value;
                         }
                     }
                 }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafObjectStruct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafObjectStruct.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.AppSec.Waf.NativeBindings

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafObjectStruct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafObjectStruct.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.AppSec.Waf.NativeBindings
@@ -16,6 +17,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
     internal struct DdwafObjectStruct
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DdwafObjectStruct>();
+        private static int _duplicateKeyWarningLogged;
 
         [FieldOffset(0)]
         public IntPtr ParameterName;
@@ -107,7 +109,18 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                             var array = (DdwafObjectStruct*)arrayPtr;
                             var key = Marshal.PtrToStringAnsi(array->ParameterName, (int)array->ParameterNameLength);
                             var value = array->Decode();
-                            res.Add(key, value);
+#if NETCOREAPP
+                            if (!res.TryAdd(key, value) && Interlocked.Exchange(ref _duplicateKeyWarningLogged, 1) == 0)
+#else
+                            if (!res.ContainsKey(key))
+                            {
+                                res.Add(key, value);
+                            }
+                            else if (Interlocked.Exchange(ref _duplicateKeyWarningLogged, 1) == 0)
+#endif
+                            {
+                                Log.Warning("Unexpected duplicate key {Key} while decoding a WAF map, ignoring entry", key);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary of changes

Handle duplicate keys being returned by WAF

## Reason for change

We saw [errors](https://app.datadoghq.com/error-tracking/issue/1e03cde2-8a65-11f1-aca7-da7ad0900002) which look like they come from the waf returning duplicate keys, which was causing the `dictionary.Add()` call to throw

## Implementation details

Initially, I was using `TryAdd()` in .NET Core and `Contains()` followed by `Add()` in .NET Framework. but I don't know if it's worth that overhead for what is clearly a rare strange scenario, so switched just to a replace instead.

That said someone from ASM should validate 1. do we _Expect_ duplicate keys coming from the waf here?
- If not, why did we get them, and how _should_ we handle them?
- If yes, we will need larger structural changes to handle that (change dictionary to a list of KeyValuePair for example)

## Test coverage

Meh
