### PR TITLE
fix(otlp): Emit a StatusCode.Error on OTLP spans when DD Span.Error field is set

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
@@ -1045,9 +1045,10 @@ internal sealed class MutableSettings : IEquatable<MutableSettings>
 
         var httpServerErrorStatusCodes = ParseHttpCodesToArray(httpServerErrorStatusCodesString);
 
+        var defaultHttpClientErrorStatusCodes = tracerSettings.OtelSemanticsEnabled ? "400-599" : "400-499";
         var httpClientErrorStatusCodesString = config
                                               .WithKeys(ConfigurationKeys.HttpClientErrorStatusCodes)
-                                              .AsString(defaultValue: "400-499");
+                                              .AsString(defaultValue: defaultHttpClientErrorStatusCodes);
 
         var httpClientErrorStatusCodes = ParseHttpCodesToArray(httpClientErrorStatusCodesString);
 

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -1137,13 +1137,14 @@ supportedConfigurations:
     documentation: |-
       Overrides the hostname reported to Datadog. When set, replaces the auto-detected hostname.
   DD_HTTP_CLIENT_ERROR_STATUSES:
-  - implementation: A
+  - implementation: B
     scope: managed
     type: string
     default: 400-499
     const_name: DeprecatedHttpClientErrorStatusCodes
     documentation: |-
       Configuration key for the application's client http statuses to set spans as errors by.
+      When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
       <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
   DD_HTTP_SERVER_ERROR_STATUSES:
   - implementation: A
@@ -3078,6 +3079,7 @@ supportedConfigurations:
     const_name: HttpClientErrorStatusCodes
     documentation: |-
       Configuration key for the application's client http statuses to set spans as errors by.
+      When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
       <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
   DD_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS:
   - implementation: A

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -3070,7 +3070,7 @@ supportedConfigurations:
       Automatically apply header values as tags on traces.
       <seealso cref="Datadog.Trace.Configuration.MutableSettings.HeaderTags"/>
   DD_TRACE_HTTP_CLIENT_ERROR_STATUSES:
-  - implementation: A
+  - implementation: B
     scope: managed
     type: string
     default: 400-499

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -3070,7 +3070,7 @@ supportedConfigurations:
       Automatically apply header values as tags on traces.
       <seealso cref="Datadog.Trace.Configuration.MutableSettings.HeaderTags"/>
   DD_TRACE_HTTP_CLIENT_ERROR_STATUSES:
-  - implementation: B
+  - implementation: C
     scope: managed
     type: string
     default: 400-499

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -117,10 +117,20 @@ namespace Datadog.Trace.ExtensionMethods
             {
                 span.Error = true;
 
-                // if an error message already exists (e.g. from a previous exception), don't replace it
-                if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorMsg)))
+                if (span.OpenTelemetrySemanticsEnabled)
                 {
-                    span.SetTag(Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");
+                    if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorType)))
+                    {
+                        span.SetTag(Tags.ErrorType, statusCodeString);
+                    }
+                }
+                else
+                {
+                    // if an error message already exists (e.g. from a previous exception), don't replace it
+                    if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorMsg)))
+                    {
+                        span.SetTag(Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");
+                    }
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -158,6 +158,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string DeprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
@@ -523,6 +524,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string HttpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -158,6 +158,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string DeprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
@@ -523,6 +524,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string HttpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -158,6 +158,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string DeprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
@@ -523,6 +524,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string HttpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -158,6 +158,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string DeprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
@@ -523,6 +524,7 @@ internal static partial class ConfigurationKeys
 
     /// <summary>
     /// Configuration key for the application's client http statuses to set spans as errors by.
+    /// When DD_TRACE_OTEL_SEMANTICS_ENABLED is true, the default is <c>400-599</c>.
     /// </summary>
     /// <seealso cref="Datadog.Trace.Configuration.MutableSettings.HttpClientErrorStatusCodes"/>
     public const string HttpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesJsonSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesJsonSerializer.cs
@@ -602,7 +602,7 @@ internal sealed class OtlpTracesJsonSerializer : ISpanBufferSerializer
         {
             "STATUS_CODE_OK" => StatusCode.Ok,
             "STATUS_CODE_ERROR" => StatusCode.Error,
-            _ => null,
+            _ => spanModel.Span.Error ? StatusCode.Error : null,
         };
         if (statusCode is not null)
         {

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesProtobufSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesProtobufSerializer.cs
@@ -545,7 +545,7 @@ internal sealed class OtlpTracesProtobufSerializer : ISpanBufferSerializer
         {
             "STATUS_CODE_OK" => StatusCode_Ok,
             "STATUS_CODE_ERROR" => StatusCode_Error,
-            _ => null,
+            _ => spanModel.Span.Error ? StatusCode_Error : null,
         };
         if (statusCode is not null)
         {

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
@@ -610,18 +610,24 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [InlineData(null, null, "400-499")]
-        [InlineData(null, "500", "500")]
-        [InlineData("555", null, "555")]
-        [InlineData("555", "525", "555")]
-        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string deprecatedClientErrorKeyValue, string expectedClientErrorCodes)
+        [InlineData(null, null, null, "400-499")]
+        [InlineData(null, null, "true", "400-599")]
+        [InlineData(null, null, "false", "400-499")]
+        [InlineData(null, "500", null, "500")]
+        [InlineData("555", null, null, "555")]
+        [InlineData("555", "525", null, "555")]
+        [InlineData(null, "500", "true", "500")]
+        [InlineData("555", null, "true", "555")]
+        [InlineData("555", "525", "true", "555")]
+        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string deprecatedClientErrorKeyValue, string otelSemanticsEnabled, string expectedClientErrorCodes)
         {
             const string httpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";
             const string deprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
 
             var source = CreateConfigurationSource(
                 (httpClientErrorStatusCodes, newClientErrorKeyValue),
-                (deprecatedHttpClientErrorStatusCodes, deprecatedClientErrorKeyValue));
+                (deprecatedHttpClientErrorStatusCodes, deprecatedClientErrorKeyValue),
+                (ConfigurationKeys.OpenTelemetry.OtelSemanticsEnabled, otelSemanticsEnabled));
 
             var errorLog = new OverrideErrorLog();
             var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
@@ -619,7 +619,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData(null, "500", "true", "500")]
         [InlineData("555", null, "true", "555")]
         [InlineData("555", "525", "true", "555")]
-        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string    , string otelSemanticsEnabled, string expectedClientErrorCodes)
+        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string deprecatedClientErrorKeyValue, string otelSemanticsEnabled, string expectedClientErrorCodes)
         {
             const string httpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";
             const string deprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
@@ -600,13 +600,11 @@ namespace Datadog.Trace.Tests.Configuration
                 (httpServerErrorStatusCodes, newServerErrorKeyValue),
                 (deprecatedHttpServerErrorStatusCodes, deprecatedServerErrorKeyValue));
 
-            var errorLog = new OverrideErrorLog();
-            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
             var tracerSettings = new TracerSettings(source);
             var mutable = GetMutableSettings(source, tracerSettings);
             var result = mutable.HttpServerErrorStatusCodes;
 
-            ValidateErrorStatusCodes(result, newServerErrorKeyValue, deprecatedServerErrorKeyValue, expectedServerErrorCodes);
+            ValidateErrorStatusCodes(result, expectedServerErrorCodes);
         }
 
         [Theory]
@@ -629,13 +627,11 @@ namespace Datadog.Trace.Tests.Configuration
                 (deprecatedHttpClientErrorStatusCodes, deprecatedClientErrorKeyValue),
                 (ConfigurationKeys.OpenTelemetry.OtelSemanticsEnabled, otelSemanticsEnabled));
 
-            var errorLog = new OverrideErrorLog();
-            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
             var tracerSettings = new TracerSettings(source);
             var mutable = GetMutableSettings(source, tracerSettings);
             var result = mutable.HttpClientErrorStatusCodes;
 
-            ValidateErrorStatusCodes(result, newClientErrorKeyValue, deprecatedClientErrorKeyValue, expectedClientErrorCodes);
+            ValidateErrorStatusCodes(result, expectedClientErrorCodes);
         }
 
         [Fact]
@@ -770,19 +766,26 @@ namespace Datadog.Trace.Tests.Configuration
                 new OverrideErrorLog(),
                 tracerSettings);
 
-        private static void ValidateErrorStatusCodes(bool[] result, string newErrorKeyValue, string deprecatedErrorKeyValue, string expectedErrorRange)
+        /// <summary>
+        /// Asserts that <paramref name="result"/> marks exactly the status codes in
+        /// <paramref name="expectedErrorRange"/> as errors, and no others. Asserting the whole
+        /// array matters here: only checking the expected codes would still pass if a wider
+        /// default (such as the OTel client default of 400-599) leaked in.
+        /// </summary>
+        /// <param name="result">The parsed error status code array under test.</param>
+        /// <param name="expectedErrorRange">A single status code ("500") or an inclusive range ("400-499").</param>
+        private static void ValidateErrorStatusCodes(bool[] result, string expectedErrorRange)
         {
-            if (newErrorKeyValue is not null || deprecatedErrorKeyValue is not null)
+            var statusCodeLimitsRange = expectedErrorRange.Split('-');
+            var lowerBound = int.Parse(statusCodeLimitsRange[0]);
+            var upperBound = statusCodeLimitsRange.Length > 1 ? int.Parse(statusCodeLimitsRange[1]) : lowerBound;
+
+            for (var statusCode = 0; statusCode < result.Length; statusCode++)
             {
-                Assert.True(result[int.Parse(expectedErrorRange)]);
-            }
-            else
-            {
-                var statusCodeLimitsRange = expectedErrorRange.Split('-');
-                for (var i = int.Parse(statusCodeLimitsRange[0]); i <= int.Parse(statusCodeLimitsRange[1]); i++)
-                {
-                    Assert.True(result[i]);
-                }
+                var isExpectedToBeAnError = statusCode >= lowerBound && statusCode <= upperBound;
+                result[statusCode]
+                   .Should()
+                   .Be(isExpectedToBeAnError, "status code {0} should{1} be treated as an error for the range '{2}'", statusCode, isExpectedToBeAnError ? string.Empty : " not", expectedErrorRange);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
@@ -611,15 +611,15 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData(null, null, null, "400-499")]
-        [InlineData(null, null, "true", "400-599")]
         [InlineData(null, null, "false", "400-499")]
+        [InlineData(null, null, "true", "400-599")]
         [InlineData(null, "500", null, "500")]
         [InlineData("555", null, null, "555")]
         [InlineData("555", "525", null, "555")]
         [InlineData(null, "500", "true", "500")]
         [InlineData("555", null, "true", "555")]
         [InlineData("555", "525", "true", "555")]
-        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string deprecatedClientErrorKeyValue, string otelSemanticsEnabled, string expectedClientErrorCodes)
+        public void ValidateClientErrorStatusCodes(string newClientErrorKeyValue, string    , string otelSemanticsEnabled, string expectedClientErrorCodes)
         {
             const string httpClientErrorStatusCodes = "DD_TRACE_HTTP_CLIENT_ERROR_STATUSES";
             const string deprecatedHttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Data;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Util;
 using Moq;
 using Xunit;
@@ -68,6 +71,61 @@ namespace Datadog.Trace.Tests.ExtensionMethods
                 Assert.Equal("myServerName" + "NoCache" + i, commandTags.OutHost);
             }
         }
+
+        [Theory]
+        [InlineData(true, 500, "500")]
+        [InlineData(true, 200, null)]
+        [InlineData(false, 500, null)]
+        [InlineData(false, 200, null)]
+        public void SetHttpStatusCode_SetsErrorTypeWhenOtelSemanticsEnabledForErrorStatusCode(
+            bool otelSemanticsEnabled,
+            int statusCode,
+            string expectedErrorType)
+        {
+            var span = CreateSpan(openTelemetrySemanticsEnabled: otelSemanticsEnabled);
+            var settings = CreateMutableSettings();
+
+            span.SetHttpStatusCode(statusCode, isServer: true, settings);
+
+            Assert.Equal(expectedErrorType, span.GetTag(Tags.ErrorType));
+        }
+
+        [Fact]
+        public void SetHttpStatusCode_ForServerSpan_DoesNotOverwriteExistingErrorType()
+        {
+            const string existingErrorType = "System.InvalidOperationException";
+            var span = CreateSpan(openTelemetrySemanticsEnabled: true);
+            var settings = CreateMutableSettings();
+            span.SetTag(Tags.ErrorType, existingErrorType);
+
+            span.SetHttpStatusCode(500, isServer: true, settings);
+
+            Assert.Equal(existingErrorType, span.GetTag(Tags.ErrorType));
+        }
+
+        [Fact]
+        public void SetHttpStatusCode_ForClientSpan_DoesNotOverwriteExistingErrorType()
+        {
+            const string existingErrorType = "System.InvalidOperationException";
+            var span = CreateSpan(openTelemetrySemanticsEnabled: true);
+            var settings = CreateMutableSettings();
+            span.SetTag(Tags.ErrorType, existingErrorType);
+
+            span.SetHttpStatusCode(500, isServer: false, settings);
+
+            Assert.Equal(existingErrorType, span.GetTag(Tags.ErrorType));
+        }
+
+        private static MutableSettings CreateMutableSettings()
+            => new TracerSettings().Manager.InitialMutableSettings;
+
+        private static Span CreateSpan(bool openTelemetrySemanticsEnabled = false)
+            => new(
+                new SpanContext(traceId: 1, spanId: 1),
+                DateTimeOffset.UtcNow,
+                tags: null,
+                links: null,
+                openTelemetrySemanticsEnabled);
 
         private static IDbCommand CreateDbCommand(string connectionString, string commandText = null)
         {

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -8,6 +8,7 @@ using System.Data;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Util;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -39,9 +40,9 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             string expectedHost)
         {
             var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
-            Assert.Equal(expectedDbName, commandTags.DbName);
-            Assert.Equal(expectedUserId, commandTags.DbUser);
-            Assert.Equal(expectedHost, commandTags.OutHost);
+            commandTags.DbName.Should().Be(expectedDbName);
+            commandTags.DbUser.Should().Be(expectedUserId);
+            commandTags.OutHost.Should().Be(expectedHost);
         }
 
         [Fact]
@@ -56,8 +57,8 @@ namespace Datadog.Trace.Tests.ExtensionMethods
 
                 var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
 
-                Assert.True(DbCommandCache.Cache.IsCaching);
-                Assert.Equal("myServerName" + i, commandTags.OutHost);
+                DbCommandCache.Cache.IsCaching.Should().BeTrue();
+                commandTags.OutHost.Should().Be("myServerName" + i);
             }
 
             // Test the logic with cache disabled
@@ -67,8 +68,8 @@ namespace Datadog.Trace.Tests.ExtensionMethods
 
                 var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
 
-                Assert.False(DbCommandCache.Cache.IsCaching);
-                Assert.Equal("myServerName" + "NoCache" + i, commandTags.OutHost);
+                DbCommandCache.Cache.IsCaching.Should().BeFalse();
+                commandTags.OutHost.Should().Be("myServerName" + "NoCache" + i);
             }
         }
 
@@ -87,7 +88,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
 
             span.SetHttpStatusCode(statusCode, isServer: true, settings);
 
-            Assert.Equal(expectedErrorType, span.GetTag(Tags.ErrorType));
+            span.GetTag(Tags.ErrorType).Should().Be(expectedErrorType);
         }
 
         [Fact]
@@ -100,7 +101,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
 
             span.SetHttpStatusCode(500, isServer: true, settings);
 
-            Assert.Equal(existingErrorType, span.GetTag(Tags.ErrorType));
+            span.GetTag(Tags.ErrorType).Should().Be(existingErrorType);
         }
 
         [Fact]
@@ -113,7 +114,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
 
             span.SetHttpStatusCode(500, isServer: false, settings);
 
-            Assert.Equal(existingErrorType, span.GetTag(Tags.ErrorType));
+            span.GetTag(Tags.ErrorType).Should().Be(existingErrorType);
         }
 
         private static MutableSettings CreateMutableSettings()

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -73,52 +73,71 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             }
         }
 
+        // With OTel semantics enabled the error status codes default to 500-599 for server
+        // spans and 400-599 for client spans; otherwise client spans default to 400-499.
+        // Under OTel semantics the error is described by error.type rather than error.msg.
         [Theory]
-        [InlineData(true, 500, "500")]
-        [InlineData(true, 200, null)]
-        [InlineData(false, 500, null)]
-        [InlineData(false, 200, null)]
-        public void SetHttpStatusCode_SetsErrorTypeWhenOtelSemanticsEnabledForErrorStatusCode(
+        // Server spans: the 500-599 default is the same either way
+        [InlineData(true, true, 500, true, "500", null)]
+        [InlineData(false, true, 500, true, null, "The HTTP response has status code 500.")]
+        [InlineData(true, true, 404, false, null, null)]
+        [InlineData(false, true, 404, false, null, null)]
+        // Client spans: 5xx is only an error under OTel semantics
+        [InlineData(true, false, 500, true, "500", null)]
+        [InlineData(false, false, 500, false, null, null)]
+        [InlineData(true, false, 404, true, "404", null)]
+        [InlineData(false, false, 404, true, null, "The HTTP response has status code 404.")]
+        // Success status codes are never errors
+        [InlineData(true, true, 200, false, null, null)]
+        [InlineData(false, true, 200, false, null, null)]
+        public void SetHttpStatusCode_SetsErrorTagsForErrorStatusCodes(
             bool otelSemanticsEnabled,
+            bool isServer,
             int statusCode,
-            string expectedErrorType)
+            bool expectedError,
+            string expectedErrorType,
+            string expectedErrorMsg)
         {
             var span = CreateSpan(openTelemetrySemanticsEnabled: otelSemanticsEnabled);
-            var settings = CreateMutableSettings();
+            var settings = CreateMutableSettings(otelSemanticsEnabled);
 
-            span.SetHttpStatusCode(statusCode, isServer: true, settings);
+            span.SetHttpStatusCode(statusCode, isServer, settings);
 
+            span.Error.Should().Be(expectedError);
             span.GetTag(Tags.ErrorType).Should().Be(expectedErrorType);
+            span.GetTag(Tags.ErrorMsg).Should().Be(expectedErrorMsg);
         }
 
-        [Fact]
-        public void SetHttpStatusCode_ForServerSpan_DoesNotOverwriteExistingErrorType()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SetHttpStatusCode_DoesNotOverwriteExistingErrorType(bool isServer)
         {
             const string existingErrorType = "System.InvalidOperationException";
             var span = CreateSpan(openTelemetrySemanticsEnabled: true);
-            var settings = CreateMutableSettings();
+            var settings = CreateMutableSettings(otelSemanticsEnabled: true);
             span.SetTag(Tags.ErrorType, existingErrorType);
 
-            span.SetHttpStatusCode(500, isServer: true, settings);
+            span.SetHttpStatusCode(500, isServer, settings);
 
+            // Guards against the assertion below passing only because the status code was
+            // never treated as an error in the first place.
+            span.Error.Should().BeTrue();
             span.GetTag(Tags.ErrorType).Should().Be(existingErrorType);
         }
 
-        [Fact]
-        public void SetHttpStatusCode_ForClientSpan_DoesNotOverwriteExistingErrorType()
+        private static MutableSettings CreateMutableSettings(bool otelSemanticsEnabled = false)
         {
-            const string existingErrorType = "System.InvalidOperationException";
-            var span = CreateSpan(openTelemetrySemanticsEnabled: true);
-            var settings = CreateMutableSettings();
-            span.SetTag(Tags.ErrorType, existingErrorType);
+            // Keep the settings in lockstep with the span's own flag: Tracer always passes
+            // TracerSettings.OtelSemanticsEnabled into the Span constructor, so the two can
+            // never disagree in production.
+            var source = new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.OpenTelemetry.OtelSemanticsEnabled, otelSemanticsEnabled ? "true" : "false" },
+            });
 
-            span.SetHttpStatusCode(500, isServer: false, settings);
-
-            span.GetTag(Tags.ErrorType).Should().Be(existingErrorType);
+            return new TracerSettings(source).Manager.InitialMutableSettings;
         }
-
-        private static MutableSettings CreateMutableSettings()
-            => new TracerSettings().Manager.InitialMutableSettings;
 
         private static Span CreateSpan(bool openTelemetrySemanticsEnabled = false)
             => new(

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Traces/OtlpTracesJsonSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Traces/OtlpTracesJsonSerializerTests.cs
@@ -3,8 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.IO;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.MessagePack;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.OpenTelemetry.Traces;
+using Datadog.Trace.Tests.Util;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -85,6 +91,116 @@ public class OtlpTracesJsonSerializerTests
         var values = json["arrayValue"]!["values"]!;
         values.Should().HaveCount(1);
         values[0]!["stringValue"]!.Value<string>().Should().Be(nestedBytes.ToString());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WriteSpan_ErrorSpanWithoutOtelStatusCodeTag_EmitsErrorStatus(bool openTelemetrySemanticsEnabled)
+    {
+        // Our own instrumentation marks spans as errors via span.Error and never sets "otel.status_code"
+        var ddSpan = CreateSpan();
+        ddSpan.Error = true;
+        ddSpan.GetTag("otel.status_code").Should().BeNull();
+
+        var json = WriteSpan(ddSpan, openTelemetrySemanticsEnabled);
+
+        var actualStatusCode = json["status"]?["code"]?.Value<int>();
+        actualStatusCode.Should().Be((int)StatusCode.Error);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WriteSpan_NonErrorSpanWithoutOtelStatusCodeTag_OmitsStatus(bool openTelemetrySemanticsEnabled)
+    {
+        var ddSpan = CreateSpan();
+        ddSpan.Error.Should().BeFalse();
+        ddSpan.GetTag("otel.status_code").Should().BeNull();
+
+        var json = WriteSpan(ddSpan, openTelemetrySemanticsEnabled);
+
+        json["status"].Should().BeNull();
+    }
+
+    [Fact]
+    public void WriteSpan_ErrorSpanWithoutOtelStatusCodeTag_UsesErrorMsgAsStatusMessage()
+    {
+        var ddSpan = CreateSpan();
+        ddSpan.Error = true;
+        ddSpan.SetTag(Tags.ErrorMsg, "oops");
+
+        var json = WriteSpan(ddSpan, openTelemetrySemanticsEnabled: true);
+
+        json["status"]!["code"]!.Value<int>().Should().Be((int)StatusCode.Error);
+        json["status"]!["message"]!.Value<string>().Should().Be("oops");
+    }
+
+    [Theory]
+    [InlineData("STATUS_CODE_OK", 1)]
+    [InlineData("STATUS_CODE_ERROR", 2)]
+    public void WriteSpan_ErrorSpanWithExplicitOtelStatusCodeTag_KeepsTheTagValue(string otelStatusCode, int expectedStatusCode)
+    {
+        // A status set through the OTel API wins over span.Error
+        var ddSpan = CreateSpan();
+        ddSpan.Error = true;
+        ddSpan.SetTag("otel.status_code", otelStatusCode);
+
+        var json = WriteSpan(ddSpan, openTelemetrySemanticsEnabled: true);
+
+        json["status"]!["code"]!.Value<int>().Should().Be(expectedStatusCode);
+    }
+
+    // Under OTel semantics SetHttpStatusCode sets error.type instead of error.msg, and per the
+    // HTTP semantic conventions the status description is left unset, so no message is written.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WriteSpan_HttpSpanWithErrorStatusCode_EmitsErrorStatus(bool openTelemetrySemanticsEnabled)
+    {
+        string? expectedMessage = openTelemetrySemanticsEnabled ? null : "The HTTP response has status code 500.";
+
+        // Regression test for HTTP spans marked as errors by SetHttpStatusCode, which sets
+        // span.Error but no "otel.status_code" tag.
+        var ddSpan = CreateSpan(openTelemetrySemanticsEnabled: openTelemetrySemanticsEnabled);
+        ddSpan.SetHttpStatusCode(500, isServer: true, new TracerSettings().Manager.InitialMutableSettings);
+        ddSpan.Error.Should().BeTrue();
+        ddSpan.GetTag("otel.status_code").Should().BeNull();
+
+        var json = WriteSpan(ddSpan, openTelemetrySemanticsEnabled);
+
+        json["status"]!["code"]!.Value<int>().Should().Be((int)StatusCode.Error);
+
+        // Assign first: "json["status"]!["message"]?.Value<string>().Should()" would short-circuit
+        // to a no-op when the message is omitted, making the assertion vacuous.
+        var actualMessage = json["status"]!["message"]?.Value<string>();
+        actualMessage.Should().Be(expectedMessage);
+    }
+
+    private static Span CreateSpan(bool openTelemetrySemanticsEnabled = false)
+    {
+        var context = new SpanContext(parent: null, new TraceContext(new StubDatadogTracer()), serviceName: "service_name");
+        var span = new Span(context, DateTimeOffset.UtcNow, tags: null, links: null, openTelemetrySemanticsEnabled)
+        {
+            OperationName = "operation_name",
+            ResourceName = "resource_name",
+        };
+        span.SetDuration(TimeSpan.FromMilliseconds(1));
+        return span;
+    }
+
+    private static JObject WriteSpan(Span span, bool openTelemetrySemanticsEnabled)
+    {
+        var serializer = new OtlpTracesJsonSerializer(openTelemetrySemanticsEnabled);
+        var traceChunk = new TraceChunkModel(new SpanCollection(new[] { span }));
+
+        using var stringWriter = new StringWriter();
+        using (var writer = new VendorJsonTextWriter(stringWriter))
+        {
+            serializer.WriteSpan(writer, traceChunk.GetSpanModel(0));
+        }
+
+        return JObject.Parse(stringWriter.ToString());
     }
 
     private static JObject WriteAnyValue(object? value)

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Traces/OtlpTracesProtobufSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetry/Traces/OtlpTracesProtobufSerializerTests.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.OpenTelemetry.Traces;
 using Datadog.Trace.Tests.Util;
 using FluentAssertions;
@@ -152,6 +154,88 @@ public class OtlpTracesProtobufSerializerTests
         span.Status.Should().NotBeNull();
         span.Status.Code.Should().Be(OtlpStatusCode.Error);
         span.Status.Message.Should().Be("oops");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SerializeSpans_ErrorSpanWithoutOtelStatusCodeTag_EmitsErrorStatus(bool openTelemetrySemanticsEnabled)
+    {
+        // Our own instrumentation marks spans as errors via span.Error and never sets "otel.status_code"
+        var ddSpan = CreateSpan(openTelemetrySemanticsEnabled: openTelemetrySemanticsEnabled);
+        ddSpan.Error = true;
+        ddSpan.GetTag("otel.status_code").Should().BeNull();
+
+        var span = SerializeAndParse(CreateChunk(ddSpan), openTelemetrySemanticsEnabled);
+
+        OtlpStatusCode? actualStatusCode = span.Status?.Code;
+        actualStatusCode.Should().Be(OtlpStatusCode.Error);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SerializeSpans_NonErrorSpanWithoutOtelStatusCodeTag_OmitsStatus(bool openTelemetrySemanticsEnabled)
+    {
+        var ddSpan = CreateSpan(openTelemetrySemanticsEnabled: openTelemetrySemanticsEnabled);
+        ddSpan.Error.Should().BeFalse();
+        ddSpan.GetTag("otel.status_code").Should().BeNull();
+
+        var span = SerializeAndParse(CreateChunk(ddSpan), openTelemetrySemanticsEnabled);
+
+        span.Status.Should().BeNull();
+    }
+
+    [Fact]
+    public void SerializeSpans_ErrorSpanWithoutOtelStatusCodeTag_UsesErrorMsgAsStatusMessage()
+    {
+        var ddSpan = CreateSpan(openTelemetrySemanticsEnabled: true);
+        ddSpan.Error = true;
+        ddSpan.SetTag(Tags.ErrorMsg, "oops");
+
+        var span = SerializeAndParse(CreateChunk(ddSpan), openTelemetrySemanticsEnabled: true);
+
+        span.Status.Code.Should().Be(OtlpStatusCode.Error);
+        span.Status.Message.Should().Be("oops");
+    }
+
+    [Theory]
+    [InlineData("STATUS_CODE_OK", OtlpStatusCode.Ok)]
+    [InlineData("STATUS_CODE_ERROR", OtlpStatusCode.Error)]
+    public void SerializeSpans_ErrorSpanWithExplicitOtelStatusCodeTag_KeepsTheTagValue(string otelStatusCode, OtlpStatusCode expectedStatusCode)
+    {
+        // A status set through the OTel API wins over span.Error
+        var ddSpan = CreateSpan(openTelemetrySemanticsEnabled: true);
+        ddSpan.Error = true;
+        ddSpan.SetTag("otel.status_code", otelStatusCode);
+
+        var span = SerializeAndParse(CreateChunk(ddSpan), openTelemetrySemanticsEnabled: true);
+
+        span.Status.Code.Should().Be(expectedStatusCode);
+    }
+
+    // Under OTel semantics SetHttpStatusCode sets error.type instead of error.msg, and per the
+    // HTTP semantic conventions the status description is left unset, so the message is empty.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SerializeSpans_HttpSpanWithErrorStatusCode_EmitsErrorStatus(bool openTelemetrySemanticsEnabled)
+    {
+        // Unlike the JSON serializer, which omits the property entirely, protobuf always
+        // round-trips Status.Message as a string, so an unset description arrives as empty.
+        string expectedMessage = openTelemetrySemanticsEnabled ? string.Empty : "The HTTP response has status code 500.";
+
+        // Regression test for HTTP spans marked as errors by SetHttpStatusCode, which sets
+        // span.Error but no "otel.status_code" tag.
+        var ddSpan = CreateSpan(openTelemetrySemanticsEnabled: openTelemetrySemanticsEnabled);
+        ddSpan.SetHttpStatusCode(500, isServer: true, new TracerSettings().Manager.InitialMutableSettings);
+        ddSpan.Error.Should().BeTrue();
+        ddSpan.GetTag("otel.status_code").Should().BeNull();
+
+        var span = SerializeAndParse(CreateChunk(ddSpan), openTelemetrySemanticsEnabled);
+
+        span.Status.Code.Should().Be(OtlpStatusCode.Error);
+        span.Status.Message.Should().Be(expectedMessage);
     }
 
     [Fact]
@@ -536,9 +620,9 @@ public class OtlpTracesProtobufSerializerTests
         return attributes[0].Value;
     }
 
-    private static OtlpSpan SerializeAndParse(TraceChunkModel chunk)
+    private static OtlpSpan SerializeAndParse(TraceChunkModel chunk, bool openTelemetrySemanticsEnabled = false)
     {
-        var serializer = new OtlpTracesProtobufSerializer(openTelemetrySemanticsEnabled: false);
+        var serializer = new OtlpTracesProtobufSerializer(openTelemetrySemanticsEnabled);
         var buffer = new byte[64 * 1024];
         var written = serializer.SerializeSpans(ref buffer, 0, chunk, spanBufferOffset: 0, maxSize: buffer.Length);
         serializer.FinishBody(ref buffer, written, maxSize: buffer.Length);
@@ -558,14 +642,15 @@ public class OtlpTracesProtobufSerializerTests
         ulong spanId = 0,
         ulong parentSpanId = 0,
         string serviceName = "service_name",
-        string resourceName = "resource_name")
+        string resourceName = "resource_name",
+        bool openTelemetrySemanticsEnabled = false)
     {
         var traceContext = new TraceContext(new StubDatadogTracer());
         SpanContext? parent = parentSpanId == 0
             ? null
             : new SpanContext(parent: null, traceContext, serviceName, traceId: traceId, spanId: parentSpanId);
         var context = new SpanContext(parent: parent, traceContext, serviceName, traceId: traceId, spanId: spanId);
-        var span = new Span(context, DateTimeOffset.UtcNow)
+        var span = new Span(context, DateTimeOffset.UtcNow, tags: null, links: null, openTelemetrySemanticsEnabled)
         {
             OperationName = "operation_name",
             ResourceName = resourceName,


### PR DESCRIPTION
## Summary of changes
Updates the OTLP JSON and OTLP protobuf serializers to emit a Span status with `StatusCode.Error` when the DD `Span.Error` field is set

Followup to #8940

## Reason for change
This gap was identified by the following [comment](https://github.com/DataDog/dd-trace-dotnet/pull/8940#discussion_r3648661410). Since this is the canonical status of an OTLP span, the DD `Span.Error` field should configure that status.

## Implementation details
When calculating the StatusCode for an OTLP span, both the JSON serializer and the protobuf serializer will set a `StatusCode.Error` field as a fallback if no `"otel.status_code"` span attribute is set (by the opentelemetry-dotnet SetStatus API) and if `Span.Error == true`.

## Test coverage
Adds unit tests for both serializers

## Other details
N/A
