### PR TITLE
[AAP] Cap recursion depth in ObjectExtractor's list/dictionary paths

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
@@ -773,9 +773,6 @@ namespace Datadog.Trace.AppSec
                 return [];
             }
 
-            // Mirrors ExtractProperties: once the incremented depth reaches the limit, stop recursing
-            // into children instead of descending unbounded (which previously risked a stack overflow
-            // for deeply nested, acyclic IEnumerable graphs).
             depth++;
             if (depth >= WafConstants.MaxContainerDepth)
             {

--- a/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
@@ -569,8 +569,6 @@ namespace Datadog.Trace.AppSec
                 return EmptyDictionary;
             }
 
-            // Mirrors ExtractProperties: once the incremented depth reaches the limit, stop recursing
-            // into children instead of descending unbounded (which previously risked a stack overflow).
             depth++;
             if (depth >= WafConstants.MaxContainerDepth)
             {

--- a/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
@@ -569,6 +569,14 @@ namespace Datadog.Trace.AppSec
                 return EmptyDictionary;
             }
 
+            // Mirrors ExtractProperties: once the incremented depth reaches the limit, stop recursing
+            // into children instead of descending unbounded (which previously risked a stack overflow).
+            depth++;
+            if (depth >= WafConstants.MaxContainerDepth)
+            {
+                return EmptyDictionary;
+            }
+
             var gtkvp = typeof(KeyValuePair<,>);
             var tkvp = gtkvp.MakeGenericType(dictType.GetGenericArguments());
             var keyProp = tkvp.GetProperty("Key");
@@ -603,7 +611,7 @@ namespace Datadog.Trace.AppSec
                         }
                         else
                         {
-                            var extractedvalue = ExtractType(dictValue.GetType(), dictValue, depth + 1, visited, extractorCache, createExtractors, useSimpleDictionaryFormat);
+                            var extractedvalue = ExtractType(dictValue.GetType(), dictValue, depth, visited, extractorCache, createExtractors, useSimpleDictionaryFormat);
                             items.Add(dictKey, extractedvalue);
                         }
 
@@ -635,6 +643,14 @@ namespace Datadog.Trace.AppSec
                 return [];
             }
 
+            // Mirrors ExtractProperties: once the incremented depth reaches the limit, stop recursing
+            // into children instead of descending unbounded (which previously risked a stack overflow).
+            depth++;
+            if (depth >= WafConstants.MaxContainerDepth)
+            {
+                return [];
+            }
+
             var gtkvp = typeof(KeyValuePair<,>);
             var tkvp = gtkvp.MakeGenericType(dictType.GetGenericArguments());
             var keyProp = tkvp.GetProperty("Key");
@@ -654,8 +670,8 @@ namespace Datadog.Trace.AppSec
 
                     var pair = new Dictionary<string, object?>(2)
                     {
-                        ["Key"] = dictKey is null ? null : ExtractType(dictKey.GetType(), dictKey, depth + 1, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
-                        ["Value"] = dictValue is null ? null : ExtractType(dictValue.GetType(), dictValue, depth + 1, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
+                        ["Key"] = dictKey is null ? null : ExtractType(dictKey.GetType(), dictKey, depth, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
+                        ["Value"] = dictValue is null ? null : ExtractType(dictValue.GetType(), dictValue, depth, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
                     };
                     items.Add(pair);
 
@@ -682,9 +698,14 @@ namespace Datadog.Trace.AppSec
         {
             var capacity = Math.Min(WafConstants.MaxContainerSize, source.Count);
 
+            // Mirrors ExtractProperties: once the incremented depth reaches the limit, stop recursing
+            // into children instead of descending unbounded (which previously risked a stack overflow).
+            depth++;
+            var depthExceeded = depth >= WafConstants.MaxContainerDepth;
+
             if (useSimpleDictionaryFormat)
             {
-                if (!visited.Add(source))
+                if (!visited.Add(source) || depthExceeded)
                 {
                     return EmptyDictionary;
                 }
@@ -700,7 +721,7 @@ namespace Datadog.Trace.AppSec
                         continue;
                     }
 
-                    map[key] = entry.Value is null ? null : ExtractType(entry.Value.GetType(), entry.Value, depth + 1, visited, extractorCache, createExtractors, useSimpleDictionaryFormat);
+                    map[key] = entry.Value is null ? null : ExtractType(entry.Value.GetType(), entry.Value, depth, visited, extractorCache, createExtractors, useSimpleDictionaryFormat);
                     if (map.Count >= WafConstants.MaxContainerSize)
                     {
                         break;
@@ -710,7 +731,7 @@ namespace Datadog.Trace.AppSec
                 return map;
             }
 
-            if (!visited.Add(source))
+            if (!visited.Add(source) || depthExceeded)
             {
                 return new List<object?>();
             }
@@ -722,8 +743,8 @@ namespace Datadog.Trace.AppSec
                 var entry = enumerator.Entry;
                 items.Add(new Dictionary<string, object?>(2)
                 {
-                    ["Key"] = entry.Key is null ? null : ExtractType(entry.Key.GetType(), entry.Key, depth + 1, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
-                    ["Value"] = entry.Value is null ? null : ExtractType(entry.Value.GetType(), entry.Value, depth + 1, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
+                    ["Key"] = entry.Key is null ? null : ExtractType(entry.Key.GetType(), entry.Key, depth, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
+                    ["Value"] = entry.Value is null ? null : ExtractType(entry.Value.GetType(), entry.Value, depth, visited, extractorCache, createExtractors, useSimpleDictionaryFormat),
                 });
                 if (items.Count >= WafConstants.MaxContainerSize)
                 {
@@ -754,6 +775,15 @@ namespace Datadog.Trace.AppSec
                 return [];
             }
 
+            // Mirrors ExtractProperties: once the incremented depth reaches the limit, stop recursing
+            // into children instead of descending unbounded (which previously risked a stack overflow
+            // for deeply nested, acyclic IEnumerable graphs).
+            depth++;
+            if (depth >= WafConstants.MaxContainerDepth)
+            {
+                return [];
+            }
+
             // Use ICollection for pre-sizing when available. Some types (e.g. HashSet<T>) implement
             // ICollection<T> but not the non-generic ICollection, so fall back to default capacity.
             var items = value is ICollection sourceColl
@@ -768,7 +798,7 @@ namespace Datadog.Trace.AppSec
                 }
                 else
                 {
-                    var extractedvalue = ExtractType(item.GetType(), item, depth + 1, visited, extractorCache, createExtractors, useSimpleDictionaryFormat);
+                    var extractedvalue = ExtractType(item.GetType(), item, depth, visited, extractorCache, createExtractors, useSimpleDictionaryFormat);
                     items.Add(extractedvalue);
                 }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ObjectExtractorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ObjectExtractorTests.cs
@@ -916,23 +916,6 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Fact]
-        public void TestDeeplyNestedAcyclicListDoesNotStackOverflow()
-        {
-            // Distinct (non-self-referential) nested lists aren't caught by cycle detection, so the
-            // MaxContainerDepth cap must stop the recursion instead. Without it this recurses until
-            // a StackOverflowException.
-            object nested = new List<object>();
-            for (var i = 0; i < 100_000; i++)
-            {
-                nested = new List<object> { nested };
-            }
-
-            Action act = () => ObjectExtractor.Extract(nested);
-
-            act.Should().NotThrow();
-        }
-
-        [Fact]
         public void TestNestedListRespectsMaxContainerDepth()
         {
             object nested = "leaf";

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ObjectExtractorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ObjectExtractorTests.cs
@@ -915,6 +915,48 @@ namespace Datadog.Trace.Security.Unit.Tests
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void TestDeeplyNestedAcyclicListDoesNotStackOverflow()
+        {
+            // Distinct (non-self-referential) nested lists aren't caught by cycle detection, so the
+            // MaxContainerDepth cap must stop the recursion instead. Without it this recurses until
+            // a StackOverflowException.
+            object nested = new List<object>();
+            for (var i = 0; i < 100_000; i++)
+            {
+                nested = new List<object> { nested };
+            }
+
+            Action act = () => ObjectExtractor.Extract(nested);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void TestNestedListRespectsMaxContainerDepth()
+        {
+            object nested = "leaf";
+            for (var i = 0; i < WafConstants.MaxContainerDepth + 5; i++)
+            {
+                nested = new List<object> { nested };
+            }
+
+            var result = ObjectExtractor.Extract(nested) as List<object>;
+
+            var current = result;
+            for (var i = 0; i < WafConstants.MaxContainerDepth - 1; i++)
+            {
+                current.Should().NotBeNull();
+                current.Should().HaveCount(1);
+                current = current![0] as List<object>;
+            }
+
+            // The list at the depth limit must be cut off empty, matching ExtractProperties' behavior
+            // for objects at the same depth (see TestNestedObjectsAboveLimit).
+            current.Should().NotBeNull();
+            current.Should().BeEmpty();
+        }
+
 #if NETFRAMEWORK
         [Fact]
         public void TestDateTimeOffsetExtractedAsObject_DataContractPath()


### PR DESCRIPTION
## Summary

An internal codex security review found that `ObjectExtractor`'s object-property extraction (`ExtractProperties`) enforces `WafConstants.MaxContainerDepth`, but the list/dictionary recursion paths (`ExtractListOrArray`, `ExtractDictionary`, `ExtractDictionaryAsKeyValuePairs`, `ExtractNonGenericDictionary`) increment depth on recursion without ever checking it against the limit. A deeply nested (acyclic) enumerable or dictionary graph can therefore recurse until `StackOverflowException`, which is process-fatal in .NET.

This became more reachable after #8706 broadened the `IEnumerable` routing to any enumerable type (not just arrays/`List<T>`), widening what data can reach the unbounded recursion (e.g. `HashSet<T>`, custom `IEnumerable` wrappers, JSON-like collection types) via AAP request/response extraction.

- Adds the same depth-cap check used by `ExtractProperties` to all four container-recursion paths.
- Confirmed the vulnerability directly: reverting the fix and running a new regression test with 100k nested lists reliably crashed the test host process with a genuine stack overflow.

## Test plan
- [x] Added `TestDeeplyNestedAcyclicListDoesNotStackOverflow` — 100k nested lists, asserts no crash (crashes the process without the fix).
- [x] Added `TestNestedListRespectsMaxContainerDepth` — asserts the list is truncated to empty exactly at `MaxContainerDepth`, mirroring the existing `TestNestedObjectsAboveLimit` object-property test.
- [x] Ran full `ObjectExtractorTests` suite across all target frameworks — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)