### PR TITLE
Exclude zero-version assemblies from dependency collection

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -36,12 +36,13 @@ namespace Datadog.Trace.Telemetry
         {
             // exclude dlls we're not interested in which have a "random" component
             // - ASP.NET site dlls's e.g. App_Web_*.dll
-            // - Assemblies without a version or explicitly version 0.0.0.0 (and have 8 aplphnumeric values)
+            // - Assemblies without a version, or with a zero version (0.0.0.0)
             // - Assemblies created by expression evaluation in VB.NET (expression_host_, Expressions12334324)
             // - Dlls loaded from asp.net temp directory
+            // Note: Build/Revision are -1 when a Version is created with fewer than 4 components
             var assemblyName = assembly.Name;
             if (assemblyName is null or ""
-             || assembly.Version is null
+             || assembly.Version is null or { Major: 0, Minor: 0, Build: <= 0, Revision: <= 0 }
              || IsTempPathPattern(assemblyName)
              || IsCompiledRazorViewPattern(assemblyName)
              || (assemblyName[0] == 'A'
@@ -57,7 +58,6 @@ namespace Datadog.Trace.Telemetry
              || assemblyName.StartsWith("EntityFrameworkDynamicProxies-", StringComparison.Ordinal)
              || assemblyName.StartsWith("expression_host_", StringComparison.Ordinal)
              || (assemblyName.StartsWith("Expressions", StringComparison.Ordinal) && IsHexString(assemblyName, 11))
-             || (assembly.Version is { Major: 0, Minor: 0, Build: 0, Revision: 0 } && IsZeroVersionAssemblyPattern(assemblyName))
              || IsGuid(assemblyName)
              || IsZxPattern(assemblyName))
             {
@@ -192,68 +192,6 @@ namespace Datadog.Trace.Telemetry
                 default:
                     return false;
             }
-        }
-
-        private static bool IsZeroVersionAssemblyPattern(string assemblyName)
-        {
-            // e.g.
-            //    454845b558934321ad350977dd095960 (32+ hex chars)
-            //    a43d8b99ea (10 hex chars)
-            //    akkynf62 (8 base32 chars)
-            //    dynamicclasses254
-            //    InMemoryAssembly
-            return (assemblyName.Length == 8
-                 && IsBase32Char(assemblyName[0])
-                 && IsBase32Char(assemblyName[1])
-                 && IsBase32Char(assemblyName[2])
-                 && IsBase32Char(assemblyName[3])
-                 && IsBase32Char(assemblyName[4])
-                 && IsBase32Char(assemblyName[5])
-                 && IsBase32Char(assemblyName[6])
-                 && IsBase32Char(assemblyName[7]))
-                || assemblyName.Equals("InMemoryAssembly", StringComparison.OrdinalIgnoreCase)
-                || (assemblyName.Length is 10 or >= 32 && IsHexString(assemblyName, 0))
-                || IsDynamicClassesPattern(assemblyName);
-        }
-
-        private static bool IsDynamicClassesPattern(string assemblyName)
-        {
-            // Pattern: "dynamicclasses" followed by digits, e.g., dynamicclasses254
-            // Length must be > 14 ("dynamicclasses".Length) to have at least one digit
-            if (assemblyName.Length <= 14)
-            {
-                return false;
-            }
-
-            // Check prefix character by character to avoid allocation (lowercase only)
-            if (assemblyName[0] != 'd'
-             || assemblyName[1] != 'y'
-             || assemblyName[2] != 'n'
-             || assemblyName[3] != 'a'
-             || assemblyName[4] != 'm'
-             || assemblyName[5] != 'i'
-             || assemblyName[6] != 'c'
-             || assemblyName[7] != 'c'
-             || assemblyName[8] != 'l'
-             || assemblyName[9] != 'a'
-             || assemblyName[10] != 's'
-             || assemblyName[11] != 's'
-             || assemblyName[12] != 'e'
-             || assemblyName[13] != 's')
-            {
-                return false;
-            }
-
-            // Verify remaining characters are all digits
-            for (int i = 14; i < assemblyName.Length; i++)
-            {
-                if (!char.IsAsciiDigit(assemblyName[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         private static bool IsBase32Char(char c)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -169,27 +169,15 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.HasChanges().Should().BeFalse($"{name} has a null version");
         }
 
-        [Fact]
-        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndHasRandom8CharName()
-        {
-            for (var i = 0; i < 1_000; i++)
-            {
-                // Path.GetRandomFileName() returns a name with the right format, so truncate
-                var name = Path.GetRandomFileName().Substring(0, 8);
-                var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
-
-                var collector = new DependencyTelemetryCollector();
-                collector.AssemblyLoaded(ignoredName, "some-guid");
-
-                collector.HasChanges().Should().BeFalse($"{name} has a zero version");
-            }
-        }
-
         [Theory]
+        [InlineData("My.Assembly")]       // an "ordinary" name: excluded purely based on the version
+        [InlineData("DynamicClasses123")]
+        [InlineData("dynamicclasses254")]
+        [InlineData("akkynf62")]
+        [InlineData("a43d8b99ea")]
         [InlineData("454845b558934321ad350977dd095960")]
-        [InlineData("41e68894e3e54239abe61eb16cb0e158")]
-        [InlineData("a1bc683e730d425c9de5fdf00dbdc003")]
-        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndHas32CharHexName(string name)
+        [InlineData("InMemoryAssembly")]
+        public void DoesNotHaveChangesWhenAssemblyVersionIsZero(string name)
         {
             var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
 
@@ -204,75 +192,17 @@ namespace Datadog.Trace.Tests.Telemetry
         }
 
         [Theory]
-        [InlineData("a43d8b99ea")]
-        [InlineData("1234567890")]
-        [InlineData("abcdef0123")]
-        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndHas10CharHexName(string name)
+        [InlineData("0.0")]
+        [InlineData("0.0.0")]
+        public void DoesNotHaveChangesWhenAssemblyVersionHasFewerComponentsAndIsZero(string version)
         {
-            var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
+            // Versions with fewer than 4 components have Build/Revision set to -1
+            var ignoredName = CreateAssemblyName(Version.Parse(version), name: "My.Assembly");
 
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(ignoredName, "some-guid");
 
-            collector.HasChanges().Should().BeFalse($"{name} has a zero version and 10 hex chars");
-
-            var nonIgnoredName = CreateAssemblyName(new Version(1, 0, 0, 0), name: name);
-            collector.AssemblyLoaded(nonIgnoredName, "some-guid");
-            collector.HasChanges().Should().BeTrue($"{nonIgnoredName} has a non-zero version");
-        }
-
-        [Theory]
-        [InlineData("dynamicclasses1")]
-        [InlineData("dynamicclasses254")]
-        [InlineData("dynamicclasses99999")]
-        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndIsDynamicClassesPattern(string name)
-        {
-            var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
-
-            var collector = new DependencyTelemetryCollector();
-            collector.AssemblyLoaded(ignoredName, "some-guid");
-
-            collector.HasChanges().Should().BeFalse($"{name} has a zero version and matches dynamicclasses pattern");
-
-            var nonIgnoredName = CreateAssemblyName(new Version(1, 0, 0, 0), name: name);
-            collector.AssemblyLoaded(nonIgnoredName, "some-guid");
-            collector.HasChanges().Should().BeTrue($"{nonIgnoredName} has a non-zero version");
-        }
-
-        [Theory]
-        [InlineData("dynamicclasses")]    // No digits
-        [InlineData("dynamicclassesabc")] // Letters instead of digits
-        [InlineData("dynamicclasses12a")] // Mixed digits and letters
-        [InlineData("mydynamicclasses1")] // Prefix before dynamicclasses
-        [InlineData("dynamic123")]        // Different prefix
-        [InlineData("DynamicClasses123")] // Wrong case (uppercase D and C)
-        [InlineData("DYNAMICCLASSES456")] // All uppercase
-        public void HasChangesWhenAssemblyNameIsNotValidDynamicClassesPattern(string name)
-        {
-            var validName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
-
-            var collector = new DependencyTelemetryCollector();
-            collector.AssemblyLoaded(validName, "some-guid");
-
-            collector.HasChanges().Should().BeTrue($"{name} should not be filtered as it doesn't match dynamicclasses pattern");
-        }
-
-        [Theory]
-        [InlineData("InMemoryAssembly")]
-        [InlineData("inmemoryassembly")]
-        [InlineData("INMEMORYASSEMBLY")]
-        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndNameIsInMemoryAssembly(string name)
-        {
-            var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
-
-            var collector = new DependencyTelemetryCollector();
-            collector.AssemblyLoaded(ignoredName, "some-guid");
-
-            collector.HasChanges().Should().BeFalse($"{name} has a zero version and matches InMemoryAssembly");
-
-            var nonIgnoredName = CreateAssemblyName(new Version(1, 0, 0, 0), name: name);
-            collector.AssemblyLoaded(nonIgnoredName, "some-guid");
-            collector.HasChanges().Should().BeTrue($"{nonIgnoredName} has a non-zero version");
+            collector.HasChanges().Should().BeFalse($"{version} is a zero version");
         }
 
         [Fact]
@@ -328,7 +258,7 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData("01234abc.DEF.cshtml")]  // Uppercase (not Base32)
         public void HasChangesWhenAssemblyNameIsNotValidCompiledRazorViewPattern(string assemblyName)
         {
-            var validName = CreateAssemblyName(new Version(0, 0, 0, 0), name: assemblyName);
+            var validName = CreateAssemblyName(new Version(1, 0, 0, 0), name: assemblyName);
 
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(validName, "some-guid");

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -207,7 +207,9 @@ public class TelemetryControllerTests
                                             .GetAssemblies()
                                             .Where(x => !x.IsDynamic)
                                             .Select(x => x.GetName())
-                                            .Select(name => new { name.Name, Version = name.Version.ToString() });
+                                            .Select(name => new { name.Name, Version = name.Version.ToString() })
+                                            // zero-version assemblies are excluded by the collector
+                                            .Where(x => x.Version != "0.0.0.0");
 
         // creating a new controller so we have the same list of assemblies
         var controller = new TelemetryController(


### PR DESCRIPTION
## Summary of changes

Exclude all zero-version assemblies from dependency collection

## Reason for change

These assemblies are almost always generated, and so are not useful, and cause cardinality explosions.

## Implementation details

- Simplify the check to exclude _all_ zero-version assemblies
- Exclude zero-version assemblies created from two or three part versions, which have -1 for the remaining parts (v. rare edge case but easy to guard against)

## Test coverage

Consolidated unit tests and added tests for "0.0" and "0.0.0" ("0" alone is not valid)

## Other details


#incident-58487