### PR TITLE
Bump the statsd default packet size

### DIFF
--- a/tracer/build/_build/UpdateVendors/VendoredDependency.cs
+++ b/tracer/build/_build/UpdateVendors/VendoredDependency.cs
@@ -549,6 +549,20 @@ namespace UpdateVendors
                     "Task.Factory.StartNew(() => Dequeue(), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)");
             }
 
+            if (normalizedPath.EndsWith("StatsdConfig.cs", StringComparison.OrdinalIgnoreCase))
+            {
+                // Upstream raised these defaults (512/2048) after 6.0.0 in dogstatsd-csharp-client#170,
+                // so bump to match them. 1432 keeps a UDP datagram inside a standard 1500-byte MTU, and
+                // 8192 matches the agent's dogstatsd_buffer_size default (its max packet size).
+                content = content.Replace(
+                    "public const int DefaultStatsdMaxUDPPacketSize = 512;",
+                    "public const int DefaultStatsdMaxUDPPacketSize = 1432;");
+
+                content = content.Replace(
+                    "public int StatsdMaxUnixDomainSocketPacketSize { get; set; } = 2048;",
+                    "public int StatsdMaxUnixDomainSocketPacketSize { get; set; } = 8192;");
+            }
+
             return content;
         }
 

--- a/tracer/src/Datadog.Trace/Vendors/StatsdClient/StatsdConfig.cs
+++ b/tracer/src/Datadog.Trace/Vendors/StatsdClient/StatsdConfig.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Vendors.StatsdClient
         /// <summary>
         /// The default UDP maximum packet size.
         /// </summary>
-        public const int DefaultStatsdMaxUDPPacketSize = 512;
+        public const int DefaultStatsdMaxUDPPacketSize = 1432;
 
         /// <summary>
         /// The name of the environment variable defining the global tags to be applied to every metric, event, and service check.
@@ -97,7 +97,7 @@ namespace Datadog.Trace.Vendors.StatsdClient
         /// Gets or sets the maximum Unix domain socket packet size.
         /// </summary>
         /// <value>The maximum Unix domain socket packet size.</value>
-        public int StatsdMaxUnixDomainSocketPacketSize { get; set; } = 2048;
+        public int StatsdMaxUnixDomainSocketPacketSize { get; set; } = 8192;
 
         /// <summary>
         /// Gets or sets a value indicating whether we truncate the metric if it is too long.

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1623,7 +1623,8 @@ namespace Datadog.Trace.TestHelpers
                 {
                     try
                     {
-                        var bytesReceived = new byte[0x1000];
+                        // Must be at least StatsdMaxUnixDomainSocketPacketSize
+                        var bytesReceived = new byte[0x2000];
                         // Connectionless protocol doesn't need Accept, Receive will block until we get something
                         var byteCount = _udsStatsSocket.Receive(bytesReceived);
                         var stats = Encoding.UTF8.GetString(bytesReceived, 0, byteCount);


### PR DESCRIPTION
## Summary of changes

Increases the default packet size used by vendored dogstatsd

## Reason for change

Customers can hit the package size limits and payloads are dropped without sending. These were increased upstream in https://github.com/DataDog/dogstatsd-csharp-client/pull/170, but as we're using an older vendored version with older limits.

## Implementation details

- Update the limits
- Update the vendored code (just for documentation really, we're never going to re-run this vendoring)

## Test coverage

Meh

## Other details

I considered making this setting actually configurable, but given the upstream code _still_ doesn't have this as configurable, and the Go reference implementation recommends these limits, I think this is probably the best approach