### PR TITLE
[Tracer] Fix Cosmos VNext query test flakiness

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosVnextTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosVnextTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         // vnext emulator only supports queries on items
         public async Task SubmitTracesQuery(string packageVersion, string metadataSchemaVersion)
         {
-            var expectedSpanCount = 4;
+            var expectedSpanCount = 13;
 
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             SetEnvironmentVariable("TEST_MODE", "Query");


### PR DESCRIPTION
## Summary of changes

We got the following error in CI:

```
2026-07-31T03:37:03.8660827Z 03:37:03 [ERR] [xUnit.net 00:10:01.13]     Datadog.Trace.ClrProfiler.IntegrationTests.CosmosVnextTests.SubmitTracesQuery(packageVersion: "3.12.0", metadataSchemaVersion: "v1") [FAIL]
2026-07-31T03:37:05.3606698Z 03:37:05 [DBG]   Failed Datadog.Trace.ClrProfiler.IntegrationTests.CosmosVnextTests.SubmitTracesQuery(packageVersion: "3.12.0", metadataSchemaVersion: "v1") [12 s]
2026-07-31T03:37:05.3609849Z 03:37:05 [DBG]   Error Message:
2026-07-31T03:37:05.3611228Z 03:37:05 [DBG]    VerifyException : Results do not match.
```

In this case, 3 spans are missing.

The cause seems that the snapshot contains 13 spans while the expected span count is 4. We should update the expected span count so the test waits for all the spans.

## Reason for change

Test failed [in master](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/205973/logs/9770).

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
