### PR TITLE
Fix flake in RabbitMQ DSM snapshots across bucket boundaries

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
@@ -89,6 +89,12 @@ public class DataStreamsMonitoringRabbitMQTests : TestHelper
             }
         }
 
-        return points.OrderBy(s => s.Hash).ThenBy(s => s.TimestampType).ToList();
+        // Stats points are aggregated by hash within 10-second buckets. If the sample crosses a
+        // bucket boundary, the same pathway can appear more than once in the collected payloads.
+        return points.GroupBy(s => new { s.Hash, s.ParentHash, s.TimestampType })
+                     .Select(g => g.First())
+                     .OrderBy(s => s.Hash)
+                     .ThenBy(s => s.TimestampType)
+                     .ToList();
     }
 }


### PR DESCRIPTION
## Summary of changes

Since the DSM stats are aggregated in 10 second buckes the same pathway can appear more than once, so this goes and groups them and then grabs the first only.

## Reason for change

Flaked here https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_build/results?buildId=206016&view=logs&j=0cad3504-1a92-5a43-34ae-f4023f981687&t=0b455496-9860-5768-a99e-6f5c6c3cdcbd

and the cause was that the snapshots changed.

## Implementation details

## Test coverage

Same

## Other details
<!-- Fixes #{issue} -->

#incident-57303
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
