### PR TITLE
Fix dsm throughput tests

### DIFF
--- a/.gitlab/benchmarks/dsm-throughput.yml
+++ b/.gitlab/benchmarks/dsm-throughput.yml
@@ -1,6 +1,6 @@
 variables:
   DSM_THROUGHPUT_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-dotnet-dsm
-  MACROBENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dotnet-throughput-7
+  MACROBENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dotnet-throughput-8
 
 stages:
   - check-azure-pipeline


### PR DESCRIPTION
## Summary of changes

Fix failing dsm throughput check

## Reason for change

The DSM throughput tests are failing on master because of `signature manifest not found`, because they're using an old benchmarking platform image (v7, instead of v8)

## Implementation details

Update to use the new image

## Test coverage

Forced a test, and it succeeded
