### PR TITLE
Fix support for building StackExchange Redis sample in latest package version

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -69,7 +69,11 @@ namespace Samples.StackExchangeRedis
                 RunCommands(new TupleList<string, Func<object>>
                 {
                     { "PING", () => db.PingAsync(CommandFlags.DemandMaster).Result },
+#if (STACKEXCHANGEREDIS_3_1_0)
+                    { "PING_SLAVE", () => db.PingAsync(CommandFlags.DemandReplica).Result },
+#else
                     { "PING_SLAVE", () => db.PingAsync(CommandFlags.DemandSlave).Result },
+#endif
                     { "INCR", () => db.StringIncrement($"{prefix}INCR") },
                     { "INCR", () => db.StringIncrement($"{prefix}INCR", 1.25) },
                     { "GET", () => db.StringGet($"{prefix}INCR") },

--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Samples.StackExchange.Redis.csproj
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Samples.StackExchange.Redis.csproj
@@ -13,6 +13,7 @@
     <DefineConstants Condition="'$(ApiVersion)'>='1.0.228'">$(DefineConstants);STACKEXCHANGEREDIS_1_0_228</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'>='1.0.219'">$(DefineConstants);STACKEXCHANGEREDIS_1_0_219</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'>='1.0.206'">$(DefineConstants);STACKEXCHANGEREDIS_1_0_206</DefineConstants>
+    <DefineConstants Condition="'$(ApiVersion)'>='3.1.0'">$(DefineConstants);STACKEXCHANGEREDIS_3_1_0</DefineConstants>
     <RequiresDockerDependency>All</RequiresDockerDependency>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->


### PR DESCRIPTION
## Summary of changes

Fix samples from breaking in latest version of StackExchange.Redis

## Reason for change

In 3.1.0, they introduce a new obsolete attribute, in preparation for removing of a property.

```
error CS0619: 'CommandFlags.DemandSlave' is obsolete: 'Starting with Redis version 5, Redis has moved to 'replica' terminology. Please use DemandReplica instead, this will be removed in 3.2.'
```

## Implementation details

Gate the problematic API on 3.1.0+

## Test coverage

I'll cherry-pick this into https://github.com/DataDog/dd-trace-dotnet/pull/8955 to confirm

## Other details

Creating as a separate PR rather than pushing directly to the test PR to avoid the fact it can automatically get re-pushed