### PR TITLE
[Profiler] Fix flaky tests caused by failing`timer_create`

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2892,6 +2892,18 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
+    # 64 signal queue slots is far below what timer_create-based CPU profiling asks for, so the
+    # profiler must fall back to the manual one. Not 0: the runtime itself needs real-time signals
+    # to suspend threads, and those are the ones that actually fail when the queue is full.
+    - template: steps/run-in-docker.yml
+      parameters:
+        baseImage: $(baseImage)
+        useNativeSdkVersion: $(useNativeSdkVersion)
+        command: "BuildAndRunProfilerSigPendingLimitTests"
+        extraArgs: "--ulimit sigpending=64:64"
+        apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 3
+
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --rm StartDependencies.Profiler
@@ -2998,6 +3010,17 @@ stages:
         baseImage: $(baseImage)
         command: "BuildAndRunProfilerCpuLimitTests"
         extraArgs: "--cpus 0.5 --env CONTAINER_CPUS=0.5"
+        apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 3
+
+    # 64 signal queue slots is far below what timer_create-based CPU profiling asks for, so the
+    # profiler must fall back to the manual one. Not 0: the runtime itself needs real-time signals
+    # to suspend threads, and those are the ones that actually fail when the queue is full.
+    - template: steps/run-in-docker.yml
+      parameters:
+        baseImage: $(baseImage)
+        command: "BuildAndRunProfilerSigPendingLimitTests"
+        extraArgs: "--ulimit sigpending=64:64"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2941,6 +2941,18 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 
+    # 64 signal queue slots is far below what timer_create-based CPU profiling asks for, so the
+    # profiler must fall back to the manual one. Not 0: the runtime itself needs real-time signals
+    # to suspend threads, and those are the ones that actually fail when the queue is full.
+    - template: steps/run-in-docker.yml
+      parameters:
+        baseImage: $(baseImage)
+        useNativeSdkVersion: $(useNativeSdkVersion)
+        command: "BuildAndRunProfilerSigPendingLimitTests"
+        extraArgs: "--ulimit sigpending=64:64"
+        apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 3
+
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --rm StartDependencies.Profiler
@@ -3048,6 +3060,17 @@ stages:
         baseImage: $(baseImage)
         command: "BuildAndRunProfilerCpuLimitTests"
         extraArgs: "--cpus 0.5 --env CONTAINER_CPUS=0.5"
+        apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 3
+
+    # 64 signal queue slots is far below what timer_create-based CPU profiling asks for, so the
+    # profiler must fall back to the manual one. Not 0: the runtime itself needs real-time signals
+    # to suspend threads, and those are the ones that actually fail when the queue is full.
+    - template: steps/run-in-docker.yml
+      parameters:
+        baseImage: $(baseImage)
+        command: "BuildAndRunProfilerSigPendingLimitTests"
+        extraArgs: "--ulimit sigpending=64:64"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -22,7 +22,6 @@
 #include <ucontext.h>
 #include <unistd.h>
 
-#include <fstream>
 #include <string>
 
 std::atomic<TimerCreateCpuProfiler*> TimerCreateCpuProfiler::Instance = nullptr;
@@ -94,15 +93,10 @@ bool TimerCreateCpuProfiler::StartImpl()
             Log::Info("RLIMIT_SIGPENDING: soft=", rl.rlim_cur, " hard=", rl.rlim_max);
         }
 
-        std::ifstream status("/proc/self/status");
-        std::string line;
-        while (std::getline(status, line))
+        auto availableSlots = OpSysTools::GetAvailableSignalQueueSlots();
+        if (availableSlots.has_value())
         {
-            if (line.rfind("SigQ:", 0) == 0)
-            {
-                Log::Info("Signal queue at startup: ", line);
-                break;
-            }
+            Log::Info("Available signal queue slots at startup: ", *availableSlots);
         }
     }
 
@@ -360,15 +354,10 @@ void TimerCreateCpuProfiler::RegisterThreadImpl(ManagedThreadInfo* threadInfo)
             Log::Error("RLIMIT_SIGPENDING: soft=", rl.rlim_cur, " hard=", rl.rlim_max);
         }
 
-        std::ifstream status("/proc/self/status");
-        std::string line;
-        while (std::getline(status, line))
+        auto availableSlots = OpSysTools::GetAvailableSignalQueueSlots();
+        if (availableSlots.has_value())
         {
-            if (line.rfind("SigQ:", 0) == 0)
-            {
-                Log::Error("Signal queue: ", line);
-                break;
-            }
+            Log::Error("Available signal queue slots: ", *availableSlots);
         }
         return;
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -541,8 +541,8 @@ CpuProfilerType Configuration::ExtractCpuProfilerType(bool isCpuProfilingEnabled
     // its siginfo) once the queue is full.
     if (isCpuProfilingEnabled &&
         cpuProfilerType == CpuProfilerType::TimerCreate &&
-        availableSignalQueueSlots.has_value() &&
-        availableSignalQueueSlots.value() < MinimumFreeSignalQueueSlots)
+        (!availableSignalQueueSlots.has_value() ||
+         availableSignalQueueSlots.value() < MinimumFreeSignalQueueSlots))
     {
         Log::Warn("Only ", availableSignalQueueSlots.value(), " signal queue slots are available out of the ",
                   MinimumFreeSignalQueueSlots, " required (see RLIMIT_SIGPENDING). ",

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -126,7 +126,7 @@ Configuration::Configuration()
         );
     _httpRequestDurationThreshold = ExtractHttpRequestDurationThreshold();
     _forceHttpSampling = GetEnvironmentValue(EnvironmentVariables::ForceHttpSampling, false);
-    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
+    _cpuProfilerType = ExtractCpuProfilerType(_isCpuProfilingEnabled, OpSysTools::GetAvailableSignalQueueSlots());
     _isWaitHandleProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::WaitHandleProfilingEnabled, false);
     _isHeapSnapshotEnabled = GetEnvironmentValue(EnvironmentVariables::HeapSnapshotEnabled, false);
     _isHeapSnapshotSkipTraversal = GetEnvironmentValue(EnvironmentVariables::HeapSnapshotSkipTraversal, false);
@@ -526,6 +526,36 @@ std::chrono::milliseconds Configuration::ExtractCpuProfilingInterval(std::chrono
     // for CI-Visibility we allow it to be less
     auto interval = GetEnvironmentValue(EnvironmentVariables::CpuProfilingInterval, DefaultCpuProfilingInterval);
     return std::max(interval, minimum);
+}
+
+CpuProfilerType Configuration::ExtractCpuProfilerType(bool isCpuProfilingEnabled, std::optional<std::uint64_t> availableSignalQueueSlots)
+{
+    auto cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
+
+#ifdef LINUX
+    // Every timer_create timer holds a signal queue slot for its whole lifetime, and the kernel
+    // accounts those slots per real user id: the budget is shared with all the other processes
+    // running as the same user. Without enough headroom for this process' threads, timer creation
+    // fails and those threads silently produce no CPU sample. The manual profiler is a safe
+    // destination because it relies on a standard signal, which the kernel keeps delivering (minus
+    // its siginfo) once the queue is full.
+    if (isCpuProfilingEnabled &&
+        cpuProfilerType == CpuProfilerType::TimerCreate &&
+        availableSignalQueueSlots.has_value() &&
+        availableSignalQueueSlots.value() < MinimumFreeSignalQueueSlots)
+    {
+        Log::Warn("Only ", availableSignalQueueSlots.value(), " signal queue slots are available out of the ",
+                  MinimumFreeSignalQueueSlots, " required (see RLIMIT_SIGPENDING). ",
+                  "Falling back to the manual CPU profiler.");
+
+        return CpuProfilerType::ManualCpuTime;
+    }
+#else
+    (void)isCpuProfilingEnabled;
+    (void)availableSignalQueueSlots;
+#endif
+
+    return cpuProfilerType;
 }
 
 std::chrono::nanoseconds Configuration::ExtractCpuWallTimeSamplingRate(int minimum)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -539,16 +539,22 @@ CpuProfilerType Configuration::ExtractCpuProfilerType(bool isCpuProfilingEnabled
     // fails and those threads silently produce no CPU sample. The manual profiler is a safe
     // destination because it relies on a standard signal, which the kernel keeps delivering (minus
     // its siginfo) once the queue is full.
-    if (isCpuProfilingEnabled &&
-        cpuProfilerType == CpuProfilerType::TimerCreate &&
-        (!availableSignalQueueSlots.has_value() ||
-         availableSignalQueueSlots.value() < MinimumFreeSignalQueueSlots))
+    if (isCpuProfilingEnabled && cpuProfilerType == CpuProfilerType::TimerCreate)
     {
-        Log::Warn("Only ", availableSignalQueueSlots.value(), " signal queue slots are available out of the ",
-                  MinimumFreeSignalQueueSlots, " required (see RLIMIT_SIGPENDING). ",
-                  "Falling back to the manual CPU profiler.");
+        if (!availableSignalQueueSlots.has_value())
+        {
+            Log::Warn("Unable to determine how many signal queue slots are available (see RLIMIT_SIGPENDING). ",
+                      "Falling back to the manual CPU profiler.");
+            return CpuProfilerType::ManualCpuTime;
+        }
 
-        return CpuProfilerType::ManualCpuTime;
+        if (availableSignalQueueSlots.value() < MinimumFreeSignalQueueSlots)
+        {
+            Log::Warn("Only ", availableSignalQueueSlots.value(), " signal queue slots are available out of the ",
+                      MinimumFreeSignalQueueSlots, " required (see RLIMIT_SIGPENDING). ",
+                      "Falling back to the manual CPU profiler.");
+            return CpuProfilerType::ManualCpuTime;
+        }
     }
 #else
     (void)isCpuProfilingEnabled;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -118,7 +118,7 @@ Configuration::Configuration()
         );
     _httpRequestDurationThreshold = ExtractHttpRequestDurationThreshold();
     _forceHttpSampling = GetEnvironmentValue(EnvironmentVariables::ForceHttpSampling, false);
-    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
+    _cpuProfilerType = ExtractCpuProfilerType(_isCpuProfilingEnabled, OpSysTools::GetAvailableSignalQueueSlots());
     _isWaitHandleProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::WaitHandleProfilingEnabled, false);
     _isHeapSnapshotEnabled = GetEnvironmentValue(EnvironmentVariables::HeapSnapshotEnabled, false);
     _isHeapSnapshotSkipTraversal = GetEnvironmentValue(EnvironmentVariables::HeapSnapshotSkipTraversal, false);
@@ -517,6 +517,36 @@ std::chrono::milliseconds Configuration::ExtractCpuProfilingInterval(std::chrono
     // for CI-Visibility we allow it to be less
     auto interval = GetEnvironmentValue(EnvironmentVariables::CpuProfilingInterval, DefaultCpuProfilingInterval);
     return std::max(interval, minimum);
+}
+
+CpuProfilerType Configuration::ExtractCpuProfilerType(bool isCpuProfilingEnabled, std::optional<std::uint64_t> availableSignalQueueSlots)
+{
+    auto cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, DefaultCpuProfilerType);
+
+#ifdef LINUX
+    // Every timer_create timer holds a signal queue slot for its whole lifetime, and the kernel
+    // accounts those slots per real user id: the budget is shared with all the other processes
+    // running as the same user. Without enough headroom for this process' threads, timer creation
+    // fails and those threads silently produce no CPU sample. The manual profiler is a safe
+    // destination because it relies on a standard signal, which the kernel keeps delivering (minus
+    // its siginfo) once the queue is full.
+    if (isCpuProfilingEnabled &&
+        cpuProfilerType == CpuProfilerType::TimerCreate &&
+        availableSignalQueueSlots.has_value() &&
+        availableSignalQueueSlots.value() < MinimumFreeSignalQueueSlots)
+    {
+        Log::Warn("Only ", availableSignalQueueSlots.value(), " signal queue slots are available out of the ",
+                  MinimumFreeSignalQueueSlots, " required (see RLIMIT_SIGPENDING). ",
+                  "Falling back to the manual CPU profiler.");
+
+        return CpuProfilerType::ManualCpuTime;
+    }
+#else
+    (void)isCpuProfilingEnabled;
+    (void)availableSignalQueueSlots;
+#endif
+
+    return cpuProfilerType;
 }
 
 std::chrono::nanoseconds Configuration::ExtractCpuWallTimeSamplingRate(int minimum)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "DeploymentMode.h"
@@ -127,6 +129,16 @@ private:
     std::chrono::milliseconds ExtractLibrariesInfoCacheStartTimeout() const;
     int32_t ExtractHeapHandleLimit() const;
     uint32_t ExtractReferenceTreeFormat() const;
+
+// The decision below is a pure function of the environment variable and of the number of signal
+// queue slots available on the host, so tests can drive every outcome by passing a slot count.
+#ifdef DD_TEST
+public:
+#endif
+    static CpuProfilerType ExtractCpuProfilerType(bool isCpuProfilingEnabled, std::optional<std::uint64_t> availableSignalQueueSlots);
+
+    // Headroom, in signal queue slots, below which timer_create-based CPU profiling is not attempted.
+    static constexpr std::uint64_t MinimumFreeSignalQueueSlots = 512;
 
 private:
     static std::string const DefaultProdSite;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "DeploymentMode.h"
@@ -125,6 +127,16 @@ private:
     std::chrono::seconds ExtractTestHeapSnapshotInterval() const;
     int32_t ExtractHeapHandleLimit() const;
     uint32_t ExtractReferenceTreeFormat() const;
+
+// The decision below is a pure function of the environment variable and of the number of signal
+// queue slots available on the host, so tests can drive every outcome by passing a slot count.
+#ifdef DD_TEST
+public:
+#endif
+    static CpuProfilerType ExtractCpuProfilerType(bool isCpuProfilingEnabled, std::optional<std::uint64_t> availableSignalQueueSlots);
+
+    // Headroom, in signal queue slots, below which timer_create-based CPU profiling is not attempted.
+    static constexpr std::uint64_t MinimumFreeSignalQueueSlots = 512;
 
 private:
     static std::string const DefaultProdSite;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1425,6 +1425,8 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
 
     _pMetadataProvider = std::make_unique<MetadataProvider>();
     _pMetadataProvider->Initialize();
+    _pMetadataProvider->Add(MetadataProvider::SectionRuntimeSettings, MetadataProvider::EffectiveCpuProfilerType,
+                            to_string(_pConfiguration->GetCpuProfilerType()));
     PrintEnvironmentVariables();
 
     _pSsiManager = std::make_unique<SsiManager>(_pConfiguration.get(), this);
@@ -2244,7 +2246,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
         _systemCallsShield->Unregister();
     }
 
-    if (_pCpuProfiler != nullptr)
+    // pThreadInfo is only set when the thread was still in the managed thread list: there is no timer
+    // to delete otherwise, and UnregisterThread would dereference a null pointer.
+    if (_pCpuProfiler != nullptr && pThreadInfo != nullptr)
     {
         _pCpuProfiler->UnregisterThread(pThreadInfo);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1459,6 +1459,8 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
 
     _pMetadataProvider = std::make_unique<MetadataProvider>();
     _pMetadataProvider->Initialize();
+    _pMetadataProvider->Add(MetadataProvider::SectionRuntimeSettings, MetadataProvider::EffectiveCpuProfilerType,
+                            to_string(_pConfiguration->GetCpuProfilerType()));
     PrintEnvironmentVariables();
 
     _pSsiManager = std::make_unique<SsiManager>(_pConfiguration.get(), this);
@@ -2312,7 +2314,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
         _systemCallsShield->Unregister();
     }
 
-    if (_pCpuProfiler != nullptr)
+    // pThreadInfo is only set when the thread was still in the managed thread list: there is no timer
+    // to delete otherwise, and UnregisterThread would dereference a null pointer.
+    if (_pCpuProfiler != nullptr && pThreadInfo != nullptr)
     {
         _pCpuProfiler->UnregisterThread(pThreadInfo);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuProfilerType.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuProfilerType.h
@@ -13,6 +13,17 @@ enum CpuProfilerType : int
 #endif
 };
 
+inline char const* to_string(CpuProfilerType profilerType)
+{
+#ifdef LINUX
+    if (profilerType == CpuProfilerType::TimerCreate)
+    {
+        return "TimerCreate";
+    }
+#endif
+    return "ManualCpuTime";
+}
+
 inline bool convert_to(shared::WSTRING const& s, CpuProfilerType& profilerType)
 {
     if (shared::string_iequal(s, WStr("ManualCpuTime")))

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MetadataProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MetadataProvider.cpp
@@ -59,6 +59,9 @@ const std::string MetadataProvider::StartTime("Start Time");
 const std::string MetadataProvider::NbCores("Number of Cores");
 const std::string MetadataProvider::CpuLimit("Cpu Limit");
 const std::string MetadataProvider::ClrVersion("Clr Version");
+// The DD_INTERNAL_CPU_PROFILER_TYPE entry above is the requested type; this one is the type actually
+// in use, which differs when the environment forces a fallback.
+const std::string MetadataProvider::EffectiveCpuProfilerType("Cpu Profiler Type");
 
 
 MetadataProvider::MetadataProvider()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MetadataProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MetadataProvider.h
@@ -60,6 +60,7 @@ public:
         static const std::string CpuLimit;
         static const std::string ClrVersion;
         static const std::string StartTime;
+        static const std::string EffectiveCpuProfilerType;
 
 public:
     MetadataProvider();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -31,6 +31,8 @@
 #include "ScopeFinalizer.h"
 
 #include <chrono>
+#include <fstream>
+#include <sstream>
 #include <thread>
 
 #include "shared/src/native-src/dd_filesystem.hpp"
@@ -564,6 +566,60 @@ std::string OpSysTools::GetProcessName()
     return name;
 #endif
 }
+
+#ifdef LINUX
+std::optional<std::uint64_t> OpSysTools::ParseAvailableSignalQueueSlots(std::istream& status)
+{
+    const std::string prefix = "SigQ:";
+
+    std::string line;
+    while (std::getline(status, line))
+    {
+        if (line.rfind(prefix, 0) != 0)
+        {
+            continue;
+        }
+
+        auto separator = line.find('/', prefix.size());
+        if (separator == std::string::npos)
+        {
+            return std::nullopt;
+        }
+
+        std::uint64_t queued = 0;
+        std::uint64_t limit = 0;
+
+        std::istringstream queuedField(line.substr(prefix.size(), separator - prefix.size()));
+        std::istringstream limitField(line.substr(separator + 1));
+        if (!(queuedField >> queued) || !(limitField >> limit))
+        {
+            return std::nullopt;
+        }
+
+        // An unlimited RLIMIT_SIGPENDING is reported as RLIM_INFINITY, which needs no special case:
+        // it dwarfs any plausible queued count and yields a headroom large enough for any caller.
+        return (limit > queued) ? limit - queued : std::uint64_t{0};
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::uint64_t> OpSysTools::GetAvailableSignalQueueSlots()
+{
+    std::ifstream status("/proc/self/status");
+    if (!status.is_open())
+    {
+        return std::nullopt;
+    }
+
+    return ParseAvailableSignalQueueSlots(status);
+}
+#else
+std::optional<std::uint64_t> OpSysTools::GetAvailableSignalQueueSlots()
+{
+    return std::nullopt;
+}
+#endif
 
 bool OpSysTools::IsSafeToStartProfiler(double coresThreshold, double& cpuLimit)
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -8,6 +8,8 @@
 #include "shared/src/native-src/string.h"
 
 #include <chrono>
+#include <iosfwd>
+#include <optional>
 #include <string>
 #include <thread>
 
@@ -60,7 +62,24 @@ public:
     static std::string GetHostname();
     static std::string GetProcessName();
 
+    /// <summary>
+    /// Number of signal queue slots still available, read from /proc/self/status.
+    /// Returns nothing when the information cannot be determined, which is always the case on
+    /// platforms where signal queues are not a concern.
+    /// </summary>
+    static std::optional<std::uint64_t> GetAvailableSignalQueueSlots();
+
 #ifdef LINUX
+    /// <summary>
+    /// Parses the "SigQ:  &lt;queued&gt;/&lt;limit&gt;" line of a /proc/&lt;pid&gt;/status stream and returns
+    /// the number of signal queue slots still available.
+    /// &lt;queued&gt; is the number of queued signals for the real user id, which is shared by every
+    /// process running as that user, while &lt;limit&gt; is this process' soft RLIMIT_SIGPENDING. They
+    /// are accounted independently, so &lt;queued&gt; can exceed &lt;limit&gt; and the subtraction saturates.
+    /// Returns nothing when the line is missing or cannot be parsed.
+    /// </summary>
+    static std::optional<std::uint64_t> ParseAvailableSignalQueueSlots(std::istream& status);
+
     static bool ParseThreadInfo(char const* line, char& state, int32_t& userTime, int32_t& kernelTime)
     {
         // based on https://linux.die.net/man/5/proc

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -201,6 +201,8 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
 
             runner.Run(agent);
 
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.Environment.LogDir);
+
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
             Assert.Single(profilerRuntimeIds.Distinct());

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
@@ -122,6 +122,8 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
 
             runner.Run(agent);
 
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.Environment.LogDir);
+
             // Ensure that we don't count too much CPU like when that nano/milli sec bug was introduced
             var cpuDuration = SamplesHelper.GetValueSum(runner.Environment.PprofDir, 0);
             // Test is supposed to run 10s so count additional seconds both for extended duration + more than 1 managed thread (tracing code for example)

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -307,6 +307,8 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
 
             runner.Run(agent);
 
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.Environment.LogDir);
+
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
             var exceptionSamples = SamplesHelper.GetSamples(runner.Environment.PprofDir, "exception").ToArray();

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/CpuProfilerHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/CpuProfilerHelper.cs
@@ -1,0 +1,54 @@
+// <copyright file="CpuProfilerHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Datadog.Profiler.IntegrationTests.Xunit;
+
+namespace Datadog.Profiler.IntegrationTests.Helpers
+{
+    internal static class CpuProfilerHelper
+    {
+        private const string DowngradeMarker = "Falling back to the manual CPU profiler";
+
+        /// <summary>
+        /// Reads the lines of every native profiler log found in the given directory.
+        /// </summary>
+        /// <param name="logDirectory">The log directory of the run.</param>
+        /// <returns>The lines of the native profiler logs.</returns>
+        public static IEnumerable<string> ReadNativeLogs(string logDirectory)
+        {
+            return Directory.EnumerateFiles(logDirectory, "DD-DotNet-Profiler-Native*.log", SearchOption.AllDirectories)
+                            .SelectMany(File.ReadLines);
+        }
+
+        /// <summary>
+        /// Skips the calling test when the profiler gave up on timer_create.
+        /// RLIMIT_SIGPENDING is accounted per user id and shared by every process of that user, so a
+        /// neighbour on the same machine can exhaust the signal queue and leave this process with no
+        /// choice but the manual CPU profiler. That is a property of the host, not a defect in the
+        /// code under test.
+        /// </summary>
+        /// <param name="logDirectory">The log directory of the run.</param>
+        public static void SkipIfTimerCreateWasDowngraded(string logDirectory)
+        {
+            SkipIfTimerCreateWasDowngraded(ReadNativeLogs(logDirectory));
+        }
+
+        /// <summary>
+        /// Skips the calling test when the profiler gave up on timer_create.
+        /// </summary>
+        /// <param name="nativeLogLines">The lines of the native profiler log.</param>
+        public static void SkipIfTimerCreateWasDowngraded(IEnumerable<string> nativeLogLines)
+        {
+            if (nativeLogLines.Any(line => line.Contains(DowngradeMarker)))
+            {
+                throw new SkipTestException(
+                    "The host signal queue is exhausted (see RLIMIT_SIGPENDING), so timer_create CPU profiling was downgraded to the manual CPU profiler.");
+            }
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SigPendingLimitTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SigPendingLimitTest.cs
@@ -1,0 +1,61 @@
+// <copyright file="SigPendingLimitTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using Datadog.Profiler.IntegrationTests.Helpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.LinuxOnly
+{
+    /// <summary>
+    /// Checks that the profiler stops asking for timer_create when the signal queue is too small for
+    /// it. Every timer_create timer holds a signal queue slot, so the run this test belongs to is
+    /// started with a container-wide RLIMIT_SIGPENDING far below what the profiler asks for.
+    /// </summary>
+    [Trait("Category", "LinuxOnly")]
+    [Trait("Category", "SigPendingLimitTest")]
+    public class SigPendingLimitTest
+    {
+        private const string CmdLine = "--timeout 10"; // default scenario is PI computation to run for 10 seconds
+
+        private readonly ITestOutputHelper _output;
+
+        public SigPendingLimitTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void CheckTimerCreateIsDowngradedWhenSignalQueueIsTooSmall(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
+            // disable default profilers except CPU
+            EnvironmentHelper.DisableDefaultProfilers(runner);
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
+
+            // asking for timer_create explicitly: the check must override the request, not only the default
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(_output);
+
+            runner.Run(agent);
+
+            var logFile = Directory.GetFiles(runner.Environment.LogDir)
+               .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
+
+            var logLines = File.ReadLines(logFile);
+
+            logLines.Should().ContainMatch("*Falling back to the manual CPU profiler*");
+            logLines.Should().ContainMatch("*Manual Cpu profiler is enabled*");
+            logLines.Should().NotContainMatch("*timer_create Cpu profiler is enabled*");
+
+            // the whole point of the fallback: CPU profiling keeps working
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotBeEmpty("No samples were found");
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
@@ -41,6 +41,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             var logLines = File.ReadLines(logFile);
 
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(logLines);
+
             logLines.Should().ContainMatch("*timer_create Cpu profiler is enabled*");
             logLines.Should().NotContainMatch("*Manual Cpu profiler is enabled*");
 
@@ -89,6 +91,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             var logLines = File.ReadLines(logFile);
 
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(logLines);
+
             logLines.Should().ContainMatch("*timer_create Cpu profiler is enabled*");
 
             logLines.Should().NotContainMatch("*Call to timer_create failed for thread 0*");
@@ -111,6 +115,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             using var agent = MockDatadogAgent.CreateHttpAgent(runner.XUnitLogger);
 
             runner.Run(agent);
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.Environment.LogDir);
 
             // only cpu  profiler enabled so should see 1 value per sample and
             var samples = SamplesHelper.GetSamples(runner.Environment.PprofDir);
@@ -138,6 +144,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             using var agent = MockDatadogAgent.CreateHttpAgent(runner.XUnitLogger);
 
             runner.Run(agent);
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.Environment.LogDir);
 
             var expectedInterval = long.Parse(samplingInterval) * 1_000_000;
             // only cpu  profiler enabled so should see 2 value per sample and

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
@@ -34,6 +34,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
@@ -99,6 +99,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [Trait("Category", "LinuxOnly")]
@@ -110,6 +112,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [Trait("Category", "LinuxOnly")]
@@ -121,6 +125,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [Trait("Category", "LinuxOnly")]
@@ -132,6 +138,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [TestAppFact("Samples.Computer01")]

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
@@ -95,6 +95,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [Trait("Category", "LinuxOnly")]
@@ -106,6 +108,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [Trait("Category", "LinuxOnly")]
@@ -117,6 +121,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [Trait("Category", "LinuxOnly")]
@@ -128,6 +134,8 @@ namespace Datadog.Profiler.SmokeTests
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.EnvironmentHelper.SetVariable(EnvironmentVariables.MemoryFootprintEnabled, "1");
             runner.RunAndCheck();
+
+            CpuProfilerHelper.SkipIfTimerCreateWasDowngraded(runner.EnvironmentHelper.LogDir);
         }
 
         [TestAppFact("Samples.Computer01")]

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerTestCase.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerTestCase.cs
@@ -84,8 +84,22 @@ namespace Datadog.Profiler.IntegrationTests.Xunit
                 delayedBus?.Dispose();
             }
 
-            Task<RunSummary> RunOnceAsync(IMessageBus bus)
-                => new ProfilerTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, bus, aggregator, cancellationTokenSource).RunAsync();
+            async Task<RunSummary> RunOnceAsync(IMessageBus bus)
+            {
+                var skippableBus = new SkippableMessageBus(bus);
+
+                var summary = await new ProfilerTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, skippableBus, aggregator, cancellationTokenSource).RunAsync();
+
+                // The runner counted the SkipTestException as a failure; only the bus knows it was a skip.
+                // Reporting it as such also keeps the retry loop above from running a skipped test again.
+                if (skippableBus.SkippedCount > 0)
+                {
+                    summary.Failed -= skippableBus.SkippedCount;
+                    summary.Skipped += skippableBus.SkippedCount;
+                }
+
+                return summary;
+            }
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/SkipTestException.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/SkipTestException.cs
@@ -1,0 +1,20 @@
+// <copyright file="SkipTestException.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Profiler.IntegrationTests.Xunit;
+
+/// <summary>
+/// Thrown by a test that cannot run on the current host.
+/// <see cref="SkippableMessageBus"/> turns the resulting failure into a skipped test.
+/// </summary>
+internal class SkipTestException : Exception
+{
+    public SkipTestException(string reason)
+        : base(reason)
+    {
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/SkippableMessageBus.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/SkippableMessageBus.cs
@@ -1,0 +1,64 @@
+// <copyright file="SkippableMessageBus.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.Threading;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Profiler.IntegrationTests.Xunit;
+
+/// <summary>
+/// Rewrites the failure of a test that threw <see cref="SkipTestException"/> into a skipped test.
+/// xUnit v2 has no way to skip a test once it has started, so the test throws and the decision
+/// is translated here, on the way to the inner bus.
+/// </summary>
+internal class SkippableMessageBus : IMessageBus
+{
+    private readonly IMessageBus _innerBus;
+    private int _skippedCount;
+
+    public SkippableMessageBus(IMessageBus innerBus)
+    {
+        _innerBus = innerBus;
+    }
+
+    /// <summary>
+    /// Gets the number of failures that were turned into skips.
+    /// </summary>
+    public int SkippedCount => _skippedCount;
+
+    public bool QueueMessage(IMessageSinkMessage message)
+    {
+        if (message is ITestFailed failed && TryGetSkipReason(failed, out var reason))
+        {
+            Interlocked.Increment(ref _skippedCount);
+            return _innerBus.QueueMessage(new TestSkipped(failed.Test, reason));
+        }
+
+        return _innerBus.QueueMessage(message);
+    }
+
+    public void Dispose()
+    {
+        // the inner bus is owned by the caller
+    }
+
+    private static bool TryGetSkipReason(ITestFailed failed, out string reason)
+    {
+        var skipExceptionName = typeof(SkipTestException).FullName;
+
+        for (var i = 0; i < failed.ExceptionTypes.Length; i++)
+        {
+            if (failed.ExceptionTypes[i] == skipExceptionName)
+            {
+                reason = i < failed.Messages.Length ? failed.Messages[i] : "Test skipped";
+                return true;
+            }
+        }
+
+        reason = null;
+        return false;
+    }
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1258,11 +1258,10 @@ TEST_F(ConfigurationTest, CheckCpuProfilerTypeIsKeptWhenSignalQueueIsJustLargeEn
     ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, availableSlots), CpuProfilerType::TimerCreate);
 }
 
-// Not being able to tell how many slots are left must not cost the accurate CPU profiler.
-TEST_F(ConfigurationTest, CheckCpuProfilerTypeIsKeptWhenSignalQueueIsUnknown)
+TEST_F(ConfigurationTest, CheckCpuProfilerTypeToManualWhenSignalQueueIsUnknown)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
-    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, std::nullopt), CpuProfilerType::TimerCreate);
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, std::nullopt), CpuProfilerType::ManualCpuTime);
 }
 
 // No timer is ever created when CPU profiling is off, so there is nothing to fall back from.

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1179,63 +1179,105 @@ TEST_F(ConfigurationTest, CheckEtwLoggingIsEnabledIfEnvVarSetToTrue)
     ASSERT_THAT(configuration.IsEtwLoggingEnabled(), expectedValue);
 }
 
+// The signal queue is a host-wide resource shared by every process of the same user, so the cases
+// checking how the environment variable is parsed pass a headroom large enough to never trigger the
+// fallback, whatever state the machine running the tests is in.
+static constexpr std::optional<std::uint64_t> PlentyOfSignalQueueSlots = 10 * Configuration::MinimumFreeSignalQueueSlots;
+
 TEST_F(ConfigurationTest, CheckDefaultCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr(""));
-    auto configuration = Configuration{};
     auto expected =
 #ifdef _WINDOWS
         CpuProfilerType::ManualCpuTime;
 #else
         CpuProfilerType::TimerCreate;
 #endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, PlentyOfSignalQueueSlots), expected);
 }
 
 TEST_F(ConfigurationTest, CheckDefaultCpuProfilerTypeWhenEnvVarNotSet)
 {
-    auto configuration = Configuration{};
     auto expected =
 #ifdef _WINDOWS
         CpuProfilerType::ManualCpuTime;
 #else
         CpuProfilerType::TimerCreate;
 #endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, PlentyOfSignalQueueSlots), expected);
 }
 
 TEST_F(ConfigurationTest, CheckUnknownCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("UnknownCpuProfilerType"));
-    auto configuration = Configuration{};
     auto expected =
 #ifdef _WINDOWS
         CpuProfilerType::ManualCpuTime;
 #else
         CpuProfilerType::TimerCreate;
 #endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, PlentyOfSignalQueueSlots), expected);
 }
 
 TEST_F(ConfigurationTest, CheckManualCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("ManualCpuTime"));
-    auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, PlentyOfSignalQueueSlots), CpuProfilerType::ManualCpuTime);
 }
 
 TEST_F(ConfigurationTest, CheckTimerCreateCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
-    auto configuration = Configuration{};
     auto expected =
 #ifdef LINUX
         CpuProfilerType::TimerCreate;
 #else
         CpuProfilerType::ManualCpuTime;
 #endif
-    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, PlentyOfSignalQueueSlots), expected);
 }
+
+#ifdef LINUX
+TEST_F(ConfigurationTest, CheckCpuProfilerTypeFallsBackWhenSignalQueueIsTooSmall)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
+    auto availableSlots = Configuration::MinimumFreeSignalQueueSlots - 1;
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, availableSlots), CpuProfilerType::ManualCpuTime);
+}
+
+TEST_F(ConfigurationTest, CheckCpuProfilerTypeFallsBackWhenSignalQueueIsExhausted)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, 0), CpuProfilerType::ManualCpuTime);
+}
+
+TEST_F(ConfigurationTest, CheckCpuProfilerTypeIsKeptWhenSignalQueueIsJustLargeEnough)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
+    auto availableSlots = Configuration::MinimumFreeSignalQueueSlots;
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, availableSlots), CpuProfilerType::TimerCreate);
+}
+
+// Not being able to tell how many slots are left must not cost the accurate CPU profiler.
+TEST_F(ConfigurationTest, CheckCpuProfilerTypeIsKeptWhenSignalQueueIsUnknown)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, std::nullopt), CpuProfilerType::TimerCreate);
+}
+
+// No timer is ever created when CPU profiling is off, so there is nothing to fall back from.
+TEST_F(ConfigurationTest, CheckCpuProfilerTypeIsKeptWhenCpuProfilingIsDisabled)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(false, 0), CpuProfilerType::TimerCreate);
+}
+
+TEST_F(ConfigurationTest, CheckManualCpuProfilerTypeIsKeptWhenSignalQueueIsExhausted)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("ManualCpuTime"));
+    ASSERT_THAT(Configuration::ExtractCpuProfilerType(true, 0), CpuProfilerType::ManualCpuTime);
+}
+#endif
 
 TEST_F(ConfigurationTest, CheckDefaultCpuProfilingInterval)
 {

--- a/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
@@ -8,6 +8,8 @@
 
 #include "OpSysTools.h"
 
+#include <sstream>
+
 #include "shared/src/native-src/dd_filesystem.hpp"
 
 // based on https://linux.die.net/man/5/proc
@@ -162,6 +164,112 @@ TEST(GetThreadInfoTest, Check_Missing_KernelTime)
     bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
 
     ASSERT_FALSE(result);
+}
+
+// The SigQ line of /proc/<pid>/status holds "<queued>/<limit>", where <queued> is the number of
+// signals queued for the real user id and <limit> the soft RLIMIT_SIGPENDING of the process.
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_SigQ_Line)
+{
+    std::istringstream status("SigQ:\t12/63641\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_TRUE(availableSlots.has_value());
+    ASSERT_EQ(std::uint64_t{63629}, availableSlots.value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_SigQ_Line_Among_Others)
+{
+    std::istringstream status(
+        "Name:\tdotnet\n"
+        "Threads:\t14\n"
+        "SigQ:\t0/63641\n"
+        "SigPnd:\t0000000000000000\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_TRUE(availableSlots.has_value());
+    ASSERT_EQ(std::uint64_t{63641}, availableSlots.value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_Exhausted_Queue)
+{
+    std::istringstream status("SigQ:\t64/64\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_TRUE(availableSlots.has_value());
+    ASSERT_EQ(std::uint64_t{0}, availableSlots.value());
+}
+
+// The two counts are accounted independently: <queued> is host-wide for the user id while <limit>
+// belongs to this process, so the subtraction must saturate instead of wrapping around.
+TEST(GetAvailableSignalQueueSlotsTest, Check_More_Queued_Than_Limit)
+{
+    std::istringstream status("SigQ:\t200/64\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_TRUE(availableSlots.has_value());
+    ASSERT_EQ(std::uint64_t{0}, availableSlots.value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_Unlimited_Queue)
+{
+    std::istringstream status("SigQ:\t12/18446744073709551615\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_TRUE(availableSlots.has_value());
+    ASSERT_EQ(std::uint64_t{18446744073709551603ULL}, availableSlots.value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_Missing_SigQ_Line)
+{
+    std::istringstream status(
+        "Name:\tdotnet\n"
+        "Threads:\t14\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_FALSE(availableSlots.has_value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_EmptyString)
+{
+    std::istringstream status("");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_FALSE(availableSlots.has_value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_Missing_Separator)
+{
+    std::istringstream status("SigQ:\t63641\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_FALSE(availableSlots.has_value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_Non_Numeric_Values)
+{
+    std::istringstream status("SigQ:\tunknown/unknown\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_FALSE(availableSlots.has_value());
+}
+
+TEST(GetAvailableSignalQueueSlotsTest, Check_Missing_Limit)
+{
+    std::istringstream status("SigQ:\t12/\n");
+
+    auto availableSlots = OpSysTools::ParseAvailableSignalQueueSlots(status);
+
+    ASSERT_FALSE(availableSlots.has_value());
 }
 
 #endif

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -340,13 +340,22 @@ partial class Build
             BuildAndRunProfilerIntegrationTestsInternal("(Category=CpuLimitTest)");
         });
 
+    Target BuildAndRunProfilerSigPendingLimitTests => _ => _
+        .After(BuildProfilerSamples)
+        .Description("Run the profiler tests that need a constrained RLIMIT_SIGPENDING")
+        .Requires(() => IsLinux)
+        .Executes(() =>
+        {
+            BuildAndRunProfilerIntegrationTestsInternal("(Category=SigPendingLimitTest)");
+        });
+
     Target BuildAndRunProfilerIntegrationTests => _ => _
         .After(BuildProfilerSamples)
         .Description("Builds and runs the profiler integration tests")
         .Executes(() =>
         {
-            // Exclude CpuLimitTest from this path: They are already launched in a specific step + specific setup
-            var filter = string.IsNullOrWhiteSpace(Filter) ? $"{(IsLinux ? "(Category!=WindowsOnly)" : "(Category!=LinuxOnly)")}&(Category!=CpuLimitTest)" : Filter;
+            // Exclude CpuLimitTest and SigPendingLimitTest from this path: They are already launched in a specific step + specific setup
+            var filter = string.IsNullOrWhiteSpace(Filter) ? $"{(IsLinux ? "(Category!=WindowsOnly)" : "(Category!=LinuxOnly)")}&(Category!=CpuLimitTest)&(Category!=SigPendingLimitTest)" : Filter;
             BuildAndRunProfilerIntegrationTestsInternal(filter);
         });
 


### PR DESCRIPTION
## Summary of changes

On Linux, the profiler now checks how many signal queue slots are free at startup and falls
back from the `timer_create` CPU profiler to the manual one when there is not enough headroom.
The effective profiler type is recorded in the profile metadata, and the integration tests that
require `timer_create` skip themselves when the fallback kicks in.

## Reason for change

Each `timer_create` timer holds a signal queue slot for its whole lifetime, and the kernel
accounts those slots per real user id, so the budget is shared with every other process running
as the same user. Once it is exhausted, `timer_create` fails and the affected threads silently
produce no CPU sample. That is what makes the profiler integration tests flaky on saturated CI
hosts, and nothing in the output distinguished it from a real bug.

## Implementation details

- `OpSysTools::GetAvailableSignalQueueSlots()` reads the `SigQ: <queued>/<limit>` line of
  `/proc/self/status`. The parsing lives in a `ParseAvailableSignalQueueSlots(std::istream&)`
  overload so it can be unit tested. `queued` is per-uid while `limit` is this process' soft
  `RLIMIT_SIGPENDING`, so they are accounted independently and the subtraction saturates at zero.
  Returns `nullopt` when the value cannot be determined, which is always the case on Windows.
- `Configuration::ExtractCpuProfilerType(isCpuProfilingEnabled, availableSlots)` is a static pure
  function called from the `Configuration` constructor. When CPU profiling is on, `TimerCreate`
  was requested and fewer than `MinimumFreeSignalQueueSlots` (512) slots are free, it warns and
  returns `ManualCpuTime`. It is public only under `DD_TEST`.
- The manual profiler is a safe destination: it uses a standard signal, which the kernel keeps
  delivering (minus its siginfo) even when the queue is full.
- `MetadataProvider` gains a `Cpu Profiler Type` entry next to the raw
  `DD_INTERNAL_CPU_PROFILER_TYPE`, so a downgrade is visible in the profile.
- `TimerCreateCpuProfiler` diagnostics now reuse the shared helper instead of parsing `/proc`
  inline.
- Fixed a latent null dereference in `CorProfilerCallback::ThreadDestroyed`, which called
  `UnregisterThread` with a possibly null `pThreadInfo`.

## Test coverage

- 10 new gtest cases for the `SigQ` parser (missing line, exhausted queue, `queued > limit`,
  unlimited, malformed input) and 6 for `ExtractCpuProfilerType`. All are driven by an explicit
  slot count, so they do not depend on the host they run on.
- New `SigPendingLimitTest` integration test, run in Docker with `--ulimit sigpending=64:64`,
  asserting that the downgrade happens and that CPU samples are still produced. Added the
  `BuildAndRunProfilerSigPendingLimitTests` Nuke target and the matching Linux CI steps, and
  excluded the category from the regular integration test run.
- `CpuProfilerHelper` detects the downgrade warning in the native log and throws
  `SkipTestException`; it is applied to the suites that force `TimerCreate`.
  `SkippableMessageBus` rewrites that failure into a skip and reconciles the `RunSummary`, so
  `[Flaky]` does not retry a test that is going to skip again.

## Other details

- No new customer-facing configuration: the 512-slot threshold is a compile-time constant.
- Windows behaviour is unchanged; the check compiles out.

#incident-57303