### PR TITLE
[Profiler] Fix flakiness due to Libraries Info Cache

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/AutoResetEvent.cpp
@@ -56,6 +56,14 @@ bool AutoResetEvent::Wait(std::chrono::milliseconds timeout)
         clock_gettime(CLOCK_REALTIME, &ts);
         ts.tv_nsec += timeout.count() % 1000 * 1'000'000;
         ts.tv_sec += timeout.count() / 1000;
+
+        // pthread_cond_timedwait rejects tv_nsec >= 1s with EINVAL, which this loop would
+        // spin on instead of timing out. Both operands are < 1s, so one carry is enough.
+        if (ts.tv_nsec >= 1'000'000'000)
+        {
+            ts.tv_nsec -= 1'000'000'000;
+            ts.tv_sec += 1;
+        }
     }
 
     while(!_impl->_isSet)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -152,7 +152,8 @@ LibrariesInfoCache::LibrariesInfoCache(IConfiguration* configuration, shared::pm
     _newSymbols{_wrappersAllocator},
 #endif
     _stopRequested{false},
-    _event(true)
+    _event(true),
+    _startTimeout(configuration->GetLibrariesInfoCacheStartTimeout())
 {
     if (_tracker)
     {
@@ -186,17 +187,11 @@ bool LibrariesInfoCache::StartImpl()
 
     // Wait for the thread to be fully started and the cache populated
     // before setting s_instance and registering with libunwind.
-    // Cache population can be slow under sanitizers (ASAN/UBSAN add overhead to
-    // every allocation and memory access) — use a longer timeout in that case.
-#if defined(DD_SANITIZERS)
-    constexpr auto startTimeout = 10s;
-#else
-    constexpr auto startTimeout = 2s;
-#endif
-    if (!startEvent->Wait(startTimeout))
+
+    if (!startEvent->Wait(_startTimeout))
     {
-        Log::Error("Failed to populate LibrariesInfoCache within timeout. "
-                   "Not registering custom iterate_phdr_function with libunwind.");
+        Log::Error("Failed to populate LibrariesInfoCache within timeout: ", _startTimeout,
+                   ". Not registering custom iterate_phdr_function with libunwind.");
         _stopRequested = true;
         _event.Set();
         _worker.join();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -13,6 +13,7 @@
 #include "shared/src/native-src/dd_memory_resource.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <link.h>
 #include <memory>
 #include <shared_mutex>
@@ -122,4 +123,7 @@ private:
     std::thread _worker;
     std::atomic<bool> _stopRequested;
     AutoResetEvent _event;
+    // How long StartImpl waits for the first cache population. Longer on slow/loaded
+    // machines (CI), where the default is not enough and the cache is silently skipped.
+    std::chrono::milliseconds _startTimeout;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -35,6 +35,14 @@ CpuProfilerType const Configuration::DefaultCpuProfilerType =
 #endif
 std::chrono::minutes const Configuration::DefaultDevHeapSnapshotInterval = 1min;
 std::chrono::minutes const Configuration::DefaultProdHeapSnapshotInterval = 5min;
+std::chrono::milliseconds const Configuration::DefaultLibrariesInfoCacheStartTimeout =
+#if defined(DD_SANITIZERS)
+    // Sanitizers instrument every allocation and memory access, so populating the
+    // cache takes considerably longer than in a regular build.
+    10s;
+#else
+    2s;
+#endif
 
 Configuration::Configuration()
 {
@@ -126,6 +134,7 @@ Configuration::Configuration()
     _heapSnapshotCheckInterval = ExtractHeapSnapshotCheckInterval();
     _heapSnapshotMemoryPressureThreshold = GetEnvironmentValue(EnvironmentVariables::HeapSnapshotMemoryPressureThreshold, 50);
     _testHeapSnapshotInterval = ExtractTestHeapSnapshotInterval();
+    _librariesInfoCacheStartTimeout = ExtractLibrariesInfoCacheStartTimeout();
     _heapHandleLimit = ExtractHeapHandleLimit();
     bool defaultUseManagedCodeCache =
     #if ARM64
@@ -935,6 +944,27 @@ std::chrono::seconds Configuration::ExtractTestHeapSnapshotInterval() const
 std::chrono::seconds Configuration::GetTestHeapSnapshotInterval() const
 {
     return _testHeapSnapshotInterval;
+}
+
+std::chrono::milliseconds Configuration::ExtractLibrariesInfoCacheStartTimeout() const
+{
+    // A negative value parses into a negative duration, and zero would make the wait
+    // return immediately, silently disabling the cache: neither is ever intended.
+    auto timeout = GetEnvironmentValue(EnvironmentVariables::LibrariesInfoCacheStartTimeout, DefaultLibrariesInfoCacheStartTimeout);
+    if (timeout <= 0ms)
+    {
+        Log::Warn("Configuration: ", EnvironmentVariables::LibrariesInfoCacheStartTimeout,
+                  " env var must be strictly positive but is set to '", timeout,
+                  "' - '", DefaultLibrariesInfoCacheStartTimeout, "' is used instead");
+        return DefaultLibrariesInfoCacheStartTimeout;
+    }
+
+    return timeout;
+}
+
+std::chrono::milliseconds Configuration::GetLibrariesInfoCacheStartTimeout() const
+{
+    return _librariesInfoCacheStartTimeout;
 }
 
 int32_t Configuration::ExtractHeapHandleLimit() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -90,6 +90,7 @@ public:
     std::chrono::milliseconds GetHeapSnapshotCheckInterval() const override;
     uint32_t GetHeapSnapshotMemoryPressureThreshold() const override;
     std::chrono::seconds GetTestHeapSnapshotInterval() const override;
+    std::chrono::milliseconds GetLibrariesInfoCacheStartTimeout() const override;
     uint32_t GetHeapHandleLimit() const override;
     bool UseManagedCodeCache() const override;
     bool IsMemoryFootprintEnabled() const override;
@@ -123,6 +124,7 @@ private:
     std::chrono::milliseconds ExtractHeapSnapshotCheckInterval() const;
     std::chrono::minutes GetDefaultHeapSnapshotInterval() const;
     std::chrono::seconds ExtractTestHeapSnapshotInterval() const;
+    std::chrono::milliseconds ExtractLibrariesInfoCacheStartTimeout() const;
     int32_t ExtractHeapHandleLimit() const;
     uint32_t ExtractReferenceTreeFormat() const;
 
@@ -140,6 +142,7 @@ private:
     static CpuProfilerType const DefaultCpuProfilerType;
     static std::chrono::minutes const DefaultDevHeapSnapshotInterval;
     static std::chrono::minutes const DefaultProdHeapSnapshotInterval;
+    static std::chrono::milliseconds const DefaultLibrariesInfoCacheStartTimeout;
 
     bool _isProfilingEnabled;
     bool _isCpuProfilingEnabled;
@@ -211,6 +214,7 @@ private:
     std::chrono::milliseconds _heapSnapshotCheckInterval;
     uint32_t _heapSnapshotMemoryPressureThreshold; // in % of used memory
     std::chrono::seconds _testHeapSnapshotInterval;
+    std::chrono::milliseconds _librariesInfoCacheStartTimeout;
     bool _useManagedCodeCache;
     bool _isMemoryFootprintEnabled;
     uint32_t _referenceTreeFormat;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -85,6 +85,7 @@ public:
     // used for tests only
     inline static const shared::WSTRING ForceHttpSampling           = WStr("DD_INTERNAL_PROFILING_FORCE_HTTP_SAMPLING");
     inline static const shared::WSTRING TestHeapSnapshotInterval    = WStr("DD_INTERNAL_PROFILING_TEST_HEAPSNAPSHOT_INTERVAL");
+    inline static const shared::WSTRING LibrariesInfoCacheStartTimeout = WStr("DD_INTERNAL_PROFILING_LIBRARIES_CACHE_START_TIMEOUT");
 
     inline static const shared::WSTRING CIVisibilityEnabled         = WStr("DD_CIVISIBILITY_ENABLED");
     inline static const shared::WSTRING InternalCIVisibilitySpanId  = WStr("DD_INTERNAL_CIVISIBILITY_SPANID");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -89,6 +89,7 @@ public:
     virtual std::chrono::milliseconds GetHeapSnapshotCheckInterval() const = 0;
     virtual uint32_t GetHeapSnapshotMemoryPressureThreshold() const = 0;
     virtual std::chrono::seconds GetTestHeapSnapshotInterval() const = 0;
+    virtual std::chrono::milliseconds GetLibrariesInfoCacheStartTimeout() const = 0;
     virtual uint32_t GetHeapHandleLimit() const = 0;
     virtual bool UseManagedCodeCache() const = 0;
     virtual bool IsMemoryFootprintEnabled() const = 0;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -195,6 +195,10 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             // Linux ARM64: native profiler requires DD_INTERNAL_PROFILING_ENABLED_ARM64; align managed enablement.
             environmentVariables["DD_INTERNAL_PROFILING_ENABLED_ARM64"] = "1";
 
+            // Test machines are slow and loaded enough that the default 2s is not always enough to
+            // populate the libraries cache, and the profiler silently falls back to slower unwinding.
+            environmentVariables[EnvironmentVariables.LibrariesInfoCacheStartTimeout] = "10000";
+
             environmentVariables["DD_TRACE_ENABLED"] = "0";
 
             environmentVariables["DD_PROFILING_UPLOAD_PERIOD"] = profilingExportIntervalInSeconds.ToString();

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -47,5 +47,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string TestHeapSnapshotInterval = "DD_INTERNAL_PROFILING_TEST_HEAPSNAPSHOT_INTERVAL";
         public const string UseManagedCodeCache = "DD_INTERNAL_PROFILING_USE_MANAGED_CODE_CACHE";
         public const string MemoryFootprintEnabled = "DD_INTERNAL_PROFILING_MEMORY_FOOTPRINT_ENABLED";
+        public const string LibrariesInfoCacheStartTimeout = "DD_INTERNAL_PROFILING_LIBRARIES_CACHE_START_TIMEOUT";
     }
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/AutoResetEventTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AutoResetEventTest.cpp
@@ -6,6 +6,8 @@
 #include "profiler/src/ProfilerEngine/Datadog.Profiler.Native/AutoResetEvent.h"
 
 #include <future>
+#include <thread>
+#include <time.h>
 
 #include "gtest/gtest.h"
 
@@ -128,6 +130,23 @@ TEST(AutoResetEventTest, EnsureEventIsSignaledIfSetIsCalledWhileWaitingWithTimeo
 
     ASSERT_DURATION_GE(100ms, event->Wait(10s));
     ASSERT_DURATION_LE(50ms, event->Set());
+}
+
+TEST(AutoResetEventTest, EnsureTimeoutExpiresWhenSubSecondTimeoutOverflowsCurrentSecond)
+{
+    // The timeout is added to the current wall clock, so the sub-second part of that sum
+    // only overflows into the next second when the clock is already late enough in the
+    // current one. Wait for that window, keeping enough margin to still be in it below.
+    struct timespec now;
+    do
+    {
+        std::this_thread::sleep_for(1ms);
+        clock_gettime(CLOCK_REALTIME, &now);
+    } while (now.tv_nsec < 900'000'000 || now.tv_nsec > 980'000'000);
+
+    auto event = CreateEvent(false);
+    ASSERT_DURATION_LE(500ms, event->Wait(200ms));
+    ASSERT_FALSE(event->IsSet());
 }
 
 TEST(AutoResetEventTest, CheckCaseWhenEventHasTimeOutButSignaledLater)

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1400,22 +1400,22 @@ TEST_F(ConfigurationTest, CheckForceHttpSamplingIsEnabledIfEnvVarIsEnabled)
 
 // Mirrors Configuration::DefaultLibrariesInfoCacheStartTimeout, which is private
 #if defined(DD_SANITIZERS)
-static constexpr auto ExpectedDefaultLibrariesInfoCacheStartTimeout = 10'000ms;
+static constexpr auto ExpectedDefaultLibrariesInfoCacheStartTimeout = 10s;
 #else
-static constexpr auto ExpectedDefaultLibrariesInfoCacheStartTimeout = 2'000ms;
+static constexpr auto ExpectedDefaultLibrariesInfoCacheStartTimeout = 2s;
 #endif
 
 #if defined(DD_SANITIZERS)
 TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutWhenEnvVarNotSetUnderSanitizers)
 {
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 10ms);
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 10s);
 }
 #else
 TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutWhenEnvVarNotSet)
 {
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 2ms);
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 2s);
 }
 #endif
 
@@ -1424,7 +1424,7 @@ TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutWhenEnvVarIsCorrect
     // Deliberately not one of the defaults, so the test fails if the env var is ignored
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LibrariesInfoCacheStartTimeout, WStr("4200"));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 4'200ms);
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 4200ms);
 }
 
 TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutIsDefaultWhenEnvVarIsNotParsable)

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1398,6 +1398,56 @@ TEST_F(ConfigurationTest, CheckForceHttpSamplingIsEnabledIfEnvVarIsEnabled)
     ASSERT_THAT(configuration.ForceHttpSampling(), expectedValue);
 }
 
+// Mirrors Configuration::DefaultLibrariesInfoCacheStartTimeout, which is private
+#if defined(DD_SANITIZERS)
+static constexpr auto ExpectedDefaultLibrariesInfoCacheStartTimeout = 10'000ms;
+#else
+static constexpr auto ExpectedDefaultLibrariesInfoCacheStartTimeout = 2'000ms;
+#endif
+
+#if defined(DD_SANITIZERS)
+TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutWhenEnvVarNotSetUnderSanitizers)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 10ms);
+}
+#else
+TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutWhenEnvVarNotSet)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 2ms);
+}
+#endif
+
+TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutWhenEnvVarIsCorrectlySet)
+{
+    // Deliberately not one of the defaults, so the test fails if the env var is ignored
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LibrariesInfoCacheStartTimeout, WStr("4200"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), 4'200ms);
+}
+
+TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutIsDefaultWhenEnvVarIsNotParsable)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LibrariesInfoCacheStartTimeout, WStr("not_an_int"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), ExpectedDefaultLibrariesInfoCacheStartTimeout);
+}
+
+TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutIsDefaultWhenEnvVarIsZero)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LibrariesInfoCacheStartTimeout, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), ExpectedDefaultLibrariesInfoCacheStartTimeout);
+}
+
+TEST_F(ConfigurationTest, CheckLibrariesInfoCacheStartTimeoutIsDefaultWhenEnvVarIsNegative)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LibrariesInfoCacheStartTimeout, WStr("-5000"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetLibrariesInfoCacheStartTimeout(), ExpectedDefaultLibrariesInfoCacheStartTimeout);
+}
+
 TEST_F(ConfigurationTest, CheckWaitHandleProfilingIsDisabledByDefault)
 {
     auto configuration = Configuration{};

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -32,15 +32,6 @@
 class MockConfiguration : public IConfiguration
 {
 public:
-    MockConfiguration()
-    {
-        // The gmock default of zero would make services that wait on this fail to start.
-        // Generous on purpose: these tests also run under ASAN/UBSAN/TSAN, where every
-        // allocation and memory access is instrumented and startup is much slower.
-        ON_CALL(*this, GetLibrariesInfoCacheStartTimeout())
-            .WillByDefault(::testing::Return(std::chrono::milliseconds(10'000)));
-    }
-
     ~MockConfiguration() override = default;
     MOCK_METHOD(bool, IsDebugLogEnabled, (), (const override));
     MOCK_METHOD(fs::path const&, GetLogDirectory, (), (const override));
@@ -110,7 +101,15 @@ public:
     MOCK_METHOD(std::chrono::milliseconds, GetHeapSnapshotCheckInterval, (), (const override));
     MOCK_METHOD(uint32_t, GetHeapSnapshotMemoryPressureThreshold, (), (const override));
     MOCK_METHOD(std::chrono::seconds, GetTestHeapSnapshotInterval, (), (const override));
-    MOCK_METHOD(std::chrono::milliseconds, GetLibrariesInfoCacheStartTimeout, (), (const override));
+    // Deliberately not mocked: the gmock default of zero would make the services that wait
+    // on it fail to start, and stubbing it with ON_CALL would register every instance with
+    // the leak detector, which breaks the fixtures that exit() out of a death test.
+    // Generous value on purpose, as these tests also run under ASAN/UBSAN/TSAN.
+    std::chrono::milliseconds GetLibrariesInfoCacheStartTimeout() const override
+    {
+        return std::chrono::seconds(10);
+    }
+
     MOCK_METHOD(uint32_t, GetHeapHandleLimit, (), (const override));
     MOCK_METHOD(bool, UseManagedCodeCache, (), (const override));
     MOCK_METHOD(bool, IsMemoryFootprintEnabled, (), (const override));

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -32,6 +32,15 @@
 class MockConfiguration : public IConfiguration
 {
 public:
+    MockConfiguration()
+    {
+        // The gmock default of zero would make services that wait on this fail to start.
+        // Generous on purpose: these tests also run under ASAN/UBSAN/TSAN, where every
+        // allocation and memory access is instrumented and startup is much slower.
+        ON_CALL(*this, GetLibrariesInfoCacheStartTimeout())
+            .WillByDefault(::testing::Return(std::chrono::milliseconds(10'000)));
+    }
+
     ~MockConfiguration() override = default;
     MOCK_METHOD(bool, IsDebugLogEnabled, (), (const override));
     MOCK_METHOD(fs::path const&, GetLogDirectory, (), (const override));
@@ -101,6 +110,7 @@ public:
     MOCK_METHOD(std::chrono::milliseconds, GetHeapSnapshotCheckInterval, (), (const override));
     MOCK_METHOD(uint32_t, GetHeapSnapshotMemoryPressureThreshold, (), (const override));
     MOCK_METHOD(std::chrono::seconds, GetTestHeapSnapshotInterval, (), (const override));
+    MOCK_METHOD(std::chrono::milliseconds, GetLibrariesInfoCacheStartTimeout, (), (const override));
     MOCK_METHOD(uint32_t, GetHeapHandleLimit, (), (const override));
     MOCK_METHOD(bool, UseManagedCodeCache, (), (const override));
     MOCK_METHOD(bool, IsMemoryFootprintEnabled, (), (const override));

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -918,6 +918,7 @@ partial class Build
                 { "DD_INTERNAL_PROFILING_DEBUG_INFO_ENABLED", "1" },
                 { "DD_INTERNAL_GC_THREADS_CPUTIME_ENABLED", "1" },
                 { "DD_PROFILING_MANAGED_ACTIVATION_ENABLED", "0" },  // disable StableConfig (i.e. don't wait for the tracer to set the configuration)
+                { "DD_INTERNAL_PROFILING_LIBRARIES_CACHE_START_TIMEOUT", "10000" }, // 10 seconds to avoid flakiness in CI
             };
 
         if (IsArm64)

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -1716,6 +1716,15 @@ supportedConfigurations:
     product: Profiler
     documentation: |-
       Minimum HTTP request duration in milliseconds required to record a request in profiles.
+  DD_INTERNAL_PROFILING_LIBRARIES_CACHE_START_TIMEOUT:
+  - implementation: A
+    scope: native
+    type: int
+    default: '2000'
+    product: Profiler
+    documentation: |-
+      Test-only override, in milliseconds, for how long the profiler waits for the libraries info cache
+      to be populated at startup. Longer values help on slow or heavily loaded machines.
   DD_INTERNAL_PROFILING_LONG_LIVED_THRESHOLD:
   - implementation: A
     scope: native


### PR DESCRIPTION
## Summary of changes

Add timeout knob for `LibrariesInfoCache`

## Reason for change

On `arm64` arch, tests may randomly fail with this error message:
```
 [2026-08-04 10:15:33.286 | error | PId: 103233 | TId: 103233] Failed to populate LibrariesInfoCache within timeout. Not registering custom iterate_phdr_function with libunwind.
```
The behavior is sound for a customer/production environment, but in CI, where we have less core and processing may take time. We should account for and make the `time to wait` longer.

## Implementation details

- Add a knob `DD_INTERNAL_PROFILING_LIBRARIES_CACHE_START_TIMEOUT`
- Change `Configuration.cpp` to read and populate its value
- Use it in `LibrariesInfoCache`

## Test coverage
- Add unit tests

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
