### PR TITLE
[Tracer] Add optional tags to OTLP trace metrics

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
@@ -261,17 +261,14 @@ namespace Datadog.Trace.Agent
                 WriteStringKvJson(writer, "datadog.svc_src", key.ServiceSource);
             }
 
-            if (bucket.PeerTags.Count > 0)
+            if (bucket.Otlp.PeerTags.Count > 0)
             {
-                WriteStringArrayKvJson(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags));
+                WriteStringArrayKvJson(writer, "datadog.peer_tags", bucket.Otlp.PeerTags);
             }
 
-            foreach (var tag in bucket.AdditionalMetricTags)
+            foreach (var tag in bucket.Otlp.AdditionalMetricTags)
             {
-                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
-                {
-                    WriteStringKvJson(writer, tagKey, tagValue);
-                }
+                WriteStringKvJson(writer, tag.Key, tag.Value);
             }
 
             writer.WriteEndArray();
@@ -558,17 +555,14 @@ namespace Datadog.Trace.Agent
                 WriteAttribute(writer, "datadog.svc_src", key.ServiceSource, FieldNumbers.HistogramDataPointAttributes);
             }
 
-            if (bucket.PeerTags.Count > 0)
+            if (bucket.Otlp.PeerTags.Count > 0)
             {
-                WriteStringArrayAttribute(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags), FieldNumbers.HistogramDataPointAttributes);
+                WriteStringArrayAttribute(writer, "datadog.peer_tags", bucket.Otlp.PeerTags, FieldNumbers.HistogramDataPointAttributes);
             }
 
-            foreach (var tag in bucket.AdditionalMetricTags)
+            foreach (var tag in bucket.Otlp.AdditionalMetricTags)
             {
-                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
-                {
-                    WriteAttribute(writer, tagKey, tagValue, FieldNumbers.HistogramDataPointAttributes);
-                }
+                WriteAttribute(writer, tag.Key, tag.Value, FieldNumbers.HistogramDataPointAttributes);
             }
 
             WriteTag(writer, FieldNumbers.HistogramDataPointStartTimeUnixNano, WireTypeFixed64);
@@ -730,49 +724,6 @@ namespace Datadog.Trace.Agent
             }
 
             return null;
-        }
-
-        private static bool TryDecodeAdditionalMetricTag(byte[] encodedTag, out string key, out string value)
-        {
-            var separatorIndex = Array.IndexOf(encodedTag, (byte)':');
-            if (separatorIndex <= 0)
-            {
-                key = EncodingHelpers.Utf8NoBom.GetString(encodedTag);
-                value = string.Empty;
-                return separatorIndex < 0 && key == StatsAggregator.BlockedByTracerSentinel;
-            }
-
-            key = EncodingHelpers.Utf8NoBom.GetString(encodedTag, 0, separatorIndex);
-            value = EncodingHelpers.Utf8NoBom.GetString(encodedTag, separatorIndex + 1, encodedTag.Length - separatorIndex - 1);
-            return !IsBuiltInDataPointAttribute(key);
-        }
-
-        private static bool IsBuiltInDataPointAttribute(string key)
-            => key is "service.name"
-                   or "status.code"
-                   or "span.kind"
-                   or "span.name"
-                   or "http.request.method"
-                   or "http.response.status_code"
-                   or "http.route"
-                   or "rpc.response.status_code"
-                   or "datadog.operation.name"
-                   or "datadog.span.type"
-                   or "datadog.span.top_level"
-                   or "datadog.is_trace_root"
-                   or "datadog.origin"
-                   or "datadog.svc_src"
-                   or "datadog.peer_tags";
-
-        private static List<string> DecodePeerTags(List<byte[]> peerTags)
-        {
-            var decoded = new List<string>(peerTags.Count);
-            foreach (var peerTag in peerTags)
-            {
-                decoded.Add(EncodingHelpers.Utf8NoBom.GetString(peerTag));
-            }
-
-            return decoded;
         }
 
         private static void WriteAttribute(BinaryWriter writer, string key, string value, int fieldNumber = FieldNumbers.Attributes)

--- a/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
@@ -263,13 +263,19 @@ namespace Datadog.Trace.Agent
 
             if (bucket.PeerTags.Count > 0)
             {
-                WriteStringArrayKvJson(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags));
+                WriteUtf8StringArrayKvJson(writer, "datadog.peer_tags", bucket.PeerTags);
             }
 
             foreach (var tag in bucket.AdditionalMetricTags)
             {
-                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
+                if (TryGetAdditionalMetricTagSeparator(tag, out var separatorIndex))
                 {
+                    var tagKey = separatorIndex < 0
+                                     ? StatsAggregator.BlockedByTracerSentinel
+                                     : EncodingHelpers.Utf8NoBom.GetString(tag, 0, separatorIndex);
+                    var tagValue = separatorIndex < 0
+                                       ? string.Empty
+                                       : EncodingHelpers.Utf8NoBom.GetString(tag, separatorIndex + 1, tag.Length - separatorIndex - 1);
                     WriteStringKvJson(writer, tagKey, tagValue);
                 }
             }
@@ -378,6 +384,31 @@ namespace Datadog.Trace.Agent
                 writer.WriteStartObject();
                 writer.WritePropertyName("stringValue");
                 writer.WriteValue(value);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        private static void WriteUtf8StringArrayKvJson(JsonTextWriter writer, string key, List<byte[]> values)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("key");
+            writer.WriteValue(key);
+            writer.WritePropertyName("value");
+            writer.WriteStartObject();
+            writer.WritePropertyName("arrayValue");
+            writer.WriteStartObject();
+            writer.WritePropertyName("values");
+            writer.WriteStartArray();
+            foreach (var value in values)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("stringValue");
+                writer.WriteValue(EncodingHelpers.Utf8NoBom.GetString(value));
                 writer.WriteEndObject();
             }
 
@@ -560,14 +591,22 @@ namespace Datadog.Trace.Agent
 
             if (bucket.PeerTags.Count > 0)
             {
-                WriteStringArrayAttribute(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags), FieldNumbers.HistogramDataPointAttributes);
+                WriteUtf8StringArrayAttribute(writer, "datadog.peer_tags", bucket.PeerTags, FieldNumbers.HistogramDataPointAttributes);
             }
 
             foreach (var tag in bucket.AdditionalMetricTags)
             {
-                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
+                if (TryGetAdditionalMetricTagSeparator(tag, out var separatorIndex))
                 {
-                    WriteAttribute(writer, tagKey, tagValue, FieldNumbers.HistogramDataPointAttributes);
+                    var keyLength = separatorIndex < 0 ? tag.Length : separatorIndex;
+                    var valueOffset = separatorIndex < 0 ? tag.Length : separatorIndex + 1;
+                    WriteUtf8Attribute(
+                        writer,
+                        tag,
+                        keyLength,
+                        valueOffset,
+                        tag.Length - valueOffset,
+                        FieldNumbers.HistogramDataPointAttributes);
                 }
             }
 
@@ -732,47 +771,55 @@ namespace Datadog.Trace.Agent
             return null;
         }
 
-        private static bool TryDecodeAdditionalMetricTag(byte[] encodedTag, out string key, out string value)
+        private static bool TryGetAdditionalMetricTagSeparator(byte[] encodedTag, out int separatorIndex)
         {
-            var separatorIndex = Array.IndexOf(encodedTag, (byte)':');
-            if (separatorIndex <= 0)
+            separatorIndex = Array.IndexOf(encodedTag, (byte)':');
+            if (separatorIndex < 0)
             {
-                key = EncodingHelpers.Utf8NoBom.GetString(encodedTag);
-                value = string.Empty;
-                return separatorIndex < 0 && key == StatsAggregator.BlockedByTracerSentinel;
+                return encodedTag.AsSpan().SequenceEqual("tracer_blocked_value"u8);
             }
 
-            key = EncodingHelpers.Utf8NoBom.GetString(encodedTag, 0, separatorIndex);
-            value = EncodingHelpers.Utf8NoBom.GetString(encodedTag, separatorIndex + 1, encodedTag.Length - separatorIndex - 1);
-            return !IsBuiltInDataPointAttribute(key);
+            return separatorIndex > 0 && !IsBuiltInDataPointAttribute(encodedTag, separatorIndex);
         }
 
-        private static bool IsBuiltInDataPointAttribute(string key)
-            => key is "service.name"
-                   or "status.code"
-                   or "span.kind"
-                   or "span.name"
-                   or "http.request.method"
-                   or "http.response.status_code"
-                   or "http.route"
-                   or "rpc.response.status_code"
-                   or "datadog.operation.name"
-                   or "datadog.span.type"
-                   or "datadog.span.top_level"
-                   or "datadog.is_trace_root"
-                   or "datadog.origin"
-                   or "datadog.svc_src"
-                   or "datadog.peer_tags";
-
-        private static List<string> DecodePeerTags(List<byte[]> peerTags)
+        private static bool IsBuiltInDataPointAttribute(byte[] encodedTag, int keyLength)
         {
-            var decoded = new List<string>(peerTags.Count);
-            foreach (var peerTag in peerTags)
-            {
-                decoded.Add(EncodingHelpers.Utf8NoBom.GetString(peerTag));
-            }
+            var key = encodedTag.AsSpan(0, keyLength);
+            return key.SequenceEqual("service.name"u8)
+                || key.SequenceEqual("status.code"u8)
+                || key.SequenceEqual("span.kind"u8)
+                || key.SequenceEqual("span.name"u8)
+                || key.SequenceEqual("http.request.method"u8)
+                || key.SequenceEqual("http.response.status_code"u8)
+                || key.SequenceEqual("http.route"u8)
+                || key.SequenceEqual("rpc.response.status_code"u8)
+                || key.SequenceEqual("datadog.operation.name"u8)
+                || key.SequenceEqual("datadog.span.type"u8)
+                || key.SequenceEqual("datadog.span.top_level"u8)
+                || key.SequenceEqual("datadog.is_trace_root"u8)
+                || key.SequenceEqual("datadog.origin"u8)
+                || key.SequenceEqual("datadog.svc_src"u8)
+                || key.SequenceEqual("datadog.peer_tags"u8);
+        }
 
-            return decoded;
+        private static void WriteUtf8Attribute(
+            BinaryWriter writer,
+            byte[] encodedTag,
+            int keyLength,
+            int valueOffset,
+            int valueLength,
+            int fieldNumber)
+        {
+            var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, valueLength);
+            var keyValueSize = GetUtf8StringFieldSize(FieldNumbers.Key, keyLength)
+                             + GetLengthDelimitedFieldSize(FieldNumbers.Value, valueSize);
+
+            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
+            WriteVarInt(writer, keyValueSize);
+            WriteUtf8StringField(writer, FieldNumbers.Key, encodedTag, 0, keyLength);
+            WriteTag(writer, FieldNumbers.Value, WireTypeLengthDelimited);
+            WriteVarInt(writer, valueSize);
+            WriteUtf8StringField(writer, AnyValueFieldNumbers.StringValue, encodedTag, valueOffset, valueLength);
         }
 
         private static void WriteAttribute(BinaryWriter writer, string key, string value, int fieldNumber = FieldNumbers.Attributes)
@@ -866,51 +913,56 @@ namespace Datadog.Trace.Agent
 
         private static void WriteStringArrayAttribute(BinaryWriter writer, string key, List<string> values, int fieldNumber = FieldNumbers.Attributes)
         {
-            var kv = SerializeStringArrayKeyValue(key, values);
-            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
-            WriteVarInt(writer, kv.Length);
-            writer.Write(kv);
-        }
-
-        private static byte[] SerializeStringArrayKeyValue(string key, List<string> values)
-        {
-            using var stream = new MemoryStream(64);
-            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
-
-            WriteStringField(writer, FieldNumbers.Key, key);
-
-            using var arrayStream = new MemoryStream(64);
-            using var arrayWriter = new BinaryWriter(arrayStream, Encoding.UTF8, leaveOpen: true);
+            var arraySize = 0;
             foreach (var value in values)
             {
-                using var elementStream = new MemoryStream(32);
-                using var elementWriter = new BinaryWriter(elementStream, Encoding.UTF8, leaveOpen: true);
-                WriteStringField(elementWriter, AnyValueFieldNumbers.StringValue, value);
-                elementWriter.Flush();
-                var elementData = elementStream.ToArray();
-
-                WriteTag(arrayWriter, ArrayValueFieldNumbers.Values, WireTypeLengthDelimited);
-                WriteVarInt(arrayWriter, elementData.Length);
-                arrayWriter.Write(elementData);
+                var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, EncodingHelpers.Utf8NoBom.GetByteCount(value));
+                arraySize += GetLengthDelimitedFieldSize(ArrayValueFieldNumbers.Values, valueSize);
             }
 
-            arrayWriter.Flush();
-            var arrayData = arrayStream.ToArray();
+            WriteStringArrayAttributeHeader(writer, key, arraySize, fieldNumber);
+            foreach (var value in values)
+            {
+                var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, EncodingHelpers.Utf8NoBom.GetByteCount(value));
+                WriteTag(writer, ArrayValueFieldNumbers.Values, WireTypeLengthDelimited);
+                WriteVarInt(writer, valueSize);
+                WriteStringField(writer, AnyValueFieldNumbers.StringValue, value);
+            }
+        }
 
-            using var anyStream = new MemoryStream(arrayData.Length + 8);
-            using var anyWriter = new BinaryWriter(anyStream, Encoding.UTF8, leaveOpen: true);
-            WriteTag(anyWriter, AnyValueFieldNumbers.ArrayValue, WireTypeLengthDelimited);
-            WriteVarInt(anyWriter, arrayData.Length);
-            anyWriter.Write(arrayData);
-            anyWriter.Flush();
-            var anyData = anyStream.ToArray();
+        private static void WriteUtf8StringArrayAttribute(BinaryWriter writer, string key, List<byte[]> values, int fieldNumber)
+        {
+            var arraySize = 0;
+            foreach (var value in values)
+            {
+                var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, value.Length);
+                arraySize += GetLengthDelimitedFieldSize(ArrayValueFieldNumbers.Values, valueSize);
+            }
 
+            WriteStringArrayAttributeHeader(writer, key, arraySize, fieldNumber);
+            foreach (var value in values)
+            {
+                var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, value.Length);
+                WriteTag(writer, ArrayValueFieldNumbers.Values, WireTypeLengthDelimited);
+                WriteVarInt(writer, valueSize);
+                WriteUtf8StringField(writer, AnyValueFieldNumbers.StringValue, value, 0, value.Length);
+            }
+        }
+
+        private static void WriteStringArrayAttributeHeader(BinaryWriter writer, string key, int arraySize, int fieldNumber)
+        {
+            var anyValueSize = GetLengthDelimitedFieldSize(AnyValueFieldNumbers.ArrayValue, arraySize);
+            var keySize = EncodingHelpers.Utf8NoBom.GetByteCount(key);
+            var keyValueSize = GetUtf8StringFieldSize(FieldNumbers.Key, keySize)
+                             + GetLengthDelimitedFieldSize(FieldNumbers.Value, anyValueSize);
+
+            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
+            WriteVarInt(writer, keyValueSize);
+            WriteStringField(writer, FieldNumbers.Key, key);
             WriteTag(writer, FieldNumbers.Value, WireTypeLengthDelimited);
-            WriteVarInt(writer, anyData.Length);
-            writer.Write(anyData);
-
-            writer.Flush();
-            return stream.ToArray();
+            WriteVarInt(writer, anyValueSize);
+            WriteTag(writer, AnyValueFieldNumbers.ArrayValue, WireTypeLengthDelimited);
+            WriteVarInt(writer, arraySize);
         }
 
         private static void WriteStringField(BinaryWriter writer, int fieldNumber, string value)
@@ -922,6 +974,33 @@ namespace Datadog.Trace.Agent
                 WriteVarInt(writer, bytes.Length);
                 writer.Write(bytes);
             }
+        }
+
+        private static void WriteUtf8StringField(BinaryWriter writer, int fieldNumber, byte[] value, int offset, int count)
+        {
+            if (count > 0)
+            {
+                WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
+                WriteVarInt(writer, count);
+                writer.Write(value, offset, count);
+            }
+        }
+
+        private static int GetUtf8StringFieldSize(int fieldNumber, int valueLength)
+            => valueLength == 0 ? 0 : GetLengthDelimitedFieldSize(fieldNumber, valueLength);
+
+        private static int GetLengthDelimitedFieldSize(int fieldNumber, int valueLength)
+            => GetVarIntSize((fieldNumber << 3) | WireTypeLengthDelimited) + GetVarIntSize(valueLength) + valueLength;
+
+        private static int GetVarIntSize(int value)
+        {
+            var size = 1;
+            while ((value >>= 7) != 0)
+            {
+                size++;
+            }
+
+            return size;
         }
 
         private static void WriteTag(BinaryWriter writer, int fieldNumber, int wireType)

--- a/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
@@ -268,11 +268,8 @@ namespace Datadog.Trace.Agent
 
             foreach (var tag in bucket.AdditionalMetricTags)
             {
-                var separatorIndex = FindEncodedTagSeparator(tag);
-                if (separatorIndex >= 0)
+                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
                 {
-                    var tagKey = EncodingHelpers.Utf8NoBom.GetString(tag, 0, separatorIndex);
-                    var tagValue = EncodingHelpers.Utf8NoBom.GetString(tag, separatorIndex + 1, tag.Length - separatorIndex - 1);
                     WriteStringKvJson(writer, tagKey, tagValue);
                 }
             }
@@ -568,10 +565,9 @@ namespace Datadog.Trace.Agent
 
             foreach (var tag in bucket.AdditionalMetricTags)
             {
-                var separatorIndex = FindEncodedTagSeparator(tag);
-                if (separatorIndex >= 0)
+                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
                 {
-                    WriteEncodedTagAttribute(writer, tag, separatorIndex, FieldNumbers.HistogramDataPointAttributes);
+                    WriteAttribute(writer, tagKey, tagValue, FieldNumbers.HistogramDataPointAttributes);
                 }
             }
 
@@ -736,11 +732,37 @@ namespace Datadog.Trace.Agent
             return null;
         }
 
-        private static int FindEncodedTagSeparator(byte[] encodedTag)
+        private static bool TryDecodeAdditionalMetricTag(byte[] encodedTag, out string key, out string value)
         {
-            // TODO: Preserve the cardinality-limit sentinel once its OTLP representation is defined.
-            return Array.IndexOf(encodedTag, (byte)':');
+            var separatorIndex = Array.IndexOf(encodedTag, (byte)':');
+            if (separatorIndex <= 0)
+            {
+                key = EncodingHelpers.Utf8NoBom.GetString(encodedTag);
+                value = string.Empty;
+                return separatorIndex < 0 && key == StatsAggregator.BlockedByTracerSentinel;
+            }
+
+            key = EncodingHelpers.Utf8NoBom.GetString(encodedTag, 0, separatorIndex);
+            value = EncodingHelpers.Utf8NoBom.GetString(encodedTag, separatorIndex + 1, encodedTag.Length - separatorIndex - 1);
+            return !IsBuiltInDataPointAttribute(key);
         }
+
+        private static bool IsBuiltInDataPointAttribute(string key)
+            => key is "service.name"
+                   or "status.code"
+                   or "span.kind"
+                   or "span.name"
+                   or "http.request.method"
+                   or "http.response.status_code"
+                   or "http.route"
+                   or "rpc.response.status_code"
+                   or "datadog.operation.name"
+                   or "datadog.span.type"
+                   or "datadog.span.top_level"
+                   or "datadog.is_trace_root"
+                   or "datadog.origin"
+                   or "datadog.svc_src"
+                   or "datadog.peer_tags";
 
         private static List<string> DecodePeerTags(List<byte[]> peerTags)
         {
@@ -756,14 +778,6 @@ namespace Datadog.Trace.Agent
         private static void WriteAttribute(BinaryWriter writer, string key, string value, int fieldNumber = FieldNumbers.Attributes)
         {
             var kv = SerializeKeyValue(key, value);
-            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
-            WriteVarInt(writer, kv.Length);
-            writer.Write(kv);
-        }
-
-        private static void WriteEncodedTagAttribute(BinaryWriter writer, byte[] encodedTag, int separatorIndex, int fieldNumber)
-        {
-            var kv = SerializeEncodedTagKeyValue(encodedTag, separatorIndex);
             WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
             WriteVarInt(writer, kv.Length);
             writer.Write(kv);
@@ -795,27 +809,6 @@ namespace Datadog.Trace.Agent
             using var anyStream = new MemoryStream(32);
             using var anyWriter = new BinaryWriter(anyStream, Encoding.UTF8, leaveOpen: true);
             WriteStringField(anyWriter, AnyValueFieldNumbers.StringValue, value);
-            anyWriter.Flush();
-            var anyData = anyStream.ToArray();
-
-            WriteTag(writer, FieldNumbers.Value, WireTypeLengthDelimited);
-            WriteVarInt(writer, anyData.Length);
-            writer.Write(anyData);
-
-            writer.Flush();
-            return stream.ToArray();
-        }
-
-        private static byte[] SerializeEncodedTagKeyValue(byte[] encodedTag, int separatorIndex)
-        {
-            using var stream = new MemoryStream(encodedTag.Length + 8);
-            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
-
-            WriteBytesField(writer, FieldNumbers.Key, encodedTag, 0, separatorIndex);
-
-            using var anyStream = new MemoryStream(encodedTag.Length - separatorIndex + 4);
-            using var anyWriter = new BinaryWriter(anyStream, Encoding.UTF8, leaveOpen: true);
-            WriteBytesField(anyWriter, AnyValueFieldNumbers.StringValue, encodedTag, separatorIndex + 1, encodedTag.Length - separatorIndex - 1);
             anyWriter.Flush();
             var anyData = anyStream.ToArray();
 
@@ -928,16 +921,6 @@ namespace Datadog.Trace.Agent
                 var bytes = Encoding.UTF8.GetBytes(value);
                 WriteVarInt(writer, bytes.Length);
                 writer.Write(bytes);
-            }
-        }
-
-        private static void WriteBytesField(BinaryWriter writer, int fieldNumber, byte[] value, int index, int count)
-        {
-            if (count > 0)
-            {
-                WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
-                WriteVarInt(writer, count);
-                writer.Write(value, index, count);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Datadog.Trace.Logging;
@@ -141,6 +142,11 @@ namespace Datadog.Trace.Agent
 
             WriteStringKvJson(writer, "datadog.runtime_id", Tracer.RuntimeId);
 
+            if (details.ProcessTags?.TagsList is { Count: > 0 } processTags)
+            {
+                WriteStringArrayKvJson(writer, "datadog.process_tags", processTags);
+            }
+
             writer.WriteEndArray();
             writer.WriteEndObject();
         }
@@ -255,6 +261,22 @@ namespace Datadog.Trace.Agent
                 WriteStringKvJson(writer, "datadog.svc_src", key.ServiceSource);
             }
 
+            if (bucket.PeerTags.Count > 0)
+            {
+                WriteStringArrayKvJson(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags));
+            }
+
+            foreach (var tag in bucket.AdditionalMetricTags)
+            {
+                var separatorIndex = FindEncodedTagSeparator(tag);
+                if (separatorIndex >= 0)
+                {
+                    var tagKey = EncodingHelpers.Utf8NoBom.GetString(tag, 0, separatorIndex);
+                    var tagValue = EncodingHelpers.Utf8NoBom.GetString(tag, separatorIndex + 1, tag.Length - separatorIndex - 1);
+                    WriteStringKvJson(writer, tagKey, tagValue);
+                }
+            }
+
             writer.WriteEndArray();
 
             // uint64 fields are encoded as strings in proto3 JSON
@@ -343,6 +365,31 @@ namespace Datadog.Trace.Agent
             writer.WriteEndObject();
         }
 
+        private static void WriteStringArrayKvJson(JsonTextWriter writer, string key, List<string> values)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("key");
+            writer.WriteValue(key);
+            writer.WritePropertyName("value");
+            writer.WriteStartObject();
+            writer.WritePropertyName("arrayValue");
+            writer.WriteStartObject();
+            writer.WritePropertyName("values");
+            writer.WriteStartArray();
+            foreach (var value in values)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("stringValue");
+                writer.WriteValue(value);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
         private static byte[] SerializeResourceMetrics(StatsBuffer buffer, long bucketDurationNs)
         {
             using var stream = new MemoryStream(512);
@@ -386,6 +433,11 @@ namespace Datadog.Trace.Agent
             WriteAttribute(writer, "telemetry.sdk.version", TracerConstants.AssemblyVersion);
 
             WriteAttribute(writer, "datadog.runtime_id", Tracer.RuntimeId);
+
+            if (details.ProcessTags?.TagsList is { Count: > 0 } processTags)
+            {
+                WriteStringArrayAttribute(writer, "datadog.process_tags", processTags);
+            }
 
             writer.Flush();
             return stream.ToArray();
@@ -507,6 +559,20 @@ namespace Datadog.Trace.Agent
             if (!StringUtil.IsNullOrEmpty(key.ServiceSource))
             {
                 WriteAttribute(writer, "datadog.svc_src", key.ServiceSource, FieldNumbers.HistogramDataPointAttributes);
+            }
+
+            if (bucket.PeerTags.Count > 0)
+            {
+                WriteStringArrayAttribute(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags), FieldNumbers.HistogramDataPointAttributes);
+            }
+
+            foreach (var tag in bucket.AdditionalMetricTags)
+            {
+                var separatorIndex = FindEncodedTagSeparator(tag);
+                if (separatorIndex >= 0)
+                {
+                    WriteEncodedTagAttribute(writer, tag, separatorIndex, FieldNumbers.HistogramDataPointAttributes);
+                }
             }
 
             WriteTag(writer, FieldNumbers.HistogramDataPointStartTimeUnixNano, WireTypeFixed64);
@@ -670,9 +736,34 @@ namespace Datadog.Trace.Agent
             return null;
         }
 
+        private static int FindEncodedTagSeparator(byte[] encodedTag)
+        {
+            // TODO: Preserve the cardinality-limit sentinel once its OTLP representation is defined.
+            return Array.IndexOf(encodedTag, (byte)':');
+        }
+
+        private static List<string> DecodePeerTags(List<byte[]> peerTags)
+        {
+            var decoded = new List<string>(peerTags.Count);
+            foreach (var peerTag in peerTags)
+            {
+                decoded.Add(EncodingHelpers.Utf8NoBom.GetString(peerTag));
+            }
+
+            return decoded;
+        }
+
         private static void WriteAttribute(BinaryWriter writer, string key, string value, int fieldNumber = FieldNumbers.Attributes)
         {
             var kv = SerializeKeyValue(key, value);
+            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
+            WriteVarInt(writer, kv.Length);
+            writer.Write(kv);
+        }
+
+        private static void WriteEncodedTagAttribute(BinaryWriter writer, byte[] encodedTag, int separatorIndex, int fieldNumber)
+        {
+            var kv = SerializeEncodedTagKeyValue(encodedTag, separatorIndex);
             WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
             WriteVarInt(writer, kv.Length);
             writer.Write(kv);
@@ -704,6 +795,27 @@ namespace Datadog.Trace.Agent
             using var anyStream = new MemoryStream(32);
             using var anyWriter = new BinaryWriter(anyStream, Encoding.UTF8, leaveOpen: true);
             WriteStringField(anyWriter, AnyValueFieldNumbers.StringValue, value);
+            anyWriter.Flush();
+            var anyData = anyStream.ToArray();
+
+            WriteTag(writer, FieldNumbers.Value, WireTypeLengthDelimited);
+            WriteVarInt(writer, anyData.Length);
+            writer.Write(anyData);
+
+            writer.Flush();
+            return stream.ToArray();
+        }
+
+        private static byte[] SerializeEncodedTagKeyValue(byte[] encodedTag, int separatorIndex)
+        {
+            using var stream = new MemoryStream(encodedTag.Length + 8);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+            WriteBytesField(writer, FieldNumbers.Key, encodedTag, 0, separatorIndex);
+
+            using var anyStream = new MemoryStream(encodedTag.Length - separatorIndex + 4);
+            using var anyWriter = new BinaryWriter(anyStream, Encoding.UTF8, leaveOpen: true);
+            WriteBytesField(anyWriter, AnyValueFieldNumbers.StringValue, encodedTag, separatorIndex + 1, encodedTag.Length - separatorIndex - 1);
             anyWriter.Flush();
             var anyData = anyStream.ToArray();
 
@@ -759,6 +871,55 @@ namespace Datadog.Trace.Agent
             return stream.ToArray();
         }
 
+        private static void WriteStringArrayAttribute(BinaryWriter writer, string key, List<string> values, int fieldNumber = FieldNumbers.Attributes)
+        {
+            var kv = SerializeStringArrayKeyValue(key, values);
+            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
+            WriteVarInt(writer, kv.Length);
+            writer.Write(kv);
+        }
+
+        private static byte[] SerializeStringArrayKeyValue(string key, List<string> values)
+        {
+            using var stream = new MemoryStream(64);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+            WriteStringField(writer, FieldNumbers.Key, key);
+
+            using var arrayStream = new MemoryStream(64);
+            using var arrayWriter = new BinaryWriter(arrayStream, Encoding.UTF8, leaveOpen: true);
+            foreach (var value in values)
+            {
+                using var elementStream = new MemoryStream(32);
+                using var elementWriter = new BinaryWriter(elementStream, Encoding.UTF8, leaveOpen: true);
+                WriteStringField(elementWriter, AnyValueFieldNumbers.StringValue, value);
+                elementWriter.Flush();
+                var elementData = elementStream.ToArray();
+
+                WriteTag(arrayWriter, ArrayValueFieldNumbers.Values, WireTypeLengthDelimited);
+                WriteVarInt(arrayWriter, elementData.Length);
+                arrayWriter.Write(elementData);
+            }
+
+            arrayWriter.Flush();
+            var arrayData = arrayStream.ToArray();
+
+            using var anyStream = new MemoryStream(arrayData.Length + 8);
+            using var anyWriter = new BinaryWriter(anyStream, Encoding.UTF8, leaveOpen: true);
+            WriteTag(anyWriter, AnyValueFieldNumbers.ArrayValue, WireTypeLengthDelimited);
+            WriteVarInt(anyWriter, arrayData.Length);
+            anyWriter.Write(arrayData);
+            anyWriter.Flush();
+            var anyData = anyStream.ToArray();
+
+            WriteTag(writer, FieldNumbers.Value, WireTypeLengthDelimited);
+            WriteVarInt(writer, anyData.Length);
+            writer.Write(anyData);
+
+            writer.Flush();
+            return stream.ToArray();
+        }
+
         private static void WriteStringField(BinaryWriter writer, int fieldNumber, string value)
         {
             if (!StringUtil.IsNullOrEmpty(value))
@@ -767,6 +928,16 @@ namespace Datadog.Trace.Agent
                 var bytes = Encoding.UTF8.GetBytes(value);
                 WriteVarInt(writer, bytes.Length);
                 writer.Write(bytes);
+            }
+        }
+
+        private static void WriteBytesField(BinaryWriter writer, int fieldNumber, byte[] value, int index, int count)
+        {
+            if (count > 0)
+            {
+                WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
+                WriteVarInt(writer, count);
+                writer.Write(value, index, count);
             }
         }
 
@@ -835,6 +1006,12 @@ namespace Datadog.Trace.Agent
             public const int StringValue = 1;
             public const int BoolValue = 2;
             public const int IntValue = 3;
+            public const int ArrayValue = 5;
+        }
+
+        private static class ArrayValueFieldNumbers
+        {
+            public const int Values = 1;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
@@ -261,14 +261,17 @@ namespace Datadog.Trace.Agent
                 WriteStringKvJson(writer, "datadog.svc_src", key.ServiceSource);
             }
 
-            if (bucket.Otlp.PeerTags.Count > 0)
+            if (bucket.PeerTags.Count > 0)
             {
-                WriteStringArrayKvJson(writer, "datadog.peer_tags", bucket.Otlp.PeerTags);
+                WriteStringArrayKvJson(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags));
             }
 
-            foreach (var tag in bucket.Otlp.AdditionalMetricTags)
+            foreach (var tag in bucket.AdditionalMetricTags)
             {
-                WriteStringKvJson(writer, tag.Key, tag.Value);
+                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
+                {
+                    WriteStringKvJson(writer, tagKey, tagValue);
+                }
             }
 
             writer.WriteEndArray();
@@ -555,14 +558,17 @@ namespace Datadog.Trace.Agent
                 WriteAttribute(writer, "datadog.svc_src", key.ServiceSource, FieldNumbers.HistogramDataPointAttributes);
             }
 
-            if (bucket.Otlp.PeerTags.Count > 0)
+            if (bucket.PeerTags.Count > 0)
             {
-                WriteStringArrayAttribute(writer, "datadog.peer_tags", bucket.Otlp.PeerTags, FieldNumbers.HistogramDataPointAttributes);
+                WriteStringArrayAttribute(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags), FieldNumbers.HistogramDataPointAttributes);
             }
 
-            foreach (var tag in bucket.Otlp.AdditionalMetricTags)
+            foreach (var tag in bucket.AdditionalMetricTags)
             {
-                WriteAttribute(writer, tag.Key, tag.Value, FieldNumbers.HistogramDataPointAttributes);
+                if (TryDecodeAdditionalMetricTag(tag, out var tagKey, out var tagValue))
+                {
+                    WriteAttribute(writer, tagKey, tagValue, FieldNumbers.HistogramDataPointAttributes);
+                }
             }
 
             WriteTag(writer, FieldNumbers.HistogramDataPointStartTimeUnixNano, WireTypeFixed64);
@@ -724,6 +730,49 @@ namespace Datadog.Trace.Agent
             }
 
             return null;
+        }
+
+        private static bool TryDecodeAdditionalMetricTag(byte[] encodedTag, out string key, out string value)
+        {
+            var separatorIndex = Array.IndexOf(encodedTag, (byte)':');
+            if (separatorIndex <= 0)
+            {
+                key = EncodingHelpers.Utf8NoBom.GetString(encodedTag);
+                value = string.Empty;
+                return separatorIndex < 0 && key == StatsAggregator.BlockedByTracerSentinel;
+            }
+
+            key = EncodingHelpers.Utf8NoBom.GetString(encodedTag, 0, separatorIndex);
+            value = EncodingHelpers.Utf8NoBom.GetString(encodedTag, separatorIndex + 1, encodedTag.Length - separatorIndex - 1);
+            return !IsBuiltInDataPointAttribute(key);
+        }
+
+        private static bool IsBuiltInDataPointAttribute(string key)
+            => key is "service.name"
+                   or "status.code"
+                   or "span.kind"
+                   or "span.name"
+                   or "http.request.method"
+                   or "http.response.status_code"
+                   or "http.route"
+                   or "rpc.response.status_code"
+                   or "datadog.operation.name"
+                   or "datadog.span.type"
+                   or "datadog.span.top_level"
+                   or "datadog.is_trace_root"
+                   or "datadog.origin"
+                   or "datadog.svc_src"
+                   or "datadog.peer_tags";
+
+        private static List<string> DecodePeerTags(List<byte[]> peerTags)
+        {
+            var decoded = new List<string>(peerTags.Count);
+            foreach (var peerTag in peerTags)
+            {
+                decoded.Add(EncodingHelpers.Utf8NoBom.GetString(peerTag));
+            }
+
+            return decoded;
         }
 
         private static void WriteAttribute(BinaryWriter writer, string key, string value, int fieldNumber = FieldNumbers.Attributes)

--- a/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
@@ -153,7 +153,10 @@ namespace Datadog.Trace.Agent
             {
                 WriteStringKvJson(writer, "datadog.runtime_id", Tracer.RuntimeId);
 
-                // TODO: emit datadog.process_tags from details.ProcessTags (not yet wired into OTLP output).
+                if (details.ProcessTags?.TagsList is { Count: > 0 } processTags)
+                {
+                    WriteStringArrayKvJson(writer, "datadog.process_tags", processTags);
+                }
             }
 
             writer.WriteEndArray();
@@ -290,7 +293,10 @@ namespace Datadog.Trace.Agent
                 }
             }
 
-            // TODO: emit datadog.peer_tags from bucket.PeerTags (not yet wired into OTLP output; mirror the legacy MessagePack shape in StatsBuffer.cs as a single combined arrayValue).
+            if (bucket.PeerTags.Count > 0)
+            {
+                WriteStringArrayKvJson(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags));
+            }
 
             writer.WriteEndArray();
 
@@ -380,6 +386,31 @@ namespace Datadog.Trace.Agent
             writer.WriteEndObject();
         }
 
+        private static void WriteStringArrayKvJson(JsonTextWriter writer, string key, List<string> values)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("key");
+            writer.WriteValue(key);
+            writer.WritePropertyName("value");
+            writer.WriteStartObject();
+            writer.WritePropertyName("arrayValue");
+            writer.WriteStartObject();
+            writer.WritePropertyName("values");
+            writer.WriteStartArray();
+            foreach (var value in values)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("stringValue");
+                writer.WriteValue(value);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
         private static byte[] SerializeResourceMetrics(StatsBuffer buffer, long bucketDurationNs, bool otelSemanticsEnabled)
         {
             using var stream = new MemoryStream(512);
@@ -425,6 +456,11 @@ namespace Datadog.Trace.Agent
             if (!otelSemanticsEnabled)
             {
                 WriteAttribute(writer, "datadog.runtime_id", Tracer.RuntimeId);
+
+                if (details.ProcessTags?.TagsList is { Count: > 0 } processTags)
+                {
+                    WriteStringArrayAttribute(writer, "datadog.process_tags", processTags);
+                }
             }
 
             writer.Flush();
@@ -565,6 +601,11 @@ namespace Datadog.Trace.Agent
                 {
                     WriteAttribute(writer, tagKey, tagValue, FieldNumbers.HistogramDataPointAttributes);
                 }
+            }
+
+            if (bucket.PeerTags.Count > 0)
+            {
+                WriteStringArrayAttribute(writer, "datadog.peer_tags", DecodePeerTags(bucket.PeerTags), FieldNumbers.HistogramDataPointAttributes);
             }
 
             WriteTag(writer, FieldNumbers.HistogramDataPointStartTimeUnixNano, WireTypeFixed64);
@@ -730,6 +771,17 @@ namespace Datadog.Trace.Agent
             return true;
         }
 
+        private static List<string> DecodePeerTags(List<byte[]> peerTags)
+        {
+            var decoded = new List<string>(peerTags.Count);
+            foreach (var peerTag in peerTags)
+            {
+                decoded.Add(EncodingHelpers.Utf8NoBom.GetString(peerTag));
+            }
+
+            return decoded;
+        }
+
         private static void WriteAttribute(BinaryWriter writer, string key, string value, int fieldNumber = FieldNumbers.Attributes)
         {
             var kv = SerializeKeyValue(key, value);
@@ -819,6 +871,55 @@ namespace Datadog.Trace.Agent
             return stream.ToArray();
         }
 
+        private static void WriteStringArrayAttribute(BinaryWriter writer, string key, List<string> values, int fieldNumber = FieldNumbers.Attributes)
+        {
+            var kv = SerializeStringArrayKeyValue(key, values);
+            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
+            WriteVarInt(writer, kv.Length);
+            writer.Write(kv);
+        }
+
+        private static byte[] SerializeStringArrayKeyValue(string key, List<string> values)
+        {
+            using var stream = new MemoryStream(64);
+            using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+            WriteStringField(writer, FieldNumbers.Key, key);
+
+            using var arrayStream = new MemoryStream(64);
+            using var arrayWriter = new BinaryWriter(arrayStream, Encoding.UTF8, leaveOpen: true);
+            foreach (var value in values)
+            {
+                using var elementStream = new MemoryStream(32);
+                using var elementWriter = new BinaryWriter(elementStream, Encoding.UTF8, leaveOpen: true);
+                WriteStringField(elementWriter, AnyValueFieldNumbers.StringValue, value);
+                elementWriter.Flush();
+                var elementData = elementStream.ToArray();
+
+                WriteTag(arrayWriter, ArrayValueFieldNumbers.Values, WireTypeLengthDelimited);
+                WriteVarInt(arrayWriter, elementData.Length);
+                arrayWriter.Write(elementData);
+            }
+
+            arrayWriter.Flush();
+            var arrayData = arrayStream.ToArray();
+
+            using var anyStream = new MemoryStream(arrayData.Length + 8);
+            using var anyWriter = new BinaryWriter(anyStream, Encoding.UTF8, leaveOpen: true);
+            WriteTag(anyWriter, AnyValueFieldNumbers.ArrayValue, WireTypeLengthDelimited);
+            WriteVarInt(anyWriter, arrayData.Length);
+            anyWriter.Write(arrayData);
+            anyWriter.Flush();
+            var anyData = anyStream.ToArray();
+
+            WriteTag(writer, FieldNumbers.Value, WireTypeLengthDelimited);
+            WriteVarInt(writer, anyData.Length);
+            writer.Write(anyData);
+
+            writer.Flush();
+            return stream.ToArray();
+        }
+
         private static void WriteStringField(BinaryWriter writer, int fieldNumber, string value)
         {
             if (!StringUtil.IsNullOrEmpty(value))
@@ -895,6 +996,12 @@ namespace Datadog.Trace.Agent
             public const int StringValue = 1;
             public const int BoolValue = 2;
             public const int IntValue = 3;
+            public const int ArrayValue = 5;
+        }
+
+        private static class ArrayValueFieldNumbers
+        {
+            public const int Values = 1;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/OtlpSpanStatsSerializer.cs
@@ -261,23 +261,14 @@ namespace Datadog.Trace.Agent
                 WriteStringKvJson(writer, "datadog.svc_src", key.ServiceSource);
             }
 
-            if (bucket.PeerTags.Count > 0)
+            if (bucket.Otlp.PeerTags.Count > 0)
             {
-                WriteUtf8StringArrayKvJson(writer, "datadog.peer_tags", bucket.PeerTags);
+                WriteStringArrayKvJson(writer, "datadog.peer_tags", bucket.Otlp.PeerTags);
             }
 
-            foreach (var tag in bucket.AdditionalMetricTags)
+            foreach (var tag in bucket.Otlp.AdditionalMetricTags)
             {
-                if (TryGetAdditionalMetricTagSeparator(tag, out var separatorIndex))
-                {
-                    var tagKey = separatorIndex < 0
-                                     ? StatsAggregator.BlockedByTracerSentinel
-                                     : EncodingHelpers.Utf8NoBom.GetString(tag, 0, separatorIndex);
-                    var tagValue = separatorIndex < 0
-                                       ? string.Empty
-                                       : EncodingHelpers.Utf8NoBom.GetString(tag, separatorIndex + 1, tag.Length - separatorIndex - 1);
-                    WriteStringKvJson(writer, tagKey, tagValue);
-                }
+                WriteStringKvJson(writer, tag.Key, tag.Value);
             }
 
             writer.WriteEndArray();
@@ -384,31 +375,6 @@ namespace Datadog.Trace.Agent
                 writer.WriteStartObject();
                 writer.WritePropertyName("stringValue");
                 writer.WriteValue(value);
-                writer.WriteEndObject();
-            }
-
-            writer.WriteEndArray();
-            writer.WriteEndObject();
-            writer.WriteEndObject();
-            writer.WriteEndObject();
-        }
-
-        private static void WriteUtf8StringArrayKvJson(JsonTextWriter writer, string key, List<byte[]> values)
-        {
-            writer.WriteStartObject();
-            writer.WritePropertyName("key");
-            writer.WriteValue(key);
-            writer.WritePropertyName("value");
-            writer.WriteStartObject();
-            writer.WritePropertyName("arrayValue");
-            writer.WriteStartObject();
-            writer.WritePropertyName("values");
-            writer.WriteStartArray();
-            foreach (var value in values)
-            {
-                writer.WriteStartObject();
-                writer.WritePropertyName("stringValue");
-                writer.WriteValue(EncodingHelpers.Utf8NoBom.GetString(value));
                 writer.WriteEndObject();
             }
 
@@ -589,25 +555,14 @@ namespace Datadog.Trace.Agent
                 WriteAttribute(writer, "datadog.svc_src", key.ServiceSource, FieldNumbers.HistogramDataPointAttributes);
             }
 
-            if (bucket.PeerTags.Count > 0)
+            if (bucket.Otlp.PeerTags.Count > 0)
             {
-                WriteUtf8StringArrayAttribute(writer, "datadog.peer_tags", bucket.PeerTags, FieldNumbers.HistogramDataPointAttributes);
+                WriteStringArrayAttribute(writer, "datadog.peer_tags", bucket.Otlp.PeerTags, FieldNumbers.HistogramDataPointAttributes);
             }
 
-            foreach (var tag in bucket.AdditionalMetricTags)
+            foreach (var tag in bucket.Otlp.AdditionalMetricTags)
             {
-                if (TryGetAdditionalMetricTagSeparator(tag, out var separatorIndex))
-                {
-                    var keyLength = separatorIndex < 0 ? tag.Length : separatorIndex;
-                    var valueOffset = separatorIndex < 0 ? tag.Length : separatorIndex + 1;
-                    WriteUtf8Attribute(
-                        writer,
-                        tag,
-                        keyLength,
-                        valueOffset,
-                        tag.Length - valueOffset,
-                        FieldNumbers.HistogramDataPointAttributes);
-                }
+                WriteAttribute(writer, tag.Key, tag.Value, FieldNumbers.HistogramDataPointAttributes);
             }
 
             WriteTag(writer, FieldNumbers.HistogramDataPointStartTimeUnixNano, WireTypeFixed64);
@@ -771,57 +726,6 @@ namespace Datadog.Trace.Agent
             return null;
         }
 
-        private static bool TryGetAdditionalMetricTagSeparator(byte[] encodedTag, out int separatorIndex)
-        {
-            separatorIndex = Array.IndexOf(encodedTag, (byte)':');
-            if (separatorIndex < 0)
-            {
-                return encodedTag.AsSpan().SequenceEqual("tracer_blocked_value"u8);
-            }
-
-            return separatorIndex > 0 && !IsBuiltInDataPointAttribute(encodedTag, separatorIndex);
-        }
-
-        private static bool IsBuiltInDataPointAttribute(byte[] encodedTag, int keyLength)
-        {
-            var key = encodedTag.AsSpan(0, keyLength);
-            return key.SequenceEqual("service.name"u8)
-                || key.SequenceEqual("status.code"u8)
-                || key.SequenceEqual("span.kind"u8)
-                || key.SequenceEqual("span.name"u8)
-                || key.SequenceEqual("http.request.method"u8)
-                || key.SequenceEqual("http.response.status_code"u8)
-                || key.SequenceEqual("http.route"u8)
-                || key.SequenceEqual("rpc.response.status_code"u8)
-                || key.SequenceEqual("datadog.operation.name"u8)
-                || key.SequenceEqual("datadog.span.type"u8)
-                || key.SequenceEqual("datadog.span.top_level"u8)
-                || key.SequenceEqual("datadog.is_trace_root"u8)
-                || key.SequenceEqual("datadog.origin"u8)
-                || key.SequenceEqual("datadog.svc_src"u8)
-                || key.SequenceEqual("datadog.peer_tags"u8);
-        }
-
-        private static void WriteUtf8Attribute(
-            BinaryWriter writer,
-            byte[] encodedTag,
-            int keyLength,
-            int valueOffset,
-            int valueLength,
-            int fieldNumber)
-        {
-            var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, valueLength);
-            var keyValueSize = GetUtf8StringFieldSize(FieldNumbers.Key, keyLength)
-                             + GetLengthDelimitedFieldSize(FieldNumbers.Value, valueSize);
-
-            WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
-            WriteVarInt(writer, keyValueSize);
-            WriteUtf8StringField(writer, FieldNumbers.Key, encodedTag, 0, keyLength);
-            WriteTag(writer, FieldNumbers.Value, WireTypeLengthDelimited);
-            WriteVarInt(writer, valueSize);
-            WriteUtf8StringField(writer, AnyValueFieldNumbers.StringValue, encodedTag, valueOffset, valueLength);
-        }
-
         private static void WriteAttribute(BinaryWriter writer, string key, string value, int fieldNumber = FieldNumbers.Attributes)
         {
             var kv = SerializeKeyValue(key, value);
@@ -930,25 +834,6 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        private static void WriteUtf8StringArrayAttribute(BinaryWriter writer, string key, List<byte[]> values, int fieldNumber)
-        {
-            var arraySize = 0;
-            foreach (var value in values)
-            {
-                var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, value.Length);
-                arraySize += GetLengthDelimitedFieldSize(ArrayValueFieldNumbers.Values, valueSize);
-            }
-
-            WriteStringArrayAttributeHeader(writer, key, arraySize, fieldNumber);
-            foreach (var value in values)
-            {
-                var valueSize = GetUtf8StringFieldSize(AnyValueFieldNumbers.StringValue, value.Length);
-                WriteTag(writer, ArrayValueFieldNumbers.Values, WireTypeLengthDelimited);
-                WriteVarInt(writer, valueSize);
-                WriteUtf8StringField(writer, AnyValueFieldNumbers.StringValue, value, 0, value.Length);
-            }
-        }
-
         private static void WriteStringArrayAttributeHeader(BinaryWriter writer, string key, int arraySize, int fieldNumber)
         {
             var anyValueSize = GetLengthDelimitedFieldSize(AnyValueFieldNumbers.ArrayValue, arraySize);
@@ -973,16 +858,6 @@ namespace Datadog.Trace.Agent
                 var bytes = Encoding.UTF8.GetBytes(value);
                 WriteVarInt(writer, bytes.Length);
                 writer.Write(bytes);
-            }
-        }
-
-        private static void WriteUtf8StringField(BinaryWriter writer, int fieldNumber, byte[] value, int offset, int count)
-        {
-            if (count > 0)
-            {
-                WriteTag(writer, fieldNumber, WireTypeLengthDelimited);
-                WriteVarInt(writer, count);
-                writer.Write(value, offset, count);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -40,10 +40,6 @@ namespace Datadog.Trace.Agent
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
         private static readonly List<byte[]> EmptyTags = [];
         private static readonly List<byte[]> BlockedByTracerSentinelList = ["tracer_blocked_value"u8.ToArray()];
-        private static readonly List<string> EmptyOtlpPeerTags = [];
-        private static readonly List<string> BlockedOtlpPeerTags = [BlockedByTracerSentinel];
-        private static readonly List<KeyValuePair<string, string>> EmptyOtlpAdditionalTags = [];
-        private static readonly List<KeyValuePair<string, string>> BlockedOtlpAdditionalTags = [new(BlockedByTracerSentinel, string.Empty)];
 
         private static readonly StatsAggregationKey OverflowKey = new(
             resource: BlockedByTracerSentinel,
@@ -124,10 +120,7 @@ namespace Datadog.Trace.Agent
 
             // StatsAdditionalTags is already deduplicated, sorted, and capped.
             // Pre-encode the UTF-8 key prefixes so BuildKey can hash without per-call string encoding.
-            var additionalTagNames = _isOtlp
-                                         ? settings.StatsAdditionalTags.Where(static tag => !IsBuiltInOtlpDataPointAttribute(tag)).ToArray()
-                                         : settings.StatsAdditionalTags;
-            var additionalTagCount = additionalTagNames.Length;
+            var additionalTagCount = settings.StatsAdditionalTags.Length;
             if (additionalTagCount == 0)
             {
                 _additionalTagKeys = [];
@@ -137,7 +130,7 @@ namespace Datadog.Trace.Agent
                 _additionalTagKeys = new AdditionalTagKey[additionalTagCount];
                 for (var i = 0; i < additionalTagCount; i++)
                 {
-                    _additionalTagKeys[i] = new AdditionalTagKey(additionalTagNames[i]);
+                    _additionalTagKeys[i] = new AdditionalTagKey(settings.StatsAdditionalTags[i]);
                 }
             }
 
@@ -559,34 +552,6 @@ namespace Datadog.Trace.Agent
             return result;
         }
 
-        private static List<string> GetOtlpPeerTags(Span span, List<PeerTagKey> peerTagKeys, in PeerTagResults results)
-        {
-            if (results.BaseService is not null)
-            {
-                return [string.Concat(Tags.BaseService, ":", results.BaseService)];
-            }
-
-            if (results.PeerTagCount == 0)
-            {
-                return EmptyOtlpPeerTags;
-            }
-
-            var result = new List<string>(results.PeerTagCount);
-            foreach (var peerTag in peerTagKeys)
-            {
-                var tagValue = span.GetTag(peerTag.Name);
-                if (string.IsNullOrEmpty(tagValue))
-                {
-                    continue;
-                }
-
-                tagValue = IpAddressObfuscationUtil.QuantizePeerIpAddresses(tagValue);
-                result.Add(string.Concat(peerTag.Name, ":", tagValue));
-            }
-
-            return result;
-        }
-
         /// <summary>
         /// Builds a "key:value" UTF-8 byte array by reusing the pre-encoded <paramref name="utf8KeyPrefix"/>
         /// (e.g. "tagKey:") and encoding only <paramref name="tagValue"/> directly into the destination
@@ -603,23 +568,6 @@ namespace Datadog.Trace.Agent
 
             return encoded;
         }
-
-        private static bool IsBuiltInOtlpDataPointAttribute(string key)
-            => key is "service.name"
-                   or "status.code"
-                   or "span.kind"
-                   or "span.name"
-                   or "http.request.method"
-                   or "http.response.status_code"
-                   or "http.route"
-                   or "rpc.response.status_code"
-                   or "datadog.operation.name"
-                   or "datadog.span.type"
-                   or "datadog.span.top_level"
-                   or "datadog.is_trace_root"
-                   or "datadog.origin"
-                   or "datadog.svc_src"
-                   or "datadog.peer_tags";
 
         /// <summary>
         /// Computes the FNV-64 hash of the span-derived additional tags present on the span, in the
@@ -696,28 +644,6 @@ namespace Datadog.Trace.Agent
                 {
                     result.Add(EncodeKeyValue(tagKey.Utf8Prefix, tagValue));
                 }
-            }
-
-            return result;
-        }
-
-        private List<KeyValuePair<string, string>> GetOtlpAdditionalTags(Span span, in AdditionalTagResults results)
-        {
-            if (results.TagCount == 0)
-            {
-                return EmptyOtlpAdditionalTags;
-            }
-
-            var result = new List<KeyValuePair<string, string>>(results.TagCount);
-            foreach (var tagKey in _additionalTagKeys)
-            {
-                var tagValue = span.GetTag(tagKey.Name);
-                if (string.IsNullOrEmpty(tagValue))
-                {
-                    continue;
-                }
-
-                result.Add(new(tagKey.Name, tagValue.Length > AdditionalTagMaxValueLength ? BlockedByTracerSentinel : tagValue));
             }
 
             return result;
@@ -835,27 +761,17 @@ namespace Datadog.Trace.Agent
 
                 if (bucket is null)
                 {
-                    if (_isOtlp)
-                    {
-                        var peerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
-                                           ? BlockedOtlpPeerTags
-                                           : GetOtlpPeerTags(span, peerTagKeys, in peerTagResults);
-                        var additionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
-                                                 ? BlockedOtlpAdditionalTags
-                                                 : GetOtlpAdditionalTags(span, in additionalTagResults);
-                        bucket = new StatsBucket(key, new StatsBucket.OtlpTags(peerTags, additionalTags));
-                    }
-                    else
-                    {
-                        var peerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
-                                           ? BlockedByTracerSentinelList
-                                           : GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
-                        var additionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
-                                                 ? BlockedByTracerSentinelList
-                                                 : GetEncodedAdditionalTags(span, in additionalTagResults);
-                        bucket = new StatsBucket(key, peerTags, additionalTags);
-                    }
+                    // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket.
+                    // The overflow row carries no peer/additional tags; folded fields encode empty/masked.
+                    var encodedPeerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
+                                              ? BlockedByTracerSentinelList
+                                              : GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
 
+                    var encodedAdditionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
+                                                    ? BlockedByTracerSentinelList
+                                                    : GetEncodedAdditionalTags(span, in additionalTagResults);
+
+                    bucket = new StatsBucket(key, encodedPeerTags, encodedAdditionalTags);
                     buffer.Buckets.Add(key, bucket);
                 }
             }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -40,6 +40,10 @@ namespace Datadog.Trace.Agent
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
         private static readonly List<byte[]> EmptyTags = [];
         private static readonly List<byte[]> BlockedByTracerSentinelList = ["tracer_blocked_value"u8.ToArray()];
+        private static readonly List<string> EmptyOtlpPeerTags = [];
+        private static readonly List<string> BlockedOtlpPeerTags = [BlockedByTracerSentinel];
+        private static readonly List<KeyValuePair<string, string>> EmptyOtlpAdditionalTags = [];
+        private static readonly List<KeyValuePair<string, string>> BlockedOtlpAdditionalTags = [new(BlockedByTracerSentinel, string.Empty)];
 
         private static readonly StatsAggregationKey OverflowKey = new(
             resource: BlockedByTracerSentinel,
@@ -120,7 +124,10 @@ namespace Datadog.Trace.Agent
 
             // StatsAdditionalTags is already deduplicated, sorted, and capped.
             // Pre-encode the UTF-8 key prefixes so BuildKey can hash without per-call string encoding.
-            var additionalTagCount = settings.StatsAdditionalTags.Length;
+            var additionalTagNames = _isOtlp
+                                         ? settings.StatsAdditionalTags.Where(static tag => !IsBuiltInOtlpDataPointAttribute(tag)).ToArray()
+                                         : settings.StatsAdditionalTags;
+            var additionalTagCount = additionalTagNames.Length;
             if (additionalTagCount == 0)
             {
                 _additionalTagKeys = [];
@@ -130,7 +137,7 @@ namespace Datadog.Trace.Agent
                 _additionalTagKeys = new AdditionalTagKey[additionalTagCount];
                 for (var i = 0; i < additionalTagCount; i++)
                 {
-                    _additionalTagKeys[i] = new AdditionalTagKey(settings.StatsAdditionalTags[i]);
+                    _additionalTagKeys[i] = new AdditionalTagKey(additionalTagNames[i]);
                 }
             }
 
@@ -552,6 +559,34 @@ namespace Datadog.Trace.Agent
             return result;
         }
 
+        private static List<string> GetOtlpPeerTags(Span span, List<PeerTagKey> peerTagKeys, in PeerTagResults results)
+        {
+            if (results.BaseService is not null)
+            {
+                return [string.Concat(Tags.BaseService, ":", results.BaseService)];
+            }
+
+            if (results.PeerTagCount == 0)
+            {
+                return EmptyOtlpPeerTags;
+            }
+
+            var result = new List<string>(results.PeerTagCount);
+            foreach (var peerTag in peerTagKeys)
+            {
+                var tagValue = span.GetTag(peerTag.Name);
+                if (string.IsNullOrEmpty(tagValue))
+                {
+                    continue;
+                }
+
+                tagValue = IpAddressObfuscationUtil.QuantizePeerIpAddresses(tagValue);
+                result.Add(string.Concat(peerTag.Name, ":", tagValue));
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Builds a "key:value" UTF-8 byte array by reusing the pre-encoded <paramref name="utf8KeyPrefix"/>
         /// (e.g. "tagKey:") and encoding only <paramref name="tagValue"/> directly into the destination
@@ -568,6 +603,23 @@ namespace Datadog.Trace.Agent
 
             return encoded;
         }
+
+        private static bool IsBuiltInOtlpDataPointAttribute(string key)
+            => key is "service.name"
+                   or "status.code"
+                   or "span.kind"
+                   or "span.name"
+                   or "http.request.method"
+                   or "http.response.status_code"
+                   or "http.route"
+                   or "rpc.response.status_code"
+                   or "datadog.operation.name"
+                   or "datadog.span.type"
+                   or "datadog.span.top_level"
+                   or "datadog.is_trace_root"
+                   or "datadog.origin"
+                   or "datadog.svc_src"
+                   or "datadog.peer_tags";
 
         /// <summary>
         /// Computes the FNV-64 hash of the span-derived additional tags present on the span, in the
@@ -644,6 +696,28 @@ namespace Datadog.Trace.Agent
                 {
                     result.Add(EncodeKeyValue(tagKey.Utf8Prefix, tagValue));
                 }
+            }
+
+            return result;
+        }
+
+        private List<KeyValuePair<string, string>> GetOtlpAdditionalTags(Span span, in AdditionalTagResults results)
+        {
+            if (results.TagCount == 0)
+            {
+                return EmptyOtlpAdditionalTags;
+            }
+
+            var result = new List<KeyValuePair<string, string>>(results.TagCount);
+            foreach (var tagKey in _additionalTagKeys)
+            {
+                var tagValue = span.GetTag(tagKey.Name);
+                if (string.IsNullOrEmpty(tagValue))
+                {
+                    continue;
+                }
+
+                result.Add(new(tagKey.Name, tagValue.Length > AdditionalTagMaxValueLength ? BlockedByTracerSentinel : tagValue));
             }
 
             return result;
@@ -761,17 +835,27 @@ namespace Datadog.Trace.Agent
 
                 if (bucket is null)
                 {
-                    // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket.
-                    // The overflow row carries no peer/additional tags; folded fields encode empty/masked.
-                    var encodedPeerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
-                                              ? BlockedByTracerSentinelList
-                                              : GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
+                    if (_isOtlp)
+                    {
+                        var peerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
+                                           ? BlockedOtlpPeerTags
+                                           : GetOtlpPeerTags(span, peerTagKeys, in peerTagResults);
+                        var additionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
+                                                 ? BlockedOtlpAdditionalTags
+                                                 : GetOtlpAdditionalTags(span, in additionalTagResults);
+                        bucket = new StatsBucket(key, new StatsBucket.OtlpTags(peerTags, additionalTags));
+                    }
+                    else
+                    {
+                        var peerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
+                                           ? BlockedByTracerSentinelList
+                                           : GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
+                        var additionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
+                                                 ? BlockedByTracerSentinelList
+                                                 : GetEncodedAdditionalTags(span, in additionalTagResults);
+                        bucket = new StatsBucket(key, peerTags, additionalTags);
+                    }
 
-                    var encodedAdditionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
-                                                    ? BlockedByTracerSentinelList
-                                                    : GetEncodedAdditionalTags(span, in additionalTagResults);
-
-                    bucket = new StatsBucket(key, encodedPeerTags, encodedAdditionalTags);
                     buffer.Buckets.Add(key, bucket);
                 }
             }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -40,6 +40,10 @@ namespace Datadog.Trace.Agent
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
         private static readonly List<byte[]> EmptyTags = [];
         private static readonly List<byte[]> BlockedByTracerSentinelList = ["tracer_blocked_value"u8.ToArray()];
+        private static readonly List<string> EmptyOtlpPeerTags = [];
+        private static readonly List<string> BlockedOtlpPeerTags = [BlockedByTracerSentinel];
+        private static readonly List<KeyValuePair<string, string>> EmptyOtlpAdditionalTags = [];
+        private static readonly List<KeyValuePair<string, string>> BlockedOtlpAdditionalTags = [new(BlockedByTracerSentinel, string.Empty)];
 
         private static readonly StatsAggregationKey OverflowKey = new(
             resource: BlockedByTracerSentinel,
@@ -120,7 +124,10 @@ namespace Datadog.Trace.Agent
 
             // StatsAdditionalTags is already deduplicated, sorted, and capped.
             // Pre-encode the UTF-8 key prefixes so BuildKey can hash without per-call string encoding.
-            var additionalTagCount = settings.StatsAdditionalTags.Length;
+            var additionalTagNames = _isOtlp
+                                         ? settings.StatsAdditionalTags.Where(static tag => !IsBuiltInOtlpDataPointAttribute(tag)).ToArray()
+                                         : settings.StatsAdditionalTags;
+            var additionalTagCount = additionalTagNames.Length;
             if (additionalTagCount == 0)
             {
                 _additionalTagKeys = [];
@@ -130,7 +137,7 @@ namespace Datadog.Trace.Agent
                 _additionalTagKeys = new AdditionalTagKey[additionalTagCount];
                 for (var i = 0; i < additionalTagCount; i++)
                 {
-                    _additionalTagKeys[i] = new AdditionalTagKey(settings.StatsAdditionalTags[i]);
+                    _additionalTagKeys[i] = new AdditionalTagKey(additionalTagNames[i]);
                 }
             }
 
@@ -552,6 +559,34 @@ namespace Datadog.Trace.Agent
             return result;
         }
 
+        private static List<string> GetOtlpPeerTags(Span span, List<PeerTagKey> peerTagKeys, in PeerTagResults results)
+        {
+            if (results.BaseService is not null)
+            {
+                return [string.Concat(Tags.BaseService, ":", results.BaseService)];
+            }
+
+            if (results.PeerTagCount == 0)
+            {
+                return EmptyOtlpPeerTags;
+            }
+
+            var result = new List<string>(results.PeerTagCount);
+            foreach (var peerTag in peerTagKeys)
+            {
+                var tagValue = span.GetTag(peerTag.Name);
+                if (string.IsNullOrEmpty(tagValue))
+                {
+                    continue;
+                }
+
+                tagValue = IpAddressObfuscationUtil.QuantizePeerIpAddresses(tagValue);
+                result.Add(string.Concat(peerTag.Name, ":", tagValue));
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Builds a "key:value" UTF-8 byte array by reusing the pre-encoded <paramref name="utf8KeyPrefix"/>
         /// (e.g. "tagKey:") and encoding only <paramref name="tagValue"/> directly into the destination
@@ -568,6 +603,23 @@ namespace Datadog.Trace.Agent
 
             return encoded;
         }
+
+        private static bool IsBuiltInOtlpDataPointAttribute(string key)
+            => key is "service.name"
+                   or "status.code"
+                   or "span.kind"
+                   or "span.name"
+                   or "http.request.method"
+                   or "http.response.status_code"
+                   or "http.route"
+                   or "rpc.response.status_code"
+                   or "datadog.operation.name"
+                   or "datadog.span.type"
+                   or "datadog.span.top_level"
+                   or "datadog.is_trace_root"
+                   or "datadog.origin"
+                   or "datadog.svc_src"
+                   or "datadog.peer_tags";
 
         /// <summary>
         /// Computes the FNV-64 hash of the span-derived additional tags present on the span, in the
@@ -644,6 +696,28 @@ namespace Datadog.Trace.Agent
                 {
                     result.Add(EncodeKeyValue(tagKey.Utf8Prefix, tagValue));
                 }
+            }
+
+            return result;
+        }
+
+        private List<KeyValuePair<string, string>> GetOtlpAdditionalTags(Span span, in AdditionalTagResults results)
+        {
+            if (results.TagCount == 0)
+            {
+                return EmptyOtlpAdditionalTags;
+            }
+
+            var result = new List<KeyValuePair<string, string>>(results.TagCount);
+            foreach (var tagKey in _additionalTagKeys)
+            {
+                var tagValue = span.GetTag(tagKey.Name);
+                if (string.IsNullOrEmpty(tagValue))
+                {
+                    continue;
+                }
+
+                result.Add(new(tagKey.Name, tagValue.Length > AdditionalTagMaxValueLength ? BlockedByTracerSentinel : tagValue));
             }
 
             return result;
@@ -763,15 +837,27 @@ namespace Datadog.Trace.Agent
                 {
                     // Cold path: encode the peer tags and span-derived primary tags for storage in the new bucket.
                     // The overflow row carries no peer/additional tags; folded fields encode empty/masked.
-                    var encodedPeerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
-                                              ? BlockedByTracerSentinelList
-                                              : GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
+                    if (_isOtlp)
+                    {
+                        var peerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
+                                           ? BlockedOtlpPeerTags
+                                           : GetOtlpPeerTags(span, peerTagKeys, in peerTagResults);
+                        var additionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
+                                                 ? BlockedOtlpAdditionalTags
+                                                 : GetOtlpAdditionalTags(span, in additionalTagResults);
+                        bucket = new StatsBucket(key, new StatsBucket.OtlpTags(peerTags, additionalTags));
+                    }
+                    else
+                    {
+                        var peerTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.PeerTags) == StatsCardinalityLimitedFields.PeerTags
+                                           ? BlockedByTracerSentinelList
+                                           : GetEncodedPeerTags(span, peerTagKeys, in peerTagResults);
+                        var additionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
+                                                 ? BlockedByTracerSentinelList
+                                                 : GetEncodedAdditionalTags(span, in additionalTagResults);
+                        bucket = new StatsBucket(key, peerTags, additionalTags);
+                    }
 
-                    var encodedAdditionalTags = (key.CardinalityLimitedFields & StatsCardinalityLimitedFields.AdditionalMetricTags) == StatsCardinalityLimitedFields.AdditionalMetricTags
-                                                    ? BlockedByTracerSentinelList
-                                                    : GetEncodedAdditionalTags(span, in additionalTagResults);
-
-                    bucket = new StatsBucket(key, encodedPeerTags, encodedAdditionalTags);
                     buffer.Buckets.Add(key, bucket);
                 }
             }

--- a/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
@@ -12,13 +12,31 @@ namespace Datadog.Trace.Agent
 {
     internal sealed class StatsBucket
     {
+        private static readonly List<byte[]> EmptyEncodedTags = [];
+        private static readonly OtlpTags EmptyOtlpTags = new([], []);
+
         public StatsBucket(StatsAggregationKey key, List<byte[]> peerTags, List<byte[]> additionalMetricTags)
+            : this(key, peerTags, additionalMetricTags, EmptyOtlpTags)
+        {
+        }
+
+        public StatsBucket(StatsAggregationKey key, OtlpTags tags)
+            : this(key, EmptyEncodedTags, EmptyEncodedTags, tags)
+        {
+        }
+
+        private StatsBucket(
+            StatsAggregationKey key,
+            List<byte[]> peerTags,
+            List<byte[]> additionalMetricTags,
+            OtlpTags otlpTags)
         {
             Key = key;
             OkSummary = CreateSketch();
             ErrorSummary = CreateSketch();
             PeerTags = peerTags;
             AdditionalMetricTags = additionalMetricTags;
+            Otlp = otlpTags;
         }
 
         public StatsAggregationKey Key { get; }
@@ -46,6 +64,8 @@ namespace Datadog.Trace.Agent
 
         public List<byte[]> AdditionalMetricTags { get; }
 
+        public OtlpTags Otlp { get; }
+
         public void Clear()
         {
             Hits = 0;
@@ -67,5 +87,9 @@ namespace Datadog.Trace.Agent
                 new CollapsingLowestDenseStore(2048),
                 new CollapsingLowestDenseStore(2048));
         }
+
+        internal sealed record OtlpTags(
+            List<string> PeerTags,
+            List<KeyValuePair<string, string>> AdditionalMetricTags);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
@@ -12,31 +12,13 @@ namespace Datadog.Trace.Agent
 {
     internal sealed class StatsBucket
     {
-        private static readonly List<byte[]> EmptyEncodedTags = [];
-        private static readonly OtlpTags EmptyOtlpTags = new([], []);
-
         public StatsBucket(StatsAggregationKey key, List<byte[]> peerTags, List<byte[]> additionalMetricTags)
-            : this(key, peerTags, additionalMetricTags, EmptyOtlpTags)
-        {
-        }
-
-        public StatsBucket(StatsAggregationKey key, OtlpTags tags)
-            : this(key, EmptyEncodedTags, EmptyEncodedTags, tags)
-        {
-        }
-
-        private StatsBucket(
-            StatsAggregationKey key,
-            List<byte[]> peerTags,
-            List<byte[]> additionalMetricTags,
-            OtlpTags otlpTags)
         {
             Key = key;
             OkSummary = CreateSketch();
             ErrorSummary = CreateSketch();
             PeerTags = peerTags;
             AdditionalMetricTags = additionalMetricTags;
-            Otlp = otlpTags;
         }
 
         public StatsAggregationKey Key { get; }
@@ -64,8 +46,6 @@ namespace Datadog.Trace.Agent
 
         public List<byte[]> AdditionalMetricTags { get; }
 
-        public OtlpTags Otlp { get; }
-
         public void Clear()
         {
             Hits = 0;
@@ -87,9 +67,5 @@ namespace Datadog.Trace.Agent
                 new CollapsingLowestDenseStore(2048),
                 new CollapsingLowestDenseStore(2048));
         }
-
-        internal sealed record OtlpTags(
-            List<string> PeerTags,
-            List<KeyValuePair<string, string>> AdditionalMetricTags);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsBucket.cs
@@ -12,13 +12,27 @@ namespace Datadog.Trace.Agent
 {
     internal sealed class StatsBucket
     {
+        private static readonly List<byte[]> EmptyEncodedTags = [];
+        private static readonly OtlpTags EmptyOtlpTags = new([], []);
+
         public StatsBucket(StatsAggregationKey key, List<byte[]> peerTags, List<byte[]> additionalMetricTags)
+            : this(key, peerTags, additionalMetricTags, EmptyOtlpTags)
+        {
+        }
+
+        public StatsBucket(StatsAggregationKey key, OtlpTags tags)
+            : this(key, EmptyEncodedTags, EmptyEncodedTags, tags)
+        {
+        }
+
+        private StatsBucket(StatsAggregationKey key, List<byte[]> peerTags, List<byte[]> additionalMetricTags, OtlpTags otlpTags)
         {
             Key = key;
             OkSummary = CreateSketch();
             ErrorSummary = CreateSketch();
             PeerTags = peerTags;
             AdditionalMetricTags = additionalMetricTags;
+            Otlp = otlpTags;
         }
 
         public StatsAggregationKey Key { get; }
@@ -46,6 +60,8 @@ namespace Datadog.Trace.Agent
 
         public List<byte[]> AdditionalMetricTags { get; }
 
+        public OtlpTags Otlp { get; }
+
         public void Clear()
         {
             Hits = 0;
@@ -67,5 +83,9 @@ namespace Datadog.Trace.Agent
                 new CollapsingLowestDenseStore(2048),
                 new CollapsingLowestDenseStore(2048));
         }
+
+        internal sealed record OtlpTags(
+            List<string> PeerTags,
+            List<KeyValuePair<string, string>> AdditionalMetricTags);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
@@ -307,6 +307,62 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public void SerializeJson_ResourceIncludesProcessTags()
+        {
+            var buffer = CreateBuffer();
+            AddHit(buffer);
+
+            var processTagValues = GetResourceArrayAttribute(SerializeToJson(buffer), "datadog.process_tags");
+
+            processTagValues.Should().NotBeEmpty();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Serialize_EmitsAllAdditionalMetricTags(bool useJson)
+        {
+            var buffer = CreateBuffer();
+            var key = CreateKey();
+            var additionalMetricTags = new List<byte[]>
+            {
+                Encoding.UTF8.GetBytes("team:payments"),
+                Encoding.UTF8.GetBytes("datadog.custom:value"),
+            };
+            buffer.Buckets.Add(key, new StatsBucket(key, EmptyPeerTags, additionalMetricTags) { Hits = 1, Duration = 5_000_000 });
+
+            var attrs = useJson ? GetDataPointAttributes(SerializeToJson(buffer)) : GetProtobufDataPointAttributes(buffer);
+
+            attrs.Should().ContainKey("team").WhoseValue.Should().Be("payments");
+            attrs.Should().ContainKey("datadog.custom").WhoseValue.Should().Be("value");
+        }
+
+        [Fact]
+        public void SerializeJson_PeerTags_EmittedAsCombinedArrayValue()
+        {
+            var buffer = CreateBuffer();
+            var key = CreateKey();
+            var peerTags = new List<byte[]>
+            {
+                Encoding.UTF8.GetBytes("peer.service:downstream"),
+                Encoding.UTF8.GetBytes("net.peer.name:downstream.example.com"),
+            };
+            buffer.Buckets.Add(key, new StatsBucket(key, peerTags, []) { Hits = 1, Duration = 5_000_000 });
+
+            var peerTagValues = GetDataPointArrayAttribute(SerializeToJson(buffer), "datadog.peer_tags");
+
+            peerTagValues.Should().Equal("peer.service:downstream", "net.peer.name:downstream.example.com");
+        }
+
+        [Fact]
+        public void SerializeJson_PeerTags_AbsentWhenEmpty()
+        {
+            var attrs = GetDataPointAttributes(SerializeToJson(CreateBufferWithOneHit()));
+
+            attrs.Should().NotContainKey("datadog.peer_tags");
+        }
+
+        [Fact]
         public void SerializeJson_AggregationTemporalityIsDelta()
         {
             var json = SerializeToJson(CreateBufferWithOneHit());
@@ -636,6 +692,49 @@ namespace Datadog.Trace.Tests.Agent
                 var key = attr["key"]!.Value<string>()!;
                 var value = attr["value"]!["stringValue"]?.Value<string>() ?? string.Empty;
                 result[key] = value;
+            }
+
+            return result;
+        }
+
+        private static List<string> GetDataPointArrayAttribute(JObject json, string key)
+        {
+            var dp = json.SelectToken("$.resourceMetrics[0].scopeMetrics[0].metrics[0].histogram.dataPoints[0]") as JObject;
+            return GetArrayAttribute(dp?.SelectToken("$.attributes"), key);
+        }
+
+        private static List<string> GetResourceArrayAttribute(JObject json, string key)
+        {
+            return GetArrayAttribute(json.SelectToken("$.resourceMetrics[0].resource.attributes"), key);
+        }
+
+        private static List<string> GetArrayAttribute(JToken? attrs, string key)
+        {
+            var result = new List<string>();
+            if (attrs == null)
+            {
+                return result;
+            }
+
+            foreach (var attr in attrs)
+            {
+                if (attr["key"]!.Value<string>() != key)
+                {
+                    continue;
+                }
+
+                var values = attr["value"]!["arrayValue"]?["values"];
+                if (values == null)
+                {
+                    return result;
+                }
+
+                foreach (var value in values)
+                {
+                    result.Add(value["stringValue"]!.Value<string>()!);
+                }
+
+                return result;
             }
 
             return result;

--- a/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
@@ -325,6 +325,28 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public void SerializeJson_OtelSemanticsDisabled_ResourceIncludesProcessTags()
+        {
+            var buffer = CreateBuffer();
+            AddHit(buffer);
+
+            var processTagValues = GetResourceArrayAttribute(SerializeToJson(buffer, otelSemanticsEnabled: false), "datadog.process_tags");
+
+            processTagValues.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void SerializeJson_OtelSemanticsEnabled_ResourceExcludesProcessTags()
+        {
+            var buffer = CreateBuffer();
+            AddHit(buffer);
+
+            var resourceAttrs = GetResourceAttributes(SerializeToJson(buffer, otelSemanticsEnabled: true));
+
+            resourceAttrs.Should().NotContainKey("datadog.process_tags");
+        }
+
+        [Fact]
         public void SerializeJson_AdditionalMetricTags_EmittedAsUnprefixedAttributes_RegardlessOfOtelSemantics()
         {
             var buffer = CreateBuffer();
@@ -335,6 +357,31 @@ namespace Datadog.Trace.Tests.Agent
             var attrs = GetDataPointAttributes(SerializeToJson(buffer, otelSemanticsEnabled: true));
 
             attrs.Should().ContainKey("team").WhoseValue.Should().Be("payments");
+        }
+
+        [Fact]
+        public void SerializeJson_PeerTags_EmittedAsCombinedArrayValue()
+        {
+            var buffer = CreateBuffer();
+            var key = CreateKey();
+            var peerTags = new List<byte[]>
+            {
+                Encoding.UTF8.GetBytes("peer.service:downstream"),
+                Encoding.UTF8.GetBytes("net.peer.name:downstream.example.com"),
+            };
+            buffer.Buckets.Add(key, new StatsBucket(key, peerTags, []) { Hits = 1, Duration = 5_000_000 });
+
+            var peerTagValues = GetDataPointArrayAttribute(SerializeToJson(buffer), "datadog.peer_tags");
+
+            peerTagValues.Should().Equal("peer.service:downstream", "net.peer.name:downstream.example.com");
+        }
+
+        [Fact]
+        public void SerializeJson_PeerTags_AbsentWhenEmpty()
+        {
+            var attrs = GetDataPointAttributes(SerializeToJson(CreateBufferWithOneHit()));
+
+            attrs.Should().NotContainKey("datadog.peer_tags");
         }
 
         [Fact]
@@ -581,6 +628,49 @@ namespace Datadog.Trace.Tests.Agent
                 var key = attr["key"]!.Value<string>()!;
                 var value = attr["value"]!["stringValue"]?.Value<string>() ?? string.Empty;
                 result[key] = value;
+            }
+
+            return result;
+        }
+
+        private static List<string> GetDataPointArrayAttribute(JObject json, string key)
+        {
+            var dp = json.SelectToken("$.resourceMetrics[0].scopeMetrics[0].metrics[0].histogram.dataPoints[0]") as JObject;
+            return GetArrayAttribute(dp?.SelectToken("$.attributes"), key);
+        }
+
+        private static List<string> GetResourceArrayAttribute(JObject json, string key)
+        {
+            return GetArrayAttribute(json.SelectToken("$.resourceMetrics[0].resource.attributes"), key);
+        }
+
+        private static List<string> GetArrayAttribute(JToken? attrs, string key)
+        {
+            var result = new List<string>();
+            if (attrs == null)
+            {
+                return result;
+            }
+
+            foreach (var attr in attrs)
+            {
+                if (attr["key"]!.Value<string>() != key)
+                {
+                    continue;
+                }
+
+                var values = attr["value"]!["arrayValue"]?["values"];
+                if (values == null)
+                {
+                    return result;
+                }
+
+                foreach (var value in values)
+                {
+                    result.Add(value["stringValue"]!.Value<string>()!);
+                }
+
+                return result;
             }
 
             return result;

--- a/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
@@ -325,14 +325,15 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
-            var additionalMetricTags = new List<KeyValuePair<string, string>>
+            var additionalMetricTags = new List<byte[]>
             {
-                new("team", "payments"),
-                new("datadog.custom", "value"),
-                new("endpoint", "https://example.com:443"),
-                new(StatsAggregator.BlockedByTracerSentinel, string.Empty),
+                Encoding.UTF8.GetBytes("team:payments"),
+                Encoding.UTF8.GetBytes("datadog.custom:value"),
+                Encoding.UTF8.GetBytes("endpoint:https://example.com:443"),
+                Encoding.UTF8.GetBytes("span.kind:custom"),
+                Encoding.UTF8.GetBytes(StatsAggregator.BlockedByTracerSentinel),
             };
-            buffer.Buckets.Add(key, new StatsBucket(key, new StatsBucket.OtlpTags([], additionalMetricTags)) { Hits = 1, Duration = 5_000_000 });
+            buffer.Buckets.Add(key, new StatsBucket(key, EmptyPeerTags, additionalMetricTags) { Hits = 1, Duration = 5_000_000 });
 
             var attrs = useJson ? GetDataPointAttributes(SerializeToJson(buffer)) : GetProtobufDataPointAttributes(buffer);
 
@@ -348,12 +349,12 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
-            var peerTags = new List<string>
+            var peerTags = new List<byte[]>
             {
-                "peer.service:downstream",
-                "net.peer.name:downstream.example.com",
+                Encoding.UTF8.GetBytes("peer.service:downstream"),
+                Encoding.UTF8.GetBytes("net.peer.name:downstream.example.com"),
             };
-            buffer.Buckets.Add(key, new StatsBucket(key, new StatsBucket.OtlpTags(peerTags, [])) { Hits = 1, Duration = 5_000_000 });
+            buffer.Buckets.Add(key, new StatsBucket(key, peerTags, []) { Hits = 1, Duration = 5_000_000 });
 
             var peerTagValues = SerializeToJson(buffer)
                                .SelectTokens("$..attributes[?(@.key == 'datadog.peer_tags')].value.arrayValue.values[*].stringValue")

--- a/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
@@ -306,14 +306,19 @@ namespace Datadog.Trace.Tests.Agent
             resourceAttrs.Should().ContainKey("datadog.runtime_id");
         }
 
-        [Fact]
-        public void SerializeJson_ResourceIncludesProcessTags()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Serialize_ResourceIncludesProcessTags(bool useJson)
         {
             var buffer = CreateBuffer();
             AddHit(buffer);
 
-            var processTagValues = SerializeToJson(buffer)
-                                  .SelectTokens("$..attributes[?(@.key == 'datadog.process_tags')].value.arrayValue.values[*].stringValue");
+            var processTagValues = useJson
+                                       ? SerializeToJson(buffer)
+                                        .SelectTokens("$..attributes[?(@.key == 'datadog.process_tags')].value.arrayValue.values[*].stringValue")
+                                        .Values<string>()
+                                       : GetProtobufResourceAttributeValues(buffer)["datadog.process_tags"].ArrayValue.Values.Select(value => value.StringValue);
 
             processTagValues.Should().NotBeEmpty();
         }
@@ -344,8 +349,10 @@ namespace Datadog.Trace.Tests.Agent
             attrs.Should().ContainKey(StatsAggregator.BlockedByTracerSentinel).WhoseValue.Should().BeEmpty();
         }
 
-        [Fact]
-        public void SerializeJson_PeerTags_EmittedAsCombinedArrayValue()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Serialize_PeerTags_EmittedAsCombinedArrayValue(bool useJson)
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
@@ -356,9 +363,11 @@ namespace Datadog.Trace.Tests.Agent
             };
             buffer.Buckets.Add(key, new StatsBucket(key, peerTags, []) { Hits = 1, Duration = 5_000_000 });
 
-            var peerTagValues = SerializeToJson(buffer)
-                               .SelectTokens("$..attributes[?(@.key == 'datadog.peer_tags')].value.arrayValue.values[*].stringValue")
-                               .Values<string>();
+            var peerTagValues = useJson
+                                    ? SerializeToJson(buffer)
+                                     .SelectTokens("$..attributes[?(@.key == 'datadog.peer_tags')].value.arrayValue.values[*].stringValue")
+                                     .Values<string>()
+                                    : GetProtobufDataPointAttributeValues(buffer)["datadog.peer_tags"].ArrayValue.Values.Select(value => value.StringValue);
 
             peerTagValues.Should().Equal("peer.service:downstream", "net.peer.name:downstream.example.com");
         }
@@ -607,6 +616,22 @@ namespace Datadog.Trace.Tests.Agent
             var result = new Dictionary<string, AnyValue>();
 
             foreach (var attribute in GetLengthDelimitedFields(dataPoint, 9))
+            {
+                var keyValue = KeyValue.Parser.ParseFrom(attribute);
+                result[keyValue.Key] = keyValue.Value;
+            }
+
+            return result;
+        }
+
+        private static Dictionary<string, AnyValue> GetProtobufResourceAttributeValues(StatsBuffer buffer)
+        {
+            var request = OtlpSpanStatsSerializer.Serialize(buffer, BucketDurationNs)!;
+            var resourceMetrics = GetLengthDelimitedFields(request, 1).Single();
+            var resource = GetLengthDelimitedFields(resourceMetrics, 1).Single();
+            var result = new Dictionary<string, AnyValue>();
+
+            foreach (var attribute in GetLengthDelimitedFields(resource, 1))
             {
                 var keyValue = KeyValue.Parser.ParseFrom(attribute);
                 result[keyValue.Key] = keyValue.Value;

--- a/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
@@ -325,15 +325,14 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
-            var additionalMetricTags = new List<byte[]>
+            var additionalMetricTags = new List<KeyValuePair<string, string>>
             {
-                Encoding.UTF8.GetBytes("team:payments"),
-                Encoding.UTF8.GetBytes("datadog.custom:value"),
-                Encoding.UTF8.GetBytes("endpoint:https://example.com:443"),
-                Encoding.UTF8.GetBytes("span.kind:custom"),
-                Encoding.UTF8.GetBytes(StatsAggregator.BlockedByTracerSentinel),
+                new("team", "payments"),
+                new("datadog.custom", "value"),
+                new("endpoint", "https://example.com:443"),
+                new(StatsAggregator.BlockedByTracerSentinel, string.Empty),
             };
-            buffer.Buckets.Add(key, new StatsBucket(key, EmptyPeerTags, additionalMetricTags) { Hits = 1, Duration = 5_000_000 });
+            buffer.Buckets.Add(key, new StatsBucket(key, new StatsBucket.OtlpTags([], additionalMetricTags)) { Hits = 1, Duration = 5_000_000 });
 
             var attrs = useJson ? GetDataPointAttributes(SerializeToJson(buffer)) : GetProtobufDataPointAttributes(buffer);
 
@@ -349,12 +348,12 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
-            var peerTags = new List<byte[]>
+            var peerTags = new List<string>
             {
-                Encoding.UTF8.GetBytes("peer.service:downstream"),
-                Encoding.UTF8.GetBytes("net.peer.name:downstream.example.com"),
+                "peer.service:downstream",
+                "net.peer.name:downstream.example.com",
             };
-            buffer.Buckets.Add(key, new StatsBucket(key, peerTags, []) { Hits = 1, Duration = 5_000_000 });
+            buffer.Buckets.Add(key, new StatsBucket(key, new StatsBucket.OtlpTags(peerTags, [])) { Hits = 1, Duration = 5_000_000 });
 
             var peerTagValues = SerializeToJson(buffer)
                                .SelectTokens("$..attributes[?(@.key == 'datadog.peer_tags')].value.arrayValue.values[*].stringValue")

--- a/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
@@ -312,7 +312,8 @@ namespace Datadog.Trace.Tests.Agent
             var buffer = CreateBuffer();
             AddHit(buffer);
 
-            var processTagValues = GetResourceArrayAttribute(SerializeToJson(buffer), "datadog.process_tags");
+            var processTagValues = SerializeToJson(buffer)
+                                  .SelectTokens("$..attributes[?(@.key == 'datadog.process_tags')].value.arrayValue.values[*].stringValue");
 
             processTagValues.Should().NotBeEmpty();
         }
@@ -320,7 +321,7 @@ namespace Datadog.Trace.Tests.Agent
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void Serialize_EmitsAllAdditionalMetricTags(bool useJson)
+        public void Serialize_EmitsAdditionalMetricTags(bool useJson)
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
@@ -328,6 +329,9 @@ namespace Datadog.Trace.Tests.Agent
             {
                 Encoding.UTF8.GetBytes("team:payments"),
                 Encoding.UTF8.GetBytes("datadog.custom:value"),
+                Encoding.UTF8.GetBytes("endpoint:https://example.com:443"),
+                Encoding.UTF8.GetBytes("span.kind:custom"),
+                Encoding.UTF8.GetBytes(StatsAggregator.BlockedByTracerSentinel),
             };
             buffer.Buckets.Add(key, new StatsBucket(key, EmptyPeerTags, additionalMetricTags) { Hits = 1, Duration = 5_000_000 });
 
@@ -335,6 +339,9 @@ namespace Datadog.Trace.Tests.Agent
 
             attrs.Should().ContainKey("team").WhoseValue.Should().Be("payments");
             attrs.Should().ContainKey("datadog.custom").WhoseValue.Should().Be("value");
+            attrs.Should().ContainKey("endpoint").WhoseValue.Should().Be("https://example.com:443");
+            attrs.Should().ContainKey("span.kind").WhoseValue.Should().Be("SPAN_KIND_SERVER");
+            attrs.Should().ContainKey(StatsAggregator.BlockedByTracerSentinel).WhoseValue.Should().BeEmpty();
         }
 
         [Fact]
@@ -349,7 +356,9 @@ namespace Datadog.Trace.Tests.Agent
             };
             buffer.Buckets.Add(key, new StatsBucket(key, peerTags, []) { Hits = 1, Duration = 5_000_000 });
 
-            var peerTagValues = GetDataPointArrayAttribute(SerializeToJson(buffer), "datadog.peer_tags");
+            var peerTagValues = SerializeToJson(buffer)
+                               .SelectTokens("$..attributes[?(@.key == 'datadog.peer_tags')].value.arrayValue.values[*].stringValue")
+                               .Values<string>();
 
             peerTagValues.Should().Equal("peer.service:downstream", "net.peer.name:downstream.example.com");
         }
@@ -692,49 +701,6 @@ namespace Datadog.Trace.Tests.Agent
                 var key = attr["key"]!.Value<string>()!;
                 var value = attr["value"]!["stringValue"]?.Value<string>() ?? string.Empty;
                 result[key] = value;
-            }
-
-            return result;
-        }
-
-        private static List<string> GetDataPointArrayAttribute(JObject json, string key)
-        {
-            var dp = json.SelectToken("$.resourceMetrics[0].scopeMetrics[0].metrics[0].histogram.dataPoints[0]") as JObject;
-            return GetArrayAttribute(dp?.SelectToken("$.attributes"), key);
-        }
-
-        private static List<string> GetResourceArrayAttribute(JObject json, string key)
-        {
-            return GetArrayAttribute(json.SelectToken("$.resourceMetrics[0].resource.attributes"), key);
-        }
-
-        private static List<string> GetArrayAttribute(JToken? attrs, string key)
-        {
-            var result = new List<string>();
-            if (attrs == null)
-            {
-                return result;
-            }
-
-            foreach (var attr in attrs)
-            {
-                if (attr["key"]!.Value<string>() != key)
-                {
-                    continue;
-                }
-
-                var values = attr["value"]!["arrayValue"]?["values"];
-                if (values == null)
-                {
-                    return result;
-                }
-
-                foreach (var value in values)
-                {
-                    result.Add(value["stringValue"]!.Value<string>()!);
-                }
-
-                return result;
             }
 
             return result;

--- a/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/OtlpSpanStatsSerializerTests.cs
@@ -330,15 +330,14 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
-            var additionalMetricTags = new List<byte[]>
+            var additionalMetricTags = new List<KeyValuePair<string, string>>
             {
-                Encoding.UTF8.GetBytes("team:payments"),
-                Encoding.UTF8.GetBytes("datadog.custom:value"),
-                Encoding.UTF8.GetBytes("endpoint:https://example.com:443"),
-                Encoding.UTF8.GetBytes("span.kind:custom"),
-                Encoding.UTF8.GetBytes(StatsAggregator.BlockedByTracerSentinel),
+                new("team", "payments"),
+                new("datadog.custom", "value"),
+                new("endpoint", "https://example.com:443"),
+                new(StatsAggregator.BlockedByTracerSentinel, string.Empty),
             };
-            buffer.Buckets.Add(key, new StatsBucket(key, EmptyPeerTags, additionalMetricTags) { Hits = 1, Duration = 5_000_000 });
+            buffer.Buckets.Add(key, new StatsBucket(key, new StatsBucket.OtlpTags([], additionalMetricTags)) { Hits = 1, Duration = 5_000_000 });
 
             var attrs = useJson ? GetDataPointAttributes(SerializeToJson(buffer)) : GetProtobufDataPointAttributes(buffer);
 
@@ -356,12 +355,12 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = CreateBuffer();
             var key = CreateKey();
-            var peerTags = new List<byte[]>
+            var peerTags = new List<string>
             {
-                Encoding.UTF8.GetBytes("peer.service:downstream"),
-                Encoding.UTF8.GetBytes("net.peer.name:downstream.example.com"),
+                "peer.service:downstream",
+                "net.peer.name:downstream.example.com",
             };
-            buffer.Buckets.Add(key, new StatsBucket(key, peerTags, []) { Hits = 1, Duration = 5_000_000 });
+            buffer.Buckets.Add(key, new StatsBucket(key, new StatsBucket.OtlpTags(peerTags, [])) { Hits = 1, Duration = 5_000_000 });
 
             var peerTagValues = useJson
                                     ? SerializeToJson(buffer)

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1400,6 +1400,25 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public async Task OtlpAdditionalTags_StoreSourceValuesAndIgnoreBuiltInAttributes()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region,span.kind"), Mock.Of<IDiscoveryService>(), Mock.Of<IStatsdManager>(), isOtlp: true);
+
+            var span = CreateTopLevelSpan(start, "svc");
+            span.SetTag("region", "us-east-1");
+            span.SetTag(Tags.SpanKind, SpanKinds.Client);
+
+            aggregator.Add(span);
+
+            aggregator.CurrentBuffer.Buckets.Should().ContainSingle();
+            var bucket = aggregator.CurrentBuffer.Buckets.Values.Single();
+            bucket.AdditionalMetricTags.Should().BeEmpty();
+            bucket.Otlp.AdditionalMetricTags.Should().HaveCount(1);
+            bucket.Otlp.AdditionalMetricTags[0].Should().Be(new KeyValuePair<string, string>("region", "us-east-1"));
+        }
+
+        [Fact]
         public async Task AdditionalTags_MissingTagBucketsSeparatelyFromPresent()
         {
             var start = DateTimeOffset.UtcNow;

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1400,25 +1400,6 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public async Task OtlpAdditionalTags_StoreSourceValuesAndIgnoreBuiltInAttributes()
-        {
-            var start = DateTimeOffset.UtcNow;
-            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region,span.kind"), Mock.Of<IDiscoveryService>(), Mock.Of<IStatsdManager>(), isOtlp: true);
-
-            var span = CreateTopLevelSpan(start, "svc");
-            span.SetTag("region", "us-east-1");
-            span.SetTag(Tags.SpanKind, SpanKinds.Client);
-
-            aggregator.Add(span);
-
-            aggregator.CurrentBuffer.Buckets.Should().ContainSingle();
-            var bucket = aggregator.CurrentBuffer.Buckets.Values.Single();
-            bucket.AdditionalMetricTags.Should().BeEmpty();
-            bucket.Otlp.AdditionalMetricTags.Should().HaveCount(1);
-            bucket.Otlp.AdditionalMetricTags[0].Should().Be(new KeyValuePair<string, string>("region", "us-east-1"));
-        }
-
-        [Fact]
         public async Task AdditionalTags_MissingTagBucketsSeparatelyFromPresent()
         {
             var start = DateTimeOffset.UtcNow;

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -1400,6 +1400,25 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public async Task OtlpAdditionalTags_StoreSourceValuesAndIgnoreBuiltInAttributes()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("region,span.kind"), Mock.Of<IDiscoveryService>(), Mock.Of<IStatsdManager>(), isOtlp: true);
+
+            var span = CreateTopLevelSpan(start, "svc");
+            span.SetTag("region", "us-east-1");
+            span.SetTag(Tags.SpanKind, SpanKinds.Client);
+
+            aggregator.Add(span);
+
+            aggregator.CurrentBuffer.Buckets.Should().ContainSingle();
+            var bucket = aggregator.CurrentBuffer.Buckets.Values.Single();
+            bucket.AdditionalMetricTags.Should().BeEmpty();
+            bucket.Otlp.AdditionalMetricTags.Should().ContainSingle()
+                  .Which.Should().Be(new KeyValuePair<string, string>("region", "us-east-1"));
+        }
+
+        [Fact]
         public async Task AdditionalTags_MissingTagBucketsSeparatelyFromPresent()
         {
             var start = DateTimeOffset.UtcNow;
@@ -1564,6 +1583,27 @@ namespace Datadog.Trace.Tests.Agent
             aggregator.Add(MakeTenant("a"));
             aggregator.CurrentBuffer.Buckets.Should().HaveCount(4);
             aggregator.CurrentBuffer.Buckets[aggregator.BuildKey(MakeTenant("a"))].Hits.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task OtlpAdditionalTags_PerBucketCapPreservesOverflowDimension()
+        {
+            var start = DateTimeOffset.UtcNow;
+            await using var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettingsWithAdditionalTags("tenant", cardinalityLimit: 1), Mock.Of<IDiscoveryService>(), Mock.Of<IStatsdManager>(), isOtlp: true);
+
+            Span MakeTenant(string tenant)
+            {
+                var span = CreateTopLevelSpan(start, "svc");
+                span.SetTag("tenant", tenant);
+                return span;
+            }
+
+            aggregator.Add(MakeTenant("admitted"), MakeTenant("blocked"));
+
+            aggregator.CurrentBuffer.Buckets.Should().HaveCount(2);
+            var blockedBucket = aggregator.CurrentBuffer.Buckets.Values
+                                          .Single(b => b.Otlp.AdditionalMetricTags.Contains(new(StatsAggregator.BlockedByTracerSentinel, string.Empty)));
+            blockedBucket.Hits.Should().Be(1);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

- emits `datadog.process_tags` as a resource string array
- emits `datadog.peer_tags` as a data-point string array
- emits configured additional metric tags as individual data-point attributes
- writes pre-encoded additional tags directly to protobuf without UTF-8 decoding

This keeps optional tag serialization separate from the core OTLP trace metrics implementation in #8992.

## Test plan

- [x] managed tracer build succeeds with no warnings
- [x] all 64 `OtlpSpanStatsSerializerTests` pass on .NET 10