### PR TITLE
[Tracer] Prevent trace drops from concurrent flushes

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -39,6 +39,7 @@ namespace Datadog.Trace.Agent
         private readonly SpanBuffer _frontBuffer;
         private readonly SpanBuffer _backBuffer;
 
+        private readonly SemaphoreSlim _flushGate = new(1, 1);
         private readonly ManualResetEventSlim _serializationMutex = new ManualResetEventSlim(initialState: false, spinCount: 0);
 
         private readonly int _batchInterval;
@@ -316,6 +317,10 @@ namespace Datadog.Trace.Agent
         /// <returns>Async operation</returns>
         private async Task FlushBuffers(bool flushAllBuffers = false)
         {
+            // A flush may be requested by the periodic loop while an explicit flush is in progress. Serializing
+            // the complete operation prevents those callers from locking opposite buffers and dropping new traces.
+            await _flushGate.WaitAsync().ConfigureAwait(false);
+
             try
             {
                 var activeBuffer = Volatile.Read(ref _activeBuffer);
@@ -333,6 +338,10 @@ namespace Datadog.Trace.Agent
             catch (Exception ex)
             {
                 Log.Error(ex, "An unhandled error occurred while flushing trace buffers");
+            }
+            finally
+            {
+                _flushGate.Release();
             }
         }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -317,14 +317,38 @@ namespace Datadog.Trace.Agent
         /// <returns>Async operation</returns>
         private async Task FlushBuffers(bool flushAllBuffers = false)
         {
-            // A flush may be requested by the periodic loop while an explicit flush is in progress. Serializing
-            // the complete operation prevents those callers from locking opposite buffers and dropping new traces.
-            await _flushGate.WaitAsync().ConfigureAwait(false);
+            bool gateAcquired;
+            if (flushAllBuffers)
+            {
+                await _flushGate.WaitAsync().ConfigureAwait(false);
+                gateAcquired = true;
+            }
+            else
+            {
+                gateAcquired = _flushGate.Wait(0);
+            }
 
             try
             {
                 var activeBuffer = Volatile.Read(ref _activeBuffer);
                 var fallbackBuffer = activeBuffer == _frontBuffer ? _backBuffer : _frontBuffer;
+
+                if (!gateAcquired)
+                {
+                    // Another caller is performing a complete flush. Avoid locking its alternate buffer for an
+                    // opportunistic flush, but still drain full buffers so a slow send cannot block ingestion.
+                    if (fallbackBuffer.IsFull)
+                    {
+                        await FlushBuffer(fallbackBuffer).ConfigureAwait(false);
+                    }
+
+                    if (activeBuffer.IsFull)
+                    {
+                        await FlushBuffer(activeBuffer).ConfigureAwait(false);
+                    }
+
+                    return;
+                }
 
                 // First, flush the back buffer if full
                 if (fallbackBuffer.IsFull || flushAllBuffers)
@@ -341,7 +365,10 @@ namespace Datadog.Trace.Agent
             }
             finally
             {
-                _flushGate.Release();
+                if (gateAcquired)
+                {
+                    _flushGate.Release();
+                }
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
@@ -586,47 +587,54 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public void AgentWriterEnqueueFlushTasks()
+        public async Task ConcurrentPeriodicAndExplicitFlushesDoNotDropTraces()
         {
             var api = new Mock<IApi>();
             var agentWriter = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
-            var flushTcs = new TaskCompletionSource<bool>();
-            int invocation = 0;
+            var releaseSends = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sentSpanIds = new List<ulong>();
 
             api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
-                .Returns(() =>
+               .Returns((ArraySegment<byte> traces, int _, bool _, long _, long _, bool _) =>
                 {
-                    // One for the front buffer, one for the back buffer
-                    if (Interlocked.Increment(ref invocation) <= 2)
+                    var payload = global::MessagePack.MessagePackSerializer.Deserialize<List<List<MockSpan>>>(traces);
+                    lock (sentSpanIds)
                     {
-                        return flushTcs.Task;
+                        sentSpanIds.AddRange(payload.SelectMany(trace => trace).Select(span => span.SpanId));
                     }
 
-                    return Task.FromResult(true);
+                    return releaseSends.Task;
                 });
 
-            var spans = CreateTraceChunk(1);
+            agentWriter.WriteTrace(CreateTraceChunk(1, startingId: 1));
+            var explicitFlush = agentWriter.FlushTracesAsync();
 
-            // Write trace to the front buffer
-            agentWriter.WriteTrace(spans);
+            agentWriter.FrontBuffer.IsLocked.Should().BeTrue();
 
-            // Flush front buffer
-            _ = agentWriter.FlushTracesAsync();
+            // The explicit flush is blocked sending the front buffer, so this trace switches to the back buffer.
+            agentWriter.WriteTrace(CreateTraceChunk(1, startingId: 2));
 
-            // This will swap to the back buffer due front buffer is blocked.
-            agentWriter.WriteTrace(spans);
+            // Invoke the same non-forced flush used by the periodic loop. Calling the private method avoids
+            // timing dependencies while still exercising the production path without adding test hooks to it.
+            var periodicFlush = InvokeFlushBuffers(agentWriter, flushAllBuffers: false);
 
-            // Flush the second buffer
-            _ = agentWriter.FlushTracesAsync();
+            agentWriter.WriteTrace(CreateTraceChunk(1, startingId: 3));
+            var droppedTracesBuffersLocked = agentWriter.DroppedTracesBuffersLocked;
 
-            // This trace will force other buffer swap and then a drop because both buffers are blocked
-            agentWriter.WriteTrace(spans);
+            releaseSends.SetResult(true);
+            await Task.WhenAll(explicitFlush, periodicFlush);
+            await agentWriter.FlushTracesAsync();
 
-            // This will try to flush the front buffer again.
-            var thirdFlush = agentWriter.FlushTracesAsync();
+            droppedTracesBuffersLocked.Should().Be(0);
+            sentSpanIds.Should().Equal(1, 2, 3);
+            await agentWriter.FlushAndCloseAsync();
+        }
 
-            // Third flush should wait for the first flush to complete.
-            thirdFlush.IsCompleted.Should().BeFalse();
+        private static Task InvokeFlushBuffers(AgentWriter agentWriter, bool flushAllBuffers)
+        {
+            var method = typeof(AgentWriter).GetMethod("FlushBuffers", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+            return (Task)method!.Invoke(agentWriter, [flushAllBuffers])!;
         }
 
         private static bool WaitForDequeue(AgentWriter agent, bool wakeUpThread = true, int delay = -1)

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -630,6 +630,68 @@ namespace Datadog.Trace.Tests.Agent
             await agentWriter.FlushAndCloseAsync();
         }
 
+        [Fact]
+        public async Task FullBufferIsDrainedWhileExplicitFlushIsBlocked()
+        {
+            var api = new Mock<IApi>();
+            var releaseFirstSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sentSpanIds = new List<ulong>();
+            var sendCount = 0;
+
+            api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
+               .Returns((ArraySegment<byte> traces, int _, bool _, long _, long _, bool _) =>
+                {
+                    var payload = global::MessagePack.MessagePackSerializer.Deserialize<List<List<MockSpan>>>(traces);
+                    lock (sentSpanIds)
+                    {
+                        sentSpanIds.AddRange(payload.SelectMany(trace => trace).Select(span => span.SpanId));
+                    }
+
+                    return Interlocked.Increment(ref sendCount) == 1 ? releaseFirstSend.Task : Task.FromResult(true);
+                });
+
+            var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
+            var agentWriter = new AgentWriter(
+                api.Object,
+                statsAggregator: null,
+                statsd: TestStatsdManager.NoOp,
+                automaticFlush: false,
+                maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1);
+
+            agentWriter.WriteTrace(CreateTraceChunk(1, startingId: 1));
+            var explicitFlush = agentWriter.FlushTracesAsync();
+
+            agentWriter.WriteTrace(CreateTraceChunk(1, startingId: 2));
+
+            // Discover that the back buffer is full. This trace is the single expected capacity drop.
+            agentWriter.WriteTrace(CreateTraceChunk(1, startingId: 3));
+            agentWriter.BackBuffer.IsFull.Should().BeTrue();
+            agentWriter.DroppedTracesBufferFullAndLocked.Should().Be(1);
+
+            var capacityFlush = InvokeFlushBuffers(agentWriter, flushAllBuffers: false);
+            var completedWithoutFirstSend = await Task.WhenAny(capacityFlush, Task.Delay(TimeSpan.FromSeconds(1))) == capacityFlush;
+            if (!completedWithoutFirstSend)
+            {
+                releaseFirstSend.TrySetResult(true);
+            }
+
+            await capacityFlush;
+
+            completedWithoutFirstSend.Should().BeTrue();
+            explicitFlush.IsCompleted.Should().BeFalse();
+            agentWriter.BackBuffer.IsEmpty.Should().BeTrue();
+
+            // The capacity flush freed the alternate buffer without waiting for the slow first send.
+            agentWriter.WriteTrace(CreateTraceChunk(1, startingId: 4));
+
+            releaseFirstSend.TrySetResult(true);
+            await explicitFlush;
+            await agentWriter.FlushTracesAsync();
+
+            sentSpanIds.Should().Equal(1, 2, 4);
+            await agentWriter.FlushAndCloseAsync();
+        }
+
         private static Task InvokeFlushBuffers(AgentWriter agentWriter, bool flushAllBuffers)
         {
             var method = typeof(AgentWriter).GetMethod("FlushBuffers", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -669,7 +669,9 @@ namespace Datadog.Trace.Tests.Agent
             agentWriter.DroppedTracesBufferFullAndLocked.Should().Be(1);
 
             var capacityFlush = InvokeFlushBuffers(agentWriter, flushAllBuffers: false);
-            var completedWithoutFirstSend = await Task.WhenAny(capacityFlush, Task.Delay(TimeSpan.FromSeconds(1))) == capacityFlush;
+            // The second mocked send completes synchronously, so the capacity flush can only remain incomplete
+            // if it is incorrectly waiting for the blocked first send.
+            var completedWithoutFirstSend = capacityFlush.IsCompleted;
             if (!completedWithoutFirstSend)
             {
                 releaseFirstSend.TrySetResult(true);


### PR DESCRIPTION
## Summary of changes

Coordinate `AgentWriter` flushes so overlapping periodic and explicit flushes cannot lock both span buffers, while preserving capacity-driven drains during slow API sends.

## Reason for change

While validating CI Visibility integration tests after #8926, a test process completed 19 tests but the mock agent received only 18 test spans. The tracer diagnostic reported one trace dropped with `BuffersLocked`.

CI Visibility explicitly calls `FlushTracesAsync()` when test modules or sessions finish. If that overlaps the writer's periodic flush, the explicit flush can hold one buffer while the periodic flush opportunistically locks the other. A trace serialized in that window finds both buffers unavailable and is dropped. Whether the two flushes overlap depends on scheduling and API-send timing, which makes the affected span-count assertions flaky.

This is a coordination bug in the shared `AgentWriter`, not a CI Visibility-specific writer bug.

## Implementation details

- Serialize forced, explicit, and shutdown drains with an asynchronous flush gate.
- Let periodic flushes acquire that gate only when it is immediately available.
- When a complete flush already owns the gate, skip opportunistic flushing of non-full buffers so the alternate buffer remains writable.
- Still drain full buffers concurrently, so a slow API send cannot prevent capacity-driven flushing and cause sustained trace drops.
- Keep `WriteTrace()`, serialization, buffer swapping, and per-buffer locking unchanged.

The gate is only consulted on the flush path. Trace producers remain non-blocking and can continue writing to the alternate buffer while an API send is in progress.

## Test coverage

The deterministic regressions cover both sides of the coordination contract:

1. A low-volume overlap blocks an explicit front-buffer send, invokes the periodic path, writes through the alternate buffer, and verifies that span IDs `1`, `2`, and `3` are sent exactly once with no `BuffersLocked` drop.
2. A capacity-pressure overlap fills the alternate buffer while the first send remains blocked, verifies that the periodic path drains the full buffer without waiting for that send, then writes another trace and verifies the exact sent IDs `1`, `2`, and `4`.

The first test fails before the original fix because the periodic flush locks the alternate buffer. The second test fails with the initial whole-operation gate because the capacity drain waits behind the slow send.

Local validation after the final change:

- `AgentWriterTests` and `SpanBufferTests`: 27 passed on .NET 8
- `Datadog.Trace`: builds for all target frameworks with 0 warnings and 0 errors
- `Datadog.Trace.Tests`: builds for all non-Windows target frameworks with 0 warnings and 0 errors
- scoped whitespace formatting and `git diff --check` pass

## Other details

The issue was exposed by the CI Visibility test flow, but the fix belongs in the shared writer because any explicit flush can race with its periodic flush loop.
