### PR TITLE
Disable default launchSettings.json generation for the Fleet Installer integration tests

### DIFF
--- a/tracer/test/Datadog.FleetInstaller.IntegrationTests/Datadog.FleetInstaller.IntegrationTests.csproj
+++ b/tracer/test/Datadog.FleetInstaller.IntegrationTests/Datadog.FleetInstaller.IntegrationTests.csproj
@@ -5,6 +5,9 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net48</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+
+    <!-- Tell Visual Studio to not create a new launchSettings.json file, even though we have AspNetCore assets -->
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

Disable default `launchSettings.json` generation for the Fleet Installer integration tests.

## Reason for change

The unused generated profile repeatedly appears in the working tree. It's annoying to be reverting/excluding it all the time.

Followed same pattern as other project files:

Datadog.Trace.IntegrationTests.csproj:7
Datadog.Trace.Security.IntegrationTests.csproj:7
Benchmarks.Trace.csproj:21