### PR TITLE
Change `AgentWriter` to only flush from a single task

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Agent
         /// <summary>
         /// The currently active buffer.
         /// Note: Thread-safetiness in this class relies on the fact that only the serialization thread can change the active buffer.
-        /// <see cref="FlushBuffers"/> runs on other threads, so cross-thread accesses use <see cref="Volatile"/>.
+        /// <see cref="FlushBuffers"/> runs on the flush loop thread, so cross-thread accesses use <see cref="Volatile"/>.
         /// </summary>
         private SpanBuffer _activeBuffer;
 
@@ -64,9 +64,6 @@ namespace Datadog.Trace.Agent
         private TaskCompletionSource<bool> _forceFlush;
         private TaskCompletionSource<bool>? _pendingFlushRequest;
         private bool _flushLoopStopped;
-
-        private Task _frontBufferFlushTask;
-        private Task _backBufferFlushTask;
 
         private long _droppedP0Traces;
         private long _droppedP0Spans;
@@ -134,10 +131,6 @@ namespace Datadog.Trace.Agent
             _apmTracingEnabled = apmTracingEnabled;
             _traceMetricsEnabled = initialTracerMetricsEnabled;
             _statsd.SetRequired(StatsdConsumer.AgentWriter, initialTracerMetricsEnabled);
-
-            // Assign before starting the loops: the serialization thread can reach RequestFlush(),
-            // and the flush loop reads these, so they must be initialized first.
-            _backBufferFlushTask = _frontBufferFlushTask = Task.CompletedTask;
 
             _serializationTask = Task.Factory.StartNew(SerializeTracesLoop, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             _serializationTask.ContinueWith(t => Log.Error(t.Exception, "Error in serialization task"), TaskContinuationOptions.OnlyOnFaulted);
@@ -397,7 +390,9 @@ namespace Datadog.Trace.Agent
         }
 
         /// <summary>
-        /// Flush the active buffer, and the fallback buffer if full
+        /// Flush the active buffer, and the fallback buffer if full. Buffers are flushed (and so locked)
+        /// one at a time, and only from <see cref="FlushBuffersTaskLoopAsync"/>, so that the serialization
+        /// thread always has a buffer available to write to.
         /// </summary>
         /// <param name="flushAllBuffers">If set to true, then flush the back buffer even if not full</param>
         /// <returns>Async operation</returns>
@@ -425,101 +420,88 @@ namespace Datadog.Trace.Agent
 
         private async Task FlushBuffer(SpanBuffer buffer)
         {
-            if (buffer == _frontBuffer)
+            // Wait for write operations to complete, then prevent further modifications
+            if (!buffer.Lock())
             {
-                await _frontBufferFlushTask.ConfigureAwait(false);
-                await (_frontBufferFlushTask = InternalBufferFlush()).ConfigureAwait(false);
-            }
-            else
-            {
-                await _backBufferFlushTask.ConfigureAwait(false);
-                await (_backBufferFlushTask = InternalBufferFlush()).ConfigureAwait(false);
+                // The flush loop is the only thing that locks buffers, and it never runs two flushes
+                // at once, so this should be unreachable in production
+                return;
             }
 
-            async Task InternalBufferFlush()
+            try
             {
-                // Wait for write operations to complete, then prevent further modifications
-                if (!buffer.Lock())
+                if (Volatile.Read(ref _traceMetricsEnabled))
                 {
-                    // Buffer is already locked, it's probably being flushed from another thread
-                    return;
-                }
-
-                try
-                {
-                    if (Volatile.Read(ref _traceMetricsEnabled))
+                    using var lease = _statsd.TryGetClientLease();
+                    if (lease.Client is { } statsd)
                     {
-                        using var lease = _statsd.TryGetClientLease();
-                        if (lease.Client is { } statsd)
-                        {
-                            statsd.Increment(TracerMetricNames.Queue.DequeuedTraces, buffer.TraceCount);
-                            statsd.Increment(TracerMetricNames.Queue.DequeuedSpans, buffer.SpanCount);
-                        }
-                    }
-
-                    var droppedTracesTooLarge = Interlocked.Exchange(ref _droppedTracesTooLarge, 0);
-                    var droppedTracesBufferFull = Interlocked.Exchange(ref _droppedTracesBufferFull, 0);
-                    var droppedTracesBufferFullAndLocked = Interlocked.Exchange(ref _droppedTracesBufferFullAndLocked, 0);
-                    var droppedTracesBuffersLocked = Interlocked.Exchange(ref _droppedTracesBuffersLocked, 0);
-
-                    if (droppedTracesTooLarge > 0 || droppedTracesBufferFull > 0 || droppedTracesBufferFullAndLocked > 0 || droppedTracesBuffersLocked > 0)
-                    {
-                        Log.Warning(
-                            "Traces were dropped since the last flush operation: {TooLargeCount} exceeded the trace buffer limit of {MaxBufferSize} bytes, {BuffersFullCount} found both buffers full, {BufferFullAndLockedCount} found one buffer full and the other unavailable while being flushed, and {BuffersLockedCount} found both buffers unavailable while being flushed.",
-                            new object?[]
-                            {
-                                droppedTracesTooLarge,
-                                _frontBuffer.MaxBufferSize,
-                                droppedTracesBufferFull,
-                                droppedTracesBufferFullAndLocked,
-                                droppedTracesBuffersLocked,
-                            });
-                    }
-
-                    if (buffer.TraceCount > 0)
-                    {
-                        long droppedP0Traces = 0;
-                        long droppedP0Spans = 0;
-
-                        if (CanComputeStats)
-                        {
-                            droppedP0Traces = Interlocked.Exchange(ref _droppedP0Traces, 0);
-                            droppedP0Spans = Interlocked.Exchange(ref _droppedP0Spans, 0);
-                            Log.Debug("Flushing {Spans} spans across {Traces} traces. CanComputeStats is enabled with {DroppedP0Traces} droppedP0Traces and {DroppedP0Spans} droppedP0Spans", buffer.SpanCount, buffer.TraceCount, droppedP0Traces, droppedP0Spans);
-                            // Metrics for unsampled traces/spans already recorded
-                        }
-                        else
-                        {
-                            Log.Debug<int, int>("Flushing {Spans} spans across {Traces} traces. CanComputeStats is disabled.", buffer.SpanCount, buffer.TraceCount);
-                        }
-
-                        var success = await _api.SendTracesAsync(buffer.Data, buffer.TraceCount, CanComputeStats, droppedP0Traces, droppedP0Spans, _apmTracingEnabled).ConfigureAwait(false);
-
-                        TelemetryFactory.Metrics.RecordCountTraceChunkSent(buffer.TraceCount);
-                        if (success)
-                        {
-                            _traceKeepRateCalculator.IncrementKeeps(buffer.TraceCount);
-                        }
-                        else
-                        {
-                            TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, buffer.TraceCount);
-                            TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, buffer.SpanCount);
-                            _traceKeepRateCalculator.IncrementDrops(buffer.TraceCount);
-                        }
+                        statsd.Increment(TracerMetricNames.Queue.DequeuedTraces, buffer.TraceCount);
+                        statsd.Increment(TracerMetricNames.Queue.DequeuedSpans, buffer.SpanCount);
                     }
                 }
-                catch (Exception ex)
+
+                var droppedTracesTooLarge = Interlocked.Exchange(ref _droppedTracesTooLarge, 0);
+                var droppedTracesBufferFull = Interlocked.Exchange(ref _droppedTracesBufferFull, 0);
+                var droppedTracesBufferFullAndLocked = Interlocked.Exchange(ref _droppedTracesBufferFullAndLocked, 0);
+                var droppedTracesBuffersLocked = Interlocked.Exchange(ref _droppedTracesBuffersLocked, 0);
+
+                if (droppedTracesTooLarge > 0 || droppedTracesBufferFull > 0 || droppedTracesBufferFullAndLocked > 0 || droppedTracesBuffersLocked > 0)
                 {
-                    Log.Error(ex, "An unhandled error occurred while flushing a buffer");
-                    _traceKeepRateCalculator.IncrementDrops(buffer.TraceCount);
-                    TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, buffer.TraceCount);
-                    TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, buffer.SpanCount);
+                    Log.Warning(
+                        "Traces were dropped since the last flush operation: {TooLargeCount} exceeded the trace buffer limit of {MaxBufferSize} bytes, {BuffersFullCount} found both buffers full, {BufferFullAndLockedCount} found one buffer full and the other unavailable while being flushed, and {BuffersLockedCount} found both buffers unavailable while being flushed.",
+                        new object?[]
+                        {
+                            droppedTracesTooLarge,
+                            _frontBuffer.MaxBufferSize,
+                            droppedTracesBufferFull,
+                            droppedTracesBufferFullAndLocked,
+                            droppedTracesBuffersLocked,
+                        });
                 }
-                finally
+
+                if (buffer.TraceCount > 0)
                 {
-                    // Clear and unlock the buffer
-                    buffer.Clear();
+                    long droppedP0Traces = 0;
+                    long droppedP0Spans = 0;
+
+                    if (CanComputeStats)
+                    {
+                        droppedP0Traces = Interlocked.Exchange(ref _droppedP0Traces, 0);
+                        droppedP0Spans = Interlocked.Exchange(ref _droppedP0Spans, 0);
+                        Log.Debug("Flushing {Spans} spans across {Traces} traces. CanComputeStats is enabled with {DroppedP0Traces} droppedP0Traces and {DroppedP0Spans} droppedP0Spans", buffer.SpanCount, buffer.TraceCount, droppedP0Traces, droppedP0Spans);
+                        // Metrics for unsampled traces/spans already recorded
+                    }
+                    else
+                    {
+                        Log.Debug<int, int>("Flushing {Spans} spans across {Traces} traces. CanComputeStats is disabled.", buffer.SpanCount, buffer.TraceCount);
+                    }
+
+                    var success = await _api.SendTracesAsync(buffer.Data, buffer.TraceCount, CanComputeStats, droppedP0Traces, droppedP0Spans, _apmTracingEnabled).ConfigureAwait(false);
+
+                    TelemetryFactory.Metrics.RecordCountTraceChunkSent(buffer.TraceCount);
+                    if (success)
+                    {
+                        _traceKeepRateCalculator.IncrementKeeps(buffer.TraceCount);
+                    }
+                    else
+                    {
+                        TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, buffer.TraceCount);
+                        TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, buffer.SpanCount);
+                        _traceKeepRateCalculator.IncrementDrops(buffer.TraceCount);
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An unhandled error occurred while flushing a buffer");
+                _traceKeepRateCalculator.IncrementDrops(buffer.TraceCount);
+                TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, buffer.TraceCount);
+                TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, buffer.SpanCount);
+            }
+            finally
+            {
+                // Clear and unlock the buffer
+                buffer.Clear();
             }
         }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -50,6 +50,8 @@ namespace Datadog.Trace.Agent
 
         private readonly bool _backgroundFlushEnabled;
 
+        private readonly object _flushRequestLock = new();
+
         /// <summary>
         /// The currently active buffer.
         /// Note: Thread-safetiness in this class relies on the fact that only the serialization thread can change the active buffer.
@@ -60,6 +62,8 @@ namespace Datadog.Trace.Agent
         private byte[] _temporaryBuffer = new byte[1024];
 
         private TaskCompletionSource<bool> _forceFlush;
+        private TaskCompletionSource<bool>? _pendingFlushRequest;
+        private bool _flushLoopStopped;
 
         private Task _frontBufferFlushTask;
         private Task _backBufferFlushTask;
@@ -216,37 +220,32 @@ namespace Datadog.Trace.Agent
                 return;
             }
 
+            // Wake up the serialization thread so that it observes _processExit, drains the queue, and exits
             _serializationMutex.Set();
 
-            var delay = Task.Delay(TimeSpan.FromSeconds(20));
+            // One deadline for the whole shutdown, rather than one per stage
+            var delay = Task.Delay(TimeSpan.FromSeconds(30));
 
-            var completedTask = await Task.WhenAny(_serializationTask, delay)
-                .ConfigureAwait(false);
+            var serializationCompleted = await Task.WhenAny(_serializationTask, delay).ConfigureAwait(false) != delay;
 
             _traceKeepRateCalculator.CancelUpdates();
 
             bool success = false;
 
-            if (completedTask != delay)
+            if (serializationCompleted)
             {
-                await Task.WhenAny(_flushTask, Task.Delay(TimeSpan.FromSeconds(20)))
-                    .ConfigureAwait(false);
+                // Now that serialization has stopped, nothing else can be written to the buffers, so the
+                // flush loop performs a final flush of both buffers, and exits. Request that flush so that
+                // we can wait for it: if the flush loop got there first, the request completes immediately,
+                // which is equally correct because that final pass flushed everything.
+                var flushed = RequestFullFlushAsync();
 
-                if (_frontBuffer.TraceCount != 0 || _backBuffer.TraceCount != 0)
-                {
-                    // In some situations, the flush thread can exit before flushing all the threads
-                    // Force a flush for the leftover traces
-                    completedTask = await Task.WhenAny(Task.Run(() => FlushBuffers(flushAllBuffers: true)), delay)
-                        .ConfigureAwait(false);
+                success = await Task.WhenAny(flushed, delay).ConfigureAwait(false) != delay;
 
-                    if (completedTask != delay)
-                    {
-                        success = true;
-                    }
-                }
-                else
+                if (success)
                 {
-                    success = true;
+                    // Wait for the loop to unwind so that nothing is still using the API when we dispose it below
+                    await Task.WhenAny(_flushTask, delay).ConfigureAwait(false);
                 }
             }
 
@@ -274,10 +273,12 @@ namespace Datadog.Trace.Agent
 
                 WriteWatermark(() => tcs.TrySetResult(default));
 
-                await tcs.Task.ConfigureAwait(false);
+                // Also wait on the serialization task: if it stops before reaching our watermark (which
+                // can only happen during shutdown) then nobody will ever invoke the callback.
+                await Task.WhenAny(tcs.Task, _serializationTask).ConfigureAwait(false);
             }
 
-            await FlushBuffers(true).ConfigureAwait(false);
+            await RequestFullFlushAsync().ConfigureAwait(false);
         }
 
         [TestingAndPrivateOnly]
@@ -291,7 +292,37 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        private void RequestFlush()
+        /// <summary>
+        /// Asks the flush loop to flush both buffers, and waits for that flush to complete. Buffers are
+        /// only ever locked and flushed by the flush loop, so that at most one buffer is unavailable to
+        /// the serialization thread at a time. Concurrent requests share a single flush pass.
+        /// </summary>
+        private Task RequestFullFlushAsync()
+        {
+            TaskCompletionSource<bool> request;
+
+            lock (_flushRequestLock)
+            {
+                if (_flushLoopStopped)
+                {
+                    // The loop has already performed its final flush of both buffers, so there is
+                    // nothing left for it to flush, and nothing left to wait for.
+                    return Task.CompletedTask;
+                }
+
+                request = _pendingFlushRequest ??= new TaskCompletionSource<bool>(TaskOptions);
+            }
+
+            // Don't wait for the next tick of the flush loop
+            WakeFlushLoop();
+
+            return request.Task;
+        }
+
+        /// <summary>
+        /// Wakes up the flush loop, without waiting for the resulting flush.
+        /// </summary>
+        private void WakeFlushLoop()
         {
             Volatile.Read(ref _forceFlush).TrySetResult(default);
         }
@@ -301,29 +332,67 @@ namespace Datadog.Trace.Agent
             Task[] tasks = new Task[3];
             tasks[0] = _serializationTask;
             tasks[1] = _forceFlush.Task;
+            var isFinalPass = false;
 
-            while (true)
+            try
             {
-                tasks[2] = Task.Delay(TimeSpan.FromSeconds(1));
-                await Task.WhenAny(tasks).ConfigureAwait(false);
-                tasks[2] = null!;
-
-                if (_forceFlush.Task.IsCompleted)
+                while (true)
                 {
-                    var forceFlush = new TaskCompletionSource<bool>(TaskOptions);
-                    Volatile.Write(ref _forceFlush, forceFlush);
-                    tasks[1] = forceFlush.Task;
+                    tasks[2] = Task.Delay(TimeSpan.FromSeconds(1));
+                    await Task.WhenAny(tasks).ConfigureAwait(false);
+                    tasks[2] = null!;
+
+                    if (_forceFlush.Task.IsCompleted)
+                    {
+                        var forceFlush = new TaskCompletionSource<bool>(TaskOptions);
+                        Volatile.Write(ref _forceFlush, forceFlush);
+                        tasks[1] = forceFlush.Task;
+                    }
+
+                    // Flush requests made while this pass is running are left for the next one
+                    TaskCompletionSource<bool>? flushRequest;
+
+                    lock (_flushRequestLock)
+                    {
+                        flushRequest = _pendingFlushRequest;
+                        _pendingFlushRequest = null;
+                    }
+
+                    // Once serialization has stopped, nothing new can be written to the buffers
+                    isFinalPass = _serializationTask.IsCompleted;
+                    var flushAllBuffers = flushRequest is not null;
+
+                    if (flushAllBuffers || isFinalPass || _backgroundFlushEnabled)
+                    {
+                        await FlushBuffers(flushAllBuffers: flushAllBuffers || isFinalPass).ConfigureAwait(false);
+                    }
+
+                    flushRequest?.TrySetResult(true);
+
+                    if (isFinalPass)
+                    {
+                        return;
+                    }
+                }
+            }
+            finally
+            {
+                if (!isFinalPass)
+                {
+                    Log.Warning("The trace flush loop stopped unexpectedly, traces will no longer be flushed");
                 }
 
-                if (_backgroundFlushEnabled)
+                TaskCompletionSource<bool>? request;
+
+                lock (_flushRequestLock)
                 {
-                    await FlushBuffers().ConfigureAwait(false);
+                    _flushLoopStopped = true;
+                    request = _pendingFlushRequest;
+                    _pendingFlushRequest = null;
                 }
 
-                if (_serializationTask.IsCompleted)
-                {
-                    return;
-                }
+                // Make sure callers requesting a flush _after_ the loop ends don't hang forever
+                request?.TrySetResult(true);
             }
         }
 
@@ -582,7 +651,7 @@ namespace Datadog.Trace.Agent
             if (buffer != null)
             {
                 // One buffer is full, request an eager flush
-                RequestFlush();
+                WakeFlushLoop();
 
                 writeStatus = buffer.TryWrite(in chunk, ref _temporaryBuffer, chunkSamplingPriority);
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -17,6 +17,7 @@ using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.Stats;
 using Datadog.Trace.TestHelpers.TestTracer;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
@@ -603,17 +604,24 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public async Task AgentWriterEnqueueFlushTasks()
         {
+            // Flushes all run on the flush loop, one at a time, so flushes requested while one is in
+            // flight wait for it. Every trace written below should still be sent, and every flush should
+            // complete, once the blocked API call is released.
             var api = new Mock<IApi>();
             var agentWriter = AgentWriterHelper.CreateWithManualFlush(api.Object);
             var flushTcs = new TaskCompletionSource<bool>();
             var firstSendEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            int invocation = 0;
+            var invocation = 0;
+            var sentTraces = 0;
 
             api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
-                .Returns(() =>
+                .Returns((ArraySegment<byte> _, int numberOfTraces, bool _, long _, long _, bool _) =>
                 {
-                    // One for the front buffer, one for the back buffer
-                    if (Interlocked.Increment(ref invocation) <= 2)
+                    Interlocked.Add(ref sentTraces, numberOfTraces);
+
+                    // The first send blocks until we release it below; the flush loop is stuck in it,
+                    // holding the front buffer locked.
+                    if (Interlocked.Increment(ref invocation) == 1)
                     {
                         firstSendEntered.TrySetResult(true);
                         return flushTcs.Task;
@@ -635,23 +643,29 @@ namespace Datadog.Trace.Tests.Agent
             // The front buffer is locked, so this swaps to the back buffer.
             agentWriter.WriteTrace(spans);
 
-            // Flush the back buffer. FlushBuffers() always flushes the front buffer too, so this
-            // queues up behind the first flush.
+            // Queues up behind the in-flight flush.
             var secondFlush = agentWriter.FlushTracesAsync();
 
             // The back buffer is still unlocked, so this is written to it.
             agentWriter.WriteTrace(spans);
 
-            // This will try to flush the front buffer again.
+            // Also queues up behind the in-flight flush, and is batched with the second one.
             var thirdFlush = agentWriter.FlushTracesAsync();
 
-            // Third flush should wait for the first flush to complete.
+            // None of the flushes can complete while the first send is blocked.
             var completed = await Task.WhenAny(thirdFlush, Task.Delay(TimeSpan.FromMilliseconds(100)));
             completed.Should().NotBeSameAs(thirdFlush);
+            firstFlush.IsCompleted.Should().BeFalse();
+            secondFlush.IsCompleted.Should().BeFalse();
 
             // Unblock the API so everything can drain and the writer can shut down.
             flushTcs.TrySetResult(true);
-            await Task.WhenAll(firstFlush, secondFlush, thirdFlush);
+            await Task.WhenAll(firstFlush, secondFlush, thirdFlush).WaitAsync(TimeSpan.FromMilliseconds(30000));
+
+            // Note that we can't assert on the DroppedTraces* counters here, because a flush resets them.
+            // All three traces reaching the API is what proves none of them were dropped.
+            Volatile.Read(ref sentTraces).Should().Be(3);
+
             await agentWriter.FlushAndCloseAsync();
         }
 
@@ -668,6 +682,127 @@ namespace Datadog.Trace.Tests.Agent
 
             // Nothing resets the counter, because the final flush ran before the write above
             agent.DroppedTracesBufferFull.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task ConcurrentFlushTracesAsync_NeverRunsMoreThanOneFlushAtATime()
+        {
+            // Buffers are only ever locked and flushed by the flush loop, so no matter how many callers
+            // are flushing concurrently, a buffer is never sent while another send is in flight.
+            var api = new Mock<IApi>();
+            var concurrentSends = 0;
+            var maxConcurrentSends = 0;
+            var maxLock = new object();
+
+            api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
+                .Returns(async () =>
+                {
+                    var current = Interlocked.Increment(ref concurrentSends);
+
+                    lock (maxLock)
+                    {
+                        maxConcurrentSends = Math.Max(maxConcurrentSends, current);
+                    }
+
+                    // Give any other flush a chance to overlap with this one
+                    await Task.Delay(20);
+
+                    Interlocked.Decrement(ref concurrentSends);
+                    return true;
+                });
+
+            // Buffers big enough for a single trace, so that they fill up and the active buffer keeps
+            // switching while flushes are in flight. Background flushes are enabled too, so those must
+            // not overlap with the requested ones either.
+            var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
+            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1, batchInterval: 0);
+
+            var flushes = new List<Task>();
+
+            for (var i = 0; i < 50; i++)
+            {
+                agent.WriteTrace(CreateTraceChunk(1));
+                flushes.Add(agent.FlushTracesAsync());
+            }
+
+            await Task.WhenAll(flushes).WaitAsync(TimeSpan.FromMilliseconds(30000));
+
+            lock (maxLock)
+            {
+                maxConcurrentSends.Should().Be(1);
+            }
+
+            await agent.FlushAndCloseAsync();
+        }
+
+        [Fact]
+        public async Task FlushTracesAsync_SendsTracesWrittenOnTheSameThread()
+        {
+            // A trace written before FlushTracesAsync() is called must have left the pending queue and be
+            // a candidate for that flush, however many times we go around.
+            var api = new MockApi();
+            var agent = new AgentWriter(api, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false, batchInterval: 0);
+
+            for (var i = 1; i <= 20; i++)
+            {
+                agent.WriteTrace(CreateTraceChunk(1, startingId: (ulong)i));
+                await agent.FlushTracesAsync();
+
+                api.Traces.Should().HaveCount(i);
+            }
+
+            await agent.FlushAndCloseAsync();
+        }
+
+        [Fact]
+        public async Task FlushTracesAsync_AfterFlushAndClose_DoesNotHang()
+        {
+            // The flush loop has already performed its final flush and stopped, so there's nothing left
+            // to flush, and nothing to wait for
+            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd: TestStatsdManager.NoOp, batchInterval: 0);
+
+            agent.WriteTrace(CreateTraceChunk(1));
+            await agent.FlushAndCloseAsync();
+
+            await agent.FlushTracesAsync().WaitAsync(TimeSpan.FromMilliseconds(30000));
+        }
+
+        [Fact]
+        public async Task FlushTracesAsync_DuringFinalFlush_DoesNotHang()
+        {
+            // A request that arrives after the final pass took its snapshot of _pendingFlushRequest
+            // can't be completed by that pass, so only the flush loop's finally block can complete it.
+            var api = new Mock<IApi>();
+            var gate = new TaskCompletionSource<bool>();
+            var firstSendEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var invocations = 0;
+
+            api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
+                .Returns(() =>
+                {
+                    if (Interlocked.Increment(ref invocations) == 1)
+                    {
+                        firstSendEntered.TrySetResult(true);
+                        return gate.Task;
+                    }
+
+                    return Task.FromResult(true);
+                });
+
+            // No background flushes, so the only send that can happen is the final pass's
+            var agent = AgentWriterHelper.CreateWithManualFlush(api.Object);
+            agent.WriteTrace(CreateTraceChunk(1));
+
+            // Serialization stops, so the flush loop starts its final pass, which blocks in the API
+            var closing = agent.FlushAndCloseAsync();
+            await firstSendEntered.Task;
+
+            var flush = agent.FlushTracesAsync();
+
+            gate.SetResult(true);
+
+            await flush.WaitAsync(TimeSpan.FromMilliseconds(30000));
+            await closing.WaitAsync(TimeSpan.FromMilliseconds(30000));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes

- Changes `AgentWriter to only ever flush from the flush thread
- Avoids dropping traces because both buffers are locked when manually flushing

## Reason for change

Previously, if you called `FlushTracesAsync()` this would execute a flush on the _same_ thread that requested it (kinda, not really because `async`, but you get the idea). During a flush, the buffer being flushed is locked, so that the serializer thread doesn't write to it. If a background flush was running at the _same_ time as the manual flush request (or if you called `FlushTracesAsync()` twice concurrently) then you could end up locking _both_ the front and back buffers. Any attempts to serialize traces in this time would just drop them.

> This isn't theoretical, recent additional logging, shows that we hit this scenario in CI with moderate frequency, and is one source of flake.

Instead, this PR enforces these requirements:

1. All flushes go through the flush thread/task
  - That means that at most one thread is flushing at a time, which means _at most_ one buffer is locked at a time
  - It's still possible to drop traces, if one buffer is full, and the _other_ buffer is locked because it's being flushed. 
  - If we want to add more resilience there, we could do that later, by adding more buffers/more queue readers/etc, but seems overkill without more information.
2. Any calls to `FlushTracesAsync()` (or `FlushAndCloseAsync()` flush any traces previously written by a `WriteTrace()` call in the same control flow.
  - This held before, but is an important invariant to specifiy
3. If you call `FlushTracesAsync()` multiple times, then the flush calls are "batched" to avoid multiple (pointless) flushes
  - I nicety really, we _could_ remove this requirement if we want

## Implementation details

- `_frontBufferFlushTask` and `_backBufferFlushTask` are gone
- `_pendingFlushRequest` is a way to hand out the same `Task` object to multiple concurrent callers of `FlushTracesAsync()`, so that they're "batched"
- `FlushAndCloseAsync` timeout reduced from "up to 40s" to "up to 30s". Not necessary, just seemed reasonable
- `FlushAndCloseAsync` doesn't need to do a final `Task.Run()` anymore
- `FlushTracesAsync` no longer runs the flushing itself immediately, instead it just wakes the flush loop, and registers itself to be notified once it's completed
  - If the flush/serialize loop has already exited (during shutdown) the flush will complete, though nothing extra actually was flushed.
  - I didn't think it was necessary to distinguish these cases (e.g. by returning a `Task<bool>` , but we _could_ if there's a need
- A couple of method renames to be clearer

## Test coverage

Updated existing tests to handle the new behaviour, and added some new unit tests to cover the new behaviour. Will also keep an eye on CI for any flake and ensure that the "all locked" gap we were worried about is fixed

## Other details

Part of a stack