### PR TITLE
[PROF-15622] Collect GC lifecycle via COR_PRF_HIGH_BASIC_GC callbacks (drop KEYWORD_GC on GC-only path)

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1583,6 +1583,25 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
     // Configure which profiler callbacks we want to receive by setting the event mask:
     DWORD eventMask = COR_PRF_MONITOR_THREADS | COR_PRF_ENABLE_STACK_SNAPSHOT | COR_PRF_MONITOR_APPDOMAIN_LOADS;
 
+    // Prefer the low-overhead COR_PRF_HIGH_BASIC_GC callbacks over the EventPipe
+    // KEYWORD_GC stream when ONLY GC profiling is enabled (allocation/heap profiling
+    // still need the GC keyword). BASIC_GC (.NET 8+) fires GarbageCollectionStarted/
+    // Finished once per collection and does not disable concurrent GC, unlike the
+    // legacy COR_PRF_MONITOR_GC. See PROF-15622.
+    _useGcCallbacks =
+        _pConfiguration->IsGarbageCollectionProfilingEnabled() &&
+        !_pConfiguration->IsAllocationProfilingEnabled() &&
+        !_pConfiguration->IsHeapProfilingEnabled() &&
+        (_pCorProfilerInfoEvents != nullptr) && // SetEventMask2 (ICorProfilerInfo5+) required for the high mask
+        (major >= 8);
+
+    if (_useGcCallbacks)
+    {
+        // COR_PRF_MONITOR_SUSPENDS gives RuntimeSuspend/Resume callbacks used to
+        // measure GC pause (suspension) time; BASIC_GC is added to the high mask below.
+        eventMask |= COR_PRF_MONITOR_SUSPENDS;
+    }
+
     if (_pConfiguration->UseManagedCodeCache())
     {
         eventMask |= COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_ENABLE_REJIT;
@@ -1608,6 +1627,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
     {
         // listen to CLR events via ICorProfilerCallback
         DWORD highMask = COR_PRF_HIGH_MONITOR_EVENT_PIPE;
+        if (_useGcCallbacks)
+        {
+            highMask |= COR_PRF_HIGH_BASIC_GC;
+        }
         hr = _pCorProfilerInfo->SetEventMask2(eventMask, highMask);
         if (FAILED(hr))
         {
@@ -1649,8 +1672,11 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
                 Log::Debug("Listen to AllocationTick event");
             }
         }
-        if (_pConfiguration->IsGarbageCollectionProfilingEnabled())
+        if (_pConfiguration->IsGarbageCollectionProfilingEnabled() && !_useGcCallbacks)
         {
+            // When _useGcCallbacks is set, GC lifecycle comes from the BASIC_GC
+            // callbacks instead, so we avoid the per-collection KEYWORD_GC event
+            // serialization (including one GCPerHeapHistory per heap under server GC).
             activatedKeywords |= ClrEventsParser::KEYWORD_GC;
         }
         if (_pConfiguration->IsContentionProfilingEnabled())
@@ -2440,6 +2466,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ManagedToUnmanagedTransition(Func
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::RuntimeSuspendStarted(COR_PRF_SUSPEND_REASON suspendReason)
 {
+    if (_useGcCallbacks)
+    {
+        OnGcCallbackSuspendStarted(suspendReason);
+    }
     return S_OK;
 }
 
@@ -2460,6 +2490,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::RuntimeResumeStarted()
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::RuntimeResumeFinished()
 {
+    if (_useGcCallbacks)
+    {
+        OnGcCallbackResumeFinished();
+    }
     return S_OK;
 }
 
@@ -2606,6 +2640,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ExceptionCLRCatcherExecute()
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
 {
+    if (_useGcCallbacks)
+    {
+        OnGcCallbackStarted(cGenerations, generationCollected, reason);
+    }
     return S_OK;
 }
 
@@ -2616,7 +2654,164 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::SurvivingReferences(ULONG cSurviv
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::GarbageCollectionFinished()
 {
+    if (_useGcCallbacks)
+    {
+        OnGcCallbackFinished();
+    }
     return S_OK;
+}
+
+// --- Low-overhead GC path (COR_PRF_HIGH_BASIC_GC) ---------------------------
+// These callbacks replace the EventPipe KEYWORD_GC stream when only GC profiling
+// is enabled. They fire once per collection (not once per heap), and feed the same
+// GarbageCollectionProvider / StopTheWorldGCProvider listeners the event path uses.
+// State is tiny and touched ~once per collection, so a plain mutex is sufficient;
+// the profiling-API reason is coarse (Induced vs other) and compaction / memory
+// pressure / background-vs-foreground type are not available here (see PROF-15622).
+
+void CorProfilerCallback::OnGcCallbackSuspendStarted(COR_PRF_SUSPEND_REASON suspendReason)
+{
+    if ((suspendReason != COR_PRF_SUSPEND_FOR_GC) && (suspendReason != COR_PRF_SUSPEND_FOR_GC_PREP))
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(_gcCallbackLock);
+    _gcSuspensionStart = OpSysTools::GetHighPrecisionTimestamp();
+}
+
+void CorProfilerCallback::OnGcCallbackResumeFinished()
+{
+    auto timestamp = OpSysTools::GetHighPrecisionTimestamp();
+
+    int32_t number;
+    uint32_t generation;
+    std::chrono::nanoseconds duration;
+    {
+        std::lock_guard<std::mutex> lock(_gcCallbackLock);
+        if (_gcSuspensionStart == std::chrono::nanoseconds::zero())
+        {
+            return;
+        }
+        duration = timestamp - _gcSuspensionStart;
+        _gcPauseDuration += duration;
+        _gcSuspensionStart = std::chrono::nanoseconds::zero();
+
+        // _gcNumber/_gcGeneration are kept as the last-seen GC (not cleared on
+        // finish) so the suspension that closes a blocking GC still attributes to it.
+        number = _gcNumber;
+        generation = _gcGeneration;
+    }
+
+    if ((number != 0) && (_pStopTheWorldProvider != nullptr))
+    {
+        _pStopTheWorldProvider->OnSuspension(timestamp, number, generation, duration);
+    }
+}
+
+void CorProfilerCallback::OnGcCallbackStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
+{
+    auto timestamp = OpSysTools::GetHighPrecisionTimestamp();
+
+    // Highest collected generation.
+    uint32_t generation = 0;
+    for (int i = 0; i < cGenerations; i++)
+    {
+        if (generationCollected[i])
+        {
+            generation = static_cast<uint32_t>(i);
+        }
+    }
+
+    GCReason gcReason = (reason == COR_PRF_GC_INDUCED) ? GCReason::Induced : GCReason::AllocSmall;
+
+    int32_t number;
+    {
+        std::lock_guard<std::mutex> lock(_gcCallbackLock);
+        _gcNumber++;
+        _gcGeneration = generation;
+        _gcReason = gcReason;
+        _gcStartTimestamp = timestamp;
+        _gcPauseDuration = std::chrono::nanoseconds::zero();
+        _gcInProgress = true;
+        number = _gcNumber;
+    }
+
+    if (_pGarbageCollectionProvider != nullptr)
+    {
+        _pGarbageCollectionProvider->OnGarbageCollectionStart(
+            timestamp, number, generation, gcReason, GCType::NonConcurrentGC);
+    }
+}
+
+void CorProfilerCallback::OnGcCallbackFinished()
+{
+    auto timestamp = OpSysTools::GetHighPrecisionTimestamp();
+
+    int32_t number;
+    uint32_t generation;
+    GCReason gcReason;
+    std::chrono::nanoseconds totalDuration;
+    std::chrono::nanoseconds pauseDuration;
+    {
+        std::lock_guard<std::mutex> lock(_gcCallbackLock);
+        if (!_gcInProgress)
+        {
+            return;
+        }
+        number = _gcNumber;
+        generation = _gcGeneration;
+        gcReason = _gcReason;
+        totalDuration = timestamp - _gcStartTimestamp;
+        // For a blocking GC the closing resume happens after this callback, so add
+        // the still-open suspension window to what has already been accumulated.
+        pauseDuration = _gcPauseDuration;
+        if (_gcSuspensionStart != std::chrono::nanoseconds::zero())
+        {
+            pauseDuration += timestamp - _gcSuspensionStart;
+        }
+        _gcInProgress = false;
+    }
+
+    // Generation sizes from the current generation bounds (once per collection).
+    uint64_t gen2Size = 0;
+    uint64_t lohSize = 0;
+    uint64_t pohSize = 0;
+    ULONG rangeCount = 0;
+    if (SUCCEEDED(_pCorProfilerInfo->GetGenerationBounds(0, &rangeCount, nullptr)) && (rangeCount != 0))
+    {
+        std::vector<COR_PRF_GC_GENERATION_RANGE> ranges(rangeCount);
+        if (SUCCEEDED(_pCorProfilerInfo->GetGenerationBounds(rangeCount, &rangeCount, ranges.data())))
+        {
+            for (ULONG i = 0; i < rangeCount; i++)
+            {
+                switch (ranges[i].generation)
+                {
+                    case COR_PRF_GC_GEN_2: gen2Size += ranges[i].rangeLength; break;
+                    case COR_PRF_GC_LARGE_OBJECT_HEAP: lohSize += ranges[i].rangeLength; break;
+                    case COR_PRF_GC_PINNED_OBJECT_HEAP: pohSize += ranges[i].rangeLength; break;
+                    default: break;
+                }
+            }
+        }
+    }
+
+    if (_pGarbageCollectionProvider != nullptr)
+    {
+        _pGarbageCollectionProvider->OnGarbageCollectionEnd(
+            number,
+            generation,
+            gcReason,
+            GCType::NonConcurrentGC,
+            /* isCompacting */ false,
+            pauseDuration,
+            totalDuration,
+            timestamp,
+            gen2Size,
+            lohSize,
+            pohSize,
+            /* memPressure */ 0);
+    }
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::FinalizeableObjectQueued(DWORD finalizerFlags, ObjectID objectID)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -49,7 +49,9 @@
 #include "shared/src/native-src/dd_memory_resource.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 class ContentionProvider;
@@ -261,6 +263,27 @@ private :
     SamplesCollector* _pSamplesCollector = nullptr;
     StopTheWorldGCProvider* _pStopTheWorldProvider = nullptr;
     GarbageCollectionProvider* _pGarbageCollectionProvider = nullptr;
+
+    // Low-overhead GC path: when only GC profiling is enabled (no allocation/heap
+    // profiling) on .NET 8+, GC lifecycle is collected via the COR_PRF_HIGH_BASIC_GC
+    // ICorProfiler callbacks instead of the EventPipe KEYWORD_GC stream. That stream
+    // makes the runtime serialize ~6 + one-per-heap (GCPerHeapHistory) events per
+    // collection; the callbacks fire once per collection, eliminating that emission.
+    // Reduced fidelity vs the event path: no compaction flag / memory-pressure /
+    // background-vs-foreground type (see PROF-15622).
+    bool _useGcCallbacks = false;
+    std::mutex _gcCallbackLock;
+    bool _gcInProgress = false;
+    int32_t _gcNumber = 0;
+    uint32_t _gcGeneration = 0;
+    GCReason _gcReason = GCReason::AllocSmall;
+    std::chrono::nanoseconds _gcStartTimestamp{0};
+    std::chrono::nanoseconds _gcSuspensionStart{0};
+    std::chrono::nanoseconds _gcPauseDuration{0};
+    void OnGcCallbackSuspendStarted(COR_PRF_SUSPEND_REASON suspendReason);
+    void OnGcCallbackResumeFinished();
+    void OnGcCallbackStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason);
+    void OnGcCallbackFinished();
     LiveObjectsProvider* _pLiveObjectsProvider = nullptr;
     ThreadLifetimeProvider* _pThreadLifetimeProvider = nullptr;
     NetworkProvider* _pNetworkProvider = nullptr;


### PR DESCRIPTION
## Summary of changes

When only GC profiling is enabled (no allocation or heap profiling) on .NET 8+,
collect the GC lifecycle from the `COR_PRF_HIGH_BASIC_GC` ICorProfiler callbacks
instead of subscribing to the EventPipe `KEYWORD_GC` keyword.

## Reason for change

Subscribing to `KEYWORD_GC` makes the runtime serialize the full per-collection
GC event set — including one `GCPerHeapHistory` event per heap under server GC —
which the profiler's processing thread then parses. GC frequency scales with
allocation rate, so this emission is the bulk of the GC profiler's cost.
`GarbageCollectionStarted`/`Finished` fire once per collection (not per heap) and,
unlike the legacy `COR_PRF_MONITOR_GC`, do not disable concurrent GC.

## Implementation details

- `SetEventMask2`: add `COR_PRF_HIGH_BASIC_GC` (high mask) and
  `COR_PRF_MONITOR_SUSPENDS` (low mask), and skip `KEYWORD_GC` on this path.
- `GarbageCollectionStarted`/`Finished` and `RuntimeSuspend`/`ResumeFinished` feed
  the existing `GarbageCollectionProvider` and `StopTheWorldGCProvider`. Generation
  sizes come from `GetGenerationBounds`; pause time from the suspend/resume pair.
- The EventPipe `KEYWORD_GC` path is unchanged and still used for older runtimes and
  whenever allocation/heap profiling is enabled (they already need the keyword).

## Test coverage

Functionally validated (Samples.Computer01 GarbageCollection scenario, GC profiling
on): 242k gen0 collections and suspension durations captured via the callbacks, with
`KEYWORD_GC` no longer subscribed.

Overhead measured on dd-trace-doe (isolated: app pinned to cores 8-15, agent to 6;
6 rounds run round-robin interleaved with no-fix; `allocs_cpu=0.006`; docker process
CPU):

| build     | off cpu | on cpu | Δ overhead |
|-----------|---------|--------|-----------|
| no-fix    | 62.2    | 69.2   | +11.2%    |
| this PR   | 65.6    | 68.7   | +4.8%     |

Paired within-round ON-cpu vs no-fix is ~2 cpu lower for this change (consistent
across rounds); vs the provider-cache variant −1.55 ± 1.30 cpu. **Context:** on
current master the *total* GC-profiling overhead at ~360k allocs/req is only ~3pp
above the ~8% wall/CPU-sampler floor — the large regression that originally
motivated this work does not reproduce here — so the absolute win is small
(~2-3% process CPU) even though the mechanism is sound.

## Functional trade-offs (what the callback path no longer has)

This path runs for the **default** profiling config (GC on, allocation/heap off,
.NET 8+). Compared with the EventPipe path it reduces GC event fidelity:

- **GC type**: always reported as `NonConcurrentGC` — background vs foreground GCs
  are not distinguished (the timeline `gc_type` label is no longer accurate).
- **Compaction**: not available → `gc_compacting` label always `false` and the
  `dotnet_gc_compacting_gen2` metric stays 0.
- **Memory pressure**: low-memory-induced GCs are not distinguished → the
  `dotnet_gc_memory_pressure` metric stays 0.
- **GC reason**: coarse — the profiling API only exposes induced-vs-other, so the
  `gc_reason` label loses `OutOfSpaceSOH/LOH`, `LowMemory`, `InducedLowMemory`, etc.
- **GC number**: a profiler-local counter, not the runtime's GC index.

Preserved: gen0/1/2 collection counts, suspension/pause durations, gen2/LOH/POH
sizes, and the induced count for explicit `GC.Collect`.

## Other details

Open question for reviewers: this changes the default config's GC timeline fidelity
for a small measured CPU win. Alternatives are to gate it behind an opt-in setting,
or to hold it until a workload with materially higher GC overhead justifies the
fidelity trade-off. Feedback welcome.

<!-- Fixes PROF-15622 -->
