### PR TITLE
Fix SnapshotSlicerTests verify prefix

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.TestHelpers;
 using DatadogDebugger.Util;
 using Newtonsoft.Json.Linq;
+using VerifyTests;
 using VerifyXunit;
 using Xunit;
 
@@ -65,7 +66,9 @@ namespace Datadog.Trace.Tests.Debugger
             var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
 
             var captures = JObject.Parse(modifiedSnapshot).SelectToken("debugger.snapshot.captures");
-            await Verifier.Verify(captures);
+            var settings = new VerifySettings();
+            settings.DisableRequireUniquePrefix();
+            await Verifier.Verify(captures, settings);
         }
 
         [Fact]
@@ -77,7 +80,9 @@ namespace Datadog.Trace.Tests.Debugger
             var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
 
             var captures = JObject.Parse(modifiedSnapshot).SelectToken("debugger.snapshot.captures");
-            await Verifier.Verify(captures);
+            var settings = new VerifySettings();
+            settings.DisableRequireUniquePrefix();
+            await Verifier.Verify(captures, settings);
         }
 
         [Fact]
@@ -89,7 +94,9 @@ namespace Datadog.Trace.Tests.Debugger
             var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
 
             var captures = JObject.Parse(modifiedSnapshot).SelectToken("debugger.snapshot.captures");
-            await Verifier.Verify(captures);
+            var settings = new VerifySettings();
+            settings.DisableRequireUniquePrefix();
+            await Verifier.Verify(captures, settings);
         }
 
         private SnapshotSlicer GetSlicer(int maxDepth, int maxSize)


### PR DESCRIPTION
## Summary of changes

Allow the three flaky `SnapshotSlicerTests` snapshot tests to reuse their Verify prefix during retries.

## Reason for change

When one of these tests hits its known JSON flake, the retry runs in the same process. Verify then rejects the second attempt because the snapshot prefix was already registered, causing the retry to fail for an unrelated reason.

[Error](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet/-/jobs/1929424000/raw):
```
2026-08-06T15:32:18.619631Z 01O 15:32:18 [ERR] [xUnit.net 00:00:43.86]     Datadog.Trace.Tests.Debugger.SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced [FAIL]
2026-08-06T15:32:19.648960Z 01O 15:32:19 [DBG]   Failed Datadog.Trace.Tests.Debugger.SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced [12 ms]
2026-08-06T15:32:19.654330Z 01O 15:32:19 [DBG]   Error Message:
2026-08-06T15:32:19.654900Z 01O 15:32:19 [DBG]    System.Exception : The prefix has already been used: c:\mnt\tracer\test\Datadog.Trace.Tests\Debugger\SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced.
2026-08-06T15:32:19.654900Z 01O 15:32:19 [DBG] This is mostly caused by a conflicting combination of `VerifierSettings.DerivePathInfo()`, `UseMethodName.UseDirectory()`, `UseMethodName.UseTypeName()`, and `UseMethodName.UseMethodName()`.
2026-08-06T15:32:19.655350Z 01O 15:32:19 [DBG] If that's not the case, and having multiple identical prefixes is acceptable, then call `VerifierSettings.DisableRequireUniquePrefix()` to disable this uniqueness validation.
2026-08-06T15:32:19.655350Z 01O 15:32:19 [DBG]   Stack Trace:
2026-08-06T15:32:19.655350Z 01O 15:32:19 [DBG]      at PrefixUnique.CheckPrefixIsUnique(String prefix) in /_/src/Verify/Naming/PrefixUnique.cs:line 11
2026-08-06T15:32:19.655350Z 01O 15:32:19 [DBG]    at InnerVerifier.ValidatePrefix(VerifySettings settings, String filePathPrefix) in /_/src/Verify/Verifier/InnerVerifier.cs:line 56
2026-08-06T15:32:19.655350Z 01O 15:32:19 [DBG]    at InnerVerifier..ctor(String sourceFile, VerifySettings settings, GetFileConvention fileConvention) in /_/src/Verify/Verifier/InnerVerifier.cs:line 31
2026-08-06T15:32:19.655350Z 01O 15:32:19 [DBG]    at VerifyXunit.Verifier.GetVerifier(VerifySettings settings, String sourceFile) in /_/src/Verify.Xunit/Verifier.cs:line 14
2026-08-06T15:32:19.655890Z 01O 15:32:19 [DBG]    at VerifyXunit.Verifier.<>c__DisplayClass1_0.<<Verify>b__0>d.MoveNext() in /_/src/Verify.Xunit/Verifier.cs:line 31
2026-08-06T15:32:19.655890Z 01O 15:32:19 [DBG] --- End of stack trace from previous location ---
2026-08-06T15:32:19.655890Z 01O 15:32:19 [DBG]    at Datadog.Trace.Tests.Debugger.SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced() in c:\mnt\tracer\test\Datadog.Trace.Tests\Debugger\SnapshotSlicerTests.cs:line 80
2026-08-06T15:32:19.656320Z 01O 15:32:19 [DBG] --- End of stack trace from previous location ---
```

## Implementation details

Pass `VerifySettings` with `DisableRequireUniquePrefix()` to the tests already marked `[Flaky]`.

## Test coverage

Built `Datadog.Trace.Tests` and ran `SnapshotBiggerThanMaxSize_TwoLevel_OneSliced` locally.

## Other details

None.