### PR TITLE
`AgentWriter` cleanup

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -90,6 +90,7 @@ namespace Datadog.Trace.Agent
         {
         }
 
+        [TestingAndPrivateOnly]
         internal AgentWriter(IApi api, IStatsAggregator? statsAggregator, IStatsdManager statsd, IKeepRateCalculator traceKeepRateCalculator, bool automaticFlush, int maxBufferSize, int batchInterval, bool apmTracingEnabled, bool initialTracerMetricsEnabled)
         {
             _statsAggregator = statsAggregator ?? new NullStatsAggregator();
@@ -136,10 +137,13 @@ namespace Datadog.Trace.Agent
             BuffersLocked,
         }
 
+        [TestingOnly]
         internal SpanBuffer ActiveBuffer => _activeBuffer;
 
+        [TestingOnly]
         internal SpanBuffer FrontBuffer => _frontBuffer;
 
+        [TestingOnly]
         internal SpanBuffer BackBuffer => _backBuffer;
 
         [TestingOnly]
@@ -263,6 +267,7 @@ namespace Datadog.Trace.Agent
             await FlushBuffers(true).ConfigureAwait(false);
         }
 
+        [TestingAndPrivateOnly]
         internal void WriteWatermark(Action watermark, bool wakeUpThread = true)
         {
             _pendingTraces.Enqueue(new WorkItem(watermark));

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -85,7 +85,16 @@ namespace Datadog.Trace.Agent
             });
         }
 
-        public AgentWriter(IApi api, IStatsAggregator? statsAggregator, IStatsdManager statsd, bool automaticFlush = true, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100, bool apmTracingEnabled = true, bool initialTracerMetricsEnabled = false)
+        public AgentWriter(IApi api, IStatsAggregator? statsAggregator, IStatsdManager statsd, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100, bool apmTracingEnabled = true, bool initialTracerMetricsEnabled = false)
+        : this(api, statsAggregator, statsd, MovingAverageKeepRateCalculator.CreateDefaultKeepRateCalculator(), automaticFlush: true, maxBufferSize, batchInterval, apmTracingEnabled, initialTracerMetricsEnabled)
+        {
+        }
+
+        // Passing automaticFlush: false makes the writer synchronous: traces are serialized on the
+        // calling thread, and neither the serialization loop nor the flush loop is started.
+        // That is only safe in tests, so production code must use the overload above.
+        [TestingOnly]
+        internal AgentWriter(IApi api, IStatsAggregator? statsAggregator, IStatsdManager statsd, bool automaticFlush, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100, bool apmTracingEnabled = true, bool initialTracerMetricsEnabled = false)
         : this(api, statsAggregator, statsd, MovingAverageKeepRateCalculator.CreateDefaultKeepRateCalculator(), automaticFlush, maxBufferSize, batchInterval, apmTracingEnabled, initialTracerMetricsEnabled)
         {
         }

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -128,8 +128,6 @@ namespace Datadog.Trace.Agent
             _backBufferFlushTask = _frontBufferFlushTask = Task.CompletedTask;
         }
 
-        internal event Action? Flushed;
-
         private enum TraceDropReason
         {
             TraceTooLarge,
@@ -304,8 +302,6 @@ namespace Datadog.Trace.Agent
                 {
                     return;
                 }
-
-                Flushed?.Invoke();
             }
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Ci.EventModel;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.Ci.Agent;
 
@@ -42,7 +43,7 @@ internal sealed class ApmAgentWriter : IEventWriter
         _agentWriter = new AgentWriter(api, statsAggregator, statsdManager, maxBufferSize: maxBufferSize, apmTracingEnabled: settings.ApmTracingEnabled, initialTracerMetricsEnabled: settings.Manager.InitialMutableSettings.TracerMetricsEnabled);
     }
 
-    // Internal for testing
+    [TestingOnly]
     internal ApmAgentWriter(IApi api, IStatsdManager statsdManager, int maxBufferSize = DefaultMaxBufferSize)
     {
         _agentWriter = new AgentWriter(api, null, statsdManager, maxBufferSize: maxBufferSize);


### PR DESCRIPTION
## Summary of changes

Minor cleanup for `AgentWriter` prior to a bigger refactor

## Reason for change

Part of a stack of big refactoring for `AgentWriter`, and wanted to extract the trivial stuff first

## Implementation details

- Make the `automaticFlush: false` path _explicitly_ (instead of implicitly) testing only
- Adding `[TestingAndPrivateOnly]` and `[TestingOnly]` as appropriate
- Remove unused `Flushed` event

## Test coverage

Covered by existing tests, nothing exciting

## Other details

Part of a stack