### PR TITLE
`AgentWriter` testing cleanup

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/ApmAgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/ApmAgentWriterTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
-    public class ApmAgentWriterTests
+    public class ApmAgentWriterTests : IAsyncLifetime
     {
         private readonly ApmAgentWriter _ciAgentWriter;
         private readonly Configuration.TracerSettings _settings;
@@ -30,6 +30,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             _api = new Mock<IApi>();
             _ciAgentWriter = new ApmAgentWriter(_api.Object, TestStatsdManager.NoOp);
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        // FlushAndCloseAsync is idempotent, so tests that already close the writer themselves
+        // are unaffected.
+        public Task DisposeAsync() => _ciAgentWriter.FlushAndCloseAsync();
 
         [Fact]
         public async Task WriteTrace_2Traces_SendToApi()

--- a/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.IntegrationTests
         private ScopedTracer GetTracer()
         {
             var settings = new TracerSettings();
-            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
             return TracerHelper.Create(settings, agentWriter, null, null, null);
         }
     }

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Datadog.Trace.IntegrationTests
 {
-    public class SpanTagTests
+    public class SpanTagTests : IAsyncLifetime
     {
         private readonly AgentWriter _writer;
         private readonly MockApi _testApi;
@@ -27,6 +27,12 @@ namespace Datadog.Trace.IntegrationTests
             _testApi = new MockApi();
             _writer = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp);
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        // Most tests dispose the writer via the tracer that wraps it, but not all of them create
+        // one. FlushAndCloseAsync is idempotent, so closing it again here is harmless.
+        public Task DisposeAsync() => _writer.FlushAndCloseAsync();
 
         [Fact]
         public async Task SpanSampler_ShouldNotAddTags_OnSpanClose_ForKeptTrace()

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/AASTagsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/AASTagsTests.cs
@@ -33,7 +33,7 @@ public class AASTagsTests
     {
         var source = GetMockVariables();
         var settings = new TracerSettings(source);
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
         using (tracer.StartActiveInternal("root"))
@@ -50,7 +50,7 @@ public class AASTagsTests
     public async Task NoAasTagsIfNotInAASContext()
     {
         var settings = new TracerSettings(null);
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
         using (tracer.StartActiveInternal("root"))
@@ -74,7 +74,7 @@ public class AASTagsTests
 
         var source = GetMockVariables();
         var settings = new TracerSettings(source);
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
         ISpan span1;

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/ProcessTagsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/ProcessTagsTests.cs
@@ -31,7 +31,7 @@ public class ProcessTagsTests
     public async Task ProcessTags_Only_In_First_Span(bool enabled)
     {
         var settings = new TracerSettings(new NameValueConfigurationSource(new NameValueCollection { { ConfigurationKeys.PropagateProcessTags, enabled ? "true" : "false" } }));
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter);
 
         using (tracer.StartActiveInternal("A"))

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
@@ -376,7 +376,7 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
     private ScopedTracer GetTracer()
     {
         var settings = new TracerSettings();
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
         return TracerHelper.Create(settings, agentWriter, null, null, null);
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceContextPropertyTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceContextPropertyTests.cs
@@ -149,7 +149,7 @@ public class TraceContextPropertyTests
     private ScopedTracer GetTracer()
     {
         var settings = new TracerSettings();
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
         return TracerHelper.Create(settings, agentWriter, null, null, null);
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/TestTracer/AgentWriterHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestTracer/AgentWriterHelper.cs
@@ -1,0 +1,30 @@
+// <copyright file="AgentWriterHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Agent;
+using Datadog.Trace.DogStatsd;
+using Datadog.Trace.TestHelpers.Stats;
+
+namespace Datadog.Trace.TestHelpers.TestTracer;
+
+internal static class AgentWriterHelper
+{
+    /// <summary>
+    /// Creates an <see cref="AgentWriter"/> for tests that drive flushing themselves.
+    /// </summary>
+    public static AgentWriter CreateWithManualFlush(
+        IApi api,
+        IStatsAggregator statsAggregator = null,
+        IStatsdManager statsd = null,
+        int maxBufferSize = 1024 * 1024 * 10,
+        bool initialTracerMetricsEnabled = false)
+        => new(
+            api,
+            statsAggregator,
+            statsd ?? TestStatsdManager.NoOp,
+            automaticFlush: false,
+            maxBufferSize,
+            initialTracerMetricsEnabled: initialTracerMetricsEnabled);
+}

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -26,7 +26,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Tests.Agent
 {
-    public class AgentWriterTests
+    public class AgentWriterTests : IAsyncLifetime
     {
         private readonly ITestOutputHelper _output;
         private readonly AgentWriter _agentWriter;
@@ -38,6 +38,10 @@ namespace Datadog.Trace.Tests.Agent
             _api = new Mock<IApi>();
             _agentWriter = new AgentWriter(_api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp);
         }
+
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public Task DisposeAsync() => _agentWriter.FlushAndCloseAsync();
 
         [Fact]
         public async Task SpanSampling_CanComputeStats_ShouldNotSend_WhenSpanSamplingDoesNotMatch()
@@ -62,7 +66,7 @@ namespace Datadog.Trace.Tests.Agent
 
             api.Verify(x => x.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()), Times.Never);
 
-            await _agentWriter.FlushAndCloseAsync();
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -104,7 +108,7 @@ namespace Datadog.Trace.Tests.Agent
             actualDroppedP0Traces.Should().Be(expectedDroppedP0Traces);
             actualDroppedP0Spans.Should().Be(expectedDroppedP0Spans);
 
-            await _agentWriter.FlushAndCloseAsync();
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -152,7 +156,7 @@ namespace Datadog.Trace.Tests.Agent
             actualDroppedP0Traces.Should().Be(expectedDroppedP0Traces);
             actualDroppedP0Spans.Should().Be(expectedDroppedP0Spans);
 
-            await _agentWriter.FlushAndCloseAsync();
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -193,11 +197,11 @@ namespace Datadog.Trace.Tests.Agent
             api.Traces.Should().HaveCount(1);
             api.Traces[0].Should().HaveCount(2);
 
-            await _agentWriter.FlushAndCloseAsync();
+            await agentWriter.FlushAndCloseAsync();
         }
 
         [Fact]
-        public void PushStats()
+        public async Task PushStats()
         {
             var spans = CreateTraceChunk(1);
             var statsAggregator = new StubStatsAggregator(shouldKeepTrace: false, x => spans);
@@ -206,6 +210,8 @@ namespace Datadog.Trace.Tests.Agent
             agent.WriteTrace(spans);
 
             statsAggregator.AddedSpans.Should().Contain(spans).Which.Count.Should().Be(1);
+
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -357,10 +363,12 @@ namespace Datadog.Trace.Tests.Agent
             agent.BackBuffer.IsEmpty.Should().BeTrue();
 
             api.Verify(a => a.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), 1, It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()), Times.Exactly(2));
+
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
-        public void DropTraces()
+        public async Task DropTraces()
         {
             // Traces should be dropped when both buffers are full
             var statsd = new Mock<IDogStatsd>();
@@ -418,10 +426,12 @@ namespace Datadog.Trace.Tests.Agent
             statsd.Verify(s => s.Increment(TracerMetricNames.Queue.DroppedTraces, 1, 1, null), Times.Once);
             statsd.Verify(s => s.Increment(TracerMetricNames.Queue.DroppedSpans, 2, 1, null), Times.Once);
             statsd.VerifyNoOtherCalls();
+
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
-        public void DropTraceWhenBothBuffersAreLocked()
+        public async Task DropTraceWhenBothBuffersAreLocked()
         {
             var agent = new AgentWriter(
                 Mock.Of<IApi>(),
@@ -438,10 +448,12 @@ namespace Datadog.Trace.Tests.Agent
             agent.DroppedTracesBufferFullAndLocked.Should().Be(0);
             agent.DroppedTracesBuffersLocked.Should().Be(1);
             agent.DroppedTracesTooLarge.Should().Be(0);
+
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
-        public void DropTraceWhenOneBufferIsFullAndOneIsLocked()
+        public async Task DropTraceWhenOneBufferIsFullAndOneIsLocked()
         {
             var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
             var agent = new AgentWriter(
@@ -459,6 +471,8 @@ namespace Datadog.Trace.Tests.Agent
             agent.DroppedTracesBufferFullAndLocked.Should().Be(1);
             agent.DroppedTracesBuffersLocked.Should().Be(0);
             agent.DroppedTracesTooLarge.Should().Be(0);
+
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -490,10 +504,12 @@ namespace Datadog.Trace.Tests.Agent
 
             agent.DroppedTracesBufferFull.Should().Be(0);
             agent.DroppedTracesTooLarge.Should().Be(0);
+
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
-        public void DropTraceThatExceedsBufferSizeWhenActiveBufferIsLocked()
+        public async Task DropTraceThatExceedsBufferSizeWhenActiveBufferIsLocked()
         {
             var agent = new AgentWriter(
                 Mock.Of<IApi>(),
@@ -511,6 +527,8 @@ namespace Datadog.Trace.Tests.Agent
             agent.BackBuffer.IsEmpty.Should().BeTrue();
             agent.DroppedTracesBufferFull.Should().Be(0);
             agent.DroppedTracesTooLarge.Should().Be(1);
+
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -586,11 +604,12 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public void AgentWriterEnqueueFlushTasks()
+        public async Task AgentWriterEnqueueFlushTasks()
         {
             var api = new Mock<IApi>();
             var agentWriter = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
             var flushTcs = new TaskCompletionSource<bool>();
+            var firstSendEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             int invocation = 0;
 
             api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
@@ -599,6 +618,7 @@ namespace Datadog.Trace.Tests.Agent
                     // One for the front buffer, one for the back buffer
                     if (Interlocked.Increment(ref invocation) <= 2)
                     {
+                        firstSendEntered.TrySetResult(true);
                         return flushTcs.Task;
                     }
 
@@ -610,23 +630,32 @@ namespace Datadog.Trace.Tests.Agent
             // Write trace to the front buffer
             agentWriter.WriteTrace(spans);
 
-            // Flush front buffer
-            _ = agentWriter.FlushTracesAsync();
+            // Flush the front buffer. This blocks inside SendTracesAsync, so the front buffer
+            // stays locked until we complete flushTcs.
+            var firstFlush = agentWriter.FlushTracesAsync();
+            await firstSendEntered.Task;
 
-            // This will swap to the back buffer due front buffer is blocked.
+            // The front buffer is locked, so this swaps to the back buffer.
             agentWriter.WriteTrace(spans);
 
-            // Flush the second buffer
-            _ = agentWriter.FlushTracesAsync();
+            // Flush the back buffer. FlushBuffers() always flushes the front buffer too, so this
+            // queues up behind the first flush.
+            var secondFlush = agentWriter.FlushTracesAsync();
 
-            // This trace will force other buffer swap and then a drop because both buffers are blocked
+            // The back buffer is still unlocked, so this is written to it.
             agentWriter.WriteTrace(spans);
 
             // This will try to flush the front buffer again.
             var thirdFlush = agentWriter.FlushTracesAsync();
 
             // Third flush should wait for the first flush to complete.
-            thirdFlush.IsCompleted.Should().BeFalse();
+            var completed = await Task.WhenAny(thirdFlush, Task.Delay(TimeSpan.FromMilliseconds(100)));
+            completed.Should().NotBeSameAs(thirdFlush);
+
+            // Unblock the API so everything can drain and the writer can shut down.
+            flushTcs.TrySetResult(true);
+            await Task.WhenAll(firstFlush, secondFlush, thirdFlush);
+            await agentWriter.FlushAndCloseAsync();
         }
 
         private static bool WaitForDequeue(AgentWriter agent, bool wakeUpThread = true, int delay = -1)

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Tests.Agent
             var api = new Mock<IApi>();
             var settings = SpanSamplingRule("*", "*", 0.0f); // don't sample any rule
             var statsAggregator = new StubStatsAggregator(shouldKeepTrace: false, x => x);
-            var agent = new AgentWriter(api.Object, statsAggregator, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agent = AgentWriterHelper.CreateWithManualFlush(api.Object, statsAggregator);
 
             await using var tracer = TracerHelper.Create(settings, agent, sampler: null, scopeManager: null, statsd: null);
 
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var statsAggregator = new StubStatsAggregator(shouldKeepTrace: false, x => x);
             var settings = SpanSamplingRule("*", "*");
-            var agent = new AgentWriter(api.Object, statsAggregator, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agent = AgentWriterHelper.CreateWithManualFlush(api.Object, statsAggregator);
             await using var tracer = TracerHelper.Create(settings, agent, sampler: null, scopeManager: null, statsd: null);
 
             var traceContext = new TraceContext(tracer);
@@ -129,7 +129,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var statsAggregator = new StubStatsAggregator(shouldKeepTrace: false, x => x);
             var settings = SpanSamplingRule("*", "*");
-            var agent = new AgentWriter(api.Object, statsAggregator, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agent = AgentWriterHelper.CreateWithManualFlush(api.Object, statsAggregator);
             await using var tracer = TracerHelper.Create(settings, agent, sampler: null, scopeManager: null, statsd: null);
 
             var traceContext = new TraceContext(tracer);
@@ -166,7 +166,7 @@ namespace Datadog.Trace.Tests.Agent
             var statsAggregator = new StubStatsAggregator(shouldKeepTrace: false, x => x);
 
             var settings = SpanSamplingRule("*", "operation");
-            var agentWriter = new AgentWriter(api, statsAggregator, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agentWriter = AgentWriterHelper.CreateWithManualFlush(api, statsAggregator);
             await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
             var traceContext = new TraceContext(tracer);
@@ -205,7 +205,7 @@ namespace Datadog.Trace.Tests.Agent
         {
             var spans = CreateTraceChunk(1);
             var statsAggregator = new StubStatsAggregator(shouldKeepTrace: false, x => spans);
-            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agent = AgentWriterHelper.CreateWithManualFlush(Mock.Of<IApi>(), statsAggregator);
 
             agent.WriteTrace(spans);
 
@@ -265,7 +265,7 @@ namespace Datadog.Trace.Tests.Agent
             // The flush thread should be able to recover from an error when calling the API
             // Also, it should free the faulty buffer
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agent = AgentWriterHelper.CreateWithManualFlush(api.Object);
 
             api.Setup(a => a.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
                .Returns(() => throw new InvalidOperationException());
@@ -344,7 +344,7 @@ namespace Datadog.Trace.Tests.Agent
             var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
 
             // Make the buffer size big enough for a single trace
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1);
+            var agent = AgentWriterHelper.CreateWithManualFlush(api.Object, maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1);
 
             agent.WriteTrace(CreateTraceChunk(1));
             agent.WriteTrace(CreateTraceChunk(1));
@@ -376,7 +376,11 @@ namespace Datadog.Trace.Tests.Agent
             var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
 
             // Make the buffer size big enough for a single trace
-            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, new TestStatsdManager(statsd.Object), automaticFlush: false, (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1, initialTracerMetricsEnabled: true);
+            var agent = AgentWriterHelper.CreateWithManualFlush(
+                Mock.Of<IApi>(),
+                statsd: new TestStatsdManager(statsd.Object),
+                maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1,
+                initialTracerMetricsEnabled: true);
 
             // Fill the two buffers
             agent.WriteTrace(CreateTraceChunk(1));
@@ -433,11 +437,7 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public async Task DropTraceWhenBothBuffersAreLocked()
         {
-            var agent = new AgentWriter(
-                Mock.Of<IApi>(),
-                statsAggregator: null,
-                statsd: TestStatsdManager.NoOp,
-                automaticFlush: false);
+            var agent = AgentWriterHelper.CreateWithManualFlush(Mock.Of<IApi>());
 
             agent.FrontBuffer.Lock().Should().BeTrue();
             agent.BackBuffer.Lock().Should().BeTrue();
@@ -456,11 +456,8 @@ namespace Datadog.Trace.Tests.Agent
         public async Task DropTraceWhenOneBufferIsFullAndOneIsLocked()
         {
             var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
-            var agent = new AgentWriter(
+            var agent = AgentWriterHelper.CreateWithManualFlush(
                 Mock.Of<IApi>(),
-                statsAggregator: null,
-                statsd: TestStatsdManager.NoOp,
-                automaticFlush: false,
                 maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1);
 
             agent.FrontBuffer.Lock().Should().BeTrue();
@@ -479,11 +476,9 @@ namespace Datadog.Trace.Tests.Agent
         public async Task DropTraceThatExceedsBufferSize()
         {
             var statsd = new Mock<IDogStatsd>();
-            var agent = new AgentWriter(
+            var agent = AgentWriterHelper.CreateWithManualFlush(
                 Mock.Of<IApi>(),
-                statsAggregator: null,
-                new TestStatsdManager(statsd.Object),
-                automaticFlush: false,
+                statsd: new TestStatsdManager(statsd.Object),
                 maxBufferSize: SpanBufferMessagePackSerializer.HeaderSizeConst,
                 initialTracerMetricsEnabled: true);
 
@@ -511,11 +506,8 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public async Task DropTraceThatExceedsBufferSizeWhenActiveBufferIsLocked()
         {
-            var agent = new AgentWriter(
+            var agent = AgentWriterHelper.CreateWithManualFlush(
                 Mock.Of<IApi>(),
-                statsAggregator: null,
-                statsd: TestStatsdManager.NoOp,
-                automaticFlush: false,
                 maxBufferSize: SpanBufferMessagePackSerializer.HeaderSizeConst);
 
             agent.ActiveBuffer.Lock().Should().BeTrue();
@@ -575,7 +567,7 @@ namespace Datadog.Trace.Tests.Agent
 
             // Make the buffer size big enough for a single trace
             var api = new MockApi();
-            var agent = new AgentWriter(api, statsAggregator: null, statsd: TestStatsdManager.NoOp, calculator, automaticFlush: false, (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1, batchInterval: 100, apmTracingEnabled: true, initialTracerMetricsEnabled: false);
+            var agent = new AgentWriter(api, statsAggregator: null, statsd: TestStatsdManager.NoOp, calculator, automaticFlush: false, (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1, batchInterval: 0, apmTracingEnabled: true, initialTracerMetricsEnabled: false);
 
             // Fill both buffers
             agent.WriteTrace(spans);
@@ -607,7 +599,7 @@ namespace Datadog.Trace.Tests.Agent
         public async Task AgentWriterEnqueueFlushTasks()
         {
             var api = new Mock<IApi>();
-            var agentWriter = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agentWriter = AgentWriterHelper.CreateWithManualFlush(api.Object);
             var flushTcs = new TaskCompletionSource<bool>();
             var firstSendEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             int invocation = 0;

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
@@ -224,7 +224,7 @@ public class SpanMessagePackFormatterTests
         var discoveryService = new DiscoveryServiceMock();
         var mockApi = new MockApi();
         var settings = TracerSettings.Create(new());
-        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(mockApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null,  NullTelemetryController.Instance, discoveryService: discoveryService);
 
         tracer.TracerManager.Start();
@@ -453,7 +453,7 @@ public class SpanMessagePackFormatterTests
     {
         var mockApi = new MockApi();
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled, generate128BitTraceId } });
-        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(mockApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null, NullTelemetryController.Instance, NullDiscoveryService.Instance);
 
         using (_ = tracer.StartActive("root"))
@@ -494,7 +494,7 @@ public class SpanMessagePackFormatterTests
     {
         var mockApi = new MockApi();
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled, false } });
-        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(mockApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null, NullTelemetryController.Instance, NullDiscoveryService.Instance);
 
         using (var scope = tracer.StartActiveInternal("root"))
@@ -636,7 +636,7 @@ public class SpanMessagePackFormatterTests
             { ConfigurationKeys.PropagateProcessTags, propagateProcessTags.ToString() },
             { ConfigurationKeys.ServiceName, "test-service" }
         });
-        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+        var agentWriter = AgentWriterHelper.CreateWithManualFlush(mockApi);
         await using var tracer = TracerHelper.Create(settings, agentWriter, sampler: null, scopeManager: null, statsd: null, NullTelemetryController.Instance, NullDiscoveryService.Instance);
 
         using (_ = tracer.StartActive("root"))

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests.Tagging
         {
             var settings = new TracerSettings();
             _testApi = new MockApi();
-            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: TestStatsdManager.NoOp, automaticFlush: false);
+            var agentWriter = AgentWriterHelper.CreateWithManualFlush(_testApi);
             _tracer = TracerHelper.Create(settings, agentWriter);
         }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -73,7 +73,8 @@ namespace Benchmarks.Trace
         [GlobalCleanup]
         public void GlobalCleanup()
         {
-            _agentWriter.FlushAndCloseAsync();
+            _agentWriter.FlushAndCloseAsync().GetAwaiter().GetResult();
+            _agentWriterNoOpFlush.FlushAndCloseAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes

Minor cleanup for tests that use `AgentWriter`, and a helper for creating a "manual flush" writer

## Reason for change

Preparatory work for larger `AgentWriter` cleanup. 

## Implementation details

- Introduces a helper for testing that means consolidating some of the logic about "manual flush"
- Adds missing cleanup to all the agent writer instances created in tests (could leak background threads causing pressure in CI)
- Avoid leaving `AgentWriter` instances permanantly looping

## Test coverage

Basically the same

## Other details

Part of a stack