### PR TITLE
Fix minor `AgentWriter` bugs

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -289,7 +289,7 @@ namespace Datadog.Trace.Agent
 
         private void RequestFlush()
         {
-            _forceFlush.TrySetResult(default);
+            Volatile.Read(ref _forceFlush).TrySetResult(default);
         }
 
         private async Task FlushBuffersTaskLoopAsync()
@@ -306,8 +306,9 @@ namespace Datadog.Trace.Agent
 
                 if (_forceFlush.Task.IsCompleted)
                 {
-                    _forceFlush = new TaskCompletionSource<bool>(TaskOptions);
-                    tasks[1] = _forceFlush.Task;
+                    var forceFlush = new TaskCompletionSource<bool>(TaskOptions);
+                    Volatile.Write(ref _forceFlush, forceFlush);
+                    tasks[1] = forceFlush.Task;
                 }
 
                 await FlushBuffers().ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/MessagePackStringCache.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/MessagePackStringCache.cs
@@ -150,8 +150,8 @@ internal static class MessagePackStringCache
             return localCachedBytes.Bytes;
         }
 
-        // encode the string into MessagePack and cache the bytes before returning them
-        var bytes = string.IsNullOrWhiteSpace(value) ? null : MessagePackSerializer.Serialize(value);
+        // Encode the string into MessagePack and cache the bytes before returning them.
+        var bytes = string.IsNullOrWhiteSpace(value) ? null : MessagePackBinary.GetEncodedStringBytes(value!);
         cachedBytes = new CachedBytes(value, bytes);
         return bytes;
     }


### PR DESCRIPTION
## Summary of changes

Fixes two minor bugs, discovered while refactoring

## Reason for change

Spotted the bugs while refactoring other things. They are unlikely to hit in production, but are worth fixing, and orthogonal to the rest of the refactoring

## Implementation details

- `MessagePackSerializer.Serialize` writes to a _shared_ buffer. Given that the cache could well be used inside a _different_ call to `MessagePackSerializer.Serialize`, that could end up corrupting the cache. Instead, get the string bytes directly, which creates a new write-sized array instead.
- The `_forceFlush` field is accessed from different threads, and is replaced from both. Need Volatile/Interlocked to ensure that you don't get a stale reference

## Test coverage

Meh, I considered a test for the MessagePackStringCache.cs issue, but it's pretty niche, and would only be re-introduced if you change the code back, so figured the comment was sufficient.

## Other details

Part of a stack