### PR TITLE
Ensure `AgentWriter` serialization always happens on the same thread

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -48,9 +48,12 @@ namespace Datadog.Trace.Agent
 
         private readonly bool _apmTracingEnabled;
 
+        private readonly bool _backgroundFlushEnabled;
+
         /// <summary>
         /// The currently active buffer.
-        /// Note: Thread-safetiness in this class relies on the fact that only the serialization thread can change the active buffer
+        /// Note: Thread-safetiness in this class relies on the fact that only the serialization thread can change the active buffer.
+        /// <see cref="FlushBuffers"/> runs on other threads, so cross-thread accesses use <see cref="Volatile"/>.
         /// </summary>
         private SpanBuffer _activeBuffer;
 
@@ -90,9 +93,9 @@ namespace Datadog.Trace.Agent
         {
         }
 
-        // Passing automaticFlush: false makes the writer synchronous: traces are serialized on the
-        // calling thread, and neither the serialization loop nor the flush loop is started.
-        // That is only safe in tests, so production code must use the overload above.
+        // Passing automaticFlush: false stops the flush loop performing flushes nobody asked
+        // for, so that buffer and drop-counter state stays stable for assertions. Both loops still
+        // run, and flushes a caller is awaiting are unaffected. Production always passes true.
         [TestingOnly]
         internal AgentWriter(IApi api, IStatsAggregator? statsAggregator, IStatsdManager statsd, bool automaticFlush, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100, bool apmTracingEnabled = true, bool initialTracerMetricsEnabled = false)
         : this(api, statsAggregator, statsd, MovingAverageKeepRateCalculator.CreateDefaultKeepRateCalculator(), automaticFlush, maxBufferSize, batchInterval, apmTracingEnabled, initialTracerMetricsEnabled)
@@ -108,6 +111,7 @@ namespace Datadog.Trace.Agent
             _statsd = statsd;
             _batchInterval = batchInterval;
             _traceKeepRateCalculator = traceKeepRateCalculator;
+            _backgroundFlushEnabled = automaticFlush;
 
             ISpanBufferSerializer CreateSpanSerializer() => api.TracesEncoding switch
             {
@@ -127,15 +131,15 @@ namespace Datadog.Trace.Agent
             _traceMetricsEnabled = initialTracerMetricsEnabled;
             _statsd.SetRequired(StatsdConsumer.AgentWriter, initialTracerMetricsEnabled);
 
-            _serializationTask = automaticFlush
-                                     ? Task.Factory.StartNew(SerializeTracesLoop, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)
-                                     : Task.CompletedTask;
+            // Assign before starting the loops: the serialization thread can reach RequestFlush(),
+            // and the flush loop reads these, so they must be initialized first.
+            _backBufferFlushTask = _frontBufferFlushTask = Task.CompletedTask;
+
+            _serializationTask = Task.Factory.StartNew(SerializeTracesLoop, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             _serializationTask.ContinueWith(t => Log.Error(t.Exception, "Error in serialization task"), TaskContinuationOptions.OnlyOnFaulted);
 
-            _flushTask = automaticFlush ? Task.Run(FlushBuffersTaskLoopAsync) : Task.CompletedTask;
+            _flushTask = Task.Run(FlushBuffersTaskLoopAsync);
             _flushTask.ContinueWith(t => Log.Error(t.Exception, "Error in flush task"), TaskContinuationOptions.OnlyOnFaulted);
-
-            _backBufferFlushTask = _frontBufferFlushTask = Task.CompletedTask;
         }
 
         private enum TraceDropReason
@@ -181,17 +185,17 @@ namespace Datadog.Trace.Agent
 
             if (_serializationTask.IsCompleted)
             {
-                // Serialization thread is not running, serialize the trace in the current thread
-                SerializeTrace(trace);
+                // The serialization loop has stopped, so nothing will ever dequeue this trace.
+                // Drop it rather than retaining it in the queue for the lifetime of the process.
+                DropTrace(trace.Count, TraceDropReason.BuffersFull);
+                return;
             }
-            else
-            {
-                _pendingTraces.Enqueue(new WorkItem(in trace));
 
-                if (!_serializationMutex.IsSet)
-                {
-                    _serializationMutex.Set();
-                }
+            _pendingTraces.Enqueue(new WorkItem(in trace));
+
+            if (!_serializationMutex.IsSet)
+            {
+                _serializationMutex.Set();
             }
 
             if (Volatile.Read(ref _traceMetricsEnabled))
@@ -311,7 +315,10 @@ namespace Datadog.Trace.Agent
                     tasks[1] = forceFlush.Task;
                 }
 
-                await FlushBuffers().ConfigureAwait(false);
+                if (_backgroundFlushEnabled)
+                {
+                    await FlushBuffers().ConfigureAwait(false);
+                }
 
                 if (_serializationTask.IsCompleted)
                 {
@@ -447,6 +454,11 @@ namespace Datadog.Trace.Agent
             }
         }
 
+        /// <summary>
+        /// Serializes a trace chunk into the active buffer. Not thread safe: it mutates
+        /// <see cref="_temporaryBuffer"/> and swaps <see cref="_activeBuffer"/>, so it must only
+        /// ever be called from <see cref="SerializeTracesLoop"/>.
+        /// </summary>
         private void SerializeTrace(in SpanCollection spans)
         {
             // Declaring as inline method because only safe to invoke in the context of SerializeTrace

--- a/tracer/test/Datadog.Trace.TestHelpers/TestTracer/AgentWriterHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestTracer/AgentWriterHelper.cs
@@ -26,5 +26,6 @@ internal static class AgentWriterHelper
             statsd ?? TestStatsdManager.NoOp,
             automaticFlush: false,
             maxBufferSize,
+            batchInterval: 0,
             initialTracerMetricsEnabled: initialTracerMetricsEnabled);
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -97,9 +97,12 @@ namespace Datadog.Trace.Tests.Agent
             traceContext.SetSamplingPriority(priority: SamplingPriorityValues.UserReject, mechanism: SamplingMechanism.Manual, rate: null, limiterRate: null);
             span.Finish();
             var traceChunk = new SpanCollection([span]);
-            var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(traceChunk, SamplingPriorityValues.UserKeep, isFirstChunkInPayload: true), SpanFormatterResolver.Instance);
 
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            // Build the expectation after the flush: serializing the chunk sets TraceContext.TracesKeepRate,
+            // which TraceChunkModel snapshots, so a model built earlier would be missing _dd.tracer_kr.
+            var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(traceChunk, SamplingPriorityValues.UserKeep, isFirstChunkInPayload: true), SpanFormatterResolver.Instance);
 
             var expectedDroppedP0Traces = 1;
             var expectedDroppedP0Spans = 0;
@@ -144,10 +147,12 @@ namespace Datadog.Trace.Tests.Agent
             keptChildSpan.Finish();
 
             var expectedChunk = new SpanCollection([rootSpan, keptChildSpan]);
-            // var size = ComputeSize(expectedChunk);
-            var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(expectedChunk, SamplingPriorityValues.UserKeep, isFirstChunkInPayload: true), SpanFormatterResolver.Instance);
 
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            // Build the expectation after the flush: serializing the chunk sets TraceContext.TracesKeepRate,
+            // which TraceChunkModel snapshots, so a model built earlier would be missing _dd.tracer_kr.
+            var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(expectedChunk, SamplingPriorityValues.UserKeep, isFirstChunkInPayload: true), SpanFormatterResolver.Instance);
 
             var expectedDroppedP0Traces = 1;
             var expectedDroppedP0Spans = 0;
@@ -207,7 +212,7 @@ namespace Datadog.Trace.Tests.Agent
             var statsAggregator = new StubStatsAggregator(shouldKeepTrace: false, x => spans);
             var agent = AgentWriterHelper.CreateWithManualFlush(Mock.Of<IApi>(), statsAggregator);
 
-            agent.WriteTrace(spans);
+            WriteTraceAndWait(agent, spans);
 
             statsAggregator.AddedSpans.Should().Contain(spans).Which.Count.Should().Be(1);
 
@@ -346,8 +351,8 @@ namespace Datadog.Trace.Tests.Agent
             // Make the buffer size big enough for a single trace
             var agent = AgentWriterHelper.CreateWithManualFlush(api.Object, maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1);
 
-            agent.WriteTrace(CreateTraceChunk(1));
-            agent.WriteTrace(CreateTraceChunk(1));
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
 
             agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
 
@@ -383,8 +388,8 @@ namespace Datadog.Trace.Tests.Agent
                 initialTracerMetricsEnabled: true);
 
             // Fill the two buffers
-            agent.WriteTrace(CreateTraceChunk(1));
-            agent.WriteTrace(CreateTraceChunk(1));
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
 
             // Buffers should have swapped
             agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
@@ -405,7 +410,7 @@ namespace Datadog.Trace.Tests.Agent
             statsd.Invocations.Clear();
 
             // Both buffers are at capacity, write a new trace
-            agent.WriteTrace(CreateTraceChunk(2));
+            WriteTraceAndWait(agent, CreateTraceChunk(2));
 
             // Buffers shouldn't have swapped since the reserve buffer was full
             agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
@@ -442,7 +447,7 @@ namespace Datadog.Trace.Tests.Agent
             agent.FrontBuffer.Lock().Should().BeTrue();
             agent.BackBuffer.Lock().Should().BeTrue();
 
-            agent.WriteTrace(CreateTraceChunk(1));
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
 
             agent.DroppedTracesBufferFull.Should().Be(0);
             agent.DroppedTracesBufferFullAndLocked.Should().Be(0);
@@ -461,8 +466,8 @@ namespace Datadog.Trace.Tests.Agent
                 maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1);
 
             agent.FrontBuffer.Lock().Should().BeTrue();
-            agent.WriteTrace(CreateTraceChunk(1));
-            agent.WriteTrace(CreateTraceChunk(2));
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
+            WriteTraceAndWait(agent, CreateTraceChunk(2));
 
             agent.DroppedTracesBufferFull.Should().Be(0);
             agent.DroppedTracesBufferFullAndLocked.Should().Be(1);
@@ -482,7 +487,7 @@ namespace Datadog.Trace.Tests.Agent
                 maxBufferSize: SpanBufferMessagePackSerializer.HeaderSizeConst,
                 initialTracerMetricsEnabled: true);
 
-            agent.WriteTrace(CreateTraceChunk(1));
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
 
             agent.FrontBuffer.IsEmpty.Should().BeTrue();
             agent.BackBuffer.IsEmpty.Should().BeTrue();
@@ -512,7 +517,7 @@ namespace Datadog.Trace.Tests.Agent
 
             agent.ActiveBuffer.Lock().Should().BeTrue();
 
-            agent.WriteTrace(CreateTraceChunk(2));
+            WriteTraceAndWait(agent, CreateTraceChunk(2));
 
             agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
             agent.FrontBuffer.IsLocked.Should().BeTrue();
@@ -570,11 +575,11 @@ namespace Datadog.Trace.Tests.Agent
             var agent = new AgentWriter(api, statsAggregator: null, statsd: TestStatsdManager.NoOp, calculator, automaticFlush: false, (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1, batchInterval: 0, apmTracingEnabled: true, initialTracerMetricsEnabled: false);
 
             // Fill both buffers
-            agent.WriteTrace(spans);
-            agent.WriteTrace(spans);
+            WriteTraceAndWait(agent, spans);
+            WriteTraceAndWait(agent, spans);
 
             // Drop one
-            agent.WriteTrace(spans);
+            WriteTraceAndWait(agent, spans);
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             // Write another one
@@ -648,6 +653,34 @@ namespace Datadog.Trace.Tests.Agent
             flushTcs.TrySetResult(true);
             await Task.WhenAll(firstFlush, secondFlush, thirdFlush);
             await agentWriter.FlushAndCloseAsync();
+        }
+
+        [Fact]
+        public async Task WriteTrace_AfterFlushAndClose_DropsTheTrace()
+        {
+            // The serialization loop has stopped, so nothing would ever dequeue the trace. It has to
+            // be dropped, otherwise it sits in the queue for the lifetime of the process.
+            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd: TestStatsdManager.NoOp, batchInterval: 0);
+
+            await agent.FlushAndCloseAsync();
+
+            agent.WriteTrace(CreateTraceChunk(1));
+
+            // Nothing resets the counter, because the final flush ran before the write above
+            agent.DroppedTracesBufferFull.Should().Be(1);
+        }
+
+        /// <summary>
+        /// Writes a trace and blocks until the serialization thread has serialized it. The
+        /// watermark is enqueued after the trace and the queue has a single consumer, so the
+        /// callback firing proves the trace has been written to a buffer.
+        /// </summary>
+        private static void WriteTraceAndWait(AgentWriter agent, SpanCollection trace)
+        {
+            agent.WriteTrace(trace);
+
+            WaitForDequeue(agent, delay: 30_000)
+                .Should().BeTrue("the serialization thread should have serialized the trace");
         }
 
         private static bool WaitForDequeue(AgentWriter agent, bool wakeUpThread = true, int delay = -1)

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -63,8 +63,8 @@ namespace Benchmarks.Trace
 
             var noOpStatsd = new StatsdManager(settings, (_, _) => null);
             var noopApi = new NullApi();
-            _agentWriter = new AgentWriter(api, statsAggregator: null, statsd: noOpStatsd, automaticFlush: false);
-            _agentWriterNoOpFlush = new AgentWriter(noopApi, statsAggregator: null, statsd: noOpStatsd, automaticFlush: false);
+            _agentWriter = new AgentWriter(api, statsAggregator: null, statsd: noOpStatsd, automaticFlush: false, batchInterval: 0);
+            _agentWriterNoOpFlush = new AgentWriter(noopApi, statsAggregator: null, statsd: noOpStatsd, automaticFlush: false, batchInterval: 0);
 
             // Warmup to reduce noise
             WriteAndFlushEnrichedTraces().GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary of changes

- Make sure the serialization thread of `AgentWriter` _always_ run
- Serialization of traces always happens on this thread

## Reason for change

There was an explicit constraint that serializing traces is not thread safe, but that constraint wasn't actually honored by the production code. Additionally, the code had two "modes" - running with the background serializer (production) and running _without_ the background thread (tests). Disambiguating which constraints needed to hold in both cases was confusing (for us _and_ AI) and meant that there were potential subtle bugs

## Implementation details

- Always run the background threads, which dequeues items from the queue and which execute flushes.
- For testing purposes, the `automaticFlush` variable now controls whether a background flush trigger actually executes the flush or not, instead of controlling whether the background threads are actually _running_.
- Fix a minor startup race in the constructor.
- If the AgentWriter has shut down (the serialization thread isn't running) then just drop the trace explicitly, instead of either serializing it directly (not thread-safe) or queuing it (queue is no longer drained, so it just sits there forever)

## Test coverage

Mostly covered by existing behaviours. Tweaked the tests to make sure they wait for the serialization thread (and set `batchInterval=0` to reduce delays in the tests, triggering a flush immediately).

One thing that may need revisiting is the AgentWriter benchmark. I suspect we'll see variation in there now, and we may need to change the test to be more focused so that we _either_

- Accept that there's changes, but that these don't impact production
- Rewrite the test to be similar to before, i.e. test "inline serialization", though this probably means calling `SerializeTrace` directly, potentially good enough

Either way, let's see what they look like for this PR first.

## Other details

Part of a stack.

Note that these changes don't affect the "double lock" issue that spurred this stack