### PR TITLE
Handle UuidToStringA failure in GenerateRuntimeId

### DIFF
--- a/shared/src/native-src/util.cpp
+++ b/shared/src/native-src/util.cpp
@@ -285,8 +285,12 @@ namespace shared
         UUID uuid;
         UuidCreate(&uuid);
 
-        unsigned char* str;
-        UuidToStringA(&uuid, &str);
+        unsigned char* str = nullptr;
+        if (UuidToStringA(&uuid, &str) != RPC_S_OK)
+        {
+            // str is left untouched on failure, so there is nothing to free
+            return GenerateUuidV4();
+        }
 
         std::string s((char*) str);
 


### PR DESCRIPTION
## Summary of changes

`GenerateRuntimeId` ignored the return value of `UuidToStringA` and freed the output pointer unconditionally. Check it, and fall back to `GenerateUuidV4()` when it fails.

## Reason for change

`UuidToStringA` returns `RPC_S_OUT_OF_MEMORY` on failure and leaves `StringUuid` untouched. `str` was uninitialised, so on that path we handed a garbage stack value to `RpcStringFreeA`. That reaches `RtlFreeHeap` with a pointer that was never a live heap block, and Windows treats it as `STATUS_HEAP_CORRUPTION`, which is a non-continuable fast-fail. The process dies immediately, with no chance to handle it.

This runs on essentially every instrumented .NET process start on Windows. `RuntimeIdStore` is a by-value member of the native loader's `CorProfiler`, so its constructor runs during `CoCreateProfiler`. A rare allocation failure inside RPC therefore becomes a hard kill of the customer's process rather than a degraded runtime id.

I found this while looking at a crash report with exactly that signature on 3.32.1: `runtimeid_store.cpp:25` -> `RpcStringFree` -> `RtlFreeHeap` -> `RtlpHeapHandleError` -> `RtlReportCriticalFailure`. To be clear, I can't prove that report was caused by this rather than by heap corruption elsewhere in the process that this free happened to be the first to detect. The unchecked return value is wrong either way, so this is worth fixing on its own merits.

## Implementation details

Initialise `str`, and return the existing `GenerateUuidV4()` fallback when `UuidToStringA` does not return `RPC_S_OK`. `GenerateUuidV4` is already the non-Windows implementation, so there is no new code behind the fallback.

Not checking `UuidCreate` on purpose. `RPC_S_UUID_LOCAL_ONLY` still yields a usable UUID, and that result has no bearing on the free.

## Test coverage

The existing `runtimeid_store` gtests only cover the success path. Covering the failure path needs a seam to inject the `UuidToStringA` result, which I left out to keep this small. Happy to add it if reviewers would rather have it.

I could not build this locally, so CI is the first compile check.

## Other details

Windows only. Linux already went through `GenerateUuidV4()`.

<!-- Fixes #{issue} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
