### PR TITLE
[ASM] Log endpoints collection failures as warnings, not errors

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/EndpointsCollection/KestrelServerImplStartAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/EndpointsCollection/KestrelServerImplStartAsyncIntegration.cs
@@ -93,11 +93,7 @@ public sealed class KestrelServerImplStartAsyncIntegration
         }
         catch (Exception ex)
         {
-            // Evaluating this property runs third-party code that can throw for reasons outside our
-            // control. The Azure Functions worker, for instance, builds its endpoints lazily from
-            // function metadata and rejects malformed route templates, so we are the first caller to
-            // trigger the failure. That is not a tracer defect, so warn instead of reporting an error
-            // to telemetry. Anything thrown by our own collection below is a defect and still errors.
+            // Evaluating this property runs third-party code, so a failure here isn't a tracer defect
             Log.Warning(ex, "API Security: Endpoints collection: Failed to evaluate the EndpointDataSource endpoints.");
             return;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/EndpointsCollection/KestrelServerImplStartAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/EndpointsCollection/KestrelServerImplStartAsyncIntegration.cs
@@ -8,6 +8,7 @@
 #if !NETFRAMEWORK
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.AppSec;
@@ -57,12 +58,7 @@ public sealed class KestrelServerImplStartAsyncIntegration
         }
         catch (Exception ex)
         {
-            // Reading EndpointDataSource.Endpoints runs third-party code that can throw for reasons
-            // outside our control (e.g. the Azure Functions worker builds its endpoints lazily and
-            // rejects a malformed route template). Endpoints collection is best-effort, so a failure
-            // here degrades the feature without affecting the application: warn rather than report
-            // an error to telemetry.
-            Log.Warning(ex, "API Security: Failed to collect endpoints.");
+            Log.Error(ex, "API Security: Failed to collect endpoints.");
         }
 
         return CallTargetState.GetDefault();
@@ -89,7 +85,24 @@ public sealed class KestrelServerImplStartAsyncIntegration
             return;
         }
 
-        AppSec.EndpointsCollection.CollectEndpoints(endpointDataSource.Endpoints);
+        IReadOnlyList<object> endpoints;
+
+        try
+        {
+            endpoints = endpointDataSource.Endpoints;
+        }
+        catch (Exception ex)
+        {
+            // Evaluating this property runs third-party code that can throw for reasons outside our
+            // control. The Azure Functions worker, for instance, builds its endpoints lazily from
+            // function metadata and rejects malformed route templates, so we are the first caller to
+            // trigger the failure. That is not a tracer defect, so warn instead of reporting an error
+            // to telemetry. Anything thrown by our own collection below is a defect and still errors.
+            Log.Warning(ex, "API Security: Endpoints collection: Failed to evaluate the EndpointDataSource endpoints.");
+            return;
+        }
+
+        AppSec.EndpointsCollection.CollectEndpoints(endpoints);
     }
 }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/EndpointsCollection/KestrelServerImplStartAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/EndpointsCollection/KestrelServerImplStartAsyncIntegration.cs
@@ -57,7 +57,12 @@ public sealed class KestrelServerImplStartAsyncIntegration
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "API Security: Failed to collect endpoints.");
+            // Reading EndpointDataSource.Endpoints runs third-party code that can throw for reasons
+            // outside our control (e.g. the Azure Functions worker builds its endpoints lazily and
+            // rejects a malformed route template). Endpoints collection is best-effort, so a failure
+            // here degrades the feature without affecting the application: warn rather than report
+            // an error to telemetry.
+            Log.Warning(ex, "API Security: Failed to collect endpoints.");
         }
 
         return CallTargetState.GetDefault();


### PR DESCRIPTION
https://app.datadoghq.com/error-tracking/issue/fc6528a2-9617-11f1-a90b-da7ad0900002

## Summary of changes

Wrap the `EndpointDataSource.Endpoints` evaluation in `KestrelServerImplStartAsyncIntegration.GatherEndpoints` in its own `try/catch` that logs at `Log.Warning`. The outer catch keeps `Log.Error`.

## Reason for change

API Security endpoints collection reads `EndpointDataSource.Endpoints` at Kestrel startup. Evaluating that property executes third-party code that can throw for reasons outside our control: in the Azure Functions isolated worker, `FunctionsEndpointDataSource` builds its endpoints lazily from function metadata and rejects malformed route templates, producing a `RoutePatternException` that shows up in Error Tracking.

Because routing only enumerates endpoints on the first request, we are the first — often the only — caller to trigger that build, so a latent app-side defect surfaces as a tracer error. It is non-fatal: `CompositeEndpointDataSource` caches only on success, so the application still builds its endpoints normally when a request arrives.

## Implementation details

Only the third-party getter is downgraded. Exceptions from our own collection path — `EndpointsCollection.CollectEndpoints`, `ReportEndpoints`, duck casts — are tracer defects and still reach the outer catch at `Log.Error`, per the logging guidance in `AGENTS.md`.

## Test coverage

None — log level only, no behaviour change.

## Other details

APPSEC-69625. Deliberately does *not* skip collection under Azure Functions: specialization env vars are applied before the customer app loads, so eager evaluation reads correct metadata, and skipping would regress Azure Functions AAP coverage.

Separately tracked on the ticket: the endpoints we collect from `FunctionsEndpointDataSource` are themselves unvalidated (`RoutePattern.RawText` keeps a leading slash for these endpoints, and [azure-functions-dotnet-worker#3009](https://github.com/Azure/azure-functions-dotnet-worker/issues/3009) means the route prefix can disagree with what the host routes on). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
