### PR TITLE
[Propagators] Benchmark W3C tracestate parsing

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/W3CTraceContextPropagatorBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/W3CTraceContextPropagatorBenchmark.cs
@@ -23,6 +23,14 @@ public class W3CTraceContextPropagatorBenchmark
         "t.usr.id:12345~,ot=rv:ef284ace7a91e1;th:e6666666666668," +
         "rojo=00f067aa0ba902b7";
 
+    private const string DatadogAndOtelTraceState =
+        "dd=s:2;o:rum;p:0123456789abcdef;t.dm:-4;t.usr.id:12345~," +
+        "ot=rv:ef284ace7a91e1;th:e6666666666668";
+
+    private const string OtelAndDatadogTraceState =
+        "ot=rv:ef284ace7a91e1;th:e6666666666668," +
+        "dd=s:2;o:rum;p:0123456789abcdef;t.dm:-4;t.usr.id:12345~";
+
     [Benchmark]
     public string ParseTraceStateWithSingleVendor()
         => W3CTraceContextPropagator.ParseTraceState(SingleVendorTraceState)
@@ -41,5 +49,15 @@ public class W3CTraceContextPropagatorBenchmark
     [Benchmark]
     public string ParseTraceStateWithMultipleVendorsAndOtelTraceState()
         => W3CTraceContextPropagator.ParseTraceState(MultipleVendorsWithOtelTraceState)
+                                     .LastParent;
+
+    [Benchmark]
+    public string ParseTraceStateWithDatadogBeforeOtel()
+        => W3CTraceContextPropagator.ParseTraceState(DatadogAndOtelTraceState)
+                                     .LastParent;
+
+    [Benchmark]
+    public string ParseTraceStateWithOtelBeforeDatadog()
+        => W3CTraceContextPropagator.ParseTraceState(OtelAndDatadogTraceState)
                                      .LastParent;
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/W3CTraceContextPropagatorBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/W3CTraceContextPropagatorBenchmark.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+using Datadog.Trace.Propagators;
+
+namespace Benchmarks.Trace;
+
+[MemoryDiagnoser]
+[BenchmarkCategory(Constants.TracerCategory, Constants.RunOnPrs, Constants.RunOnMaster)]
+public class W3CTraceContextPropagatorBenchmark
+{
+    private const string SingleVendorTraceState =
+        "dd=s:2;o:rum;p:0123456789abcdef;t.dm:-4;t.usr.id:12345~";
+
+    private const string MultipleVendorsTraceState =
+        "congo=t61rcWkgMzE,dd=s:2;o:rum;p:0123456789abcdef;t.dm:-4;" +
+        "t.usr.id:12345~,rojo=00f067aa0ba902b7";
+
+    private const string MultipleVendorsWithDatadogFirstTraceState =
+        "dd=s:2;o:rum;p:0123456789abcdef;t.dm:-4;t.usr.id:12345~," +
+        "congo=t61rcWkgMzE,rojo=00f067aa0ba902b7";
+
+    private const string MultipleVendorsWithOtelTraceState =
+        "congo=t61rcWkgMzE,dd=s:2;o:rum;p:0123456789abcdef;t.dm:-4;" +
+        "t.usr.id:12345~,ot=rv:ef284ace7a91e1;th:e6666666666668," +
+        "rojo=00f067aa0ba902b7";
+
+    [Benchmark]
+    public string ParseTraceStateWithSingleVendor()
+        => W3CTraceContextPropagator.ParseTraceState(SingleVendorTraceState)
+                                     .LastParent;
+
+    [Benchmark]
+    public string ParseTraceStateWithMultipleVendors()
+        => W3CTraceContextPropagator.ParseTraceState(MultipleVendorsTraceState)
+                                     .LastParent;
+
+    [Benchmark]
+    public string ParseTraceStateWithMultipleVendorsAndDatadogFirst()
+        => W3CTraceContextPropagator.ParseTraceState(MultipleVendorsWithDatadogFirstTraceState)
+                                     .LastParent;
+
+    [Benchmark]
+    public string ParseTraceStateWithMultipleVendorsAndOtelTraceState()
+        => W3CTraceContextPropagator.ParseTraceState(MultipleVendorsWithOtelTraceState)
+                                     .LastParent;
+}


### PR DESCRIPTION
Not required to merge

Adds W3C tracestate parsing benchmarks for common vendor layouts, including dd-first and ot=rv/th members. (this was used for developing #9000 and #8983)

