### PR TITLE
[Debugger] Harden ClrMD memory assertions

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Assertions/DumpHeapLive.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Assertions/DumpHeapLive.cs
@@ -38,6 +38,9 @@ internal static class DumpHeapLive
 
         output?.WriteLine($"Creating snapshot of process ID {process.Id}");
         using var target = DataTarget.CreateSnapshotAndAttach(process.Id);
+        // ClrMD 3.2 resolves field types while caching field names. On .NET 7, this can try to
+        // calculate the size of a void placeholder and throw "Unexpected element type."
+        target.CacheOptions.CacheFieldNames = StringCaching.None;
         if (ct.IsCancellationRequested)
         {
             throw new OperationCanceledException();

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Assertions/MemoryAssertions.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Assertions/MemoryAssertions.cs
@@ -92,10 +92,10 @@ internal class MemoryAssertions
             output?.WriteLine($"Skipping memory assertion because ClrMD failed to capture or analyze the heap: {ex}");
             throw new SkipException($"ClrMD failed to capture or analyze the heap: {ex.Message}");
         }
-        catch (InvalidOperationException ex) when (IsClrMdStackRootEnumerationFailure(ex))
+        catch (Exception ex) when (IsClrMdFailure(ex))
         {
-            output?.WriteLine($"Skipping memory assertion because ClrMD failed while enumerating stack roots: {ex}");
-            throw new SkipException($"ClrMD failed while enumerating stack roots: {ex.Message}");
+            output?.WriteLine($"Skipping memory assertion because ClrMD failed to capture or analyze the heap: {ex}");
+            throw new SkipException($"ClrMD failed to capture or analyze the heap: {ex.Message}");
         }
     }
 
@@ -151,12 +151,23 @@ internal class MemoryAssertions
         }
     }
 
-    private static bool IsClrMdStackRootEnumerationFailure(Exception exception)
+    private static bool IsClrMdFailure(Exception exception)
     {
-        var stackTrace = exception.StackTrace;
-        return stackTrace is not null &&
-               stackTrace.IndexOf("Microsoft.Diagnostics.Runtime", StringComparison.Ordinal) >= 0 &&
-               stackTrace.IndexOf("EnumerateStackRoots", StringComparison.Ordinal) >= 0;
+        // ClrMD can leak BCL exceptions from its internals.
+        var hasClrMdFrame = false;
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is OutOfMemoryException or StackOverflowException or AccessViolationException)
+            {
+                return false;
+            }
+
+            var stackTrace = current.StackTrace;
+            hasClrMdFrame |= stackTrace is not null &&
+                             stackTrace.IndexOf("Microsoft.Diagnostics.Runtime", StringComparison.Ordinal) >= 0;
+        }
+
+        return hasClrMdFrame;
     }
 
     private string GetDumpDetails()


### PR DESCRIPTION
## Summary of changes
- Prevent unnecessary ClrMD field-type resolution during heap analysis.
- Skip affected debugger integration tests when unexpected ClrMD failures prevent heap analysis.

## Reason for change
- ClrMD 3.2 throws `Unexpected element type` on .NET 7 while resolving field metadata.
- The previous filter only handled a specific stack-root failure.

## Implementation details
- Disable only ClrMD field-name caching, avoiding eager type resolution.
- Identify ClrMD failures using an intentionally simple stack-trace heuristic across the exception chain.
- Allow fatal runtime exceptions to propagate normally.

## Other details
- Enabling these tests on .NET 8+ and evaluating ClrMD 4 will follow separately.
