### PR TITLE
[Profiler] Fix start/stop crash at shutdown

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -647,10 +647,6 @@ void CorProfilerCallback::InitializeServices()
         _pCpuTimeProvider,
         _metricsRegistry);
 
-    // Completes the wiring: StackSamplerLoop needed StackSamplerLoopManager to already exist (just
-    // passed above), but the manager needs StackSamplerLoop back (for its Windows deadlock-progress
-    // check) and that couldn't be constructor-injected the other way around, since StackSamplerLoop
-    // didn't exist yet when the manager was constructed.
     _pStackSamplerLoopManager->SetStackSamplerLoop(_pStackSamplerLoop);
 
 #ifdef ARM64

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -621,8 +621,8 @@ void CorProfilerCallback::InitializeServices()
     auto const& sampleTypeDefinitions = valueTypeProvider.GetValueTypes();
     Sample::ValuesCount = sampleTypeDefinitions.size();
 
-    // Shared by StackSamplerLoopManager and StackSamplerLoop (registered separately below), so it's
-    // constructed here rather than by either of them.
+    // Stack frames collector is shared by StackSamplerLoopManager and StackSamplerLoop
+    //  (registered separately below), so it's constructed here rather than by either of them.
     _callstackProvider = CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize));
     _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(
         _pCorProfilerInfo, _pConfiguration.get(), &_callstackProvider, _metricsRegistry);
@@ -635,11 +635,6 @@ void CorProfilerCallback::InitializeServices()
         _pStackFramesCollector.get(),
         _metricsRegistry);
 
-    // StackSamplerLoop is registered as its own independent service (rather than being privately
-    // owned and started/stopped by StackSamplerLoopManager) so that StartServices()/StopServices()'s
-    // existing, already-correct forward/reverse-order machinery governs its lifecycle directly:
-    // it starts after the manager's watcher thread is confirmed running, and stops before the
-    // manager (and before ManagedThreadList/CodeHotspotsThreadList, both registered earlier above).
     _pStackSamplerLoop = RegisterService<StackSamplerLoop>(
         _pCorProfilerInfo,
         _pConfiguration.get(),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -53,6 +53,8 @@
 #include "Sample.h"
 #include "SampleValueTypeProvider.h"
 #include "SsiManager.h"
+#include "StackFramesCollectorBase.h"
+#include "StackSamplerLoop.h"
 #include "StackSamplerLoopManager.h"
 #include "ThreadsCpuManager.h"
 #include "WallTimeProvider.h"
@@ -619,18 +621,42 @@ void CorProfilerCallback::InitializeServices()
     auto const& sampleTypeDefinitions = valueTypeProvider.GetValueTypes();
     Sample::ValuesCount = sampleTypeDefinitions.size();
 
+    // Shared by StackSamplerLoopManager and StackSamplerLoop (registered separately below), so it's
+    // constructed here rather than by either of them.
+    _callstackProvider = CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize));
+    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(
+        _pCorProfilerInfo, _pConfiguration.get(), &_callstackProvider, _metricsRegistry);
+
     _pStackSamplerLoopManager = RegisterService<StackSamplerLoopManager>(
         _pCorProfilerInfo,
-        _pConfiguration.get(),
         _metricsSender,
         _pClrLifetime.get(),
+        _pThreadsCpuManager,
+        _pStackFramesCollector.get(),
+        _metricsRegistry);
+
+    // StackSamplerLoop is registered as its own independent service (rather than being privately
+    // owned and started/stopped by StackSamplerLoopManager) so that StartServices()/StopServices()'s
+    // existing, already-correct forward/reverse-order machinery governs its lifecycle directly:
+    // it starts after the manager's watcher thread is confirmed running, and stops before the
+    // manager (and before ManagedThreadList/CodeHotspotsThreadList, both registered earlier above).
+    _pStackSamplerLoop = RegisterService<StackSamplerLoop>(
+        _pCorProfilerInfo,
+        _pConfiguration.get(),
+        _pStackFramesCollector.get(),
+        _pStackSamplerLoopManager,
         _pThreadsCpuManager,
         _pManagedThreadList,
         _pCodeHotspotsThreadList,
         _pWallTimeProvider,
         _pCpuTimeProvider,
-        _metricsRegistry,
-        CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize)));
+        _metricsRegistry);
+
+    // Completes the wiring: StackSamplerLoop needed StackSamplerLoopManager to already exist (just
+    // passed above), but the manager needs StackSamplerLoop back (for its Windows deadlock-progress
+    // check) and that couldn't be constructor-injected the other way around, since StackSamplerLoop
+    // didn't exist yet when the manager was constructed.
+    _pStackSamplerLoopManager->SetStackSamplerLoop(_pStackSamplerLoop);
 
 #ifdef ARM64
     if (Log::IsDebugEnabled())
@@ -978,6 +1004,7 @@ bool CorProfilerCallback::DisposeServices()
 
     _pThreadsCpuManager = nullptr;
     _pStackSamplerLoopManager = nullptr;
+    _pStackSamplerLoop = nullptr;
     _pManagedThreadList = nullptr;
     _pNativeThreadList = nullptr;
     _pCodeHotspotsThreadList = nullptr;
@@ -1844,6 +1871,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown()
 
     // A final .pprof should be generated before exiting
     // The aggregator must be stopped before the provider, since it will call them to get the last samples
+    // (StopServices() will also call Stop() on both of these again later, in the correct reverse-of-
+    // registration order; both are one-shot services, so those later calls are guaranteed no-ops.)
+    _pStackSamplerLoop->Stop();
     _pStackSamplerLoopManager->Stop();
 
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -10,6 +10,7 @@
 
 #include "AllocationsProvider.h"
 #include "ApplicationStore.h"
+#include "CallstackProvider.h"
 #include "EngineActiveGuard.h"
 #include "EventPipeEventsManager.h"
 #include "ExceptionsProvider.h"
@@ -60,7 +61,9 @@ class IService;
 class IThreadsCpuManager;
 class IManagedThreadList;
 class INativeThreadList;
+class StackSamplerLoop;
 class StackSamplerLoopManager;
+class StackFramesCollectorBase;
 class IConfiguration;
 class IExporter;
 class RawSampleTransformer;
@@ -257,6 +260,7 @@ private :
     // Their lifetime is managed by the _services vector.
     IThreadsCpuManager* _pThreadsCpuManager = nullptr;
     StackSamplerLoopManager* _pStackSamplerLoopManager = nullptr;
+    StackSamplerLoop* _pStackSamplerLoop = nullptr;
     IManagedThreadList* _pManagedThreadList = nullptr;
     IManagedThreadList* _pCodeHotspotsThreadList = nullptr;
     IApplicationStore* _pApplicationStore = nullptr;
@@ -285,6 +289,13 @@ private :
 #endif // LINUX
 
     std::vector<std::unique_ptr<IService>> _services;
+
+    // Shared by StackSamplerLoopManager and StackSamplerLoop (both registered in _services above).
+    // StackFramesCollectorBase is not itself an IService (no Start/Stop lifecycle), so it - and the
+    // CallstackProvider backing it - are owned directly here instead, and handed to both as a raw,
+    // non-owning pointer.
+    CallstackProvider _callstackProvider;
+    std::unique_ptr<StackFramesCollectorBase> _pStackFramesCollector;
 
     std::unique_ptr<IExporter> _pExporter = nullptr;
     std::shared_ptr<IConfiguration> _pConfiguration = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -33,6 +33,10 @@
 using namespace std::chrono_literals;
 constexpr const WCHAR* ThreadName = WStr("DD_StackSampler");
 
+// Make sure the sampler thread does not hang Start() forever - mirrors
+// StackSamplerLoopManager::RunWatcher()'s WatcherStartupTimeout.
+constexpr std::chrono::seconds LoopStartupTimeout = 2s;
+
 StackSamplerLoop::StackSamplerLoop(
     ICorProfilerInfo4* pCorProfilerInfo,
     IConfiguration* pConfiguration,
@@ -110,21 +114,48 @@ const char* StackSamplerLoop::GetName()
 
 bool StackSamplerLoop::StartImpl()
 {
-    _pLoopThread = std::make_unique<std::thread>([this]
-        {
-            OpSysTools::SetNativeThreadName(ThreadName);
-            MainLoop();
-        });
+    std::promise<void> loopReadyPromise;
+    std::future<void> loopReadyFuture = loopReadyPromise.get_future();
 
-    return true;
+    try
+    {
+        _pLoopThread = std::make_unique<std::thread>(
+            [this, promise = std::move(loopReadyPromise)]() mutable
+            {
+                OpSysTools::SetNativeThreadName(ThreadName);
+                MainLoop(std::move(promise));
+            });
+    }
+    catch (const std::exception& ex)
+    {
+        Log::Error("StackSamplerLoop::StartImpl - Failed to create the sampler thread: ", ex.what());
+        return false;
+    }
+
+    if (loopReadyFuture.wait_for(LoopStartupTimeout) == std::future_status::ready)
+    {
+        return true;
+    }
+
+    Log::Error("StackSamplerLoop::StartImpl - Timed out after ", LoopStartupTimeout.count(),
+               " seconds waiting for the sampler thread to start.");
+
+    // Request the (possibly just slow, not necessarily stuck) thread to shut down as soon as it
+    // does get scheduled, instead of leaving it running unsupervised - mirrors
+    // StackSamplerLoopManager::RunWatcher()'s identical timeout handling. Not joined right here,
+    // deliberately: join() could itself hang on a genuinely stuck thread, which would just move
+    // the unbounded-wait problem this timeout exists to avoid onto the caller of Start() instead.
+    _shutdownRequested = true;
+
+    return false;
 }
 
 bool StackSamplerLoop::StopImpl()
 {
-    _shutdownRequested = true;
-
     if (_pLoopThread != nullptr)
     {
+        _shutdownRequested = true;
+
         try
         {
             _pLoopThread->join();
@@ -134,13 +165,18 @@ bool StackSamplerLoop::StopImpl()
         {
         }
     }
-
     return true;
 }
 
-void StackSamplerLoop::MainLoop()
+void StackSamplerLoop::MainLoop(std::promise<void> loopReadyPromise)
 {
     Log::Debug("StackSamplerLoop::MainLoop started.");
+
+    // Signal readiness before the InitializeCurrentThread() CLR call below: the promise only
+    // needs to prove the OS actually scheduled this thread - the invariant StartImpl()'s bounded
+    // wait exists to check - not that its own setup has finished, and it must not be gated on
+    // anything that could itself block, or a slow-but-fine CLR call could trip that timeout.
+    loopReadyPromise.set_value();
 
     HRESULT hr = _pCorProfilerInfo->InitializeCurrentThread();
     if (hr != S_OK)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -8,6 +8,7 @@
 #include <atlcomcli.h>
 #endif
 
+#include <atomic>
 #include <memory>
 #include <unordered_map>
 
@@ -77,7 +78,7 @@ private:
 
     std::unique_ptr<std::thread> _pLoopThread;
     DWORD _loopThreadOsId;
-    volatile bool _shutdownRequested = false;
+    std::atomic<bool> _shutdownRequested = false;
     std::shared_ptr<ManagedThreadInfo> _targetThread;
     uint32_t _iteratorWallTime;
     uint32_t _iteratorCpuTime;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -9,6 +9,7 @@
 #endif
 
 #include <atomic>
+#include <future>
 #include <memory>
 #include <unordered_map>
 
@@ -97,7 +98,7 @@ private:
     std::shared_ptr<MeanMaxMetric> _cpuDurationMetric;
 
 private:
-    void MainLoop();
+    void MainLoop(std::promise<void> loopReadyPromise);
     void MainLoopIteration();
     void CpuProfilingIteration();
     void WalltimeProfilingIteration();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -114,6 +114,16 @@ bool StackSamplerLoopManager::StopImpl()
 
 bool StackSamplerLoopManager::RunWatcher()
 {
+    // StartImpl() returning false resets this service back to State::Init (see
+    // ServiceBase::Start()), and StartServices() happily calls Start() again on any service that
+    // isn't IsStarted() yet (e.g. from OnStartDelayedProfiling(), for SSI's deferred-start path).
+    // So a previous timed-out attempt's watcher thread can still be sitting in _pWatcherThread,
+    // unjoined, when we get here again. Clean it up first: overwriting _pWatcherThread below
+    // while it's still joinable would call std::terminate() in std::thread's destructor. This is
+    // a safe no-op on the common, non-retry path, where _pWatcherThread is still null.
+    ShutdownWatcher();
+    _isWatcherShutdownRequested = false;
+
     std::promise<void> watcherReadyPromise;
     std::future<void> watcherReadyFuture = watcherReadyPromise.get_future();
 
@@ -140,6 +150,17 @@ bool StackSamplerLoopManager::RunWatcher()
 
     Log::Error("StackSamplerLoopManager::RunWatcher - Timed out after ", WatcherStartupTimeout.count(),
                " seconds waiting for the watcher thread to start.");
+
+    // Request the (possibly just slow, not necessarily stuck) thread to shut down as soon as it
+    // does get scheduled, instead of leaving it running unsupervised: StartImpl() having failed
+    // means this service's state is back to Init, so ServiceBase::Stop()'s CAS guard will reject
+    // a Stop() call - StopImpl() (which would otherwise call ShutdownWatcher()) never runs until
+    // either a retried Start() reaches the cleanup above, or this manager is destroyed. Not
+    // joined right here, deliberately: join() could itself hang on a genuinely stuck thread,
+    // which would just move the unbounded-wait problem this timeout exists to avoid onto the
+    // caller of Start() instead.
+    _isWatcherShutdownRequested = true;
+
     return false;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -67,12 +67,6 @@ StackSamplerLoopManager::~StackSamplerLoopManager()
     // Just in case it was not called explicitely
     Stop();
 
-    // If Start() timed out waiting for the watcher thread (see RunWatcher()) but the thread was
-    // nonetheless successfully created, Stop()'s one-shot guard above is a no-op (this service's
-    // state never reached Started), so ShutdownWatcher() would otherwise never run - leaving
-    // _pWatcherThread joinable here, which would call std::terminate() when it is destroyed right
-    // after this destructor returns. Calling it unconditionally is a safe no-op if Stop() already
-    // handled it (ShutdownWatcher() resets _pWatcherThread to null after a successful join).
     ShutdownWatcher();
 
     ICorProfilerInfo4* pCorProfilerInfo = _pCorProfilerInfo;
@@ -114,16 +108,6 @@ bool StackSamplerLoopManager::StopImpl()
 
 bool StackSamplerLoopManager::RunWatcher()
 {
-    // StartImpl() returning false resets this service back to State::Init (see
-    // ServiceBase::Start()), and StartServices() happily calls Start() again on any service that
-    // isn't IsStarted() yet (e.g. from OnStartDelayedProfiling(), for SSI's deferred-start path).
-    // So a previous timed-out attempt's watcher thread can still be sitting in _pWatcherThread,
-    // unjoined, when we get here again. Clean it up first: overwriting _pWatcherThread below
-    // while it's still joinable would call std::terminate() in std::thread's destructor. This is
-    // a safe no-op on the common, non-retry path, where _pWatcherThread is still null.
-    ShutdownWatcher();
-    _isWatcherShutdownRequested = false;
-
     std::promise<void> watcherReadyPromise;
     std::future<void> watcherReadyFuture = watcherReadyPromise.get_future();
 
@@ -151,14 +135,6 @@ bool StackSamplerLoopManager::RunWatcher()
     Log::Error("StackSamplerLoopManager::RunWatcher - Timed out after ", WatcherStartupTimeout.count(),
                " seconds waiting for the watcher thread to start.");
 
-    // Request the (possibly just slow, not necessarily stuck) thread to shut down as soon as it
-    // does get scheduled, instead of leaving it running unsupervised: StartImpl() having failed
-    // means this service's state is back to Init, so ServiceBase::Stop()'s CAS guard will reject
-    // a Stop() call - StopImpl() (which would otherwise call ShutdownWatcher()) never runs until
-    // either a retried Start() reaches the cleanup above, or this manager is destroyed. Not
-    // joined right here, deliberately: join() could itself hang on a genuinely stuck thread,
-    // which would just move the unbounded-wait problem this timeout exists to avoid onto the
-    // caller of Start() instead.
     _isWatcherShutdownRequested = true;
 
     return false;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -26,25 +26,15 @@ const std::chrono::nanoseconds StackSamplerLoopManager::StatisticAggregationPeri
 
 StackSamplerLoopManager::StackSamplerLoopManager(
     ICorProfilerInfo4* pCorProfilerInfo,
-    IConfiguration* pConfiguration,
     std::shared_ptr<IMetricsSender> metricsSender,
     IClrLifetime const* clrLifetime,
     IThreadsCpuManager* pThreadsCpuManager,
-    IManagedThreadList* pManagedThreadList,
-    IManagedThreadList* pCodeHotspotThreadList,
-    ICollector<RawWallTimeSample>* pWallTimeCollector,
-    ICollector<RawCpuSample>* pCpuTimeCollector,
-    MetricsRegistry& metricsRegistry,
-    CallstackProvider callstackProvider
+    StackFramesCollectorBase* pStackFramesCollector,
+    MetricsRegistry& metricsRegistry
     ) :
     _pCorProfilerInfo{pCorProfilerInfo},
-    _pConfiguration{pConfiguration},
     _pThreadsCpuManager{pThreadsCpuManager},
-    _pManagedThreadList{pManagedThreadList},
-    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
-    _pWallTimeCollector{pWallTimeCollector},
-    _pCpuTimeCollector{pCpuTimeCollector},
-    _pStackFramesCollector{nullptr},
+    _pStackFramesCollector{pStackFramesCollector},
     _pStackSamplerLoop{nullptr},
     _deadlockInterventionInProgress{0},
     _pWatcherThread{nullptr},
@@ -59,12 +49,9 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     _totalDeadlockDetectionsCount{0},
     _metricsSender{metricsSender},
     _statisticsReadyToSend{nullptr},
-    _metricsRegistry{metricsRegistry},
-    _callstackProvider{std::move(callstackProvider)}
+    _metricsRegistry{metricsRegistry}
 {
     _pCorProfilerInfo->AddRef();
-    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(
-        _pCorProfilerInfo, pConfiguration, &_callstackProvider, _metricsRegistry);
 
     _currentStatistics = std::make_unique<Statistics>();
     _statisticCollectionStartNs = OpSysTools::GetHighPrecisionNanoseconds();
@@ -90,45 +77,45 @@ const char* StackSamplerLoopManager::GetName()
     return _serviceName;
 }
 
+void StackSamplerLoopManager::SetStackSamplerLoop(StackSamplerLoop* pStackSamplerLoop)
+{
+    _pStackSamplerLoop = pStackSamplerLoop;
+}
+
 bool StackSamplerLoopManager::StartImpl()
 {
-    InitializeSampler();
-    RunWatcherAndSampler();
+    if (_pStackSamplerLoop == nullptr)
+    {
+        Log::Error("StackSamplerLoopManager::StartImpl - StackSamplerLoop was not wired in "
+                   "(SetStackSamplerLoop() must be called before Start()). This is a bug.");
+        return false;
+    }
 
-    return true;
+    return RunWatcher();
 }
 
 bool StackSamplerLoopManager::StopImpl()
 {
-    _pStackSamplerLoop->Stop();
-
     ShutdownWatcher();
 
     return true;
 }
 
-void StackSamplerLoopManager::InitializeSampler()
-{
-    _pStackSamplerLoop = std::make_unique<StackSamplerLoop>(
-        _pCorProfilerInfo,
-        _pConfiguration,
-        _pStackFramesCollector.get(),
-        this,
-        _pThreadsCpuManager,
-        _pManagedThreadList,
-        _pCodeHotspotsThreadList,
-        _pWallTimeCollector,
-        _pCpuTimeCollector,
-        _metricsRegistry);
-}
-
-void StackSamplerLoopManager::RunWatcherAndSampler()
+bool StackSamplerLoopManager::RunWatcher()
 {
     _pWatcherThread = std::make_unique<std::thread>([this]
         {
             OpSysTools::SetNativeThreadName(WatcherThreadName);
             WatcherLoop();
         });
+
+    // Block until WatcherLoop() has actually started running (its first action), so that by the
+    // time Start() returns, the deadlock watchdog is guaranteed to be up. This preserves the
+    // ordering PR #6134 established (the watcher must exist before the sampler's first sample),
+    // now enforced here instead of by starting the sampler from inside the watcher thread.
+    std::unique_lock<std::mutex> lock(_watcherReadyLock);
+    _watcherReadySignal.wait(lock, [this] { return _isWatcherReady; });
+    return true;
 }
 
 void StackSamplerLoopManager::ShutdownWatcher()
@@ -146,8 +133,11 @@ void StackSamplerLoopManager::WatcherLoop()
     Log::Info("StackSamplerLoopManager::WatcherLoop started.");
     _pThreadsCpuManager->Map(OpSysTools::GetThreadId(), WatcherThreadName);
 
-    // Start the sampler loop only when the watcher is ready
-    _pStackSamplerLoop->Start();
+    {
+        std::lock_guard<std::mutex> lock(_watcherReadyLock);
+        _isWatcherReady = true;
+    }
+    _watcherReadySignal.notify_all();
 
     while (false == _isWatcherShutdownRequested)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -92,7 +92,7 @@ bool StackSamplerLoopManager::StartImpl()
     if (_pStackSamplerLoop == nullptr)
     {
         Log::Error("StackSamplerLoopManager::StartImpl - StackSamplerLoop was not wired in "
-                   "(SetStackSamplerLoop() must be called before Start()). This is a bug.");
+                   "(SetStackSamplerLoop() must be called before Start()).");
         return false;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -14,6 +14,9 @@ constexpr std::chrono::milliseconds DeadlockDetectionInterval = 1s;
 constexpr std::chrono::milliseconds MaxExpectedStackSampleCollectionDurationMs = 500ms;
 constexpr std::chrono::nanoseconds CollectionDurationThresholdNs = std::chrono::nanoseconds(MaxExpectedStackSampleCollectionDurationMs);
 
+// Make sure the Watcher thread does not hang Start() forever.
+constexpr std::chrono::seconds WatcherStartupTimeout = 2s;
+
 #ifdef NDEBUG
 constexpr std::chrono::milliseconds StatsAggregationPeriodMs = 30000ms;
 #else
@@ -64,6 +67,14 @@ StackSamplerLoopManager::~StackSamplerLoopManager()
     // Just in case it was not called explicitely
     Stop();
 
+    // If Start() timed out waiting for the watcher thread (see RunWatcher()) but the thread was
+    // nonetheless successfully created, Stop()'s one-shot guard above is a no-op (this service's
+    // state never reached Started), so ShutdownWatcher() would otherwise never run - leaving
+    // _pWatcherThread joinable here, which would call std::terminate() when it is destroyed right
+    // after this destructor returns. Calling it unconditionally is a safe no-op if Stop() already
+    // handled it (ShutdownWatcher() resets _pWatcherThread to null after a successful join).
+    ShutdownWatcher();
+
     ICorProfilerInfo4* pCorProfilerInfo = _pCorProfilerInfo;
     if (pCorProfilerInfo != nullptr)
     {
@@ -103,19 +114,33 @@ bool StackSamplerLoopManager::StopImpl()
 
 bool StackSamplerLoopManager::RunWatcher()
 {
-    _pWatcherThread = std::make_unique<std::thread>([this]
-        {
-            OpSysTools::SetNativeThreadName(WatcherThreadName);
-            WatcherLoop();
-        });
+    std::promise<void> watcherReadyPromise;
+    std::future<void> watcherReadyFuture = watcherReadyPromise.get_future();
 
-    // Block until WatcherLoop() has actually started running (its first action), so that by the
-    // time Start() returns, the deadlock watchdog is guaranteed to be up. This preserves the
-    // ordering PR #6134 established (the watcher must exist before the sampler's first sample),
-    // now enforced here instead of by starting the sampler from inside the watcher thread.
-    std::unique_lock<std::mutex> lock(_watcherReadyLock);
-    _watcherReadySignal.wait(lock, [this] { return _isWatcherReady; });
-    return true;
+    try
+    {
+        _pWatcherThread = std::make_unique<std::thread>(
+            [this, promise = std::move(watcherReadyPromise)]() mutable
+            {
+                OpSysTools::SetNativeThreadName(WatcherThreadName);
+                WatcherLoop(std::move(promise));
+            });
+    }
+    catch (const std::exception& ex)
+    {
+        Log::Error("StackSamplerLoopManager::RunWatcher - Failed to create the watcher thread: ", ex.what());
+        return false;
+    }
+
+    // Wait for the watcher thread to be ready before returning
+    if (watcherReadyFuture.wait_for(WatcherStartupTimeout) == std::future_status::ready)
+    {
+        return true;
+    }
+
+    Log::Error("StackSamplerLoopManager::RunWatcher - Timed out after ", WatcherStartupTimeout.count(),
+               " seconds waiting for the watcher thread to start.");
+    return false;
 }
 
 void StackSamplerLoopManager::ShutdownWatcher()
@@ -124,20 +149,23 @@ void StackSamplerLoopManager::ShutdownWatcher()
     {
         _isWatcherShutdownRequested = true;
 
-        _pWatcherThread->join();
+        try
+        {
+            _pWatcherThread->join();
+            _pWatcherThread.reset();
+        }
+        catch (const std::exception&)
+        {
+        }
     }
 }
 
-void StackSamplerLoopManager::WatcherLoop()
+void StackSamplerLoopManager::WatcherLoop(std::promise<void> watcherReadyPromise)
 {
     Log::Info("StackSamplerLoopManager::WatcherLoop started.");
     _pThreadsCpuManager->Map(OpSysTools::GetThreadId(), WatcherThreadName);
 
-    {
-        std::lock_guard<std::mutex> lock(_watcherReadyLock);
-        _isWatcherReady = true;
-    }
-    _watcherReadySignal.notify_all();
+    watcherReadyPromise.set_value();
 
     while (false == _isWatcherShutdownRequested)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -94,9 +94,6 @@ public:
     void NotifyCollectionEnd() override;
     void NotifyIterationFinished() override;
 
-    // Wires in the independently-registered StackSamplerLoop service this manager monitors.
-    // Must be called once, before Start(), after both services are constructed - see
-    // CorProfilerCallback::InitializeServices(). StartImpl() defends against this being skipped.
     void SetStackSamplerLoop(StackSamplerLoop* pStackSamplerLoop);
 
 private:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -5,7 +5,7 @@
 
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -108,7 +108,7 @@ private:
     bool RunWatcher();
     void ShutdownWatcher();
 
-    void WatcherLoop();
+    void WatcherLoop(std::promise<void> watcherReadyPromise);
     void WatcherLoopIteration();
     void PerformDeadlockIntervention(const std::chrono::nanoseconds& ongoingStackSampleCollectionDurationNs);
     void LogDeadlockIntervention(
@@ -210,14 +210,6 @@ private:
 
     std::unique_ptr<std::thread> _pWatcherThread;
     std::atomic<bool> _isWatcherShutdownRequested;
-
-    // One-shot "the watcher thread is actually running" handshake: RunWatcher() blocks on this
-    // so that StartImpl() cannot return until the watcher is up, preserving the invariant that
-    // the deadlock watchdog exists before StackSamplerLoop::Start() is called (by
-    // CorProfilerCallback::StartServices(), right after this manager's own Start() returns).
-    std::mutex _watcherReadyLock;
-    std::condition_variable _watcherReadySignal;
-    bool _isWatcherReady = false;
 
     std::mutex _watcherActivityLock;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <thread>
 #include <unordered_map>
 
@@ -13,7 +16,6 @@
 #include "corprof.h"
 // end
 
-#include "CallstackProvider.h"
 #include "CounterMetric.h"
 #include "ICollector.h"
 #include "IMetricsSender.h"
@@ -25,8 +27,6 @@
 #include "RawCpuSample.h"
 #include "RawWallTimeSample.h"
 #include "StackSamplerLoop.h"
-#include "MetricsRegistry.h"
-#include "CounterMetric.h"
 #include "ServiceBase.h"
 
 // forward declaration
@@ -78,16 +78,11 @@ class StackSamplerLoopManager
 public:
     StackSamplerLoopManager(
         ICorProfilerInfo4* pCorProfilerInfo,
-        IConfiguration* pConfiguration,
         std::shared_ptr<IMetricsSender> metricsSender,
         IClrLifetime const* clrLifetime,
         IThreadsCpuManager* pThreadsCpuManager,
-        IManagedThreadList* pManagedThreadList,
-        IManagedThreadList* pCodeHotspotThreadList,
-        ICollector<RawWallTimeSample>* pWallTimeCollector,
-        ICollector<RawCpuSample>* pCpuTimeCollector,
-        MetricsRegistry& metricsRegistry,
-        CallstackProvider callstackProvider);
+        StackFramesCollectorBase* pStackFramesCollector,
+        MetricsRegistry& metricsRegistry);
 
     ~StackSamplerLoopManager() override;
 
@@ -99,15 +94,18 @@ public:
     void NotifyCollectionEnd() override;
     void NotifyIterationFinished() override;
 
+    // Wires in the independently-registered StackSamplerLoop service this manager monitors.
+    // Must be called once, before Start(), after both services are constructed - see
+    // CorProfilerCallback::InitializeServices(). StartImpl() defends against this being skipped.
+    void SetStackSamplerLoop(StackSamplerLoop* pStackSamplerLoop);
+
 private:
     StackSamplerLoopManager() = delete;
 
     inline bool GetUpdateIsThreadSafeForStackSampleCollection(ManagedThreadInfo* pThreadInfo, bool* pIsStatusChanged);
     static inline bool ShouldCollectThread(std::uint64_t threadAggPeriodDeadlockCount, std::uint64_t globalAggPeriodDeadlockCount) ;
 
-    void InitializeSampler();
-
-    void RunWatcherAndSampler();
+    bool RunWatcher();
     void ShutdownWatcher();
 
     void WatcherLoop();
@@ -202,19 +200,24 @@ private:
 private:
     const char* _serviceName = "StackSamplerLoopManager";
     ICorProfilerInfo4* _pCorProfilerInfo;
-    IConfiguration* _pConfiguration = nullptr;
     IThreadsCpuManager* _pThreadsCpuManager = nullptr;
-    IManagedThreadList* _pManagedThreadList = nullptr;
-    IManagedThreadList* _pCodeHotspotsThreadList = nullptr;
-    ICollector<RawWallTimeSample>* _pWallTimeCollector = nullptr;
-    ICollector<RawCpuSample>* _pCpuTimeCollector = nullptr;
 
-    std::unique_ptr<StackSamplerLoop> _pStackSamplerLoop;
-    std::unique_ptr<StackFramesCollectorBase> _pStackFramesCollector;
+    // Non-owning: both are independently-registered IServices; lifetime is managed by
+    // CorProfilerCallback::_services. See SetStackSamplerLoop().
+    StackFramesCollectorBase* _pStackFramesCollector = nullptr;
+    StackSamplerLoop* _pStackSamplerLoop = nullptr;
     std::uint8_t _deadlockInterventionInProgress;
 
     std::unique_ptr<std::thread> _pWatcherThread;
-    bool _isWatcherShutdownRequested;
+    std::atomic<bool> _isWatcherShutdownRequested;
+
+    // One-shot "the watcher thread is actually running" handshake: RunWatcher() blocks on this
+    // so that StartImpl() cannot return until the watcher is up, preserving the invariant that
+    // the deadlock watchdog exists before StackSamplerLoop::Start() is called (by
+    // CorProfilerCallback::StartServices(), right after this manager's own Start() returns).
+    std::mutex _watcherReadyLock;
+    std::condition_variable _watcherReadySignal;
+    bool _isWatcherReady = false;
 
     std::mutex _watcherActivityLock;
 
@@ -241,6 +244,4 @@ private:
     std::unique_ptr<Statistics> _currentStatistics;
     MetricsRegistry& _metricsRegistry;
     std::shared_ptr<CounterMetric> _deadlockCountMetric;
-
-    CallstackProvider _callstackProvider;
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/StackSamplerLoopManagerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/StackSamplerLoopManagerTest.cpp
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ManagedThreadList.h"
+#include "MetricsRegistry.h"
+#include "MockProfilerInfo.h"
+#include "ProfilerMockedInterface.h"
+#include "StackSamplerLoop.h"
+#include "StackSamplerLoopManager.h"
+#include "ThreadsCpuManager.h"
+
+using ::testing::Return;
+
+// These tests cover the fix for a shutdown-time SEGV in StackSamplerLoop::CodeHotspotIteration():
+// StackSamplerLoop used to be a private implementation detail owned and started/stopped by
+// StackSamplerLoopManager via an ad hoc, asynchronous sequence (started from inside a freshly-
+// spawned watcher thread, with no synchronization back to the caller). If CorProfilerCallback::
+// Shutdown()'s early, explicit Stop() call raced ahead of that async start, it silently no-opped
+// (StackSamplerLoop's one-shot ServiceBase CAS guard rejected it), and the sampler thread went on
+// to start anyway - running unsupervised, after shutdown had already begun destroying the
+// ManagedThreadList instances it depends on.
+//
+// The fix promotes StackSamplerLoop to its own independently-registered IService, so
+// CorProfilerCallback's existing, already-correct StartServices()/StopServices() forward/reverse
+// loops govern its lifecycle directly instead of relying on StackSamplerLoopManager to get an
+// internal call sequence right by hand. These tests exercise that lifecycle directly, without
+// needing a full CorProfilerCallback.
+
+namespace
+{
+    // Wall-time/CPU profiling are disabled in every test below, so StackSamplerLoop's background
+    // thread never selects a target thread to sample - CollectOneThreadStackSample() (the only
+    // place that would dereference the StackFramesCollectorBase*/collector pointers) is never
+    // reached. That makes it safe to pass nullptr for those collector-related dependencies here;
+    // this test is about start/stop lifecycle ordering, not stack-walking.
+    void StubOutSamplingConfig(MockConfiguration& config)
+    {
+        ON_CALL(config, IsWallTimeProfilingEnabled()).WillByDefault(Return(false));
+        ON_CALL(config, IsCpuProfilingEnabled()).WillByDefault(Return(false));
+        ON_CALL(config, IsInternalMetricsEnabled()).WillByDefault(Return(false));
+        ON_CALL(config, WalltimeThreadsThreshold()).WillByDefault(Return(0));
+        ON_CALL(config, CpuThreadsThreshold()).WillByDefault(Return(0));
+        ON_CALL(config, CodeHotspotsThreadsThreshold()).WillByDefault(Return(0));
+        // Avoid a tight busy-spin in StackSamplerLoop::MainLoop() (OpSysTools::Sleep(0ns)) between
+        // the Start() and Stop() calls each test issues.
+        ON_CALL(config, CpuWallTimeSamplingRate()).WillByDefault(Return(std::chrono::milliseconds(50)));
+    }
+}
+
+TEST(StackSamplerLoopManagerTest, StartFailsCleanlyWhenStackSamplerLoopWasNeverWiredIn)
+{
+    MockProfilerInfo profilerInfo;
+    ThreadsCpuManager threadsCpuManager;
+    MetricsRegistry metricsRegistry;
+
+    StackSamplerLoopManager manager(
+        &profilerInfo, nullptr /*metricsSender*/, nullptr /*clrLifetime*/,
+        &threadsCpuManager, nullptr /*stackFramesCollector*/, metricsRegistry);
+
+    // SetStackSamplerLoop() is deliberately never called. Before the fix, a mistake like this
+    // (e.g. dropping the wiring call in a future refactor of CorProfilerCallback::
+    // InitializeServices()) would let RunWatcher() spawn a watcher thread that immediately
+    // dereferences a null StackSamplerLoop* - a SIGSEGV on every single startup. StartImpl()'s
+    // safety-net check must turn that into a clean, logged Start() failure instead.
+    ASSERT_FALSE(manager.Start());
+    ASSERT_FALSE(manager.IsStarted());
+}
+
+TEST(StackSamplerLoopManagerTest, StackSamplerLoopStartsAndStopsIndependentlyOfTheManager)
+{
+    MockProfilerInfo profilerInfo;
+    auto [configHolder, config] = CreateConfiguration();
+    StubOutSamplingConfig(config);
+
+    ThreadsCpuManager threadsCpuManager;
+    ManagedThreadList managedThreadList(nullptr);
+    ManagedThreadList codeHotspotThreadList(nullptr);
+    MetricsRegistry metricsRegistry;
+
+    // The manager is only constructed here because StackSamplerLoop's constructor requires a
+    // StackSamplerLoopManager* to notify - it is never Start()ed. Being able to Start()/Stop() the
+    // sampler on its own, without the manager's watcher running at all, is exactly the
+    // independence this fix is meant to provide (previously, StackSamplerLoop had no lifecycle of
+    // its own to test - it was entirely internal to StackSamplerLoopManager).
+    StackSamplerLoopManager manager(
+        &profilerInfo, nullptr, nullptr, &threadsCpuManager, nullptr, metricsRegistry);
+
+    StackSamplerLoop stackSamplerLoop(
+        &profilerInfo, configHolder.get(), nullptr /*stackFramesCollector*/, &manager,
+        &threadsCpuManager, &managedThreadList, &codeHotspotThreadList,
+        nullptr /*wallTimeCollector*/, nullptr /*cpuTimeCollector*/, metricsRegistry);
+
+    ASSERT_TRUE(stackSamplerLoop.Start());
+    ASSERT_TRUE(stackSamplerLoop.IsStarted());
+    ASSERT_TRUE(stackSamplerLoop.Stop());
+    ASSERT_FALSE(stackSamplerLoop.IsStarted());
+}
+
+TEST(StackSamplerLoopManagerTest, FullLifecycleMatchesStartServicesAndStopServicesOrdering)
+{
+    MockProfilerInfo profilerInfo;
+    auto [configHolder, config] = CreateConfiguration();
+    StubOutSamplingConfig(config);
+
+    ThreadsCpuManager threadsCpuManager;
+    ManagedThreadList managedThreadList(nullptr);
+    ManagedThreadList codeHotspotThreadList(nullptr);
+    MetricsRegistry metricsRegistry;
+
+    StackSamplerLoopManager manager(
+        &profilerInfo, nullptr, nullptr, &threadsCpuManager, nullptr, metricsRegistry);
+
+    StackSamplerLoop stackSamplerLoop(
+        &profilerInfo, configHolder.get(), nullptr, &manager, &threadsCpuManager,
+        &managedThreadList, &codeHotspotThreadList, nullptr, nullptr, metricsRegistry);
+
+    manager.SetStackSamplerLoop(&stackSamplerLoop);
+
+    // Mirrors CorProfilerCallback::InitializeServices()'s registration order and
+    // StartServices()'s plain forward loop: StackSamplerLoopManager is registered (and thus
+    // started) before StackSamplerLoop.
+    //
+    // manager.Start() spawns the watcher thread and blocks - via a std::promise/std::future
+    // handshake bounded by a 2s timeout (WatcherStartupTimeout in StackSamplerLoopManager.cpp) -
+    // until that thread actually signals it's running, not merely constructed. If that
+    // synchronization were broken (e.g. reverted to a bare std::make_unique<std::thread>(...)
+    // with no wait), this call would still "succeed" as far as the type system is concerned; what
+    // a bug there would actually produce is either this assertion failing once the watcher never
+    // signals and the 2s timeout elapses, or a flaky downstream failure under scheduler
+    // contention - which is exactly the class of bug that caused the original crash. A clean,
+    // prompt pass here is the signal that the handshake is intact.
+    ASSERT_TRUE(manager.Start());
+
+    // StackSamplerLoop::Start() is no longer triggered asynchronously from inside the watcher
+    // thread - it's called directly, synchronously, by whoever starts the services in sequence
+    // (StartServices() in production, this test here). That's the structural fix: there is no
+    // longer an async gap in which a Stop() call could race ahead of it.
+    ASSERT_TRUE(stackSamplerLoop.Start());
+    ASSERT_TRUE(stackSamplerLoop.IsStarted());
+
+    // Mirrors StopServices()'s existing REVERSE loop: StackSamplerLoop (registered later) is
+    // stopped before StackSamplerLoopManager (registered earlier). This keeps the watcher alive
+    // while the sampler's background thread is being joined (preserving the deadlock-rescue
+    // behavior), and guarantees the sampler is fully stopped before anything it depends on
+    // (ManagedThreadList/CodeHotspotsThreadList, both registered even earlier in production) can
+    // be destroyed.
+    ASSERT_TRUE(stackSamplerLoop.Stop());
+    ASSERT_FALSE(stackSamplerLoop.IsStarted());
+
+    ASSERT_TRUE(manager.Stop());
+    ASSERT_FALSE(manager.IsStarted());
+}

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -814,8 +814,12 @@ partial class Build
             // Filtering tests is temporary.
             // For now, false negatives are reported by the tool because dependencies are not built
             // against thread sanitizer lib (ex: libdatadog).
-            // For now we focus on the ring buffer unit tests.
-            RunProfilerUnitTests("Datadog.Profiler.Native.Tests", Configuration.Release, MSBuildTargetPlatform.x64, SanitizerKind.Tsan, testsFilter: "*RingBuffer*");
+            // For now we focus on the ring buffer unit tests, plus the StackSamplerLoop/
+            // StackSamplerLoopManager lifecycle tests added for the shutdown-crash fix - they stub
+            // out the stack-walking/collector path entirely (see StubOutSamplingConfig() in
+            // StackSamplerLoopManagerTest.cpp), so they shouldn't hit the same libdatadog-related
+            // noise the rest of the unfiltered suite can.
+            RunProfilerUnitTests("Datadog.Profiler.Native.Tests", Configuration.Release, MSBuildTargetPlatform.x64, SanitizerKind.Tsan, testsFilter: "*RingBuffer*:*StackSamplerLoop*");
         });
 
     Target BuildProfilerSampleForSanitiserTests => _ => _


### PR DESCRIPTION
## Summary of changes

Fixes a shutdown-time SIGSEGV in the Continuous Profiler: `StackSamplerLoop` is promoted from a private implementation detail of `StackSamplerLoopManager` to its own independently-registered `IService`, so its start/stop lifecycle is owned directly by `CorProfilerCallback`'s existing `StartServices()`/`StopServices()` machinery instead of an ad hoc, asynchronous internal sequence. Two related data races (`volatile bool` → `std::atomic<bool>`) are also fixed, found while adding tests for the new lifecycle.


## Reason for change

A customer crash report showed the sampler thread segfaulting inside `StackSamplerLoop::CodeHotspotIteration()` while the process's main thread was, at the same instant, blocked in CLR shutdown joining that same thread. Two compounding issues caused it:

- `StackSamplerLoop::Start()` was called asynchronously from inside a freshly-spawned watcher thread, with nothing guaranteeing it had actually run before `StackSamplerLoopManager::StartImpl()` returned.
- `CorProfilerCallback::Shutdown()` calls `StackSamplerLoopManager::Stop()` explicitly and early. If the watcher thread hadn't reached `Start()` yet (an unbounded race, worse under CPU contention), that `Stop()` silently no-opped — the sampler's one-shot guard rejected it — and the watcher went on to start it anyway, after shutdown had already begun tearing down the `ManagedThreadList` instances it depends on. The only thing left to stop it at that point was `~StackSamplerLoop()`'s last-resort destructor call, by which time those dependencies could already be gone.

## Implementation details

- **`StackSamplerLoop` becomes a real service.** It already inherited `ServiceBase`; it just wasn't registered. `CorProfilerCallback::InitializeServices()` now registers it right after `StackSamplerLoopManager`:
  - **Start** (forward order): the manager starts first — spawns the watcher and blocks until it's actually running — then the sampler starts, called directly and synchronously. No more watcher-thread indirection.
  - **Stop** (existing reverse-order loop, unchanged): the sampleeeps the watcher alive in case it needs to rescue a deadlockedsample) and well before `ManagedThreadList`'s `Stop()`/destruction, since that was registered much earlier and so is stopped much later — guaranteeing the
sampler is fully dead before anything it depends on is touched.
- **Watcher startup is a bounded wait, not fire-and-forget.** `RunWatcher()` (renamed from `RunWatcherAndSampler()`) spawns the watcher thread and blocks on a
`std::promise`/`std::future` handshake until it signals it's runn idiom `ManagedCodeCache::Initialize()` already uses elsewhere. Atimeout logs an error and returns `false` instead of hanging `Initialize()` forever; the possibly-still-starting thread is joined later, deferred to `Stop()` or
the destructor.
- **Cross-wiring**: `StackSamplerLoop` takes a `StackSamplerLoopManager*` at construction; the manager gets a `StackSamplerLoop*` back via a one-time
`SetStackSamplerLoop()` setter, since the loop doesn't exist yet tartImpl()` checks this was actually called and fails cleanly witha logged error rather than null-deref'ing if a future refactor drops it.
- **Ownership shuffle**: `StackFramesCollectorBase`/`CallstackProrCallback` (constructed once, shared by both services as rawnon-owning pointers), since the manager no longer constructs `StackSamplerLoop` itself.
- **Two data races fixed along the way**, caught by TSan while wrcise this code path directly:`StackSamplerLoop::_shutdownRequested` and `StackSamplerLoopManager::_isWatcherShutdownRequested`, both `volatile bool` → `std::atomic<bool>`. Straight type
swap, no behavior change.
- `CorProfilerCallback::Shutdown()`'s existing early `Stop()` call (needed so the final `.pprof` captures the last samples) now stops both services explicitly;
`StopServices()` calling them again later is a guaranteed no-op.

## Test coverage

New file `StackSamplerLoopManagerTest.cpp` exercises the new lifeng a full `CorProfilerCallback`:
- `StartFailsCleanlyWhenStackSamplerLoopWasNeverWiredIn` — the safety-net check when `SetStackSamplerLoop()` is skipped.
- `StackSamplerLoopStartsAndStopsIndependentlyOfTheManager` — thet/stop lifecycle, testable in isolation from the manager.
- `FullLifecycleMatchesStartServicesAndStopServicesOrdering` — full start (forward order) / stop (reverse order) cycle matching production's
`StartServices()`/`StopServices()` sequencing.

Worth running locally with TSan (`-DRUN_TSAN=1`) to confirm the tob currently filters to `*RingBuffer*` only, so it won't exercisethese new tests until that filter is widened.

## Other details

- No intended behavior change on the non-crash path — this only changes *ordering/synchronization* of an already-existing start/stop sequence.
- Not attempting a deterministic repro of the original race in CI contention during CLR shutdown to surface, and forcing that timing window would just produce a flaky test.
- Windows build not yet verified for the new test file — Linux ane test CMake targets.