### PR TITLE
Fix globstar expansion in CI Vis code owners

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
@@ -141,10 +141,14 @@ namespace Datadog.Trace.Ci
             var rx = Regex.Escape(pattern);
 
             // A globstar surrounded by slashes matches zero or more directories.
-            rx = rx.Replace("/\\*\\*/", "/(?:.*/)?");
+            rx = rx.Replace("/\\*\\*/", "/(?:[^/]+/)*");
 
             // A leading globstar followed by a slash also matches at the repository root.
-            rx = rx.Replace("\\*\\*/", "(?:.*/)?");
+            const string leadingGlobstar = "\\*\\*/";
+            if (rx.StartsWith(leadingGlobstar, StringComparison.Ordinal))
+            {
+                rx = "(?:[^/]+/)*" + rx.Substring(leadingGlobstar.Length);
+            }
 
             rx = rx.Replace("\\*\\*", ".*"); // multi-level wildcard
             rx = rx.Replace("\\*", "[^/]*"); // single‑level wildcard

--- a/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
@@ -137,12 +137,12 @@ namespace Datadog.Trace.Ci
         /// </summary>
         private static Regex CompileGlob(string pattern)
         {
-            var effectivePattern = pattern.StartsWith("**/", StringComparison.Ordinal)
-                                       ? pattern.Substring(3)
-                                       : pattern;
+            var patternWithoutLeadingGlobstar = pattern.StartsWith("**/", StringComparison.Ordinal)
+                                                    ? pattern.Substring(3)
+                                                    : pattern;
 
             // Escape regex metachars first.
-            var rx = Regex.Escape(effectivePattern);
+            var rx = Regex.Escape(patternWithoutLeadingGlobstar);
 
             // A globstar surrounded by slashes matches zero or more directories.
             rx = rx.Replace("/\\*\\*/", "/(?:[^/]+/)*");

--- a/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
@@ -137,18 +137,15 @@ namespace Datadog.Trace.Ci
         /// </summary>
         private static Regex CompileGlob(string pattern)
         {
+            var effectivePattern = pattern.StartsWith("**/", StringComparison.Ordinal)
+                                       ? pattern.Substring(3)
+                                       : pattern;
+
             // Escape regex metachars first.
-            var rx = Regex.Escape(pattern);
+            var rx = Regex.Escape(effectivePattern);
 
             // A globstar surrounded by slashes matches zero or more directories.
             rx = rx.Replace("/\\*\\*/", "/(?:[^/]+/)*");
-
-            // A leading globstar followed by a slash also matches at the repository root.
-            const string leadingGlobstar = "\\*\\*/";
-            if (rx.StartsWith(leadingGlobstar, StringComparison.Ordinal))
-            {
-                rx = "(?:[^/]+/)*" + rx.Substring(leadingGlobstar.Length);
-            }
 
             rx = rx.Replace("\\*\\*", ".*"); // multi-level wildcard
             rx = rx.Replace("\\*", "[^/]*"); // single‑level wildcard

--- a/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
@@ -146,10 +146,8 @@ namespace Datadog.Trace.Ci
             // A leading globstar followed by a slash also matches at the repository root.
             rx = rx.Replace("\\*\\*/", "(?:.*/)?");
 
-            // Temporary sentinel for ** that we restore after dealing with single *.
-            rx = rx.Replace("\\*\\*", "§§DOUBLESTAR§§");
+            rx = rx.Replace("\\*\\*", ".*"); // multi-level wildcard
             rx = rx.Replace("\\*", "[^/]*"); // single‑level wildcard
-            rx = rx.Replace("§§DOUBLESTAR§§", ".*"); // multi‑level wildcard
             rx = rx.Replace("\\?", "."); // single char
 
             if (pattern.EndsWith("/"))

--- a/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
@@ -141,7 +141,10 @@ namespace Datadog.Trace.Ci
             var rx = Regex.Escape(pattern);
 
             // A globstar surrounded by slashes matches zero or more directories.
-            rx = rx.Replace("/\\*\\*/", "/(?:[^/]+/)*");
+            rx = rx.Replace("/\\*\\*/", "/(?:.*/)?");
+
+            // A leading globstar followed by a slash also matches at the repository root.
+            rx = rx.Replace("\\*\\*/", "(?:.*/)?");
 
             // Temporary sentinel for ** that we restore after dealing with single *.
             rx = rx.Replace("\\*\\*", "§§DOUBLESTAR§§");

--- a/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwners.cs
@@ -140,6 +140,9 @@ namespace Datadog.Trace.Ci
             // Escape regex metachars first.
             var rx = Regex.Escape(pattern);
 
+            // A globstar surrounded by slashes matches zero or more directories.
+            rx = rx.Replace("/\\*\\*/", "/(?:[^/]+/)*");
+
             // Temporary sentinel for ** that we restore after dealing with single *.
             rx = rx.Replace("\\*\\*", "§§DOUBLESTAR§§");
             rx = rx.Replace("\\*", "[^/]*"); // single‑level wildcard

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
@@ -54,6 +54,21 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [InlineData("/globstar/target", "[\"@globstar-owner\"]")]
         [InlineData("/globstar/one/target", "[\"@globstar-owner\"]")]
         [InlineData("/globstar/one/two/target", "[\"@globstar-owner\"]")]
+        [InlineData("/globstar/one/not-target", "[\"@global-owner1\",\"@global-owner2\"]")]
+        // Leading globstar
+        [InlineData("foo", "[\"@foo-owner\"]")]
+        [InlineData("one/foo", "[\"@foo-owner\"]")]
+        [InlineData("one/two/foo", "[\"@foo-owner\"]")]
+        [InlineData("foo/bar", "[\"@foo-bar-owner\"]")]
+        [InlineData("one/foo/bar", "[\"@foo-bar-owner\"]")]
+        [InlineData("one/two/foo/bar", "[\"@foo-bar-owner\"]")]
+        [InlineData("foobar", "[\"@global-owner1\",\"@global-owner2\"]")]
+        // Trailing globstar
+        [InlineData("abc/file", "[\"@abc-owner\"]")]
+        [InlineData("abc/one/file", "[\"@abc-owner\"]")]
+        [InlineData("abc/one/two/file", "[\"@abc-owner\"]")]
+        [InlineData("abc", "[\"@global-owner1\",\"@global-owner2\"]")]
+        [InlineData("abcd/file", "[\"@global-owner1\",\"@global-owner2\"]")]
         public void CheckGithubCodeOwners(string value, string expected)
         {
             var match = _githubCodeOwners.Match(value);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
@@ -51,6 +51,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         // New GitHub quirks
         [InlineData("/x/logs/error.txt", "[\"@octo-org/octocats\"]")] // **/logs pattern
         [InlineData("docs/getting-started.md", "[\"docs@example.com\"]")] // docs/* pattern
+        [InlineData("/globstar/target", "[\"@globstar-owner\"]")]
+        [InlineData("/globstar/one/target", "[\"@globstar-owner\"]")]
+        [InlineData("/globstar/one/two/target", "[\"@globstar-owner\"]")]
         public void CheckGithubCodeOwners(string value, string expected)
         {
             var match = _githubCodeOwners.Match(value);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CodeOwnersTests.cs
@@ -69,6 +69,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [InlineData("abc/one/two/file", "[\"@abc-owner\"]")]
         [InlineData("abc", "[\"@global-owner1\",\"@global-owner2\"]")]
         [InlineData("abcd/file", "[\"@global-owner1\",\"@global-owner2\"]")]
+        // An embedded **/ must not receive leading-globstar semantics
+        [InlineData("prefixtarget", "[\"@global-owner1\",\"@global-owner2\"]")]
         public void CheckGithubCodeOwners(string value, string expected)
         {
             var match = _githubCodeOwners.Match(value);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/CODEOWNERS_GITHUB
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/CODEOWNERS_GITHUB
@@ -55,3 +55,10 @@ apps/ @octocat
 
 # A globstar between slashes matches zero or more directories.
 /globstar/**/target @globstar-owner
+
+# A leading globstar matches at any depth, including the repository root.
+**/foo @foo-owner
+**/foo/bar @foo-bar-owner
+
+# A trailing globstar matches everything inside the directory.
+abc/** @abc-owner

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/CODEOWNERS_GITHUB
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/CODEOWNERS_GITHUB
@@ -52,3 +52,6 @@ apps/ @octocat
 # subdirectory, as its owners are left empty.
 /apps/ @octocat
 /apps/github
+
+# A globstar between slashes matches zero or more directories.
+/globstar/**/target @globstar-owner

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/CODEOWNERS_GITHUB
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/CODEOWNERS_GITHUB
@@ -62,3 +62,6 @@ apps/ @octocat
 
 # A trailing globstar matches everything inside the directory.
 abc/** @abc-owner
+
+# Consecutive stars outside a globstar position are not a leading globstar.
+prefix**/target @embedded-star-owner


### PR DESCRIPTION
## Summary of changes

Makes it so that `/**/` patterns when expanded/computed/regexed by CI Visibility will handle cases where there are zero matches.

## Reason for change

We ran into this issue with `/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/**/DataStreamsMonitoring*` in our CODEOWNERs where this specific test `Datadog.Trace.ClrProfiler.IntegrationTests.DataStreamsMonitoringHttpClientTests` at the top level of `Datadog.Trace.ClrProfiler.IntegrationTests` wasn't being matched to the correct teams in CI Visibility.

This was because `/**/` was being interpreted as `/.*/` for the cases with no directory (works fine for cases where there are directories though)

`/.*/` -> match 0 to N characters but if no matches becomes `//` exactly.


## Implementation details

This changes `/.*/` to `/(?:.*/)?`

- Match the first slash, then match (optionally) anything that comes after

## Test coverage

some basic tests added

Also played around with it in regex101 to see if it works and it seems like it does

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
