### PR TITLE
Pin LLM validation gate to v0.1.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'DataDog/llm-validation-platform'
-    ref: 05545826328c529ffba6987007528c3dd23d0e63   # TESTING PR#27 (nacho/UpdateDocs2) fetch-by-SHA clone; revert to v0.1.1 tag/SHA before merge
+    ref: 0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf   # v0.1.1 (immutable SHA; a tag could be retargeted)
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
   # GitLab does not expand top-level `variables:` inside `include:` keywords,
@@ -43,7 +43,7 @@ variables:
 
 "llm validation":
   variables:
-    LLMVAL_PLATFORM_REF: "05545826328c529ffba6987007528c3dd23d0e63"   # TESTING PR#27 fetch-by-SHA clone; must match include ref above
+    LLMVAL_PLATFORM_REF: "0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf"   # v0.1.1 (must match include ref above)
 
 build-windows-ci-image:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'DataDog/llm-validation-platform'
-    ref: v0.1.0
+    ref: bda782c7e9cb4fa1256d567a487ffce34c9d1cf0   # v0.1.0 (immutable SHA; a tag could be retargeted)
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
   # GitLab does not expand top-level `variables:` inside `include:` keywords,
@@ -43,7 +43,7 @@ variables:
 
 "llm validation":
   variables:
-    LLMVAL_PLATFORM_REF: "v0.1.0"
+    LLMVAL_PLATFORM_REF: "bda782c7e9cb4fa1256d567a487ffce34c9d1cf0"   # v0.1.0 (must match include ref above)
 
 build-windows-ci-image:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,6 @@ stages:
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'DataDog/llm-validation-platform'
-    # Pin to an immutable released tag (not a mutable branch): this ref selects which copy of the template
-    # GitLab merges in, and the matching LLMVAL_PLATFORM_REF override below pins the ref whose run.sh + CLI
-    # actually execute in this pipeline. Keep the two identical; bump both together to adopt a new release.
-    # (Variables don't expand inside `include:` here — see the touchpoint note below — so this is a literal.)
     ref: v0.1.0
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
@@ -45,11 +41,6 @@ variables:
   SLS_CI_BRANCH: main
   WINDOWS_BUILD_IMAGE_BASE: "registry.ddbuild.io/ci/dd-trace-dotnet/dd-trace-dotnet-docker-build"
 
-# Pin the LLM Validation gate to a released tag (supply chain). The template above is git-cloned and its CLI is
-# built and EXECUTED in this pipeline, so pinning the `include: ref:` alone is not enough — LLMVAL_PLATFORM_REF
-# is the ref that actually runs. It MUST match the include ref above; bump both together to adopt a new release.
-# This is a job-level override (not a top-level variable) on purpose: the template sets LLMVAL_PLATFORM_REF as a
-# job-level default, and in GitLab a job-level variable beats a global one — so a top-level override wouldn't win.
 "llm validation":
   variables:
     LLMVAL_PLATFORM_REF: "v0.1.0"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'DataDog/llm-validation-platform'
-    ref: bda782c7e9cb4fa1256d567a487ffce34c9d1cf0   # v0.1.0 (immutable SHA; a tag could be retargeted)
+    ref: 05545826328c529ffba6987007528c3dd23d0e63   # TESTING PR#27 (nacho/UpdateDocs2) fetch-by-SHA clone; revert to v0.1.1 tag/SHA before merge
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
   # GitLab does not expand top-level `variables:` inside `include:` keywords,
@@ -43,7 +43,7 @@ variables:
 
 "llm validation":
   variables:
-    LLMVAL_PLATFORM_REF: "bda782c7e9cb4fa1256d567a487ffce34c9d1cf0"   # v0.1.0 (must match include ref above)
+    LLMVAL_PLATFORM_REF: "05545826328c529ffba6987007528c3dd23d0e63"   # TESTING PR#27 fetch-by-SHA clone; must match include ref above
 
 build-windows-ci-image:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,11 @@ stages:
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'DataDog/llm-validation-platform'
-    ref: main
+    # Pin to an immutable released tag (not a mutable branch): this ref selects which copy of the template
+    # GitLab merges in, and the matching LLMVAL_PLATFORM_REF override below pins the ref whose run.sh + CLI
+    # actually execute in this pipeline. Keep the two identical; bump both together to adopt a new release.
+    # (Variables don't expand inside `include:` here — see the touchpoint note below — so this is a literal.)
+    ref: v0.1.0
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
   # GitLab does not expand top-level `variables:` inside `include:` keywords,
@@ -40,6 +44,15 @@ variables:
   LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 43000000
   SLS_CI_BRANCH: main
   WINDOWS_BUILD_IMAGE_BASE: "registry.ddbuild.io/ci/dd-trace-dotnet/dd-trace-dotnet-docker-build"
+
+# Pin the LLM Validation gate to a released tag (supply chain). The template above is git-cloned and its CLI is
+# built and EXECUTED in this pipeline, so pinning the `include: ref:` alone is not enough — LLMVAL_PLATFORM_REF
+# is the ref that actually runs. It MUST match the include ref above; bump both together to adopt a new release.
+# This is a job-level override (not a top-level variable) on purpose: the template sets LLMVAL_PLATFORM_REF as a
+# job-level default, and in GitLab a job-level variable beats a global one — so a top-level override wouldn't win.
+"llm validation":
+  variables:
+    LLMVAL_PLATFORM_REF: "v0.1.0"
 
 build-windows-ci-image:
   stage: build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 
 ## Tracer Structure
 
-  - `tracer/src/Datadog.Trace` — Core managed tracer library
+- `tracer/src/Datadog.Trace` — Core managed tracer library.
   - `Activity` — System.Diagnostics.Activity bridge/helpers.
   - `Agent` — Agent transport, payloads, health, serialization.
   - `AppSec` — Application Security (WAF/RASP) components.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 
 ## Tracer Structure
 
-- `tracer/src/Datadog.Trace` — Core managed tracer library
+  - `tracer/src/Datadog.Trace` — Core managed tracer library
   - `Activity` — System.Diagnostics.Activity bridge/helpers.
   - `Agent` — Agent transport, payloads, health, serialization.
   - `AppSec` — Application Security (WAF/RASP) components.


### PR DESCRIPTION
## Summary of changes

Pin the LLM validation gate to the immutable **`v0.1.1` commit SHA** (both refs) instead of tracking `main`, plus a one-character `AGENTS.md` edit to exercise the gate.

## Reason for change

Both refs previously tracked the mutable `main` branch. `LLMVAL_PLATFORM_REF` is the ref this pipeline git-clones and **executes** (`run.sh` + the CLI it builds), and `include: ref:` selects which template merges into the pipeline — so tracking `main` is a supply-chain risk (arbitrary code execution here if `main` moves). Pinning both to an immutable release closes it.

Pinning to the full commit **SHA** rather than the `v0.1.1` tag because a lightweight tag can be retargeted (no protected-tag rule is enforced on the platform repo); a SHA is content-addressed and immutable.

## Implementation details

- Both refs → `0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf` (`# v0.1.1`), kept identical.
- `include: ref:` must be a literal — ddbuild GitLab doesn't expand `variables:` inside `include:`, so the SHA can't be factored into a single shared variable (hence it appears in two places; bump both together).
- `LLMVAL_PLATFORM_REF` is overridden in the `"llm validation"` job block, not top-level `variables:` (job-level beats global; a top-level override would silently lose to the template's `main` default).
- SHA pinning requires v0.1.1's fetch-by-SHA clone — the v0.1.0 release cloned with `git clone --branch`, which accepts a tag/branch only.
- `AGENTS.md`: a trivial neutral edit (a trailing period) to trigger a gate run and confirm the pinned platform executes end-to-end.

## Test coverage

The `llm validation` job is the check — it clones `v0.1.1` by SHA (visible in the clone step) and PASSes on the neutral change. Confirmed green against the release SHA.


Fixes APMSP-3917