### PR TITLE
Update CODEOWNERS for integration tests ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@
 
 ## integration tests for auto-instrumentations
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/                                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoring*                          @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/**/DataStreamsMonitoring*                       @DataDog/tracing-dotnet  @DataDog/data-streams-monitoring
 
 ### co-owned integrations tests


### PR DESCRIPTION
## Summary of changes

Tweak codeowners to work around a bug in our testlogger

## Reason for change

Currently there's a bug in the CODEOWNERS parser with the pattern `something/**/here` which means it recognizes `/something/else/here` but not `/something/else`. This is a workaround, until we fix the test logger

## Implementation details

Add the extra entry

## Test coverage

errr

## Other details

See https://github.com/DataDog/dd-trace-dotnet/pull/9045 for the real fix

#incident-57303