### PR TITLE
[Profiler] Fix crashes at shutdown

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1057,7 +1057,17 @@ void CorProfilerCallback::DisposeInternal()
             _pEtwEventsManager->Stop();
         }
 
-        DisposeServices();
+        {
+            // _isShutdown must be set to true before this lock releases, not after - see
+            // EngineActiveGuard.h. From this point on, no EngineActiveGuard can ever report
+            // IsActive() again (the mutex's own synchronizes-with guarantee ensures every future
+            // lock acquisition, on any thread, observes _isShutdown == true), so no guarded
+            // ICorProfilerCallback method can race DisposeServices() below, or run after it and
+            // find already-destroyed service pointers.
+            std::unique_lock<std::shared_mutex> exclusiveLock(_engineLifetimeMutex);
+            _isShutdown = true;
+            DisposeServices();
+        }
 
         ICorProfilerInfo5* pCorProfilerInfo = _pCorProfilerInfo;
         if (pCorProfilerInfo != nullptr)
@@ -2012,6 +2022,15 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::AppDomainCreationStarted(AppDomai
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::AppDomainCreationFinished(AppDomainID appDomainId, HRESULT hrStatus)
 {
+    // Previously unguarded entirely (unlike its siblings below, which at least had the racy
+    // _isInitialized check) - _pRuntimeIdStore is a _services-managed pointer DisposeServices()
+    // can free concurrently. See EngineActiveGuard.h.
+    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    if (!engineGuard.IsActive())
+    {
+        return S_OK;
+    }
+
     _pAppDomainStore->Register(appDomainId);
     if (_pConfiguration->GetDeploymentMode() == DeploymentMode::SingleStepInstrumentation)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -2079,9 +2079,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ModuleLoadStarted(ModuleID module
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus)
 {
-    if (false == _isInitialized.load())
+    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    if (!engineGuard.IsActive())
     {
-        // If this CorProfilerCallback has not yet initialized, or if it has already shut down, then this callback is a No-Op.
         return S_OK;
     }
 
@@ -2552,9 +2552,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::RootReferences(ULONG cRootRefs, O
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::ExceptionThrown(ObjectID thrownObjectId)
 {
-    if (false == _isInitialized.load())
+    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    if (!engineGuard.IsActive())
     {
-        // If this CorProfilerCallback has not yet initialized, or if it has already shut down, then this callback is a No-Op.
         return S_OK;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1058,14 +1058,14 @@ void CorProfilerCallback::DisposeInternal()
         }
 
         {
-            // _isShutdown must be set to true before this lock releases, not after - see
+            // _isServicesShutdown must be set to true before this lock releases, not after - see
             // EngineActiveGuard.h. From this point on, no EngineActiveGuard can ever report
             // IsActive() again (the mutex's own synchronizes-with guarantee ensures every future
-            // lock acquisition, on any thread, observes _isShutdown == true), so no guarded
+            // lock acquisition, on any thread, observes _isServicesShutdown == true), so no guarded
             // ICorProfilerCallback method can race DisposeServices() below, or run after it and
             // find already-destroyed service pointers.
             std::unique_lock<std::shared_mutex> exclusiveLock(_engineLifetimeMutex);
-            _isShutdown = true;
+            _isServicesShutdown = true;
             DisposeServices();
         }
 
@@ -2025,7 +2025,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::AppDomainCreationFinished(AppDoma
     // Previously unguarded entirely (unlike its siblings below, which at least had the racy
     // _isInitialized check) - _pRuntimeIdStore is a _services-managed pointer DisposeServices()
     // can free concurrently. See EngineActiveGuard.h.
-    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
     if (!engineGuard.IsActive())
     {
         return S_OK;
@@ -2079,7 +2079,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ModuleLoadStarted(ModuleID module
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus)
 {
-    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
     if (!engineGuard.IsActive())
     {
         return S_OK;
@@ -2201,7 +2201,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadCreated(ThreadID threadId)
 {
     Log::Debug("Callback invoked: ThreadCreated(threadId=0x", std::hex, threadId, std::dec, ")");
 
-    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
     if (!engineGuard.IsActive())
     {
         return S_OK;
@@ -2255,7 +2255,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
 {
     Log::Debug("Callback invoked: ThreadDestroyed(threadId=0x", std::hex, threadId, std::dec, ")");
 
-    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
     if (!engineGuard.IsActive())
     {
         return S_OK;
@@ -2304,7 +2304,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
 {
     Log::Debug("Callback invoked: ThreadAssignedToOSThread(managedThreadId=0x", std::hex, managedThreadId, ", osThreadId=", std::dec, osThreadId, ")");
 
-    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
     if (!engineGuard.IsActive())
     {
         return S_OK;
@@ -2415,7 +2415,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[])
 {
-    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
     if (!engineGuard.IsActive())
     {
         return S_OK;
@@ -2552,7 +2552,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::RootReferences(ULONG cRootRefs, O
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::ExceptionThrown(ObjectID thrownObjectId)
 {
-    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
     if (!engineGuard.IsActive())
     {
         return S_OK;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -2201,9 +2201,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadCreated(ThreadID threadId)
 {
     Log::Debug("Callback invoked: ThreadCreated(threadId=0x", std::hex, threadId, std::dec, ")");
 
-    if (false == _isInitialized.load())
+    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    if (!engineGuard.IsActive())
     {
-        // If this CorProfilerCallback has not yet initialized, or if it has already shut down, then this callback is a No-Op.
         return S_OK;
     }
 
@@ -2255,9 +2255,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
 {
     Log::Debug("Callback invoked: ThreadDestroyed(threadId=0x", std::hex, threadId, std::dec, ")");
 
-    if (false == _isInitialized.load())
+    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    if (!engineGuard.IsActive())
     {
-        // If this CorProfilerCallback has not yet initialized, or if it has already shut down, then this callback is a No-Op.
         return S_OK;
     }
 
@@ -2304,9 +2304,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
 {
     Log::Debug("Callback invoked: ThreadAssignedToOSThread(managedThreadId=0x", std::hex, managedThreadId, ", osThreadId=", std::dec, osThreadId, ")");
 
-    if (false == _isInitialized.load())
+    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    if (!engineGuard.IsActive())
     {
-        // If this CorProfilerCallback has not yet initialized, or if it has already shut down, then this callback is a No-Op.
         return S_OK;
     }
 
@@ -2415,9 +2415,9 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
 
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadNameChanged(ThreadID threadId, ULONG cchName, WCHAR name[])
 {
-    if (false == _isInitialized.load())
+    EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+    if (!engineGuard.IsActive())
     {
-        // If this CorProfilerCallback has not yet initialized, or if it has already shut down, then this callback is a No-Op.
         return S_OK;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -10,6 +10,7 @@
 
 #include "AllocationsProvider.h"
 #include "ApplicationStore.h"
+#include "EngineActiveGuard.h"
 #include "EventPipeEventsManager.h"
 #include "ExceptionsProvider.h"
 #include "IAppDomainStore.h"
@@ -50,6 +51,7 @@
 
 #include <atomic>
 #include <memory>
+#include <shared_mutex>
 #include <vector>
 
 class ContentionProvider;
@@ -246,6 +248,12 @@ private :
     inline static bool _isNet46OrGreater = false;
     std::shared_ptr<IMetricsSender> _metricsSender;
     std::atomic<bool> _isInitialized{false}; // pay attention to keeping ProfilerEngineStatus::IsProfilerEngiveActive in sync with this!
+
+    // Guards ICorProfilerCallback methods (see EngineActiveGuard.h) against DisposeInternal()
+    // concurrently tearing down the service pointers below. _isShutdown must only ever be
+    // read/written while holding this mutex (shared or exclusive) - never as a bare flag check.
+    mutable std::shared_mutex _engineLifetimeMutex;
+    bool _isShutdown = false;
 
     // The pointer here are observable pointer which means that they are used only to access the data.
     // Their lifetime is managed by the _services vector.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -249,9 +249,7 @@ private :
     std::shared_ptr<IMetricsSender> _metricsSender;
     std::atomic<bool> _isInitialized{false}; // pay attention to keeping ProfilerEngineStatus::IsProfilerEngiveActive in sync with this!
 
-    // Guards ICorProfilerCallback methods (see EngineActiveGuard.h) against DisposeInternal()
-    // concurrently tearing down the service pointers below. _isServicesShutdown must only ever be
-    // read/written while holding this mutex (shared or exclusive) - never as a bare flag check.
+    // Synchronizes access to the services below, and the engine lifetime flag.
     mutable std::shared_mutex _engineLifetimeMutex;
     bool _isServicesShutdown = false;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -250,10 +250,10 @@ private :
     std::atomic<bool> _isInitialized{false}; // pay attention to keeping ProfilerEngineStatus::IsProfilerEngiveActive in sync with this!
 
     // Guards ICorProfilerCallback methods (see EngineActiveGuard.h) against DisposeInternal()
-    // concurrently tearing down the service pointers below. _isShutdown must only ever be
+    // concurrently tearing down the service pointers below. _isServicesShutdown must only ever be
     // read/written while holding this mutex (shared or exclusive) - never as a bare flag check.
     mutable std::shared_mutex _engineLifetimeMutex;
-    bool _isShutdown = false;
+    bool _isServicesShutdown = false;
 
     // The pointer here are observable pointer which means that they are used only to access the data.
     // Their lifetime is managed by the _services vector.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EngineActiveGuard.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EngineActiveGuard.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <shared_mutex>
 
 // Non-blocking guard for ICorProfilerCallback methods that read service pointers whose lifetime
@@ -15,13 +16,17 @@
 // use of it - a stock std::atomic<bool> check has no way to close that gap, because there is
 // nothing serializing "read the flag" against "the object is being destroyed right now".
 //
-// This class turns "is the engine alive" into a question that can only ever be answered while
-// holding the same mutex the teardown path holds exclusively while it tears things down - never
-// as a bare, lock-free flag read, which is what made the previous
-// `if (false == _isInitialized.load()) return S_OK;` pattern racy in the first place.
+// This class checks two things, replacing the single (and, for the shutdown half, racy)
+// `if (false == _isInitialized.load()) return S_OK;` pattern the affected callbacks used to have:
+//   - isInitialized: has Initialize() finished constructing the services yet? This direction of
+//     the lifecycle never destroys anything concurrently, so a bare atomic read is fine here, same
+//     as before.
+//   - isServicesShutdown: has teardown started? This direction *does* concurrently destroy things, so it
+//     can only ever be answered while holding the same mutex the teardown path holds exclusively
+//     while it tears things down - never as a bare, lock-free flag read.
 //
 // Usage in a callback:
-//     EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+//     EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
 //     if (!engineGuard.IsActive())
 //     {
 //         return S_OK;
@@ -31,21 +36,21 @@
 // Usage at teardown (CorProfilerCallback::DisposeInternal()):
 //     {
 //         std::unique_lock<std::shared_mutex> exclusiveLock(_engineLifetimeMutex);
-//         _isShutdown = true;   // must be set before the lock is released below, not after
+//         _isServicesShutdown = true;   // must be set before the lock is released below, not after
 //         DisposeServices();
 //     }   // lock releases here (normal RAII) - safe, because any callback that acquires the
 //         // lock afterward is guaranteed - via the mutex's own synchronizes-with relationship -
-//         // to observe _isShutdown == true, and will no-op before touching any service pointer.
+//         // to observe _isServicesShutdown == true, and will no-op before touching any service pointer.
 //
-// _isShutdown must never be read or written except while holding _engineLifetimeMutex (shared or
+// _isServicesShutdown must never be read or written except while holding _engineLifetimeMutex (shared or
 // exclusive). Reading it as a bare flag anywhere - even "just this once, for a quick check" -
 // reintroduces the exact race this class exists to close.
 class EngineActiveGuard
 {
 public:
-    EngineActiveGuard(std::shared_mutex& mutex, bool const& isShutdown) :
+    EngineActiveGuard(std::atomic<bool> const& isInitialized, std::shared_mutex& mutex, bool const& isServicesShutdown) :
         _lock(mutex, std::try_to_lock),
-        _isActive(_lock.owns_lock() && !isShutdown)
+        _isActive(isInitialized.load() && _lock.owns_lock() && !isServicesShutdown)
     {
     }
 
@@ -55,9 +60,9 @@ public:
     EngineActiveGuard(EngineActiveGuard&&) = delete;
     EngineActiveGuard& operator=(EngineActiveGuard&&) = delete;
 
-    // True if the engine was confirmed alive (lock acquired, not yet shut down) for the duration
-    // of this guard's lifetime. Service pointers may only be used while this is true, and only
-    // for as long as this guard object stays in scope.
+    // True if the engine was confirmed initialized-and-not-yet-shut-down for the duration of this
+    // guard's lifetime. Service pointers may only be used while this is true, and only for as
+    // long as this guard object stays in scope.
     bool IsActive() const { return _isActive; }
 
 private:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EngineActiveGuard.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EngineActiveGuard.h
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <shared_mutex>
+
+// Non-blocking guard for ICorProfilerCallback methods that read service pointers whose lifetime
+// is tied to CorProfilerCallback::DisposeServices(). The CLR can invoke these callbacks
+// concurrently with CorProfilerCallback::Shutdown()/DisposeInternal() tearing services down - with
+// no interlock, a callback that reads "the engine looks alive" can still end up touching an
+// already-destroyed (or mid-destruction) service afterward. A real crash was traced to exactly
+// this: ThreadNameChanged read _isInitialized.load() == true, then CorProfilerCallback::
+// DisposeInternal() destroyed ThreadsCpuManager on another thread before the callback reached its
+// use of it - a stock std::atomic<bool> check has no way to close that gap, because there is
+// nothing serializing "read the flag" against "the object is being destroyed right now".
+//
+// This class turns "is the engine alive" into a question that can only ever be answered while
+// holding the same mutex the teardown path holds exclusively while it tears things down - never
+// as a bare, lock-free flag read, which is what made the previous
+// `if (false == _isInitialized.load()) return S_OK;` pattern racy in the first place.
+//
+// Usage in a callback:
+//     EngineActiveGuard engineGuard(_engineLifetimeMutex, _isShutdown);
+//     if (!engineGuard.IsActive())
+//     {
+//         return S_OK;
+//     }
+//     ... safe to use service pointers for engineGuard's lifetime ...
+//
+// Usage at teardown (CorProfilerCallback::DisposeInternal()):
+//     {
+//         std::unique_lock<std::shared_mutex> exclusiveLock(_engineLifetimeMutex);
+//         _isShutdown = true;   // must be set before the lock is released below, not after
+//         DisposeServices();
+//     }   // lock releases here (normal RAII) - safe, because any callback that acquires the
+//         // lock afterward is guaranteed - via the mutex's own synchronizes-with relationship -
+//         // to observe _isShutdown == true, and will no-op before touching any service pointer.
+//
+// _isShutdown must never be read or written except while holding _engineLifetimeMutex (shared or
+// exclusive). Reading it as a bare flag anywhere - even "just this once, for a quick check" -
+// reintroduces the exact race this class exists to close.
+class EngineActiveGuard
+{
+public:
+    EngineActiveGuard(std::shared_mutex& mutex, bool const& isShutdown) :
+        _lock(mutex, std::try_to_lock),
+        _isActive(_lock.owns_lock() && !isShutdown)
+    {
+    }
+
+    ~EngineActiveGuard() = default;
+    EngineActiveGuard(EngineActiveGuard const&) = delete;
+    EngineActiveGuard& operator=(EngineActiveGuard const&) = delete;
+    EngineActiveGuard(EngineActiveGuard&&) = delete;
+    EngineActiveGuard& operator=(EngineActiveGuard&&) = delete;
+
+    // True if the engine was confirmed alive (lock acquired, not yet shut down) for the duration
+    // of this guard's lifetime. Service pointers may only be used while this is true, and only
+    // for as long as this guard object stays in scope.
+    bool IsActive() const { return _isActive; }
+
+private:
+    std::shared_lock<std::shared_mutex> _lock;
+    bool _isActive;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EngineActiveGuard.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EngineActiveGuard.h
@@ -6,45 +6,8 @@
 #include <atomic>
 #include <shared_mutex>
 
-// Non-blocking guard for ICorProfilerCallback methods that read service pointers whose lifetime
-// is tied to CorProfilerCallback::DisposeServices(). The CLR can invoke these callbacks
-// concurrently with CorProfilerCallback::Shutdown()/DisposeInternal() tearing services down - with
-// no interlock, a callback that reads "the engine looks alive" can still end up touching an
-// already-destroyed (or mid-destruction) service afterward. A real crash was traced to exactly
-// this: ThreadNameChanged read _isInitialized.load() == true, then CorProfilerCallback::
-// DisposeInternal() destroyed ThreadsCpuManager on another thread before the callback reached its
-// use of it - a stock std::atomic<bool> check has no way to close that gap, because there is
-// nothing serializing "read the flag" against "the object is being destroyed right now".
-//
-// This class checks two things, replacing the single (and, for the shutdown half, racy)
-// `if (false == _isInitialized.load()) return S_OK;` pattern the affected callbacks used to have:
-//   - isInitialized: has Initialize() finished constructing the services yet? This direction of
-//     the lifecycle never destroys anything concurrently, so a bare atomic read is fine here, same
-//     as before.
-//   - isServicesShutdown: has teardown started? This direction *does* concurrently destroy things, so it
-//     can only ever be answered while holding the same mutex the teardown path holds exclusively
-//     while it tears things down - never as a bare, lock-free flag read.
-//
-// Usage in a callback:
-//     EngineActiveGuard engineGuard(_isInitialized, _engineLifetimeMutex, _isServicesShutdown);
-//     if (!engineGuard.IsActive())
-//     {
-//         return S_OK;
-//     }
-//     ... safe to use service pointers for engineGuard's lifetime ...
-//
-// Usage at teardown (CorProfilerCallback::DisposeInternal()):
-//     {
-//         std::unique_lock<std::shared_mutex> exclusiveLock(_engineLifetimeMutex);
-//         _isServicesShutdown = true;   // must be set before the lock is released below, not after
-//         DisposeServices();
-//     }   // lock releases here (normal RAII) - safe, because any callback that acquires the
-//         // lock afterward is guaranteed - via the mutex's own synchronizes-with relationship -
-//         // to observe _isServicesShutdown == true, and will no-op before touching any service pointer.
-//
-// _isServicesShutdown must never be read or written except while holding _engineLifetimeMutex (shared or
-// exclusive). Reading it as a bare flag anywhere - even "just this once, for a quick check" -
-// reintroduces the exact race this class exists to close.
+// This class checks the engine state and make sure that services are not not access during teardown
+// or before the engine is initialized.
 class EngineActiveGuard
 {
 public:

--- a/profiler/test/Datadog.Profiler.Native.Tests/EngineActiveGuardTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/EngineActiveGuardTest.cpp
@@ -1,0 +1,142 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gtest/gtest.h"
+
+#include "EngineActiveGuard.h"
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <shared_mutex>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+// These tests cover the fix for a shutdown-time use-after-free: an ICorProfilerCallback method
+// used to check _isInitialized.load() - a bare, lock-free atomic read - then, several lines
+// later, dereference a service pointer that CorProfilerCallback::DisposeInternal() could
+// concurrently null out and destroy on another thread. A real crash (ExecutionEngineException,
+// a ThreadsCpuManager use-after-free deep inside std::unordered_map's internals) was traced to
+// exactly this gap: the check and the use were never serialized against each other at all.
+//
+// EngineActiveGuard replaces that single check with two: isInitialized (has Initialize()
+// finished? - a plain atomic read is fine, this direction never destroys anything concurrently)
+// and isServicesShutdown (has teardown started? - only ever answered while holding the same
+// mutex the teardown path holds exclusively). These tests exercise both halves directly, without
+// needing a full CorProfilerCallback.
+
+TEST(EngineActiveGuardTest, ActiveWhenInitializedNotShutdownAndUncontended)
+{
+    std::atomic<bool> isInitialized{true};
+    std::shared_mutex mutex;
+    bool isServicesShutdown = false;
+
+    EngineActiveGuard guard(isInitialized, mutex, isServicesShutdown);
+
+    ASSERT_TRUE(guard.IsActive());
+}
+
+TEST(EngineActiveGuardTest, NotActiveBeforeInitialization)
+{
+    // Mirrors the "has not yet initialized" half of the original
+    // `if (false == _isInitialized.load()) return S_OK;` check - a callback firing before
+    // Initialize() has finished constructing the services must still no-op, exactly as before.
+    std::atomic<bool> isInitialized{false};
+    std::shared_mutex mutex;
+    bool isServicesShutdown = false;
+
+    EngineActiveGuard guard(isInitialized, mutex, isServicesShutdown);
+
+    ASSERT_FALSE(guard.IsActive());
+}
+
+TEST(EngineActiveGuardTest, NotActiveOnceServicesShutdownFlagIsSet)
+{
+    std::atomic<bool> isInitialized{true};
+    std::shared_mutex mutex;
+    bool isServicesShutdown = true;
+
+    // No writer holds the mutex here - a bare try_to_lock would succeed. This is exactly the gap
+    // the fix closes: acquiring the lock is not enough on its own, IsActive() must also observe
+    // isServicesShutdown while still holding it, or a callback arriving right after teardown
+    // releases the lock would sail through and touch already-destroyed service pointers.
+    EngineActiveGuard guard(isInitialized, mutex, isServicesShutdown);
+
+    ASSERT_FALSE(guard.IsActive());
+}
+
+TEST(EngineActiveGuardTest, NotActiveWhileWriterHoldsTheExclusiveLock)
+{
+    std::atomic<bool> isInitialized{true};
+    std::shared_mutex mutex;
+    bool isServicesShutdown = false;
+
+    std::promise<void> writerHasTheLock;
+    std::promise<void> readerHasChecked;
+    auto readerHasCheckedFuture = readerHasChecked.get_future();
+
+    // Mirrors DisposeInternal() holding the exclusive lock for the duration of DisposeServices().
+    std::thread writer(
+        [&]
+        {
+            std::unique_lock<std::shared_mutex> exclusiveLock(mutex);
+            writerHasTheLock.set_value();
+            readerHasCheckedFuture.wait();
+        });
+
+    writerHasTheLock.get_future().wait();
+
+    // A callback arriving while teardown is in progress must fail to acquire the lock at all
+    // (non-blocking try_to_lock), not block waiting for it - callbacks must never wait.
+    EngineActiveGuard guard(isInitialized, mutex, isServicesShutdown);
+    ASSERT_FALSE(guard.IsActive());
+
+    readerHasChecked.set_value();
+    writer.join();
+}
+
+TEST(EngineActiveGuardTest, WriterBlocksUntilReaderGuardIsReleased)
+{
+    std::atomic<bool> isInitialized{true};
+    std::shared_mutex mutex;
+    bool isServicesShutdown = false;
+
+    auto guard = std::make_unique<EngineActiveGuard>(isInitialized, mutex, isServicesShutdown);
+    ASSERT_TRUE(guard->IsActive());
+
+    std::atomic<bool> writerAcquired{false};
+    std::thread writer(
+        [&]
+        {
+            std::unique_lock<std::shared_mutex> exclusiveLock(mutex);
+            writerAcquired.store(true);
+        });
+
+    // The writer (teardown) must not be able to proceed while an in-flight callback still holds
+    // its shared lock - this is what guarantees a callback that already passed its guard check
+    // gets to finish using service pointers before DisposeServices() can destroy them.
+    std::this_thread::sleep_for(50ms);
+    ASSERT_FALSE(writerAcquired.load());
+
+    guard.reset(); // release the reader's shared lock
+    writer.join();
+
+    ASSERT_TRUE(writerAcquired.load());
+}
+
+TEST(EngineActiveGuardTest, MultipleReadersCanBeActiveConcurrently)
+{
+    std::atomic<bool> isInitialized{true};
+    std::shared_mutex mutex;
+    bool isServicesShutdown = false;
+
+    // Callbacks legitimately run concurrently on different threads in normal operation - the
+    // guard must not serialize them against each other, only against the writer.
+    EngineActiveGuard first(isInitialized, mutex, isServicesShutdown);
+    EngineActiveGuard second(isInitialized, mutex, isServicesShutdown);
+
+    ASSERT_TRUE(first.IsActive());
+    ASSERT_TRUE(second.IsActive());
+}


### PR DESCRIPTION
## Summary of changes

This PR fixes a bunch of crashes that happen at shutdown. TOCTOU : Time Of Check to Time Of Use.

ICorprofiler callbacks where using .NET profiler services at shutdown 💥

## Reason for change

A crash report brought a crash of the .NET profiler:
```
Error UnhandledException: Process was terminated due to an unhandled exception of type 'System.ExecutionEngineException'
0x7FF8D0CE4515 EEPolicy::HandleFatalError(unsigned int, unsigned long long, wchar_t const*, _EXCEPTION_POINTERS*, wchar_t const*, wchar_t const*) (D:\a\_work\1\s\src\coreclr\vm\eepolicy.cpp:777)
0x7FF8D0C6457F ProcessCLRException(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*) (D:\a\_work\1\s\src\coreclr\vm\exceptionhandling.cpp:1066)
0x7FF9024052EF C:\Windows\SYSTEM32\ntdll.dll!<unknown>+a52ef
0x7FF90239192E C:\Windows\SYSTEM32\ntdll.dll!<unknown>+3192e
0x7FF9024042EE C:\Windows\SYSTEM32\ntdll.dll!<unknown>+a42ee
std::_Hash<std::_Umap_traits<unsigned long,std::unique_ptr<ThreadCpuInfo,std::default_delete<ThreadCpuInfo> >,std::_Uhash_compare<unsigned long,std::hash<unsigned long>,std::equal_to<unsigned long> >,std::allocator<std::pair<unsigned long const ,std::unique_ptr<ThreadCpuInfo,std::default_delete<ThreadCpuInfo> > > >,0> >::_Find_last(unsigned long const&, const unsigned long long) const (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\xhash:1587)
0x7FF8EA873899 std::_Hash<std::_Umap_traits<unsigned long,std::unique_ptr<ThreadCpuInfo,std::default_delete<ThreadCpuInfo> >,std::_Uhash_compare<unsigned long,std::hash<unsigned long>,std::equal_to<unsigned long> >,std::allocator<std::pair<unsigned long const ,std::unique_ptr<ThreadCpuInfo,std::default_delete<ThreadCpuInfo> > > >,0> >::_Try_emplace<unsigned long const &>(unsigned long const&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\xhash:701)
std::unordered_map<unsigned long,std::unique_ptr<ThreadCpuInfo,std::default_delete<ThreadCpuInfo> >,std::hash<unsigned long>,std::equal_to<unsigned long>,std::allocator<std::pair<unsigned long const ,std::unique_ptr<ThreadCpuInfo,std::default_delete<ThreadCpuInfo> > > > >::operator[](unsigned long const&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\unordered_map:433)
0x7FF8EA873646 ThreadsCpuManager::Map(unsigned long, wchar_t const*) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\ThreadsCpuManager.cpp:51)
0x7FF8EA8453C5 CorProfilerCallback::ThreadNameChanged(unsigned long long, unsigned long, wchar_t*) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\CorProfilerCallback.cpp:2174)
0x7FF8EA9A5C92 datadog::shared::nativeloader::CorProfiler::ThreadNameChanged(unsigned long long, unsigned long, wchar_t*) (c:\mnt\shared\src\Datadog.Trace.ClrProfiler.Native\cor_profiler.cpp:988)
0x7FF8D0CEC7B6 EEToProfInterfaceImpl::ThreadNameChanged(unsigned long long, unsigned long, wchar_t*) (D:\a\_work\1\s\src\coreclr\vm\eetoprofinterfaceimpl.cpp:3071)
0x7FF8D0CDD04C ProfControlBlock::DoProfilerCallbackHelper<int (__cdecl*)(ProfilerInfo *),long (__cdecl*)(EEToProfInterfaceImpl *,unsigned __int64,unsigned long,wchar_t * const),unsigned __int64,unsigned long,wchar_t *>(ProfilerInfo*, int (*)(ProfilerInfo*), HRESULT (*)(EEToProfInterfaceImpl*, unsigned long long, unsigned long, wchar_t*), HRESULT*, unsigned long long, unsigned long, wchar_t*) (D:\a\_work\1\s\src\coreclr\inc\profilepriv.h:284)
0x7FF8D0C7FAF8 ThreadNative::InformThreadNameChange(Thread*, wchar_t const*, int) (D:\a\_work\1\s\src\coreclr\vm\comsynchronizable.cpp:970)
0x7FF8D0BD5E00 ThreadNative_InformThreadNameChange(QCall::ThreadHandle, wchar_t const*, int) (D:\a\_work\1\s\src\coreclr\vm\comsynchronizable.cpp:946)
0x7FF87427D256 System.Private.CoreLib.dll!System.Threading.Thread.SetThreadPoolWorkerThreadName
0x2441C77E620 <unknown>
0x7FF871089128 <unknown>
0xFEB42AFA80 <unknown>
0xFEB42AF818 <unknown>
0xFEB42AF7E0 <unknown>
0x180 <unknown>
0x878110FAF624 <unknown>
0x7FF8D0E839E0 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\8.0.21\coreclr.dll!<unknown>+3f39e0
0xFEB42AFBB8 <unknown>
0x7FF871111C48 <unknown>
0x7FF8D0A90000 C:\Program Files\dotnet\shared\Microsoft.NETCore.App\8.0.21\coreclr.dll!<unknown>+0
0xFEB42AF7E0 <unknown>
0x7FF87427D256 <unknown>
0xFEB42AF8A0 <unknown>
0x7FF87427CECA System.Private.CoreLib.dll!System.Threading.PortableThreadPool+WorkerThread.WorkerThreadStart
```

And in some other threads were could see that IIS was shutting down the application.



## Implementation details

Use `EngineActiveGuard` to know if it's safe to use a service from within a callback.

This uses a reader/writer lock to prevent services from being destroyed while executing a callback but also prevent the callback from using the service(s) if they are cleaned up.

## Test coverage

Add unit tests.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
