### PR TITLE
Fix flake in `AgentWriterTests`

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -704,8 +704,9 @@ namespace Datadog.Trace.Tests.Agent
                         maxConcurrentSends = Math.Max(maxConcurrentSends, current);
                     }
 
-                    // Give any other flush a chance to overlap with this one
-                    await Task.Delay(20);
+                    // Give any other flush a chance to overlap with this one, but not too big,
+                    // otherwise could cause flake
+                    await Task.Delay(5);
 
                     Interlocked.Decrement(ref concurrentSends);
                     return true;
@@ -719,7 +720,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var flushes = new List<Task>();
 
-            for (var i = 0; i < 50; i++)
+            for (var i = 0; i < 10; i++)
             {
                 agent.WriteTrace(CreateTraceChunk(1));
                 flushes.Add(agent.FlushTracesAsync());


### PR DESCRIPTION
## Summary of changes

Reduces the risk of flake in `AgentWriterTests`

## Reason for change

#9007 added some additional tests, but they flaked in CI, and I failed to push this fix up before the auto-merge kicked in 🤦 

## Implementation details

Reduce the load in the test to reduce the risk of flake in CI

## Test coverage

The test is just a smoke test, it doesn't give any other guarantees, so there's no point in going crazy. If it continues to flake, we can always just remove it.
