### PR TITLE
fix(ffe): validate regexes and canonical error codes

### DIFF
--- a/tracer/src/Datadog.Trace/FeatureFlags/Rcm/Model/ConditionConfiguration.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Rcm/Model/ConditionConfiguration.cs
@@ -22,36 +22,26 @@ internal sealed class ConditionConfiguration
 
     public object? Value { get; set; }
 
+    internal bool HasValidRegex()
+    {
+        try
+        {
+            _ = GetOrCreateRegex();
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
     internal bool MatchesRegex(object attributeValue)
     {
-        if (_regex == null)
-        {
-            var pattern = Value?.ToString() ?? string.Empty;
-            if (pattern is not { Length: > 0 })
-            {
-                throw new FormatException("Condition value can not be null nor empty");
-            }
-
-            if (pattern.StartsWith("(?u)", StringComparison.Ordinal))
-            {
-                pattern = pattern.Substring(4);
-            }
-
-            pattern = pattern.Replace("[:alnum:]", @"\p{L}\p{N}");
-
-            try
-            {
-                _regex = new Regex(pattern, RegexOptions.Compiled);
-            }
-            catch (ArgumentException ex)
-            {
-                throw new FormatException($"Invalid regex pattern: {pattern}", ex);
-            }
-        }
+        var regex = GetOrCreateRegex();
 
         try
         {
-            return _regex.IsMatch(ToString(attributeValue));
+            return regex.IsMatch(ToString(attributeValue));
         }
         catch
         {
@@ -63,6 +53,38 @@ internal sealed class ConditionConfiguration
             if (attributeValue is null) { return string.Empty; }
             if (attributeValue is bool boolValue) { return boolValue ? "true" : "false"; }
             return Convert.ToString(attributeValue, CultureInfo.InvariantCulture) ?? string.Empty;
+        }
+    }
+
+    private Regex GetOrCreateRegex()
+    {
+        if (_regex is not null)
+        {
+            return _regex;
+        }
+
+        var pattern = Value?.ToString() ?? string.Empty;
+        if (pattern is not { Length: > 0 })
+        {
+            throw new FormatException("Condition value can not be null nor empty");
+        }
+
+        if (pattern.StartsWith("(?u)", StringComparison.Ordinal))
+        {
+            pattern = pattern.Substring(4);
+        }
+
+        // Rust regex treats POSIX alnum as ASCII, so preserve the canonical semantics.
+        pattern = pattern.Replace("[:alnum:]", "0-9A-Za-z");
+
+        try
+        {
+            _regex = new Regex(pattern, RegexOptions.Compiled);
+            return _regex;
+        }
+        catch (ArgumentException ex)
+        {
+            throw new FormatException($"Invalid regex pattern: {pattern}", ex);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/FeatureFlags/Rcm/Model/FlagCollectionJsonConverter.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Rcm/Model/FlagCollectionJsonConverter.cs
@@ -137,6 +137,11 @@ internal sealed class FlagCollectionJsonConverter : JsonConverter<FlagCollection
 
     private static bool HasValidOperand(ConditionConfiguration condition)
     {
+        if (condition.Operator is ConditionOperator.MATCHES or ConditionOperator.NOT_MATCHES)
+        {
+            return condition.HasValidRegex();
+        }
+
         if (condition.Operator is ConditionOperator.ONE_OF or ConditionOperator.NOT_ONE_OF)
         {
             return condition.Value is JArray;

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvaluatorTests.Bundle.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvaluatorTests.Bundle.cs
@@ -75,6 +75,11 @@ public partial class FeatureFlagsEvaluatorTests
         }
 
         Assert.Equal(testCase.Result.Reason, ToCanonicalReason(result.Reason));
+        if (testCase.Result.ErrorCode is not null)
+        {
+            Assert.Equal(testCase.Result.ErrorCode, result.Error);
+            Assert.Equal(testCase.Result.ErrorCode, result.FlagMetadata?["errorCode"]);
+        }
 
         Assert.NotNull(description);
 
@@ -221,7 +226,7 @@ public partial class FeatureFlagsEvaluatorTests
 
             public string? Variant { get; set; }
 
-            public string? Error { get; set; }
+            public string? ErrorCode { get; set; }
 
             public Dictionary<string, string>? FlagMetadata { get; set; }
         }

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvaluatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvaluatorTests.cs
@@ -153,6 +153,65 @@ public partial class FeatureFlagsEvaluatorTests
     }
 
     [Fact]
+    public void InvalidRegexIsRejectedWithoutEvaluatingItsCondition()
+    {
+        const string json = """
+                            {
+                              "flags": {
+                                "invalid-regex": {
+                                  "key": "invalid-regex",
+                                  "enabled": true,
+                                  "variationType": "STRING",
+                                  "variations": {
+                                    "targeted": { "key": "targeted", "value": "targeted" },
+                                    "catch-all": { "key": "catch-all", "value": "catch-all" }
+                                  },
+                                  "allocations": [
+                                    {
+                                      "key": "invalid-regex-allocation",
+                                      "rules": [
+                                        {
+                                          "conditions": [
+                                            { "attribute": "email", "operator": "MATCHES", "value": "*@example.com" }
+                                          ]
+                                        }
+                                      ],
+                                      "splits": [{ "variationKey": "targeted", "shards": [] }]
+                                    },
+                                    {
+                                      "key": "catch-all-allocation",
+                                      "rules": [],
+                                      "splits": [{ "variationKey": "catch-all", "shards": [] }]
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                            """;
+        var config = JsonConvert.DeserializeObject<ServerConfiguration>(json)!;
+        var evaluator = new FeatureFlagsEvaluator(null, config);
+
+        var result = evaluator.Evaluate("invalid-regex", ValueType.String, "default", new EvaluationContext("target"));
+
+        Assert.Equal("default", result.Value);
+        Assert.Equal(EvaluationReason.Error, result.Reason);
+        Assert.Equal("PARSE_ERROR", result.Error);
+    }
+
+    [Fact]
+    public void PosixAlnumUsesAsciiSemantics()
+    {
+        var condition = new ConditionConfiguration
+        {
+            Operator = ConditionOperator.MATCHES,
+            Value = "^[[:alnum:]]+$",
+        };
+
+        Assert.True(condition.MatchesRegex("abc123"));
+        Assert.False(condition.MatchesRegex("mañana"));
+    }
+
+    [Fact]
     public void MergeReplacesFlagParsingState()
     {
         var originalFlag = new Flag();


### PR DESCRIPTION
## Summary of changes

### Changes

- Validate `MATCHES` and `NOT_MATCHES` regex operands while parsing each flag, so an invalid regex invalidates that flag even when evaluation context would not reach the condition.
- Preserve the canonical ASCII semantics of the POSIX `[:alnum:]` class.
- Bind and assert every canonical fixture `result.errorCode` against both the evaluator error and OpenFeature metadata.

## Reason for change

### Motivation

The canonical fixtures exposed two conformance bugs left after #8616:

- invalid regex flags could incorrectly evaluate a later catch-all allocation when the request context did not reach the regex condition;
- `[:alnum:]` was translated to Unicode letters and numbers, allowing values that the canonical evaluator rejects.

The fixture runner also silently ignored `errorCode`, so it could not catch regressions in `PARSE_ERROR` and `FLAG_NOT_FOUND` behavior.

## Implementation details

### Decisions

Regexes are compiled and cached during flag parsing. A compile error causes only that flag to be recorded as invalid, so evaluating it returns `PARSE_ERROR`; other flags in the same UFC remain available. Runtime match failures retain the existing no-match behavior.

The POSIX class is translated to `0-9A-Za-z` to match the portable fixture semantics.

## Test coverage

- Added a regression where the evaluation context omits the regex attribute and a later catch-all allocation exists.
- Added positive ASCII and negative non-ASCII `[:alnum:]` coverage.
- Enabled all canonical `errorCode` assertions.
- `FeatureFlagsEvaluatorTests`: 328 passed on `net9.0`.
- `FeatureFlagsEvaluatorTests`: 328 passed on `netcoreapp3.1`.

## Other details

Follow-up to #8616.
