### PR TITLE
fix(ffe): replace refreshed remote config

### DIFF
--- a/tracer/src/Datadog.Trace/FeatureFlags/Rcm/FfeProduct.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Rcm/FfeProduct.cs
@@ -51,7 +51,18 @@ internal sealed class FfeProduct
                     var serverConfigFile = new NamedRawFile(ffeConfig.Path, ffeConfig.Contents).Deserialize<ServerConfiguration>();
                     if (serverConfigFile.TypedFile is not null)
                     {
-                        _serverConfigurations.Add(new KeyValuePair<string, ServerConfiguration>(ffeConfig.Path.Path, serverConfigFile.TypedFile));
+                        var path = ffeConfig.Path.Path;
+                        var updatedConfig = new KeyValuePair<string, ServerConfiguration>(path, serverConfigFile.TypedFile);
+                        var existingIndex = _serverConfigurations.FindIndex(config => config.Key == path);
+                        if (existingIndex >= 0)
+                        {
+                            _serverConfigurations[existingIndex] = updatedConfig;
+                        }
+                        else
+                        {
+                            _serverConfigurations.Add(updatedConfig);
+                        }
+
                         res.Add(ApplyDetails.FromOk(ffeConfig.Path.Path));
                         apply = true;
                     }

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsModuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsModuleTests.cs
@@ -75,6 +75,46 @@ public class FeatureFlagsModuleTests
         result.Reason.Should().Be(EvaluationReason.Error);
     }
 
+    [Fact]
+    public void UpdateRemoteConfig_WithExistingPath_ReplacesPreviousConfiguration()
+    {
+        var rcmManager = new MockRcmSubscriptionManager();
+        var module = new FeatureFlagsModule(CreateSettings(), rcmManager);
+        var configPath = RemoteConfigurationPath.FromPath($"datadog/2/{RcmProducts.FfeFlags}/test-config/config");
+
+        rcmManager.LastSubscription!.Invoke(
+            new Dictionary<string, List<RemoteConfiguration>>
+            {
+                [RcmProducts.FfeFlags] = [CreateRemoteConfiguration(configPath, "old-flag")]
+            },
+            null);
+
+        module.Evaluate("old-flag", FeatureFlagsValueType.Boolean, false, "user-1", null).Error.Should().BeNull();
+
+        rcmManager.LastSubscription.Invoke(
+            new Dictionary<string, List<RemoteConfiguration>>
+            {
+                [RcmProducts.FfeFlags] = [CreateRemoteConfiguration(configPath, "new-flag")]
+            },
+            null);
+
+        module.Evaluate("old-flag", FeatureFlagsValueType.Boolean, false, "user-1", null).Error.Should().Be("FLAG_NOT_FOUND");
+        module.Evaluate("new-flag", FeatureFlagsValueType.Boolean, false, "user-1", null).Error.Should().BeNull();
+    }
+
+    private static RemoteConfiguration CreateRemoteConfiguration(RemoteConfigurationPath configPath, string flagKey)
+    {
+        var configJson = JsonConvert.SerializeObject(new ServerConfiguration
+        {
+            Flags = new FlagCollection
+            {
+                [flagKey] = new Flag { Key = flagKey, Enabled = true, VariationType = FeatureFlagsValueType.Boolean }
+            }
+        });
+        var configBytes = System.Text.Encoding.UTF8.GetBytes(configJson);
+        return new RemoteConfiguration(configPath, configBytes, configBytes.Length, new Dictionary<string, string> { { "sha256", "dummy" } }, 1);
+    }
+
     private static TracerSettings CreateSettings()
     {
         var collection = new NameValueCollection


### PR DESCRIPTION
## Summary of changes

### Changes

Replace an existing FFE remote configuration when Remote Configuration refreshes the same path, instead of appending a second copy.

## Reason for change

### Motivation

`FfeProduct` appended every successful update. When a refreshed UFC at the same path removed a flag, the stale earlier copy remained in the merged evaluator configuration, so customers could continue evaluating a flag that no longer existed.

## Implementation details

### Decisions

Look up configurations by their Remote Configuration path and replace the existing entry in place. Replacing in place preserves the existing merge precedence across distinct configuration paths, while ensuring each path contributes only its latest contents.

New paths are still appended, and invalid updates keep the previously applied configuration through the existing failure path.

## Test coverage

- Added a regression that applies `old-flag`, refreshes the same path with only `new-flag`, then verifies `old-flag` returns `FLAG_NOT_FOUND` and `new-flag` remains available.
- `FeatureFlagsModuleTests`: 2 passed on `net9.0`.
- `FeatureFlagsModuleTests`: 2 passed on `netcoreapp3.1`.

## Other details

This fixes a pre-existing refresh bug identified during the final review of #8616.
