### PR TITLE
[AppSec] Free the WAF diagnostics of every config applied to the builder

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -251,10 +251,15 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                             {
                                 var configObj = encoded.ResultDdwafObject;
                                 var path = config.Key;
-                                if (!_wafLibraryInvoker.BuilderAddOrUpdateConfig(wafBuilderHandle, path, ref configObj, ref diagnostics))
+
+                                var configDiagnostics = default(DdwafObjectStruct);
+                                if (!_wafLibraryInvoker.BuilderAddOrUpdateConfig(wafBuilderHandle, path, ref configObj, ref configDiagnostics))
                                 {
                                     Log.Debug("WAF builder: Config failed to load : {0}", path); // Check were all these error codes are defined
                                 }
+
+                                _wafLibraryInvoker.ObjectDestroy(ref diagnostics);
+                                diagnostics = configDiagnostics;
                             }
                         }
                     }


### PR DESCRIPTION
## Summary of changes

`WafConfigurator.Update` now uses a fresh `DdwafObjectStruct` for each `ddwaf_builder_add_or_update_config` call and releases the previous one, instead of passing the same object to every call in the loop.

## Reason for change

`ddwaf_builder_add_or_update_config` allocates a brand new diagnostics tree on every call and *overwrites* the object it is given without freeing it. libddwaf is explicit about it ([`src/interface.cpp`](https://github.com/DataDog/libddwaf/blob/2.0.1/src/interface.cpp#L497-L500)):

```cpp
if (diagnostics != nullptr) {
    // avoid to_borrowed(diagnostics, ...) = ... as that would destroy
    // the current value in diagnostics, which could be uninitialized
    *to_ptr(diagnostics) = ri.to_object().move();
}
```

We passed a single `diagnostics` through the whole `configs.Updates` loop and the caller (`Waf.Create` / `Waf.Update`) destroyed it once, so every config but the last leaked its diagnostics tree. That is native memory invisible to the GC, leaked on each WAF init and on every RCM update cycle that carries more than one config.

The same file already got this right for the obfuscator config (`ApplyObfuscatorConfig`, with the comment "diagnostics are always allocated by the WAF with the default allocator"); this brings the ruleset loop in line.

## Implementation details

Per iteration: pass a local `configDiagnostics`, then `ObjectDestroy` the accumulated `diagnostics` and take over the new one. Reported diagnostics semantics are unchanged — the last applied config still wins, which is what the WAF's overwrite already gave us — so `UpdateResult`/telemetry output is identical.

## Test coverage

Covered indirectly by the existing WAF init/update tests (`Datadog.Trace.Security.Unit.Tests`), which assert the reported diagnostics after applying multiple configs; the behaviour they check is unchanged. The leak itself is native and not observable from a managed unit test.

## Other details

Found while investigating native memory growth with AppSec enabled (SCRS-2370). This is a real but small leak (tens of KB per update cycle) and is *not* the main suspect for that escalation — it is filed separately because it is an independent bug.