### PR TITLE
[AppSec] Dispose the WAF context when a non-web local root span closes

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -175,6 +175,13 @@ internal partial class AppSecRequestContext
     private IContext? _context;
 
     /// <summary>
+    /// Creates an instance that will never hand out a WAF context, for traces where the WAF must not run anymore
+    /// </summary>
+    /// <returns>an instance whose additive context is already disposed</returns>
+    internal static AppSecRequestContext CreateWithDisposedAdditiveContext()
+        => new() { _isAdditiveContextDisposed = true };
+
+    /// <summary>
     /// Disposes the WAF's context stored in HttpContext.Items[]. If it doesn't exist, nothing happens, no crash
     /// </summary>
     internal void DisposeAdditiveContext()

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -174,13 +174,19 @@ internal partial class AppSecRequestContext
     /// </summary>
     internal void DisposeAdditiveContext()
     {
-        // creation and disposal have to be mutually exclusive: without the lock a context being
-        // created here could be assigned right after this method has run, so it would never be
-        // disposed and its native memory would only be released by the finalizer
         lock (_sync)
         {
             _context?.Dispose();
             _isAdditiveContextDisposed = true;
+        }
+    }
+
+    internal void ReopenAdditiveContext()
+    {
+        lock (_sync)
+        {
+            _context = null;
+            _isAdditiveContextDisposed = false;
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -165,6 +165,11 @@ internal sealed partial class AppSecRequestContext
 
 internal partial class AppSecRequestContext
 {
+    // dedicated lock: this state is disjoint from what _sync guards, and _sync is held
+    // during MessagePack/JSON serialization in CloseWebSpan, while DisposeAdditiveContext
+    // runs under the trace segment lock
+    private readonly object _contextSync = new();
+
     private bool _isAdditiveContextDisposed;
 
     private IContext? _context;
@@ -174,7 +179,7 @@ internal partial class AppSecRequestContext
     /// </summary>
     internal void DisposeAdditiveContext()
     {
-        lock (_sync)
+        lock (_contextSync)
         {
             _context?.Dispose();
             _isAdditiveContextDisposed = true;
@@ -183,7 +188,7 @@ internal partial class AppSecRequestContext
 
     internal void ReopenAdditiveContext()
     {
-        lock (_sync)
+        lock (_contextSync)
         {
             _context = null;
             _isAdditiveContextDisposed = false;
@@ -192,7 +197,7 @@ internal partial class AppSecRequestContext
 
     internal IContext? GetOrCreateAdditiveContext(Security security)
     {
-        lock (_sync)
+        lock (_contextSync)
         {
             if (_isAdditiveContextDisposed)
             {

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -165,19 +165,13 @@ internal sealed partial class AppSecRequestContext
 
 internal partial class AppSecRequestContext
 {
-    // dedicated lock: this state is disjoint from what _sync guards, and _sync is held
-    // during MessagePack/JSON serialization in CloseWebSpan, while DisposeAdditiveContext
-    // runs under the trace segment lock
+    // dedicated lock: _sync is held while CloseWebSpan serializes
     private readonly object _contextSync = new();
 
     private bool _isAdditiveContextDisposed;
 
     private IContext? _context;
 
-    /// <summary>
-    /// Creates an instance that will never hand out a WAF context, for traces where the WAF must not run anymore
-    /// </summary>
-    /// <returns>an instance whose additive context is already disposed</returns>
     internal static AppSecRequestContext CreateWithDisposedAdditiveContext()
         => new() { _isAdditiveContextDisposed = true };
 

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -193,15 +193,6 @@ internal partial class AppSecRequestContext
         }
     }
 
-    internal void ReopenAdditiveContext()
-    {
-        lock (_contextSync)
-        {
-            _context = null;
-            _isAdditiveContextDisposed = false;
-        }
-    }
-
     internal IContext? GetOrCreateAdditiveContext(Security security)
     {
         lock (_contextSync)

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -174,24 +174,33 @@ internal partial class AppSecRequestContext
     /// </summary>
     internal void DisposeAdditiveContext()
     {
-        _context?.Dispose();
-        _isAdditiveContextDisposed = true;
+        // creation and disposal have to be mutually exclusive: without the lock a context being
+        // created here could be assigned right after this method has run, so it would never be
+        // disposed and its native memory would only be released by the finalizer
+        lock (_sync)
+        {
+            _context?.Dispose();
+            _isAdditiveContextDisposed = true;
+        }
     }
 
     internal IContext? GetOrCreateAdditiveContext(Security security)
     {
-        if (_isAdditiveContextDisposed)
+        lock (_sync)
         {
-            Log.Debug("Additive context was requested when already disposed");
-            return null;
-        }
+            if (_isAdditiveContextDisposed)
+            {
+                Log.Debug("Additive context was requested when already disposed");
+                return null;
+            }
 
-        if (_context is not null)
-        {
+            if (_context is not null)
+            {
+                return _context;
+            }
+
+            _context = security.CreateAdditiveContext();
             return _context;
         }
-
-        _context = security.CreateAdditiveContext();
-        return _context;
     }
 }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -138,15 +138,20 @@ namespace Datadog.Trace
         {
             var created = new AppSecRequestContext();
 
-            if (Interlocked.CompareExchange(ref _appSecRequestContext, created, null) is null && _rootSpan is { } rootSpan)
+            if (_rootSpan is not { } rootSpan)
             {
-                lock (rootSpan)
+                Interlocked.CompareExchange(ref _appSecRequestContext, created, null);
+                return _appSecRequestContext!;
+            }
+
+            lock (rootSpan)
+            {
+                if (_segmentClosed || (rootSpan.Type == SpanTypes.Web && rootSpan.IsFinished))
                 {
-                    if (_segmentClosed)
-                    {
-                        created.DisposeAdditiveContext();
-                    }
+                    created.DisposeAdditiveContext();
                 }
+
+                Interlocked.CompareExchange(ref _appSecRequestContext, created, null);
             }
 
             return _appSecRequestContext!;

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -227,14 +227,6 @@ namespace Datadog.Trace
                     spansToWrite = _spans;
                     _spans = default;
                     TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();
-
-                    // A WAF context can be created on any local root span, not just a web one (the user
-                    // events SDKs and the ASP.NET Core Identity integrations don't check the span type),
-                    // and it holds native memory that is only released when it is disposed. Web traces
-                    // release it as soon as their local root span closes, above; for every other trace
-                    // this is the point where nothing can use it anymore. Disposing twice is a no-op.
-                    // This has to happen while holding the lock, or AddSpan could reopen the segment
-                    // in between and we would dispose the context of a span that is still running.
                     _appSecRequestContext?.DisposeAdditiveContext();
                 }
                 else if (TestOptimization.Instance.IsRunning && span.IsCiVisibilitySpan())

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace
         private SpanCollection _spans;
         private int _openSpans;
 
+        private bool _segmentClosed;
+
         private IastRequestContext? _iastRequestContext;
         private AppSecRequestContext? _appSecRequestContext;
 
@@ -46,6 +48,7 @@ namespace Datadog.Trace
         // _rootSpan was chosen in #4125 to be the lock that protects
         // * _spans
         // * _openSpans
+        // * _segmentClosed
         // although it's a nullable field, the _rootSpan must always be set before operations on
         // _spans take place, so it's okay to use it as a lock key
         // even though we need to override the nullable warnings in some places.
@@ -119,15 +122,7 @@ namespace Datadog.Trace
         internal AppSecRequestContext AppSecRequestContext
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                if (Volatile.Read(ref _appSecRequestContext) is null)
-                {
-                    Interlocked.CompareExchange(ref _appSecRequestContext, new(), null);
-                }
-
-                return _appSecRequestContext!;
-            }
+            get => Volatile.Read(ref _appSecRequestContext) ?? CreateAppSecRequestContext();
         }
 
         internal bool WafExecuted { get; set; }
@@ -137,6 +132,25 @@ namespace Datadog.Trace
 
         internal static TraceContext? GetTraceContext(in SpanCollection spans)
             => spans.FirstSpan?.Context.TraceContext;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private AppSecRequestContext CreateAppSecRequestContext()
+        {
+            var created = new AppSecRequestContext();
+
+            if (Interlocked.CompareExchange(ref _appSecRequestContext, created, null) is null && _rootSpan is { } rootSpan)
+            {
+                lock (rootSpan)
+                {
+                    if (_segmentClosed)
+                    {
+                        created.DisposeAdditiveContext();
+                    }
+                }
+            }
+
+            return _appSecRequestContext!;
+        }
 
         /// <summary>
         /// Gets the feature-flag span-enrichment state for this trace (created on first use), or null
@@ -176,6 +190,16 @@ namespace Datadog.Trace
             lock (_rootSpan)
             {
                 _openSpans++;
+
+                if (_openSpans == 1 && _segmentClosed)
+                {
+                    _segmentClosed = false;
+
+                    if (_rootSpan.Type != SpanTypes.Web)
+                    {
+                        _appSecRequestContext?.ReopenAdditiveContext();
+                    }
+                }
             }
         }
 
@@ -206,8 +230,11 @@ namespace Datadog.Trace
                         }
                     }
 
-                    _appSecRequestContext?.CloseWebSpan(span);
-                    _appSecRequestContext?.DisposeAdditiveContext();
+                    if (_appSecRequestContext is not null)
+                    {
+                        _appSecRequestContext.CloseWebSpan(span);
+                        _appSecRequestContext.DisposeAdditiveContext();
+                    }
                 }
             }
 
@@ -226,6 +253,7 @@ namespace Datadog.Trace
                 {
                     spansToWrite = _spans;
                     _spans = default;
+                    _segmentClosed = true;
                     TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();
                     _appSecRequestContext?.DisposeAdditiveContext();
                 }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -206,12 +206,14 @@ namespace Datadog.Trace
                         }
                     }
 
-                    if (_appSecRequestContext is not null)
-                    {
-                        _appSecRequestContext.CloseWebSpan(span);
-                        _appSecRequestContext.DisposeAdditiveContext();
-                    }
+                    _appSecRequestContext?.CloseWebSpan(span);
                 }
+
+                // A WAF context can be created on any local root span, not just a web one (the user
+                // events SDKs and the ASP.NET Core Identity integrations don't check the span type),
+                // and it holds native memory that is only released when it is disposed. The trace is
+                // over once its local root span closes, so nothing will need the context after this.
+                _appSecRequestContext?.DisposeAdditiveContext();
             }
 
             if (span.ServiceName is not null &&

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -190,16 +190,6 @@ namespace Datadog.Trace
             lock (_rootSpan)
             {
                 _openSpans++;
-
-                if (_openSpans == 1 && _segmentClosed)
-                {
-                    _segmentClosed = false;
-
-                    if (_rootSpan.Type != SpanTypes.Web)
-                    {
-                        _appSecRequestContext?.ReopenAdditiveContext();
-                    }
-                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -184,6 +184,7 @@ namespace Datadog.Trace
             bool ShouldTriggerPartialFlush() => Tracer.Settings.PartialFlushEnabled && _spans.Count >= Tracer.Settings.PartialFlushMinSpans;
 
             SpanCollection spansToWrite = default;
+            var allSpansClosed = false;
 
             // Propagate the resource name to the profiler for root web spans
             if (span.IsRootSpan)
@@ -207,13 +208,8 @@ namespace Datadog.Trace
                     }
 
                     _appSecRequestContext?.CloseWebSpan(span);
+                    _appSecRequestContext?.DisposeAdditiveContext();
                 }
-
-                // A WAF context can be created on any local root span, not just a web one (the user
-                // events SDKs and the ASP.NET Core Identity integrations don't check the span type),
-                // and it holds native memory that is only released when it is disposed. The trace is
-                // over once its local root span closes, so nothing will need the context after this.
-                _appSecRequestContext?.DisposeAdditiveContext();
             }
 
             if (span.ServiceName is not null &&
@@ -231,6 +227,7 @@ namespace Datadog.Trace
                 {
                     spansToWrite = _spans;
                     _spans = default;
+                    allSpansClosed = true;
                     TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();
                 }
                 else if (TestOptimization.Instance.IsRunning && span.IsCiVisibilitySpan())
@@ -259,6 +256,16 @@ namespace Datadog.Trace
                     _spans = new SpanCollection(spansToWrite.Count);
                     TelemetryFactory.Metrics.RecordCountTracePartialFlush(MetricTags.PartialFlushReason.LargeTrace);
                 }
+            }
+
+            if (allSpansClosed)
+            {
+                // A WAF context can be created on any local root span, not just a web one (the user
+                // events SDKs and the ASP.NET Core Identity integrations don't check the span type),
+                // and it holds native memory that is only released when it is disposed. Web traces
+                // release it as soon as their local root span closes, above; for every other trace
+                // this is the point where nothing can use it anymore. Disposing twice is a no-op.
+                _appSecRequestContext?.DisposeAdditiveContext();
             }
 
             if (spansToWrite.Count > 0)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -235,11 +235,7 @@ namespace Datadog.Trace
                         }
                     }
 
-                    if (_appSecRequestContext is not null)
-                    {
-                        _appSecRequestContext.CloseWebSpan(span);
-                        _appSecRequestContext.DisposeAdditiveContext();
-                    }
+                    _appSecRequestContext?.CloseWebSpan(span);
                 }
             }
 
@@ -248,6 +244,8 @@ namespace Datadog.Trace
             {
                 ExtraServicesProvider.Instance.AddService(span.ServiceName);
             }
+
+            var disposeAdditiveContext = span.IsRootSpan && span.Type == SpanTypes.Web;
 
             lock (_rootSpan!)
             {
@@ -259,8 +257,8 @@ namespace Datadog.Trace
                     spansToWrite = _spans;
                     _spans = default;
                     _segmentClosed = true;
+                    disposeAdditiveContext = true;
                     TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();
-                    _appSecRequestContext?.DisposeAdditiveContext();
                 }
                 else if (TestOptimization.Instance.IsRunning && span.IsCiVisibilitySpan())
                 {
@@ -287,6 +285,11 @@ namespace Datadog.Trace
                     // Therefore, we bypass the resize logic and immediately allocate the array to its maximum size
                     _spans = new SpanCollection(spansToWrite.Count);
                     TelemetryFactory.Metrics.RecordCountTracePartialFlush(MetricTags.PartialFlushReason.LargeTrace);
+                }
+
+                if (disposeAdditiveContext)
+                {
+                    _appSecRequestContext?.DisposeAdditiveContext();
                 }
             }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -136,25 +136,20 @@ namespace Datadog.Trace
         [MethodImpl(MethodImplOptions.NoInlining)]
         private AppSecRequestContext CreateAppSecRequestContext()
         {
-            var created = new AppSecRequestContext();
-
             if (_rootSpan is not { } rootSpan)
             {
-                Interlocked.CompareExchange(ref _appSecRequestContext, created, null);
-                return _appSecRequestContext!;
+                var created = new AppSecRequestContext();
+                return Interlocked.CompareExchange(ref _appSecRequestContext, created, null) ?? created;
             }
 
             lock (rootSpan)
             {
-                if (_segmentClosed || (rootSpan.Type == SpanTypes.Web && rootSpan.IsFinished))
-                {
-                    created.DisposeAdditiveContext();
-                }
+                var created = _segmentClosed || (rootSpan.Type == SpanTypes.Web && rootSpan.IsFinished)
+                                  ? AppSecRequestContext.CreateWithDisposedAdditiveContext()
+                                  : new AppSecRequestContext();
 
-                Interlocked.CompareExchange(ref _appSecRequestContext, created, null);
+                return Interlocked.CompareExchange(ref _appSecRequestContext, created, null) ?? created;
             }
-
-            return _appSecRequestContext!;
         }
 
         /// <summary>
@@ -235,7 +230,7 @@ namespace Datadog.Trace
                         }
                     }
 
-                    _appSecRequestContext?.CloseWebSpan(span);
+                    Volatile.Read(ref _appSecRequestContext)?.CloseWebSpan(span);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -184,7 +184,6 @@ namespace Datadog.Trace
             bool ShouldTriggerPartialFlush() => Tracer.Settings.PartialFlushEnabled && _spans.Count >= Tracer.Settings.PartialFlushMinSpans;
 
             SpanCollection spansToWrite = default;
-            var allSpansClosed = false;
 
             // Propagate the resource name to the profiler for root web spans
             if (span.IsRootSpan)
@@ -227,8 +226,16 @@ namespace Datadog.Trace
                 {
                     spansToWrite = _spans;
                     _spans = default;
-                    allSpansClosed = true;
                     TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();
+
+                    // A WAF context can be created on any local root span, not just a web one (the user
+                    // events SDKs and the ASP.NET Core Identity integrations don't check the span type),
+                    // and it holds native memory that is only released when it is disposed. Web traces
+                    // release it as soon as their local root span closes, above; for every other trace
+                    // this is the point where nothing can use it anymore. Disposing twice is a no-op.
+                    // This has to happen while holding the lock, or AddSpan could reopen the segment
+                    // in between and we would dispose the context of a span that is still running.
+                    _appSecRequestContext?.DisposeAdditiveContext();
                 }
                 else if (TestOptimization.Instance.IsRunning && span.IsCiVisibilitySpan())
                 {
@@ -256,16 +263,6 @@ namespace Datadog.Trace
                     _spans = new SpanCollection(spansToWrite.Count);
                     TelemetryFactory.Metrics.RecordCountTracePartialFlush(MetricTags.PartialFlushReason.LargeTrace);
                 }
-            }
-
-            if (allSpansClosed)
-            {
-                // A WAF context can be created on any local root span, not just a web one (the user
-                // events SDKs and the ASP.NET Core Identity integrations don't check the span type),
-                // and it holds native memory that is only released when it is disposed. Web traces
-                // release it as soon as their local root span closes, above; for every other trace
-                // this is the point where nothing can use it anymore. Disposing twice is a no-op.
-                _appSecRequestContext?.DisposeAdditiveContext();
             }
 
             if (spansToWrite.Count > 0)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -5,8 +5,10 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Security.Unit.Tests.Utils;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
@@ -14,8 +16,30 @@ using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests;
 
-public class AppSecContextTests
+public class AppSecContextTests : WafLibraryRequiredTest
 {
+    [Theory]
+    [InlineData(null)]
+    [InlineData(SpanTypes.Web)]
+    [InlineData(SpanTypes.Custom)]
+    public async Task GivenAWafContext_WhenTheLocalRootSpanCloses_ThenItIsDisposed(string spanType)
+    {
+        var settings = TracerSettings.Create(new Dictionary<string, object>());
+        await using var tracer = TracerHelper.Create(settings);
+        using var security = new AppSec.Security(waf: CreateWaf().Waf);
+
+        AppSecRequestContext appSecContext;
+        using (var rootTestScope = (Scope)tracer.StartActive("test.trace"))
+        {
+            rootTestScope.Span.Type = spanType;
+            appSecContext = rootTestScope.Span.Context.TraceContext.AppSecRequestContext;
+            appSecContext.GetOrCreateAdditiveContext(security).Should().NotBeNull();
+        }
+
+        // once disposed the additive context is never handed out again, whatever the span type was
+        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
+    }
+
     [InlineData(-2, -2, -1, 0, -2, -1)]
     [InlineData(2, -2, -1, 1, null, -1)]
     [InlineData(2, 2, 1, 2, null, null)]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -95,6 +95,24 @@ public class AppSecContextTests : WafLibraryRequiredTest
         traceContext.AppSecRequestContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
+    [Fact]
+    public async Task GivenAFinishedWebSpan_WhenALateSpanUsesAppSecForTheFirstTime_ThenNoWafContextIsHandedOut()
+    {
+        var settings = TracerSettings.Create(new Dictionary<string, object>());
+        await using var tracer = TracerHelper.Create(settings);
+        using var security = new AppSec.Security(waf: CreateWaf().Waf);
+
+        var rootTestScope = (Scope)tracer.StartActive("test.trace");
+        rootTestScope.Span.Type = SpanTypes.Web;
+        var capturedParent = rootTestScope.Span.Context;
+        rootTestScope.Dispose();
+
+        using var lateTestScope = (Scope)tracer.StartActive("test.late", new SpanCreationSettings { Parent = capturedParent });
+        var appSecContext = lateTestScope.Span.Context.TraceContext.AppSecRequestContext;
+
+        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
+    }
+
     [InlineData(-2, -2, -1, 0, -2, -1)]
     [InlineData(2, -2, -1, 1, null, -1)]
     [InlineData(2, 2, 1, 2, null, null)]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -40,6 +40,27 @@ public class AppSecContextTests : WafLibraryRequiredTest
         appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
+    [Fact]
+    public async Task GivenAWafContextOnANonWebSpan_WhenTheRootClosesBeforeItsChildren_ThenItSurvivesUntilTheyClose()
+    {
+        var settings = TracerSettings.Create(new Dictionary<string, object>());
+        await using var tracer = TracerHelper.Create(settings);
+        using var security = new AppSec.Security(waf: CreateWaf().Waf);
+
+        var rootTestScope = (Scope)tracer.StartActive("test.trace");
+        var childTestScope = (Scope)tracer.StartActive("test.child");
+        var appSecContext = rootTestScope.Span.Context.TraceContext.AppSecRequestContext;
+        appSecContext.GetOrCreateAdditiveContext(security).Should().NotBeNull();
+
+        rootTestScope.Dispose();
+
+        // the trace isn't over, the still open child span can run the WAF
+        appSecContext.GetOrCreateAdditiveContext(security).Should().NotBeNull();
+
+        childTestScope.Dispose();
+        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
+    }
+
     [InlineData(-2, -2, -1, 0, -2, -1)]
     [InlineData(2, -2, -1, 1, null, -1)]
     [InlineData(2, 2, 1, 2, null, null)]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -74,9 +74,9 @@ public class AppSecContextTests : WafLibraryRequiredTest
     }
 
     [Theory]
-    [InlineData(SpanTypes.Custom, true)]
-    [InlineData(SpanTypes.Web, false)]
-    public async Task GivenAClosedTraceSegment_WhenALateSpanReopensIt_ThenOnlyANonWebTraceGetsANewWafContext(string spanType, bool expectedContext)
+    [InlineData(SpanTypes.Custom)]
+    [InlineData(SpanTypes.Web)]
+    public async Task GivenAClosedTraceSegment_WhenALateSpanIsAdded_ThenTheWafContextStaysDisposed(string spanType)
     {
         await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
@@ -91,7 +91,7 @@ public class AppSecContextTests : WafLibraryRequiredTest
         appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
 
         using var lateTestScope = (Scope)tracer.StartActive("test.late", new SpanCreationSettings { Parent = capturedParent });
-        (appSecContext.GetOrCreateAdditiveContext(security) is not null).Should().Be(expectedContext);
+        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
     [Fact]
@@ -108,9 +108,9 @@ public class AppSecContextTests : WafLibraryRequiredTest
     }
 
     [Theory]
-    [InlineData(SpanTypes.Custom, true)]
-    [InlineData(SpanTypes.Web, false)]
-    public async Task GivenAClosedTraceSegment_WhenALateSpanUsesAppSecForTheFirstTime_ThenOnlyANonWebTraceGetsAWafContext(string spanType, bool expectedContext)
+    [InlineData(SpanTypes.Custom)]
+    [InlineData(SpanTypes.Web)]
+    public async Task GivenAClosedTraceSegment_WhenALateSpanUsesAppSecForTheFirstTime_ThenNoWafContextIsHandedOut(string spanType)
     {
         await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
@@ -123,7 +123,7 @@ public class AppSecContextTests : WafLibraryRequiredTest
         using var lateTestScope = (Scope)tracer.StartActive("test.late", new SpanCreationSettings { Parent = capturedParent });
         var appSecContext = lateTestScope.Span.Context.TraceContext.AppSecRequestContext;
 
-        (appSecContext.GetOrCreateAdditiveContext(security) is not null).Should().Be(expectedContext);
+        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
     [InlineData(-2, -2, -1, 0, -2, -1)]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Waf;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.Security.Unit.Tests.Utils;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers.TestTracer;
@@ -24,8 +23,7 @@ public class AppSecContextTests : WafLibraryRequiredTest
     [InlineData(SpanTypes.Custom)]
     public async Task GivenAWafContext_WhenTheLocalRootSpanCloses_ThenItIsDisposed(string spanType)
     {
-        var settings = TracerSettings.Create(new Dictionary<string, object>());
-        await using var tracer = TracerHelper.Create(settings);
+        await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
 
         AppSecRequestContext appSecContext;
@@ -42,8 +40,7 @@ public class AppSecContextTests : WafLibraryRequiredTest
     [Fact]
     public async Task GivenAWafContextOnANonWebSpan_WhenTheRootClosesBeforeItsChildren_ThenItSurvivesUntilTheyClose()
     {
-        var settings = TracerSettings.Create(new Dictionary<string, object>());
-        await using var tracer = TracerHelper.Create(settings);
+        await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
@@ -62,8 +59,7 @@ public class AppSecContextTests : WafLibraryRequiredTest
     [Fact]
     public async Task GivenAWafContextOnAWebSpan_WhenTheRootClosesBeforeItsChildren_ThenItIsDisposed()
     {
-        var settings = TracerSettings.Create(new Dictionary<string, object>());
-        await using var tracer = TracerHelper.Create(settings);
+        await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
@@ -82,8 +78,7 @@ public class AppSecContextTests : WafLibraryRequiredTest
     [InlineData(SpanTypes.Web, false)]
     public async Task GivenAClosedTraceSegment_WhenALateSpanReopensIt_ThenOnlyANonWebTraceGetsANewWafContext(string spanType, bool expectedContext)
     {
-        var settings = TracerSettings.Create(new Dictionary<string, object>());
-        await using var tracer = TracerHelper.Create(settings);
+        await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
@@ -100,10 +95,9 @@ public class AppSecContextTests : WafLibraryRequiredTest
     }
 
     [Fact]
-    public async Task GivenAClosedTraceSegment_WhenTheAppSecContextIsCreatedAfterwards_ThenNoWafContextIsHandedOut()
+    public async Task GivenAClosedTraceSegmentWithNoLateSpan_WhenTheAppSecContextIsCreatedAfterwards_ThenNoWafContextIsHandedOut()
     {
-        var settings = TracerSettings.Create(new Dictionary<string, object>());
-        await using var tracer = TracerHelper.Create(settings);
+        await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
@@ -113,22 +107,23 @@ public class AppSecContextTests : WafLibraryRequiredTest
         traceContext.AppSecRequestContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
-    [Fact]
-    public async Task GivenAFinishedWebSpan_WhenALateSpanUsesAppSecForTheFirstTime_ThenNoWafContextIsHandedOut()
+    [Theory]
+    [InlineData(SpanTypes.Custom, true)]
+    [InlineData(SpanTypes.Web, false)]
+    public async Task GivenAClosedTraceSegment_WhenALateSpanUsesAppSecForTheFirstTime_ThenOnlyANonWebTraceGetsAWafContext(string spanType, bool expectedContext)
     {
-        var settings = TracerSettings.Create(new Dictionary<string, object>());
-        await using var tracer = TracerHelper.Create(settings);
+        await using var tracer = TracerHelper.Create(new());
         using var security = new AppSec.Security(waf: CreateWaf().Waf);
 
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
-        rootTestScope.Span.Type = SpanTypes.Web;
+        rootTestScope.Span.Type = spanType;
         var capturedParent = rootTestScope.Span.Context;
         rootTestScope.Dispose();
 
         using var lateTestScope = (Scope)tracer.StartActive("test.late", new SpanCreationSettings { Parent = capturedParent });
         var appSecContext = lateTestScope.Span.Context.TraceContext.AppSecRequestContext;
 
-        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
+        (appSecContext.GetOrCreateAdditiveContext(security) is not null).Should().Be(expectedContext);
     }
 
     [InlineData(-2, -2, -1, 0, -2, -1)]
@@ -137,8 +132,7 @@ public class AppSecContextTests : WafLibraryRequiredTest
     [Theory]
     public async Task GivenAQuery_WhenWAFError_ThenSpanHasErrorTags(int raspErrorCode, int wafErrorCode, int wafErrorCode2, int wafTimeouts, int? expectedRaspErrorCode, int? expectedWafErrorCode)
     {
-        var settings = TracerSettings.Create(new Dictionary<string, object>());
-        await using var tracer = TracerHelper.Create(settings);
+        await using var tracer = TracerHelper.Create(new());
         var rootTestScope = (Scope)tracer.StartActive("test.trace");
 
         var appSecContext = rootTestScope.Span.Context.TraceContext.AppSecRequestContext;

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -36,7 +36,6 @@ public class AppSecContextTests : WafLibraryRequiredTest
             appSecContext.GetOrCreateAdditiveContext(security).Should().NotBeNull();
         }
 
-        // once disposed the additive context is never handed out again, whatever the span type was
         appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
@@ -54,11 +53,46 @@ public class AppSecContextTests : WafLibraryRequiredTest
 
         rootTestScope.Dispose();
 
-        // the trace isn't over, the still open child span can run the WAF
         appSecContext.GetOrCreateAdditiveContext(security).Should().NotBeNull();
 
         childTestScope.Dispose();
         appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(SpanTypes.Custom, true)]
+    [InlineData(SpanTypes.Web, false)]
+    public async Task GivenAClosedTraceSegment_WhenALateSpanReopensIt_ThenOnlyANonWebTraceGetsANewWafContext(string spanType, bool expectedContext)
+    {
+        var settings = TracerSettings.Create(new Dictionary<string, object>());
+        await using var tracer = TracerHelper.Create(settings);
+        using var security = new AppSec.Security(waf: CreateWaf().Waf);
+
+        var rootTestScope = (Scope)tracer.StartActive("test.trace");
+        rootTestScope.Span.Type = spanType;
+        var capturedParent = rootTestScope.Span.Context;
+        var appSecContext = rootTestScope.Span.Context.TraceContext.AppSecRequestContext;
+        appSecContext.GetOrCreateAdditiveContext(security).Should().NotBeNull();
+
+        rootTestScope.Dispose();
+        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
+
+        using var lateTestScope = (Scope)tracer.StartActive("test.late", new SpanCreationSettings { Parent = capturedParent });
+        (appSecContext.GetOrCreateAdditiveContext(security) is not null).Should().Be(expectedContext);
+    }
+
+    [Fact]
+    public async Task GivenAClosedTraceSegment_WhenTheAppSecContextIsCreatedAfterwards_ThenNoWafContextIsHandedOut()
+    {
+        var settings = TracerSettings.Create(new Dictionary<string, object>());
+        await using var tracer = TracerHelper.Create(settings);
+        using var security = new AppSec.Security(waf: CreateWaf().Waf);
+
+        var rootTestScope = (Scope)tracer.StartActive("test.trace");
+        var traceContext = rootTestScope.Span.Context.TraceContext;
+        rootTestScope.Dispose();
+
+        traceContext.AppSecRequestContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
     [InlineData(-2, -2, -1, 0, -2, -1)]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/AppSecContextTests.cs
@@ -59,6 +59,24 @@ public class AppSecContextTests : WafLibraryRequiredTest
         appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
     }
 
+    [Fact]
+    public async Task GivenAWafContextOnAWebSpan_WhenTheRootClosesBeforeItsChildren_ThenItIsDisposed()
+    {
+        var settings = TracerSettings.Create(new Dictionary<string, object>());
+        await using var tracer = TracerHelper.Create(settings);
+        using var security = new AppSec.Security(waf: CreateWaf().Waf);
+
+        var rootTestScope = (Scope)tracer.StartActive("test.trace");
+        rootTestScope.Span.Type = SpanTypes.Web;
+        using var childTestScope = (Scope)tracer.StartActive("test.child");
+        var appSecContext = rootTestScope.Span.Context.TraceContext.AppSecRequestContext;
+        appSecContext.GetOrCreateAdditiveContext(security).Should().NotBeNull();
+
+        rootTestScope.Dispose();
+
+        appSecContext.GetOrCreateAdditiveContext(security).Should().BeNull();
+    }
+
     [Theory]
     [InlineData(SpanTypes.Custom, true)]
     [InlineData(SpanTypes.Web, false)]


### PR DESCRIPTION
## Summary of changes

The WAF (additive) context is now disposed when the **last span of the trace segment** closes, not only when a local root span of type `web` closes. Creation and disposal are serialized so they can't race.

## Reason for change

Creation and release were asymmetric. Creation goes through `SecurityCoordinator.TryGet`, which only requires a non-null `CoreHttpContextStore.Instance.Get()` and never checks the local root span type — reachable from `EventTrackingSdk`/`EventTrackingSdkV2.RunSecurityChecksAndReport` and from `UserManagerCreateIntegration` on the ASP.NET Core Identity signup path. Release only happened under `span.IsRootSpan && span.Type == SpanTypes.Web`.

So a `TrackUserLoginSuccess`/`SetUser`/Identity-signup call under a non-web local root span (background worker, queue consumer, `Task.Run` continuation) created a context that nothing ever disposed. Each libddwaf context owns a [`monotonic_buffer_resource`](https://github.com/DataDog/libddwaf/blob/2.0.1/src/context.hpp#L250) released only on destruction — native memory invisible to the GC, so it showed up as RSS growth with a flat managed heap.

## Implementation details

- `TraceContext.CloseSpan` disposes in the `_openSpans == 0` branch, under the lock that guards `_openSpans` so `AddSpan` can't reopen the segment in between. Waiting for the last span rather than the local root matters because a child span or a captured continuation can outlive the root on a non-web trace.
- The additive-context state gets its own lock rather than the shared `_sync`, which `CloseWebSpan` holds during MessagePack/JSON serialization.
- Adding a span to an already-closed segment does not resurrect the context: disposal is terminal for non-web and web roots alike. That scenario is broken for reporting anyway — AppSec results are written to the local root span, which has already been serialized — so it is deliberately not supported.
- The lazy `AppSecRequestContext` getter re-checks the segment state under the trace lock, so a first WAF use racing with the last span closing can't install a context with no disposal point. The fast path is still a single volatile read.

## Test coverage

Six new tests in `AppSecContextTests`, all verified to fail without the corresponding change. On net8.0: the full `Datadog.Trace.Security.Unit.Tests` suite and the `TraceContext`/`PartialFlush`/`Span`/`Tracer`/`DistributedTrace` tests of `Datadog.Trace.Tests` pass.

## Other details

Found while investigating native memory growth with AppSec enabled (SCRS-2370). #8989 removed one route into this but not the asymmetry. Refusing to create the context outside a web root span would be complementary hardening, but it changes detection behaviour, so it is deliberately left out.


