### PR TITLE
Fix flaky grpc tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -243,12 +243,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             HttpClientIntegrationType httpClientIntegrationType,
             string metadataSchemaVersion)
         {
-            const int requestCount = 2 // Unary  (sync + async)
-                                    + 1 // 1 server streaming
-                                    + 1 // 1 client streaming
-                                    + 1 // 1 both streaming
-                                    + 1 // Deadline exceeded (async)
-                                    + (4 * 2); // 4 Error types (sync + async)
+            var requestCount = 2 // Unary (sync + async)
+                             + 1 // 1 server streaming
+                             + 1 // 1 client streaming
+                             + 1 // 1 both streaming
+                             + 1 // Deadline exceeded (async)
+                             + (4 * 2) // 4 Error types (sync + async)
+                             + (_usesAspNetCore ? 2 : 0); // Invalid content type + deadline exceeded (sync), GrpcDotNet only
 
             // Get between 3 and 5 spans per request:
             // (grpc + http) outbound + (grpc + aspnetcore) inbound


### PR DESCRIPTION
## Summary of changes

Fix flaky gRPC snapshot tests by waiting for all expected spans.

## Reason for change

`GrpcDotNet` sends 16 requests, but the [shared test](https://github.com/DataDog/dd-trace-dotnet/pull/9058) counted only the 14 sent by `GrpcLegacy`. The mock agent could therefore return a partial snapshot after 70 of the expected 80 spans arrived.

## Implementation details

Include the two `GrpcDotNet`-only requests in the expected count while leaving the legacy count unchanged.

## Test coverage

Covered by the existing gRPC integration tests and snapshots.