### PR TITLE
[Agentless] Introduce global agentless configuration key

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -50,6 +50,17 @@ supportedConfigurations:
       Configuration key to disable polling the /info endpoint in the trace agent for feature discovery.
       Default value is true (polling enabled).
       <seealso cref="TracerSettings.AgentFeaturePollingEnabled"/>
+  DD_AGENTLESS_ENABLED:
+  - implementation: A
+    scope: managed, native
+    type: boolean
+    default: 'false'
+    const_name: AgentlessEnabled
+    documentation: |-
+      Global switch for sending supported product data directly to Datadog intake instead of through the local Agent.
+      When explicitly set, this value takes precedence over supported product-specific agentless settings.
+      Existing product-specific settings may be used as compatibility fallbacks when this key is not set.
+      Default value is false (disabled).
   DD_API_KEY:
   - implementation: A
     scope: managed, native

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -36,6 +36,14 @@ internal static partial class ConfigurationKeys
     public const string AgentHost = "DD_AGENT_HOST";
 
     /// <summary>
+    /// Global switch for sending supported product data directly to Datadog intake instead of through the local Agent.
+    /// When explicitly set, this value takes precedence over supported product-specific agentless settings.
+    /// Existing product-specific settings may be used as compatibility fallbacks when this key is not set.
+    /// Default value is false (disabled).
+    /// </summary>
+    public const string AgentlessEnabled = "DD_AGENTLESS_ENABLED";
+
+    /// <summary>
     /// Configuration key for setting the API key, used by the Agent.
     /// </summary>
     public const string ApiKey = "DD_API_KEY";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -36,6 +36,14 @@ internal static partial class ConfigurationKeys
     public const string AgentHost = "DD_AGENT_HOST";
 
     /// <summary>
+    /// Global switch for sending supported product data directly to Datadog intake instead of through the local Agent.
+    /// When explicitly set, this value takes precedence over supported product-specific agentless settings.
+    /// Existing product-specific settings may be used as compatibility fallbacks when this key is not set.
+    /// Default value is false (disabled).
+    /// </summary>
+    public const string AgentlessEnabled = "DD_AGENTLESS_ENABLED";
+
+    /// <summary>
     /// Configuration key for setting the API key, used by the Agent.
     /// </summary>
     public const string ApiKey = "DD_API_KEY";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -36,6 +36,14 @@ internal static partial class ConfigurationKeys
     public const string AgentHost = "DD_AGENT_HOST";
 
     /// <summary>
+    /// Global switch for sending supported product data directly to Datadog intake instead of through the local Agent.
+    /// When explicitly set, this value takes precedence over supported product-specific agentless settings.
+    /// Existing product-specific settings may be used as compatibility fallbacks when this key is not set.
+    /// Default value is false (disabled).
+    /// </summary>
+    public const string AgentlessEnabled = "DD_AGENTLESS_ENABLED";
+
+    /// <summary>
     /// Configuration key for setting the API key, used by the Agent.
     /// </summary>
     public const string ApiKey = "DD_API_KEY";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.g.cs
@@ -36,6 +36,14 @@ internal static partial class ConfigurationKeys
     public const string AgentHost = "DD_AGENT_HOST";
 
     /// <summary>
+    /// Global switch for sending supported product data directly to Datadog intake instead of through the local Agent.
+    /// When explicitly set, this value takes precedence over supported product-specific agentless settings.
+    /// Existing product-specific settings may be used as compatibility fallbacks when this key is not set.
+    /// Default value is false (disabled).
+    /// </summary>
+    public const string AgentlessEnabled = "DD_AGENTLESS_ENABLED";
+
+    /// <summary>
     /// Configuration key for setting the API key, used by the Agent.
     /// </summary>
     public const string ApiKey = "DD_API_KEY";


### PR DESCRIPTION
## Summary of changes
- Add `DD_AGENTLESS_ENABLED` as a configuration key.
- Generate `ConfigurationKeys.AgentlessEnabled` for all supported TFMs.

## Reason for change
- Establish a global switch for consistent agentless configuration across supported products.
- Allow existing product-specific settings to remain compatibility fallbacks.

## Implementation details
- Defaults agentless mode to disabled.
- Documents global-key precedence without changing product behavior in this PR.
