### PR TITLE
[Agentless] Protect API keys on agentless HTTP transports

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiKeyHttpTransportException.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiKeyHttpTransportException.cs
@@ -1,0 +1,23 @@
+// <copyright file="ApiKeyHttpTransportException.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.Agent.Transports;
+
+internal sealed class ApiKeyHttpTransportException : InvalidOperationException
+{
+    public ApiKeyHttpTransportException(string message)
+        : base(message)
+    {
+    }
+
+    public ApiKeyHttpTransportException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiKeyHttpTransportGuard.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiKeyHttpTransportGuard.cs
@@ -1,0 +1,51 @@
+// <copyright file="ApiKeyHttpTransportGuard.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.Agent.Transports;
+
+internal static class ApiKeyHttpTransportGuard
+{
+    internal const string ApiKeyHeaderName = "DD-API-KEY";
+
+    public static bool IsPlaintextLoopback(Uri endpoint)
+        => string.Equals(endpoint.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) && endpoint.IsLoopback;
+
+    public static void RejectLateApiKeyHeader(string headerName)
+    {
+        if (string.Equals(headerName, ApiKeyHeaderName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ApiKeyHttpTransportException("DD-API-KEY must be configured when constructing the request factory.");
+        }
+    }
+
+    public static void EnsureSafeEndpoint(Uri endpoint)
+    {
+        if (string.Equals(endpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+            IsPlaintextLoopback(endpoint))
+        {
+            return;
+        }
+
+        throw new ApiKeyHttpTransportException(
+            "Refusing to send DD-API-KEY unless the endpoint uses HTTPS or loopback HTTP.");
+    }
+
+    public static void EnsureSafe(Uri endpoint, bool isProxyDisabled, bool redirectsDisabled)
+    {
+        EnsureSafeEndpoint(endpoint);
+
+        if (redirectsDisabled && (!IsPlaintextLoopback(endpoint) || isProxyDisabled))
+        {
+            return;
+        }
+
+        throw new ApiKeyHttpTransportException(
+            "Refusing to send DD-API-KEY unless automatic redirects are disabled and the endpoint uses HTTPS or direct loopback HTTP.");
+    }
+}

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -24,17 +24,24 @@ namespace Datadog.Trace.Agent.Transports
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ApiWebRequest>();
         private readonly HttpWebRequest _request;
+        private readonly bool _hasApiKeyHeader;
 
         private byte[] _boundarySeparatorInBytes;
         private byte[] _boundaryTrailerInBytes;
 
-        public ApiWebRequest(HttpWebRequest request)
+        public ApiWebRequest(HttpWebRequest request, bool hasApiKeyHeader)
         {
             _request = request;
+            _hasApiKeyHeader = hasApiKeyHeader;
+            if (hasApiKeyHeader)
+            {
+                ConfigureApiKeyTransport();
+            }
         }
 
         public void AddHeader(string name, string value)
         {
+            ApiKeyHttpTransportGuard.RejectLateApiKeyHeader(name);
             _request.Headers.Add(name, value);
         }
 
@@ -193,6 +200,51 @@ namespace Datadog.Trace.Agent.Transports
             else
             {
                 _request.Headers.Set(HttpRequestHeader.ContentEncoding, contentEncoding);
+            }
+
+            ValidateApiKeyTransport();
+        }
+
+        private void ConfigureApiKeyTransport()
+        {
+            try
+            {
+                _request.AllowAutoRedirect = false;
+                var endpoint = _request.RequestUri;
+                if (ApiKeyHttpTransportGuard.IsPlaintextLoopback(endpoint))
+                {
+                    // Proxy bypass checks are mutable and racy. Enforce a direct connection instead.
+                    _request.Proxy = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new ApiKeyHttpTransportException("Unable to configure a safe HTTP transport for DD-API-KEY.", ex);
+            }
+        }
+
+        private void ValidateApiKeyTransport()
+        {
+            if (!_hasApiKeyHeader)
+            {
+                return;
+            }
+
+            try
+            {
+                var endpoint = _request.RequestUri;
+                ApiKeyHttpTransportGuard.EnsureSafe(
+                    endpoint,
+                    isProxyDisabled: !ApiKeyHttpTransportGuard.IsPlaintextLoopback(endpoint) || _request.Proxy is null,
+                    redirectsDisabled: !_request.AllowAutoRedirect);
+            }
+            catch (ApiKeyHttpTransportException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new ApiKeyHttpTransportException("Unable to verify a safe HTTP transport for DD-API-KEY.", ex);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
@@ -53,12 +53,17 @@ namespace Datadog.Trace.Agent.Transports
                 request.Timeout = (int)_timeout.Value.TotalMilliseconds;
             }
 
+            var hasApiKeyHeader = false;
             foreach (var pair in _defaultHeaders)
             {
                 request.Headers.Add(pair.Key, pair.Value);
+                if (string.Equals(pair.Key, ApiKeyHttpTransportGuard.ApiKeyHeaderName, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasApiKeyHeader = true;
+                }
             }
 
-            return new ApiWebRequest(request);
+            return new ApiWebRequest(request, hasApiKeyHeader);
         }
 
         public void SetProxy(WebProxy proxy, NetworkCredential credential)

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -24,13 +24,15 @@ namespace Datadog.Trace.Agent.Transports
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<HttpClientRequest>();
 
         private readonly HttpClient _client;
+        private readonly HttpClientHandler _apiKeyProtectedHandler;
         private readonly HttpRequestMessage _postRequest;
         private readonly HttpRequestMessage _getRequest;
         private readonly Uri _uri;
 
-        public HttpClientRequest(HttpClient client, Uri endpoint)
+        public HttpClientRequest(HttpClient client, HttpClientHandler apiKeyProtectedHandler, Uri endpoint)
         {
             _client = client;
+            _apiKeyProtectedHandler = apiKeyProtectedHandler;
             _postRequest = new HttpRequestMessage(HttpMethod.Post, endpoint);
             _getRequest = new HttpRequestMessage(HttpMethod.Get, endpoint);
             _uri = endpoint;
@@ -38,6 +40,7 @@ namespace Datadog.Trace.Agent.Transports
 
         public void AddHeader(string name, string value)
         {
+            ApiKeyHttpTransportGuard.RejectLateApiKeyHeader(name);
             _postRequest.Headers.Add(name, value);
             _getRequest.Headers.Add(name, value);
         }
@@ -46,7 +49,7 @@ namespace Datadog.Trace.Agent.Transports
         {
             _getRequest.Content = null;
 
-            return new HttpClientResponse(await _client.SendAsync(_getRequest).ConfigureAwait(false));
+            return new HttpClientResponse(await SendAsync(_getRequest).ConfigureAwait(false));
         }
 
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
@@ -65,7 +68,7 @@ namespace Datadog.Trace.Agent.Transports
 
                 _postRequest.Content = content;
 
-                var response = await _client.SendAsync(_postRequest).ConfigureAwait(false);
+                var response = await SendAsync(_postRequest).ConfigureAwait(false);
 
                 return new HttpClientResponse(response);
             }
@@ -91,7 +94,7 @@ namespace Datadog.Trace.Agent.Transports
 
             _postRequest.Content = content;
 
-            var response = await _client.SendAsync(_postRequest).ConfigureAwait(false);
+            var response = await SendAsync(_postRequest).ConfigureAwait(false);
             return new HttpClientResponse(response);
         }
 
@@ -114,7 +117,7 @@ namespace Datadog.Trace.Agent.Transports
             }
 
             _postRequest.Content = content;
-            var response = await _client.SendAsync(_postRequest).ConfigureAwait(false);
+            var response = await SendAsync(_postRequest).ConfigureAwait(false);
 
             return new HttpClientResponse(response);
         }
@@ -175,8 +178,34 @@ namespace Datadog.Trace.Agent.Transports
                 _postRequest.Content = formDataContent;
             }
 
-            var response = await _client.SendAsync(_postRequest).ConfigureAwait(false);
+            var response = await SendAsync(_postRequest).ConfigureAwait(false);
             return new HttpClientResponse(response);
+        }
+
+        private Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            if (_apiKeyProtectedHandler is not null)
+            {
+                ApiKeyHttpTransportGuard.EnsureSafe(
+                    _uri,
+                    isProxyDisabled: IsProxyDisabledForEndpoint(),
+                    redirectsDisabled: AreRedirectsDisabled());
+            }
+
+            return _client.SendAsync(request);
+        }
+
+        private bool AreRedirectsDisabled()
+            => !_apiKeyProtectedHandler.AllowAutoRedirect;
+
+        private bool IsProxyDisabledForEndpoint()
+        {
+            if (!ApiKeyHttpTransportGuard.IsPlaintextLoopback(_uri))
+            {
+                return true;
+            }
+
+            return !_apiKeyProtectedHandler.UseProxy;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
@@ -20,13 +20,45 @@ namespace Datadog.Trace.Agent.Transports
     {
         private readonly HttpClient _client;
         private readonly HttpMessageHandler _handler;
+        private readonly HttpClientHandler _apiKeyProtectedHandler;
+        private readonly bool _disableProxyForPlaintextLoopback;
+        private readonly bool _hasApiKeyHeader;
         private readonly Uri _baseEndpoint;
 
-        public HttpClientRequestFactory(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders, HttpMessageHandler handler = null, TimeSpan? timeout = null)
+        public HttpClientRequestFactory(
+            Uri baseEndpoint,
+            KeyValuePair<string, string>[] defaultHeaders,
+            HttpMessageHandler handler = null,
+            TimeSpan? timeout = null,
+            DecompressionMethods automaticDecompression = DecompressionMethods.None)
         {
-            _handler = handler ?? new HttpClientHandler();
-            _client = new HttpClient(_handler);
             _baseEndpoint = baseEndpoint;
+            foreach (var pair in defaultHeaders)
+            {
+                if (string.Equals(pair.Key, ApiKeyHttpTransportGuard.ApiKeyHeaderName, StringComparison.OrdinalIgnoreCase))
+                {
+                    _hasApiKeyHeader = true;
+                }
+            }
+
+            if (_hasApiKeyHeader && handler is not null)
+            {
+                throw new ApiKeyHttpTransportException("Caller-provided HTTP handlers are not supported for protected DD-API-KEY transport.");
+            }
+
+            _handler = handler ?? new HttpClientHandler { AutomaticDecompression = automaticDecompression };
+            _disableProxyForPlaintextLoopback = _hasApiKeyHeader && ApiKeyHttpTransportGuard.IsPlaintextLoopback(baseEndpoint);
+            if (_hasApiKeyHeader)
+            {
+                _apiKeyProtectedHandler = (HttpClientHandler)_handler;
+                _apiKeyProtectedHandler.AllowAutoRedirect = false;
+                if (_disableProxyForPlaintextLoopback)
+                {
+                    _apiKeyProtectedHandler.UseProxy = false;
+                }
+            }
+
+            _client = new HttpClient(_handler);
             if (timeout.HasValue)
             {
                 _client.Timeout = timeout.Value;
@@ -54,11 +86,16 @@ namespace Datadog.Trace.Agent.Transports
 
         public IApiRequest Create(Uri endpoint)
         {
-            return new HttpClientRequest(_client, endpoint);
+            return new HttpClientRequest(_client, _apiKeyProtectedHandler, endpoint);
         }
 
         public void SetProxy(WebProxy proxy, NetworkCredential credential)
         {
+            if (_disableProxyForPlaintextLoopback)
+            {
+                return;
+            }
+
             if (_handler is HttpClientHandler handler)
             {
                 handler.Proxy = proxy;

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -35,6 +35,7 @@ namespace Datadog.Trace.Agent.Transports
 
         public void AddHeader(string name, string value)
         {
+            ApiKeyHttpTransportGuard.RejectLateApiKeyHeader(name);
             _headers.Add(name, value);
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -8,6 +8,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
@@ -24,12 +25,12 @@ namespace Datadog.Trace.Ci.Agent;
 
 internal sealed class CIWriterHttpSender : ICIVisibilityProtocolWriterSender
 {
-    private const string ApiKeyHeader = "dd-api-key";
     private const string EvpSubdomainHeader = "X-Datadog-EVP-Subdomain";
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CIWriterHttpSender>();
 
     private readonly IApiRequestFactory _apiRequestFactory;
     private readonly bool _isDebugEnabled;
+    private int _apiKeyTransportRejected;
 
     public CIWriterHttpSender(IApiRequestFactory apiRequestFactory)
     {
@@ -91,6 +92,11 @@ internal sealed class CIWriterHttpSender : ICIVisibilityProtocolWriterSender
 
     private async Task SendPayloadAsync<T>(EventPlatformPayload payload, Func<IApiRequest, EventPlatformPayload, T, Task<IApiResponse>> senderFunc, T state)
     {
+        if (Volatile.Read(ref _apiKeyTransportRejected) != 0)
+        {
+            return;
+        }
+
         // retry up to 5 times with exponential back-off
         const int retryLimit = 5;
         var retryCount = 1;
@@ -111,10 +117,12 @@ internal sealed class CIWriterHttpSender : ICIVisibilityProtocolWriterSender
                 {
                     request.AddHeader(EvpSubdomainHeader, payload.EventPlatformSubdomain);
                 }
-                else
-                {
-                    request.AddHeader(ApiKeyHeader, TestOptimization.Instance.Settings.ApiKey);
-                }
+            }
+            catch (ApiKeyHttpTransportException ex)
+            {
+                DisableForUnsafeApiKeyTransport(ex);
+                TelemetryFactory.Metrics.RecordCountCIVisibilityEndpointPayloadDropped(payload.TelemetryEndpoint);
+                return;
             }
             catch (Exception ex)
             {
@@ -130,6 +138,12 @@ internal sealed class CIWriterHttpSender : ICIVisibilityProtocolWriterSender
             try
             {
                 statusCode = await SendPayloadAsync(senderFunc, request, payload, state, isFinalTry).ConfigureAwait(false);
+            }
+            catch (ApiKeyHttpTransportException ex)
+            {
+                DisableForUnsafeApiKeyTransport(ex);
+                TelemetryFactory.Metrics.RecordCountCIVisibilityEndpointPayloadDropped(payload.TelemetryEndpoint);
+                return;
             }
             catch (Exception ex)
             {
@@ -182,6 +196,14 @@ internal sealed class CIWriterHttpSender : ICIVisibilityProtocolWriterSender
 
             Log.Debug<string>("Successfully sent events to {AgentEndpoint}", _apiRequestFactory.Info(url));
             return;
+        }
+    }
+
+    private void DisableForUnsafeApiKeyTransport(ApiKeyHttpTransportException exception)
+    {
+        if (Interlocked.Exchange(ref _apiKeyTransportRejected, 1) == 0)
+        {
+            Log.Error(exception, "Disabling CI Visibility agentless uploads because the API-key transport is unsafe.");
         }
     }
 

--- a/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.cs
@@ -15,6 +15,7 @@ using System.Net.Sockets;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
@@ -35,7 +36,6 @@ namespace Datadog.Trace.Ci.Net;
 
 internal sealed partial class TestOptimizationClient : ITestOptimizationClient
 {
-    private const string ApiKeyHeader = "DD-API-KEY";
     private const string EvpSubdomainHeader = "X-Datadog-EVP-Subdomain";
 
     private const int MaxRetries = 5;
@@ -57,6 +57,7 @@ internal sealed partial class TestOptimizationClient : ITestOptimizationClient
     private readonly string _repositoryUrl;
     private readonly string _branchName;
     private readonly string _commitSha;
+    private int _apiKeyTransportRejected;
 
     static TestOptimizationClient()
     {
@@ -414,10 +415,6 @@ internal sealed partial class TestOptimizationClient : ITestOptimizationClient
         {
             request.AddHeader(EvpSubdomainHeader, "api");
         }
-        else
-        {
-            request.AddHeader(ApiKeyHeader, _testOptimization.Settings.ApiKey);
-        }
     }
 
     private void CheckResponseStatusCode(IApiResponse response, byte[]? responseContent, bool finalTry)
@@ -450,6 +447,11 @@ internal sealed partial class TestOptimizationClient : ITestOptimizationClient
 
     private async Task<T> WithRetries<T, TState>(Func<TState, bool, Task<T>> sendDelegate, TState state, int numOfRetries)
     {
+        if (Volatile.Read(ref _apiKeyTransportRejected) != 0)
+        {
+            throw new ApiKeyHttpTransportException("Test Optimization agentless requests are disabled because the API-key transport is unsafe.");
+        }
+
         var retryCount = 1;
         var sleepDuration = 100; // in milliseconds
 
@@ -472,6 +474,16 @@ internal sealed partial class TestOptimizationClient : ITestOptimizationClient
             if (exceptionDispatchInfo is not null)
             {
                 var sourceException = exceptionDispatchInfo.SourceException;
+
+                if (sourceException is ApiKeyHttpTransportException)
+                {
+                    if (Interlocked.Exchange(ref _apiKeyTransportRejected, 1) == 0)
+                    {
+                        Log.Error(sourceException, "Disabling Test Optimization agentless requests because the API-key transport is unsafe.");
+                    }
+
+                    exceptionDispatchInfo.Throw();
+                }
 
                 if (isFinalTry ||
                     sourceException is RateLimitException { DelayTimeInSeconds: null } ||

--- a/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManagement.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimizationTracerManagement.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -160,7 +161,7 @@ internal sealed class TestOptimizationTracerManagement : ITestOptimizationTracer
     {
         IApiRequestFactory? factory;
         var exporterSettings = tracerSettings.Manager.InitialExporterSettings;
-        if (exporterSettings.TracesTransport != TracesTransportType.Default)
+        if (!_settings.Agentless && exporterSettings.TracesTransport != TracesTransportType.Default)
         {
             factory = AgentTransportStrategy.Get(
                 exporterSettings,
@@ -170,16 +171,30 @@ internal sealed class TestOptimizationTracerManagement : ITestOptimizationTracer
         }
         else
         {
+            var baseEndpoint = exporterSettings.AgentUri;
+            var defaultHeaders = AgentHttpHeaderNames.DefaultHeaders;
+            if (_settings.Agentless)
+            {
+                baseEndpoint = string.IsNullOrWhiteSpace(_settings.AgentlessUrl)
+                                   ? new Uri($"https://api.{_settings.Site}")
+                                   : new Uri(_settings.AgentlessUrl);
+                defaultHeaders =
+                [
+                    ..AgentHttpHeaderNames.DefaultHeaders,
+                    new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, _settings.ApiKey!)
+                ];
+            }
+
 #if NETCOREAPP
             Log.Information("TestOptimizationTracerManagement: Using {FactoryType} for trace transport.", nameof(HttpClientRequestFactory));
             factory = new HttpClientRequestFactory(
-                exporterSettings.AgentUri,
-                AgentHttpHeaderNames.DefaultHeaders,
-                handler: new System.Net.Http.HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate, },
-                timeout: timeout);
+                baseEndpoint,
+                defaultHeaders,
+                timeout: timeout,
+                automaticDecompression: DecompressionMethods.GZip | DecompressionMethods.Deflate);
 #else
             Log.Information("TestOptimizationTracerManagement: Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
-            factory = new ApiWebRequestFactory(exporterSettings.AgentUri, AgentHttpHeaderNames.DefaultHeaders, timeout: timeout);
+            factory = new ApiWebRequestFactory(baseEndpoint, defaultHeaders, timeout: timeout);
 #endif
             if (!string.IsNullOrWhiteSpace(_settings.ProxyHttps))
             {

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerTransportStrategy.cs
@@ -16,8 +16,15 @@ namespace Datadog.Trace.Debugger
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebuggerTransportStrategy));
 
-        public static IApiRequestFactory Get(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders)
+        public static IApiRequestFactory Get(Uri baseEndpoint, string apiKey)
         {
+            KeyValuePair<string, string>[] defaultHeaders =
+            [
+                ..AgentHttpHeaderNames.DefaultHeaders,
+                new(ApiKeyHttpTransportGuard.ApiKeyHeaderName, apiKey),
+                new("DD-EVP-ORIGIN", "dd-trace-dotnet")
+            ];
+
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for debugger transport.", nameof(HttpClientRequestFactory));
             return new HttpClientRequestFactory(baseEndpoint, defaultHeaders);

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayTransportFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayTransportFactory.cs
@@ -6,9 +6,9 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
@@ -39,13 +39,17 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 return null;
             }
 
-            var apiFactory = DebuggerTransportStrategy.Get(
-                baseUri,
-                [
-                    ..AgentHttpHeaderNames.DefaultHeaders,
-                    new KeyValuePair<string, string>("DD-API-KEY", settings.AgentlessApiKey),
-                    new KeyValuePair<string, string>("DD-EVP-ORIGIN", "dd-trace-dotnet")
-                ]);
+            try
+            {
+                ApiKeyHttpTransportGuard.EnsureSafeEndpoint(baseUri);
+            }
+            catch (ApiKeyHttpTransportException ex)
+            {
+                Log.ErrorSkipTelemetry(ex, "Exception Replay agentless uploads enabled but the intake URL does not support safe API-key transport. Disabling Exception Replay.");
+                return null;
+            }
+
+            var apiFactory = DebuggerTransportStrategy.Get(baseUri, settings.AgentlessApiKey);
             return new ExceptionReplayTransportInfo(apiFactory, null, relativePath, isAgentless: true);
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Sink/BatchUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/BatchUploader.cs
@@ -7,7 +7,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Debugger.Upload;
 using Datadog.Trace.Logging;
 
@@ -29,6 +31,7 @@ namespace Datadog.Trace.Debugger.Sink
         private readonly StringBuilder _sb;
 
         private byte[] _serializedPayloads = new byte[InitialPayloadSizeBytes];
+        private int _apiKeyTransportRejected;
 
         private BatchUploader(IBatchUploadApi api)
         {
@@ -43,11 +46,23 @@ namespace Datadog.Trace.Debugger.Sink
 
         public async Task Upload(IEnumerable<string> payloads)
         {
+            if (Volatile.Read(ref _apiKeyTransportRejected) != 0)
+            {
+                return;
+            }
+
             try
             {
                 foreach (var batch in GetBatches(payloads))
                 {
                     await _api.SendBatchAsync(batch).ConfigureAwait(false);
+                }
+            }
+            catch (ApiKeyHttpTransportException e)
+            {
+                if (Interlocked.Exchange(ref _apiKeyTransportRejected, 1) == 0)
+                {
+                    Log.Error(e, "Disabling debugger batch uploads because the API-key transport is unsafe.");
                 }
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/SymbolUploadApi.cs
@@ -35,6 +35,7 @@ namespace Datadog.Trace.Debugger.Upload
         private readonly string _runtimeId;
         private readonly bool _enableCompression;
         private readonly Func<TimeSpan, Task> _delayAsync;
+        private int _apiKeyTransportRejected;
         private int _uploadFailureCount;
 
         private SymbolUploadApi(
@@ -131,6 +132,11 @@ namespace Datadog.Trace.Debugger.Upload
                 ThrowHelper.ThrowArgumentNullException(nameof(writeSymbols));
             }
 
+            if (Volatile.Read(ref _apiKeyTransportRejected) != 0)
+            {
+                return false;
+            }
+
             var uri = BuildUri();
             if (string.IsNullOrEmpty(uri))
             {
@@ -143,14 +149,29 @@ namespace Datadog.Trace.Debugger.Upload
 
             while (retries < MaxRetries)
             {
-                var request = _apiRequestFactory.Create(endpoint);
-                using var response = await request
-                           .PostAsync(
-                                stream => WriteMultipartFormData(stream, writeSymbols, state, metadata),
-                                MimeTypes.MultipartFormData,
-                                contentEncoding: null,
-                                DatadogHttpValues.Boundary)
-                           .ConfigureAwait(false);
+                IApiResponse response;
+                try
+                {
+                    var request = _apiRequestFactory.Create(endpoint);
+                    response = await request
+                                    .PostAsync(
+                                         stream => WriteMultipartFormData(stream, writeSymbols, state, metadata),
+                                         MimeTypes.MultipartFormData,
+                                         contentEncoding: null,
+                                         DatadogHttpValues.Boundary)
+                                    .ConfigureAwait(false);
+                }
+                catch (ApiKeyHttpTransportException e)
+                {
+                    if (Interlocked.Exchange(ref _apiKeyTransportRejected, 1) == 0)
+                    {
+                        Log.Error(e, "Disabling symbol database uploads because the API-key transport is unsafe.");
+                    }
+
+                    return false;
+                }
+
+                using var responseToDispose = response;
 
                 if (response.StatusCode is >= 200 and <= 299)
                 {

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             }
 
             var apiFactory = LogsTransportStrategy.Get(directLogSettings);
-            var logsApi = new LogsApi(directLogSettings.ApiKey, apiFactory);
+            var logsApi = new LogsApi(apiFactory);
 
             return new DirectLogSubmissionManager(directLogSettings, new DirectSubmissionLogSink(logsApi, formatter, directLogSettings.CreateBatchingSinkOptions()), formatter);
         }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Logging.DirectSubmission.Sink;
@@ -19,13 +20,18 @@ namespace Datadog.Trace.Logging.DirectSubmission
         {
             // Still quite a long time, but we could be sending a lot of data
             var timeout = TimeSpan.FromSeconds(15);
+            KeyValuePair<string, string>[] defaultHeaders =
+            [
+                ..LogsApiHeaderNames.DefaultHeaders,
+                new(ApiKeyHttpTransportGuard.ApiKeyHeaderName, settings.ApiKey)
+            ];
 
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for log submission transport.", nameof(HttpClientRequestFactory));
-            return new HttpClientRequestFactory(settings.IntakeUrl, LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
+            return new HttpClientRequestFactory(settings.IntakeUrl, defaultHeaders, timeout: timeout);
 #else
             Log.Information("Using {FactoryType} for log submission transport.", nameof(ApiWebRequestFactory));
-            return new ApiWebRequestFactory(settings.IntakeUrl, LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
+            return new ApiWebRequestFactory(settings.IntakeUrl, defaultHeaders, timeout: timeout);
 #endif
         }
     }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
@@ -6,8 +6,10 @@
 
 using System;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util.Http;
@@ -17,7 +19,6 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
     internal sealed class LogsApi : ILogsApi
     {
         internal const string LogIntakePath = "/api/v2/logs";
-        internal const string IntakeHeaderNameApiKey = "DD-API-KEY";
 
         private const string MimeType = "application/json";
 
@@ -26,13 +27,12 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LogsApi>();
 
-        private readonly string _apiKey;
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly Uri _logsIntakeEndpoint;
+        private int _apiKeyTransportRejected;
 
-        public LogsApi(string apiKey, IApiRequestFactory apiRequestFactory)
+        public LogsApi(IApiRequestFactory apiRequestFactory)
         {
-            _apiKey = apiKey;
             _apiRequestFactory = apiRequestFactory;
             _logsIntakeEndpoint = _apiRequestFactory.GetEndpoint(LogIntakePath);
             Log.Debug("Using logs intake endpoint {LogsIntakeEndpoint}", _logsIntakeEndpoint.ToString());
@@ -44,6 +44,11 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
 
         public async Task<bool> SendLogsAsync(ArraySegment<byte> logs, int numberOfLogs)
         {
+            if (Volatile.Read(ref _apiKeyTransportRejected) != 0)
+            {
+                return false;
+            }
+
             var retriesRemaining = MaxNumberRetries - 1;
             var nextSleepDuration = InitialSleepDurationMs;
 
@@ -57,14 +62,16 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                 {
                     request = _apiRequestFactory.Create(_logsIntakeEndpoint);
                 }
+                catch (ApiKeyHttpTransportException ex)
+                {
+                    DisableForUnsafeApiKeyTransport(ex);
+                    return false;
+                }
                 catch (Exception ex)
                 {
                     Log.Error(ex, "An error occurred while generating request to send logs to the intake at {IntakeEndpoint}", _apiRequestFactory.Info(_logsIntakeEndpoint));
                     return false;
                 }
-
-                // Set additional headers
-                request.AddHeader(IntakeHeaderNameApiKey, _apiKey);
 
                 Exception? exception = null;
                 var isFinalTry = retriesRemaining <= 0;
@@ -109,6 +116,11 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                         response?.Dispose();
                     }
                 }
+                catch (ApiKeyHttpTransportException ex)
+                {
+                    DisableForUnsafeApiKeyTransport(ex);
+                    return false;
+                }
                 catch (Exception ex)
                 {
                     var tag = ex is TimeoutException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
@@ -142,6 +154,15 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                 await Task.Delay(nextSleepDuration).ConfigureAwait(false);
                 retriesRemaining--;
                 nextSleepDuration *= 2;
+            }
+        }
+
+        private void DisableForUnsafeApiKeyTransport(ApiKeyHttpTransportException exception)
+        {
+            if (Interlocked.Exchange(ref _apiKeyTransportRejected, 1) == 0)
+            {
+                TelemetryFactory.Metrics.RecordCountDirectLogApiErrors(MetricTags.ApiError.NetworkError);
+                Log.Error(exception, "Disabling direct log submission because the API-key transport is unsafe.");
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
@@ -29,6 +30,7 @@ namespace Datadog.Trace.Telemetry.Transports
         private readonly ContainerMetadata _containerMetadata;
         private readonly bool _enableDebug;
         private readonly bool _telemetryGzipCompressionEnabled;
+        private int _apiKeyTransportRejected;
 
         protected JsonTelemetryTransport(IApiRequestFactory requestFactory, bool enableDebug, string telemetryCompressionMethod, ContainerMetadata containerMetadata)
         {
@@ -43,6 +45,11 @@ namespace Datadog.Trace.Telemetry.Transports
 
         public async Task<TelemetryPushResult> PushTelemetry(TelemetryData data)
         {
+            if (Volatile.Read(ref _apiKeyTransportRejected) != 0)
+            {
+                return TelemetryPushResult.FatalError;
+            }
+
             var endpointMetricTag = GetEndpointMetricTag();
 
             try
@@ -78,6 +85,16 @@ namespace Datadog.Trace.Telemetry.Transports
 
                 Log.Debug("Error sending telemetry to '{Endpoint}' {StatusCode} . CompressionEnabled {Compression}", GetEndpointInfo(), response.StatusCode, _telemetryGzipCompressionEnabled);
                 return TelemetryPushResult.TransientFailure;
+            }
+            catch (ApiKeyHttpTransportException ex)
+            {
+                if (Interlocked.Exchange(ref _apiKeyTransportRejected, 1) == 0)
+                {
+                    Log.Error(ex, "Disabling direct telemetry because the API-key transport is unsafe.");
+                }
+
+                TelemetryFactory.Metrics.RecordCountTelemetryApiErrors(endpointMetricTag, MetricTags.ApiError.NetworkError);
+                return TelemetryPushResult.FatalError;
             }
             catch (Exception ex) when (IsFatalException(ex))
             {

--- a/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiKeyHttpTransportGuardTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiKeyHttpTransportGuardTests.cs
@@ -1,0 +1,167 @@
+// <copyright file="ApiKeyHttpTransportGuardTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+#endif
+using Datadog.Trace.Agent.Transports;
+#if NETCOREAPP3_1_OR_GREATER
+using Datadog.Trace.Ci;
+using Datadog.Trace.Ci.Configuration;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+#endif
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Agent.Transports;
+
+public class ApiKeyHttpTransportGuardTests
+{
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://localhost")]
+    [InlineData("http://127.0.0.1")]
+    [InlineData("http://[::1]")]
+    public void AllowsSecureOrLoopbackEndpointWithApiKey(string endpoint)
+    {
+        var action = () => ApiKeyHttpTransportGuard.EnsureSafeEndpoint(new Uri(endpoint));
+
+        action.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("http://example.com")]
+    [InlineData("ftp://example.com")]
+    public void RejectsUnsafeEndpointWithApiKey(string endpoint)
+    {
+        var action = () => ApiKeyHttpTransportGuard.EnsureSafeEndpoint(new Uri(endpoint));
+
+        action.Should()
+              .Throw<ApiKeyHttpTransportException>()
+              .WithMessage("*DD-API-KEY*");
+    }
+
+    [Theory]
+    [InlineData("https://example.com", true, false)]
+    [InlineData("http://localhost", false, true)]
+    public void RejectsUnsafeTransport(string endpoint, bool isProxyDisabled, bool redirectsDisabled)
+    {
+        var action = () => ApiKeyHttpTransportGuard.EnsureSafe(
+            new Uri(endpoint),
+            isProxyDisabled,
+            redirectsDisabled);
+
+        action.Should().Throw<ApiKeyHttpTransportException>();
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Fact]
+    public async Task HttpClientRequestRejectsUnsafeDefaultApiKeyHeader()
+    {
+        var factory = new HttpClientRequestFactory(
+            new Uri("http://example.com"),
+            [new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, "test-key")]);
+        var request = factory.Create(factory.GetEndpoint("/intake"));
+
+        Func<Task> action = async () => { await request.GetAsync(); };
+
+        await action.Should().ThrowAsync<ApiKeyHttpTransportException>();
+    }
+
+    [Fact]
+    public void HttpClientRequestFactoryConfiguresOwnedProtectedHandler()
+    {
+        var factory = new HttpClientRequestFactory(
+            new Uri("https://example.com"),
+            [new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, "test-key")],
+            automaticDecompression: DecompressionMethods.GZip | DecompressionMethods.Deflate);
+
+        var handler = GetHandler(factory);
+        handler.AllowAutoRedirect.Should().BeFalse();
+        handler.AutomaticDecompression.Should().Be(DecompressionMethods.GZip | DecompressionMethods.Deflate);
+    }
+
+    [Fact]
+    public void HttpClientRequestFactoryDisablesProxyForPlaintextLoopback()
+    {
+        var factory = new HttpClientRequestFactory(
+            new Uri("http://localhost"),
+            [new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, "test-key")]);
+        factory.SetProxy(new WebProxy("http://example.com"), credential: null);
+
+        var handler = GetHandler(factory);
+
+        handler.UseProxy.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HttpClientRequestFactoryRejectsProtectedApiKeyWithCallerOwnedHandler()
+    {
+        var handler = new HttpClientHandler { AllowAutoRedirect = true };
+
+        var action = () => new HttpClientRequestFactory(
+            new Uri("https://example.com"),
+            [new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, "test-key")],
+            handler);
+
+        action.Should().Throw<ApiKeyHttpTransportException>();
+    }
+
+    [Fact]
+    public void HttpClientRequestRejectsApiKeyAddedToKeylessFactoryRequest()
+    {
+        var factory = new HttpClientRequestFactory(
+            new Uri("https://example.com"),
+            []);
+        var request = factory.Create(factory.GetEndpoint("/intake"));
+
+        var action = () => request.AddHeader(ApiKeyHttpTransportGuard.ApiKeyHeaderName.ToLowerInvariant(), "test-key");
+
+        action.Should().Throw<ApiKeyHttpTransportException>();
+    }
+
+    [Theory]
+    [InlineData(true, "unix:///tmp/apm.socket")]
+    [InlineData(false, "http://localhost:8126")]
+    public void TestOptimizationFactoryUsesProtectedHttpTransportOnlyInAgentlessMode(bool agentless, string agentUri)
+    {
+        const string apiKey = "test-key";
+        var values = new NameValueCollection();
+        values.Add(ConfigurationKeys.AgentUri, agentUri);
+        var source = new NameValueConfigurationSource(values);
+        var settings = new TestOptimizationSettings(source, NullConfigurationTelemetry.Instance);
+        settings.SetAgentlessConfiguration(agentless, apiKey, "https://example.com");
+        var management = new TestOptimizationTracerManagement(settings);
+        var tracerSettings = settings.InitializeTracerSettings(source);
+
+        var factory = management.GetRequestFactory(tracerSettings).Should().BeOfType<HttpClientRequestFactory>().Subject;
+
+        GetClient(factory).DefaultRequestHeaders.Contains(ApiKeyHttpTransportGuard.ApiKeyHeaderName).Should().Be(agentless);
+    }
+
+    private static HttpClientHandler GetHandler(HttpClientRequestFactory factory)
+    {
+        var field = typeof(HttpClientRequestFactory).GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull();
+        return field!.GetValue(factory).Should().BeOfType<HttpClientHandler>().Subject;
+    }
+
+    private static HttpClient GetClient(HttpClientRequestFactory factory)
+    {
+        var field = typeof(HttpClientRequestFactory).GetField("_client", BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull();
+        return field!.GetValue(factory).Should().BeOfType<HttpClient>().Subject;
+    }
+#endif
+}

--- a/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiWebRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiWebRequestFactoryTests.cs
@@ -4,9 +4,13 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Agent.Transports
@@ -46,6 +50,72 @@ namespace Datadog.Trace.Tests.Agent.Transports
 
             // Make sure we properly restored the old WebRequest factory
             Assert.IsType<HttpWebRequest>(WebRequest.Create("http://localhost/"));
+        }
+
+        [Fact]
+        public async Task RejectsUnsafeDefaultApiKeyHeader()
+        {
+            var factory = new ApiWebRequestFactory(
+                new Uri("http://example.com"),
+                [new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, "test-key")]);
+            var request = factory.Create(factory.GetEndpoint("/intake"));
+
+            GetHttpWebRequest(request).AllowAutoRedirect.Should().BeFalse();
+            await Assert.ThrowsAsync<ApiKeyHttpTransportException>(() => request.GetAsync());
+        }
+
+        [Fact]
+        public void RejectsApiKeyAddedToKeylessFactoryRequest()
+        {
+            var factory = new ApiWebRequestFactory(
+                new Uri("https://example.com"),
+                []);
+            var request = factory.Create(factory.GetEndpoint("/intake"));
+
+            var action = () => request.AddHeader(ApiKeyHttpTransportGuard.ApiKeyHeaderName.ToLowerInvariant(), "test-key");
+
+            action.Should().Throw<ApiKeyHttpTransportException>();
+        }
+
+        [Fact]
+        public void DisablesProxyForPlaintextLoopbackWithApiKey()
+        {
+            var factory = new ApiWebRequestFactory(
+                new Uri("http://localhost"),
+                [new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, "test-key")]);
+            factory.SetProxy(new WebProxy("http://example.com"), credential: null);
+
+            var request = factory.Create(factory.GetEndpoint("/intake"));
+
+            GetHttpWebRequest(request).Proxy.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task RejectsPlaintextLoopbackIfProxyIsReenabled()
+        {
+            var factory = new ApiWebRequestFactory(
+                new Uri("http://localhost"),
+                [new KeyValuePair<string, string>(ApiKeyHttpTransportGuard.ApiKeyHeaderName, "test-key")]);
+            var request = factory.Create(factory.GetEndpoint("/intake"));
+            GetHttpWebRequest(request).Proxy = new NeverBypassProxy();
+
+            await Assert.ThrowsAsync<ApiKeyHttpTransportException>(() => request.GetAsync());
+        }
+
+        private static HttpWebRequest GetHttpWebRequest(IApiRequest request)
+        {
+            var field = typeof(ApiWebRequest).GetField("_request", BindingFlags.Instance | BindingFlags.NonPublic);
+            field.Should().NotBeNull();
+            return field!.GetValue(request).Should().BeOfType<HttpWebRequest>().Subject;
+        }
+
+        private sealed class NeverBypassProxy : IWebProxy
+        {
+            public ICredentials Credentials { get; set; }
+
+            public Uri GetProxy(Uri destination) => new("http://example.com");
+
+            public bool IsBypassed(Uri host) => false;
         }
 
         private class CustomWebRequestCreator : IWebRequestCreate

--- a/tracer/test/Datadog.Trace.Tests/Ci/CIWriterHttpSenderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/CIWriterHttpSenderTests.cs
@@ -1,0 +1,51 @@
+// <copyright file="CIWriterHttpSenderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Ci.Agent;
+using Datadog.Trace.Ci.Agent.MessagePack;
+using Datadog.Trace.Ci.Agent.Payloads;
+using Datadog.Trace.Ci.Configuration;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Ci;
+
+public class CIWriterHttpSenderTests
+{
+    [Fact]
+    public async Task DoesNotRetryAfterApiKeyTransportRejection()
+    {
+        var settings = new TestOptimizationSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
+        settings.SetAgentlessConfiguration(enabled: true, apiKey: "test-key", agentlessUrl: "https://example.com");
+        var payload = new CITestCyclePayload(settings, CIFormatterResolver.Instance);
+        var requestFactory = new TestRequestFactory(new Uri("https://example.com"), x => new UnsafeApiKeyTransportRequest(x));
+        var sender = new CIWriterHttpSender(requestFactory);
+
+        await sender.SendPayloadAsync(payload);
+        await sender.SendPayloadAsync(payload);
+
+        requestFactory.RequestsSent.Should().ContainSingle();
+    }
+
+    private sealed class UnsafeApiKeyTransportRequest : TestApiRequest
+    {
+        public UnsafeApiKeyTransportRequest(Uri endpoint)
+            : base(endpoint)
+        {
+        }
+
+        public override Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
+            => Task.FromException<IApiResponse>(new ApiKeyHttpTransportException("Unsafe API-key transport."));
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationClientTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationClientTests.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.CiEnvironment;
 using Datadog.Trace.Ci.Configuration;
@@ -19,6 +21,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.TransportHelpers;
 using Datadog.Trace.Util.Json;
 using FluentAssertions;
 using Moq;
@@ -508,6 +511,27 @@ public class TestOptimizationClientTests : SettingsTestsBase
     }
 
     [Fact]
+    public async Task ApiKeyTransportRejectionStopsRetriesAndFutureRequests()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), $"dd-trace-dotnet-api-key-transport-{Guid.NewGuid():N}");
+        var settings = CreateSettings();
+        settings.SetAgentlessConfiguration(enabled: true, apiKey: "test-key", agentlessUrl: "https://example.com");
+        var requestFactory = new TestRequestFactory(new Uri("https://example.com"), x => new UnsafeApiKeyTransportRequest(x));
+        var tracerManagement = new Mock<ITestOptimizationTracerManagement>();
+        tracerManagement.Setup(x => x.GetRequestFactory(It.IsAny<TracerSettings>(), It.IsAny<TimeSpan>())).Returns(requestFactory);
+        var testOptimization = CreateTestOptimization(settings, workspacePath);
+        testOptimization.Setup(x => x.TracerManagement).Returns(tracerManagement.Object);
+        var client = TestOptimizationClient.Create(workspacePath, testOptimization.Object);
+
+        Func<Task> firstRequest = async () => await client.GetSettingsAsync();
+        Func<Task> secondRequest = async () => await client.GetSettingsAsync();
+
+        await firstRequest.Should().ThrowAsync<ApiKeyHttpTransportException>();
+        await secondRequest.Should().ThrowAsync<ApiKeyHttpTransportException>();
+        requestFactory.RequestsSent.Should().ContainSingle();
+    }
+
+    [Fact]
     public void UnscopedSkippableCandidateKeepsLegacyMatching()
     {
         var candidate = new SkippableTest(
@@ -525,10 +549,14 @@ public class TestOptimizationClientTests : SettingsTestsBase
 
     private static Mock<ITestOptimization> CreateTestOptimization(TestOptimizationSettings settings, string workspacePath)
     {
+        var hostInfo = new Mock<ITestOptimizationHostInfo>();
+        hostInfo.Setup(x => x.GetOperatingSystemVersion()).Returns("test-os-version");
+
         var testOptimization = new Mock<ITestOptimization>();
         testOptimization.Setup(x => x.RunId).Returns("test-run");
         testOptimization.Setup(x => x.Settings).Returns(settings);
         testOptimization.Setup(x => x.CIValues).Returns(new TestCIEnvironmentValues(workspacePath));
+        testOptimization.Setup(x => x.HostInfo).Returns(hostInfo.Object);
         testOptimization.Setup(x => x.Log).Returns(DatadogLogging.GetLoggerFor(typeof(TestOptimizationClientTests)));
         return testOptimization;
     }
@@ -572,6 +600,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
         public TestCIEnvironmentValues(string workspacePath)
         {
             WorkspacePath = workspacePath;
+            Repository = "https://github.com/DataDog/dd-trace-dotnet";
             Branch = "main";
             Commit = "abcdef123456";
         }
@@ -579,5 +608,16 @@ public class TestOptimizationClientTests : SettingsTestsBase
         protected override void Setup(IGitInfo gitInfo)
         {
         }
+    }
+
+    private sealed class UnsafeApiKeyTransportRequest : TestApiRequest
+    {
+        public UnsafeApiKeyTransportRequest(Uri endpoint)
+            : base(endpoint)
+        {
+        }
+
+        public override Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
+            => Task.FromException<IApiResponse>(new ApiKeyHttpTransportException("Unsafe API-key transport."));
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/BatchUploaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/BatchUploaderTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Upload;
 using FluentAssertions;
@@ -130,6 +131,18 @@ public class BatchUploaderTests
     }
 
     [Fact]
+    public async Task ApiKeyTransportFailureDisablesSubsequentUploads()
+    {
+        var api = new UnsafeApiKeyTransport();
+        var uploader = BatchUploader.Create(api);
+
+        await uploader.Upload(new[] { "Test1" });
+        await uploader.Upload(new[] { "Test2" });
+
+        api.SendCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task CheckMediumOutput()
     {
         var str = GenerateString(1023 * 1024);
@@ -165,6 +178,17 @@ public class BatchUploaderTests
         {
             Segments.Add(symbols.ToArray());
             return Task.FromResult(true);
+        }
+    }
+
+    private sealed class UnsafeApiKeyTransport : IBatchUploadApi
+    {
+        public int SendCount { get; private set; }
+
+        public Task<bool> SendBatchAsync(ArraySegment<byte> symbols)
+        {
+            SendCount++;
+            return Task.FromException<bool>(new ApiKeyHttpTransportException("unsafe endpoint"));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ExceptionReplayTransportFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ExceptionReplayTransportFactoryTests.cs
@@ -71,5 +71,20 @@ namespace Datadog.Trace.Tests.Debugger
                      .ToString()
                      .Should().Be("https://custom-host.example.com/api/v2/debugger");
         }
+
+        [Fact]
+        public void AgentlessTransport_RejectsUnsafeOverrideUrlDuringCreation()
+        {
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new NameValueCollection()));
+            var collection = new NameValueCollection
+            {
+                { ConfigurationKeys.Debugger.ExceptionReplayAgentlessEnabled, "true" },
+                { ConfigurationKeys.ApiKey, "test-key" },
+                { ConfigurationKeys.Debugger.ExceptionReplayAgentlessUrl, "http://example.com" }
+            };
+            var erSettings = new ExceptionReplaySettings(new NameValueConfigurationSource(collection), NullConfigurationTelemetry.Instance);
+
+            ExceptionReplayTransportFactory.Create(tracerSettings, erSettings, NullDiscoveryService.Instance).Should().BeNull();
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -152,6 +152,28 @@ public class SymbolUploadApiTests
     }
 
     [Fact]
+    public async Task SendBatchAsync_ApiKeyTransportFailureDisablesSubsequentUploads()
+    {
+        var metadata = new SymDbUploadMetadata(
+            Service: "benchmark-service",
+            Version: "1.0.0",
+            UploadId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            BatchNum: 7,
+            Final: false);
+        var requestFactory = CapturingRequestFactory.RejectUnsafeApiKeyTransport();
+        var discoveryService = new DiscoveryServiceMock();
+        var api = SymbolUploadApi.Create(requestFactory, discoveryService, new NullGitMetadataProvider(), enableCompression: false);
+        discoveryService.TriggerChange(symbolDbEndpoint: "symdb/v1/input");
+
+        var firstResult = await api.SendBatchAsync(static (_, _) => Task.CompletedTask, state: 0, metadata: metadata);
+        var secondResult = await api.SendBatchAsync(static (_, _) => Task.CompletedTask, state: 0, metadata: metadata);
+
+        firstResult.Should().BeFalse();
+        secondResult.Should().BeFalse();
+        requestFactory.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
     public async Task SendBatchAsync_DoesNotDelayAfterFinalRetry()
     {
         const string symbolsJson = """{"service":"benchmark","scopes":[{"name":"type"}]}""";
@@ -293,16 +315,26 @@ public class SymbolUploadApiTests
     private sealed class CapturingRequestFactory : IApiRequestFactory
     {
         private readonly Uri _baseEndpoint = new("http://localhost:8126/");
+        private readonly bool _rejectUnsafeApiKeyTransport;
         private readonly Queue<int> _statusCodes;
 
         public CapturingRequestFactory(params int[] statusCodes)
+            : this(rejectUnsafeApiKeyTransport: false, statusCodes: statusCodes)
         {
+        }
+
+        private CapturingRequestFactory(bool rejectUnsafeApiKeyTransport, params int[] statusCodes)
+        {
+            _rejectUnsafeApiKeyTransport = rejectUnsafeApiKeyTransport;
             _statusCodes = new Queue<int>(statusCodes.Length == 0 ? new[] { 200 } : statusCodes);
         }
 
         public List<CapturingRequest> Requests { get; } = new();
 
         public CapturingRequest Request => Requests[0];
+
+        public static CapturingRequestFactory RejectUnsafeApiKeyTransport()
+            => new(rejectUnsafeApiKeyTransport: true);
 
         public string Info(Uri endpoint)
             => endpoint.ToString();
@@ -313,7 +345,7 @@ public class SymbolUploadApiTests
         public IApiRequest Create(Uri endpoint)
         {
             var statusCode = _statusCodes.Count > 0 ? _statusCodes.Dequeue() : 200;
-            var request = new CapturingRequest(statusCode);
+            var request = new CapturingRequest(statusCode, _rejectUnsafeApiKeyTransport);
             Requests.Add(request);
             return request;
         }
@@ -326,10 +358,12 @@ public class SymbolUploadApiTests
     private sealed class CapturingRequest : IApiRequest
     {
         private readonly int _statusCode;
+        private readonly bool _rejectUnsafeApiKeyTransport;
 
-        public CapturingRequest(int statusCode)
+        public CapturingRequest(int statusCode, bool rejectUnsafeApiKeyTransport)
         {
             _statusCode = statusCode;
+            _rejectUnsafeApiKeyTransport = rejectUnsafeApiKeyTransport;
         }
 
         public byte[] Body { get; private set; } = [];
@@ -365,6 +399,11 @@ public class SymbolUploadApiTests
 
         public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
         {
+            if (_rejectUnsafeApiKeyTransport)
+            {
+                throw new ApiKeyHttpTransportException("unsafe endpoint");
+            }
+
             using var stream = new MemoryStream();
             await writeToRequestStream(stream).ConfigureAwait(false);
             Body = stream.ToArray();

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
@@ -5,10 +5,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Logging.DirectSubmission.Sink;
 using Datadog.Trace.TestHelpers.TransportHelpers;
 using FluentAssertions;
@@ -29,8 +36,8 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             = x => new FaultyApiRequest(x);
 
         [Theory]
-        [InlineData("http://http-intake.logs.datadoghq.com", "http://http-intake.logs.datadoghq.com/api/v2/logs")]
-        [InlineData("http://http-intake.logs.datadoghq.com/", "http://http-intake.logs.datadoghq.com/api/v2/logs")]
+        [InlineData("https://http-intake.logs.datadoghq.com", "https://http-intake.logs.datadoghq.com/api/v2/logs")]
+        [InlineData("https://http-intake.logs.datadoghq.com/", "https://http-intake.logs.datadoghq.com/api/v2/logs")]
         [InlineData("https://http-intake.logs.datadoghq.com:443", "https://http-intake.logs.datadoghq.com:443/api/v2/logs")]
         [InlineData("http://localhost:8080", "http://localhost:8080/api/v2/logs")]
         [InlineData("http://localhost:8080/sub-path", "http://localhost:8080/sub-path/api/v2/logs")]
@@ -40,7 +47,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             var baseEndpoint = new Uri(baseUri);
             var requestFactory = new TestRequestFactory(baseEndpoint);
 
-            var api = new LogsApi("SECR3TZ", requestFactory);
+            var api = new LogsApi(requestFactory);
             var result = await api.SendLogsAsync(Logs, NumberOfLogs);
 
             requestFactory.RequestsSent.Should()
@@ -50,13 +57,29 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         }
 
         [Fact]
+        public async Task RejectsUnsafeUrlWithProductionTransport()
+        {
+            var source = new NameValueConfigurationSource(
+                new NameValueCollection
+                {
+                    { ConfigurationKeys.ApiKey, "test-key" },
+                    { ConfigurationKeys.DirectLogSubmission.Url, "http://example.com" }
+                });
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
+            var api = new LogsApi(LogsTransportStrategy.Get(settings));
+
+            var result = await api.SendLogsAsync(Logs, NumberOfLogs);
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
         public async Task ShouldRetryRequestsWhenTheyFail()
         {
             // two faults, then success
             var requestFactory = new TestRequestFactory(new Uri(DefaultIntake), SingleFaultyRequest, SingleFaultyRequest);
 
-            var apiKey = "SECR3TZ";
-            var api = new LogsApi(apiKey, requestFactory);
+            var api = new LogsApi(requestFactory);
             var result = await api.SendLogsAsync(Logs, NumberOfLogs);
 
             requestFactory.RequestsSent
@@ -72,18 +95,31 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         }
 
         [Fact]
-        public async Task ShouldAddApiKeyToAllRequests()
+        public async Task ShouldNotRetryAfterApiKeyTransportRejection()
         {
-            var requestFactory = new TestRequestFactory(new Uri(DefaultIntake), SingleFaultyRequest);
+            var requestFactory = new TestRequestFactory(new Uri(DefaultIntake), x => new UnsafeApiKeyTransportRequest(x));
+            var api = new LogsApi(requestFactory);
 
-            var apiKey = "SECR3TZ";
-            var api = new LogsApi(apiKey, requestFactory);
-            await api.SendLogsAsync(Logs, NumberOfLogs);
+            var firstResult = await api.SendLogsAsync(Logs, NumberOfLogs);
+            var secondResult = await api.SendLogsAsync(Logs, NumberOfLogs);
 
-            requestFactory.RequestsSent.Should()
-                          .NotBeEmpty()
-                          .And.OnlyContain(x => x.ExtraHeaders.ContainsKey(LogsApi.IntakeHeaderNameApiKey))
-                          .And.OnlyContain(x => x.ExtraHeaders[LogsApi.IntakeHeaderNameApiKey] == apiKey);
+            firstResult.Should().BeFalse();
+            secondResult.Should().BeFalse();
+            requestFactory.RequestsSent.Should().ContainSingle();
+        }
+
+        [Fact]
+        public async Task ShouldNotRetryAfterApiKeyTransportRejectionDuringRequestCreation()
+        {
+            var requestFactory = new RejectingRequestFactory(new Uri(DefaultIntake));
+            var api = new LogsApi(requestFactory);
+
+            var firstResult = await api.SendLogsAsync(Logs, NumberOfLogs);
+            var secondResult = await api.SendLogsAsync(Logs, NumberOfLogs);
+
+            firstResult.Should().BeFalse();
+            secondResult.Should().BeFalse();
+            requestFactory.CreationAttempts.Should().Be(1);
         }
 
         [Fact]
@@ -91,7 +127,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         {
             var requestFactory = new TestRequestFactory(new Uri(DefaultIntake), SingleFaultyRequest);
 
-            var api = new LogsApi("SECR3TZ", requestFactory);
+            var api = new LogsApi(requestFactory);
             await api.SendLogsAsync(Logs, NumberOfLogs);
 
             using var scope = new AssertionScope();
@@ -109,7 +145,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
         {
             var requestFactory = new TestRequestFactory(new Uri(DefaultIntake), x => new FaultyApiRequest(x, statusCode: 400));
 
-            var api = new LogsApi("SECR3TZ", requestFactory);
+            var api = new LogsApi(requestFactory);
             var result = await api.SendLogsAsync(Logs, NumberOfLogs);
 
             using var scope = new AssertionScope();
@@ -117,6 +153,43 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             request.Responses.Should().ContainSingle().Which.StatusCode.Should().Be(400);
 
             result.Should().BeFalse();
+        }
+
+        private sealed class UnsafeApiKeyTransportRequest : TestApiRequest
+        {
+            public UnsafeApiKeyTransportRequest(Uri endpoint)
+                : base(endpoint)
+            {
+            }
+
+            public override Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
+                => Task.FromException<IApiResponse>(new ApiKeyHttpTransportException("Unsafe API-key transport."));
+        }
+
+        private sealed class RejectingRequestFactory : IApiRequestFactory
+        {
+            private readonly Uri _baseEndpoint;
+
+            public RejectingRequestFactory(Uri baseEndpoint)
+            {
+                _baseEndpoint = baseEndpoint;
+            }
+
+            public int CreationAttempts { get; private set; }
+
+            public Uri GetEndpoint(string relativePath) => new(_baseEndpoint, relativePath);
+
+            public string Info(Uri endpoint) => endpoint.ToString();
+
+            public IApiRequest Create(Uri endpoint)
+            {
+                CreationAttempts++;
+                throw new ApiKeyHttpTransportException("Unsafe API-key transport.");
+            }
+
+            public void SetProxy(WebProxy proxy, NetworkCredential credential)
+            {
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
@@ -87,6 +87,38 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
 #endif
 
         [Fact]
+        public async Task ApiKeyTransportExceptionIsFatalAndDisablesSubsequentPushes()
+        {
+            var requestMock = new Mock<IApiRequest>();
+            requestMock.Setup(x => x.PostAsJsonAsync(It.IsAny<TelemetryData>(), It.IsAny<MultipartCompression>(), It.IsAny<JsonSerializerSettings>()))
+                       .ThrowsAsync(new ApiKeyHttpTransportException("unsafe endpoint"));
+            var requestFactoryMock = new Mock<IApiRequestFactory>();
+            requestFactoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
+            var transport = new AgentlessTelemetryTransport(
+                requestFactoryMock.Object,
+                debugEnabled: false,
+                telemetryCompressionMethod: string.Empty,
+                containerMetadata: new ContainerMetadata(containerId: null, entityId: null));
+            var data = new TelemetryData(
+                "request-type",
+                tracerTime: 0,
+                string.Empty,
+                seqId: 0,
+                new ApplicationTelemetryData(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty),
+                new HostTelemetryData(string.Empty, string.Empty, string.Empty),
+                payload: null);
+
+            var firstResult = await transport.PushTelemetry(data);
+            var secondResult = await transport.PushTelemetry(data);
+
+            firstResult.Should().Be(TelemetryPushResult.FatalError);
+            secondResult.Should().Be(TelemetryPushResult.FatalError);
+            requestMock.Verify(
+                x => x.PostAsJsonAsync(It.IsAny<TelemetryData>(), It.IsAny<MultipartCompression>(), It.IsAny<JsonSerializerSettings>()),
+                Times.Once);
+        }
+
+        [Fact]
         public void SerializedAppStartedShouldProduceJsonWithExpectedFormat()
         {
             var expectedJson = JToken.Parse(GetAppStartedData());


### PR DESCRIPTION
## Summary of changes

- Added a shared API-key transport guard.
- Require `DD-API-KEY` to be configured in request-factory default headers; per-request API-key additions are rejected.
- Migrated direct logs and agentless CI Visibility/Test Optimization to factory-owned API-key headers.
- Protected API-key requests from redirects, unsafe plaintext endpoints, and proxied plaintext loopback connections.
- Added terminal failure handling for telemetry, debugger batch uploads, SymDB, direct logs, CI Visibility, and Test Optimization.
- Validate Exception Replay agentless overrides during transport creation so unsafe configurations are disabled immediately.

## Reason for change

- API keys added after request creation bypassed transport protection and could be sent through redirects, plaintext off-box HTTP, or a proxy configured for loopback HTTP.
- Transport safety must be established before the key is attached and revalidated immediately before sending.
- Unsafe transport configuration is permanent, so retrying repeatedly creates noise without any possibility of recovery.

## Implementation details

- An API-key transport is accepted only when:
  - automatic redirects are disabled; and
  - the endpoint uses HTTPS; or
  - the endpoint uses plaintext loopback HTTP with a direct, proxy-free connection.
- HTTPS proxies remain supported.
- Factories detect `DD-API-KEY` in their default headers and configure the transport:
  - `HttpClientRequestFactory` owns its protected `HttpClientHandler`, disables redirects, and disables proxy use for plaintext loopback.
  - `ApiWebRequest` disables redirects and clears the proxy for plaintext loopback.
  - Caller-owned HTTP handlers are rejected for protected API-key transports because their behavior cannot be controlled reliably.
- Send-time validation checks the mutable handler/request state again before transmitting.
- `AddHeader("DD-API-KEY", ...)` is rejected by all `IApiRequest` implementations. This makes construction-time ownership the only supported API-key path.
- Agentless CI Visibility and Test Optimization receive the API key through `TestOptimizationTracerManagement`. Agent/EVP mode remains keyless and continues adding only the EVP routing header.
- Agentless CI traffic always uses an HTTP request factory, even when an agent UDS or named-pipe transport is configured. Gzip/deflate response handling is preserved through the factory-owned handler.
- Permanent rejection state uses `Volatile.Read` and `Interlocked.Exchange` to stop future attempts and log the first failure once.
- The implementation supports both HTTP transport and `HttpWebRequest`.

## Test coverage

- Coverage includes:
  - unsafe endpoint, redirect, and proxy rejection;
  - late API-key header rejection;
  - agentless-only CI/Test Optimization key ownership;
  - agent transport isolation;
  - Exception Replay creation-time validation;
  - terminal rejection and retry suppression;
  - direct logs rejection using the production transport factory.

## Other details

- No configuration keys or defaults changed.
- Valid HTTPS and direct loopback agentless configurations continue working.
- Unsafe custom intake URLs now disable the affected product instead of attempting transmission.