### PR TITLE
Migrate databases to use Testcontainers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,22 +27,9 @@ services:
 
   mysql_arm64:
     image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
-    environment:
-    - MYSQL_DATABASE=world
-    - MYSQL_ROOT_PASSWORD=mysqldb
-    - MYSQL_USER=mysqldb
-    - MYSQL_PASSWORD=mysqldb
-    ports:
-    - "3306"
 
   postgres_arm64:
     image: postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117
-    environment:
-    - POSTGRES_PASSWORD=postgres
-    - POSTGRES_USER=postgres
-    - POSTGRES_DB=postgres
-    ports:
-    - "5432"
 
   rabbitmq_arm64:
     image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
@@ -53,14 +40,6 @@ services:
 
   servicestackredis_arm64:
     image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
-
-  sqledge_arm64:
-    image: mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf
-    ports:
-    - "1433"
-    environment:
-    - ACCEPT_EULA=Y
-    - SA_PASSWORD=Strong!Passw0rd
 
   cosmosdb-emulator_arm64:
     image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview@sha256:54d7bc334494c50cea867c270880671a7db080626a9732832b34c0d69342f9b0
@@ -155,44 +134,15 @@ services:
 
   postgres:
     image: postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117
-    profiles: ["group1"]
-    environment:
-    - POSTGRES_PASSWORD=postgres
-    - POSTGRES_USER=postgres
-    - POSTGRES_DB=postgres
-    ports:
-    - "127.0.0.1:5432:5432"
 
   mysql:
     image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
-    profiles: ["group1"]
-    environment:
-    - MYSQL_DATABASE=world
-    - MYSQL_ROOT_PASSWORD=mysqldb
-    - MYSQL_USER=mysqldb
-    - MYSQL_PASSWORD=mysqldb
-    ports:
-    - "127.0.0.1:3307:3306"
 
   mysql57:
     image: mysql/mysql-server:5.7@sha256:1178cdd375f758968cd834ac4057bae41307e64b7c69a9e145896e7b11f48064
-    profiles: ["group1"]
-    environment:
-    - MYSQL_DATABASE=world
-    - MYSQL_ROOT_PASSWORD=mysqldb
-    - MYSQL_USER=mysqldb
-    - MYSQL_PASSWORD=mysqldb
-    ports:
-    - "127.0.0.1:3407:3306"
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server:latest@sha256:2cd0aec4a3bfc3cf9205bed3f7922f4c6208f7c767dc62edcee308d0fd7d56d0
-    profiles: ["group1"]
-    ports:
-    - "127.0.0.1:1433:1433"
-    environment:
-    - ACCEPT_EULA=Y
-    - SA_PASSWORD=Strong!Passw0rd
 
   sqledge:
     image: mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf
@@ -405,12 +355,6 @@ services:
       - ELASTICSEARCH7_HOST=elasticsearch7:9200
       - ELASTICSEARCH6_HOST=elasticsearch6:9200
       - ELASTICSEARCH5_HOST=elasticsearch5:9200
-      - SQLSERVER_CONNECTION_STRING=Server=sqlserver;User=sa;Password=Strong!Passw0rd;TrustServerCertificate=true
-      - POSTGRES_HOST=postgres
-      - MYSQL_HOST=mysql
-      - MYSQL_PORT=3306
-      - MYSQL57_HOST=mysql57
-      - MYSQL57_PORT=3306
       - RABBITMQ_HOST=rabbitmq
       - KAFKA_BROKER_HOST=kafka-broker:29092
       - AWS_SDK_HOST=localstack:4566
@@ -617,10 +561,6 @@ services:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     profiles: ["group1"]
     depends_on:
-      - sqlserver
-      - postgres
-      - mysql
-      - mysql57
       - rabbitmq
       - kafka-broker
       - kafka-zookeeper
@@ -628,7 +568,7 @@ services:
       - test-agent
     environment:
       - TIMEOUT_LENGTH=120
-    command: sqlserver:1433 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 couchbase:11210 test-agent:8126 test-agent:4317 test-agent:4318
+    command: rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 couchbase:11210 test-agent:8126 test-agent:4317 test-agent:4318
 
   StartDependencies.Group2:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
@@ -683,10 +623,6 @@ services:
       - ELASTICSEARCH7_HOST=elasticsearch7_arm64:9200
       - ELASTICSEARCH6_HOST=elasticsearch7_arm64:9200
       - ELASTICSEARCH5_HOST=elasticsearch7_arm64:9200
-      - SQLSERVER_CONNECTION_STRING=Server=sqledge_arm64;User=sa;Password=Strong!Passw0rd;TrustServerCertificate=true
-      - POSTGRES_HOST=postgres_arm64
-      - MYSQL_HOST=mysql_arm64
-      - MYSQL_PORT=3306
       - RABBITMQ_HOST=rabbitmq_arm64
       - AWS_SDK_HOST=localstack_arm64:4566
       - COSMOSDB_ENDPOINT=https://cosmosdb-emulator_arm64:8081
@@ -720,10 +656,7 @@ services:
       - TEST_AGENT_HOST=test-agent
     depends_on:
       - elasticsearch7_arm64
-      - sqledge_arm64
       - mongo_arm64
-      - postgres_arm64
-      - mysql_arm64
       - rabbitmq_arm64
       - localstack_arm64
       - test-agent
@@ -733,17 +666,14 @@ services:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
       - elasticsearch7_arm64
-      - sqledge_arm64
       - mongo_arm64
-      - postgres_arm64
-      - mysql_arm64
       - rabbitmq_arm64
       - localstack_arm64
       - test-agent
       - cosmosdb-emulator_arm64
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch7_arm64:9200 sqledge_arm64:1433 mongo_arm64:27017 postgres_arm64:5432 mysql_arm64:3306 rabbitmq_arm64:5672 localstack_arm64:4566 test-agent:8126 test-agent:4317 test-agent:4318 cosmosdb-emulator_arm64:8081
+    command: elasticsearch7_arm64:9200 mongo_arm64:27017 rabbitmq_arm64:5672 localstack_arm64:4566 test-agent:8126 test-agent:4317 test-agent:4318 cosmosdb-emulator_arm64:8081
 
   IntegrationTests.ARM64.Debugger:
     build:
@@ -817,15 +747,12 @@ services:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
       - elasticsearch7_osx_arm64
-      - sqledge_osx_arm64
       - mongo_osx_arm64
-      - postgres_osx_arm64
-      - mysql_osx_arm64
       - rabbitmq_osx_arm64
       - localstack_osx_arm64
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch7_osx_arm64:9200 sqledge_osx_arm64:1433 mongo_osx_arm64:27017 postgres_osx_arm64:5432 mysql_osx_arm64:3306 rabbitmq_osx_arm64:5672 localstack_osx_arm64:4566
+    command: elasticsearch7_osx_arm64:9200 mongo_osx_arm64:27017 rabbitmq_osx_arm64:5672 localstack_osx_arm64:4566
 
   # OSX ARM64 dependencies
 
@@ -858,22 +785,9 @@ services:
 
   mysql_osx_arm64:
     image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
-    environment:
-      - MYSQL_DATABASE=world
-      - MYSQL_ROOT_PASSWORD=mysqldb
-      - MYSQL_USER=mysqldb
-      - MYSQL_PASSWORD=mysqldb
-    ports:
-      - "3306:3306"
 
   postgres_osx_arm64:
     image: postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117
-    environment:
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=postgres
-    ports:
-      - "5432:5432"
 
   rabbitmq_osx_arm64:
     image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
@@ -893,14 +807,6 @@ services:
 
   stackexchangeredis_osx_arm64-single:
     image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
-
-  sqledge_osx_arm64:
-    image: mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf
-    ports:
-      - "1433:1433"
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=Strong!Passw0rd
 
   # keep syncronized image version with tracer\test\Datadog.Trace.TestHelpers.AutoInstrumentation\Containers\AerospikeFixture.cs
   aerospike:

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1882,6 +1882,7 @@ partial class Build
                     // Don't apply a custom filter to these tests, they should all be able to be run
                     .When(!string.IsNullOrWhiteSpace(AddAreaFilter(Filter)), c => c.SetFilter(AddAreaFilter(Filter)))
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
+                    .When(IsWin && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING")), o => o.SetProcessEnvironmentVariable("SQLSERVER_CONNECTION_STRING", @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60"))
                     .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(parallelJobs, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -1904,6 +1905,7 @@ partial class Build
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(!string.IsNullOrWhiteSpace(filter), c => c.SetFilter(filter))
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
+                    .When(IsWin && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING")), o => o.SetProcessEnvironmentVariable("SQLSERVER_CONNECTION_STRING", @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60"))
                     .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -2052,6 +2054,7 @@ partial class Build
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
+                    .When(IsWin && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING")), o => o.SetProcessEnvironmentVariable("SQLSERVER_CONNECTION_STRING", @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60"))
                     .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -272,10 +272,6 @@ internal static partial class DotNetSettingsExtensions
               .SetProcessEnvironmentVariable("ELASTICSEARCH7_HOST", "localhost:9200")
               .SetProcessEnvironmentVariable("ELASTICSEARCH6_HOST", "localhost:9200")
               .SetProcessEnvironmentVariable("ELASTICSEARCH5_HOST", "localhost:9200")
-              .SetProcessEnvironmentVariable("SQLSERVER_CONNECTION_STRING", "Server=localhost;User=sa;Password=Strong!Passw0rd")
-              .SetProcessEnvironmentVariable("POSTGRES_HOST", "localhost")
-              .SetProcessEnvironmentVariable("MYSQL_HOST", "localhost")
-              .SetProcessEnvironmentVariable("MYSQL_PORT", "3306")
               .SetProcessEnvironmentVariable("RABBITMQ_HOST", "localhost")
               .SetProcessEnvironmentVariable("AWS_SDK_HOST", "localhost:4566");
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,12 +14,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
+    [Collection(PostgresCollection.Name)]
     public class DapperTests : TracingIntegrationTest
     {
-        public DapperTests(ITestOutputHelper output)
+        public DapperTests(ITestOutputHelper output, PostgresFixture postgresFixture)
             : base("Dapper", output)
         {
             SetServiceVersion("1.0.0");
+            ConfigureContainers(postgresFixture);
         }
 
         // Assert Npgsql because the Dapper application uses Postgres for the actual client

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,12 +19,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
+    [Collection(SqlServerCollection.Name)]
     public class MicrosoftDataSqlClientTests : TracingIntegrationTest
     {
-        public MicrosoftDataSqlClientTests(ITestOutputHelper output)
+        public MicrosoftDataSqlClientTests(ITestOutputHelper output, SqlServerFixture sqlServerFixture)
             : base("Microsoft.Data.SqlClient", output)
         {
             SetServiceVersion("1.0.0");
+            ConfigureContainers(sqlServerFixture);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsSqlClient(metadataSchemaVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -22,12 +23,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
     [UsesVerify]
-    public class MySqlCommandTests : TracingIntegrationTest
+    [Collection(MySqlCollection.Name)]
+    public class MySqlCommandTests : TracingIntegrationTest, IClassFixture<MySql57Fixture>
     {
-        public MySqlCommandTests(ITestOutputHelper output)
+        private readonly MySql8Fixture _mySql8Fixture;
+        private readonly MySql57Fixture _mySql57Fixture;
+
+        public MySqlCommandTests(ITestOutputHelper output, MySql8Fixture mySql8Fixture, MySql57Fixture mySql57Fixture)
             : base("MySql", output)
         {
+            _mySql8Fixture = mySql8Fixture;
+            _mySql57Fixture = mySql57Fixture;
             SetServiceVersion("1.0.0");
+            ConfigureContainers(mySql8Fixture, mySql57Fixture);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsMySql(metadataSchemaVersion);
@@ -121,6 +129,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(new Regex("MySql-Test-[a-zA-Z0-9]{32}"), "MySql-Test-GUID");
+            settings.AddSimpleScrubber($"out.host: {_mySql8Fixture.Host}", "out.host: mysql");
+            if (_mySql57Fixture.Host is { } mySql57Host)
+            {
+                settings.AddSimpleScrubber($"out.host: {mySql57Host}", "out.host: mysql");
+            }
+
             settings.AddSimpleScrubber("out.host: localhost", "out.host: mysql");
             settings.AddSimpleScrubber("out.host: mysql57", "out.host: mysql");
             settings.AddSimpleScrubber("out.host: mysql_arm64", "out.host: mysql");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,12 +19,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
+    [Collection(MySqlCollection.Name)]
     public class MySqlConnectorTests : TracingIntegrationTest
     {
-        public MySqlConnectorTests(ITestOutputHelper output)
+        public MySqlConnectorTests(ITestOutputHelper output, MySql8Fixture mySqlFixture)
             : base("MySqlConnector", output)
         {
             SetServiceVersion("1.0.0");
+            ConfigureContainers(mySqlFixture);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsMySql(metadataSchemaVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -21,12 +22,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
     [UsesVerify]
+    [Collection(PostgresCollection.Name)]
     public class NpgsqlCommandTests : TracingIntegrationTest
     {
-        public NpgsqlCommandTests(ITestOutputHelper output)
+        private readonly PostgresFixture _postgresFixture;
+
+        public NpgsqlCommandTests(ITestOutputHelper output, PostgresFixture postgresFixture)
             : base("Npgsql", output)
         {
+            _postgresFixture = postgresFixture;
             SetServiceVersion("1.0.0");
+            ConfigureContainers(postgresFixture);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsNpgsql(metadataSchemaVersion);
@@ -77,6 +83,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(new Regex("Npgsql-Test-[a-zA-Z0-9]{32}"), "Npgsql-Test-GUID");
+            settings.AddSimpleScrubber($"out.host: {_postgresFixture.Host}", "out.host: postgres");
             settings.AddSimpleScrubber("out.host: localhost", "out.host: postgres");
             settings.AddSimpleScrubber("out.host: postgres_arm64", "out.host: postgres");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -22,12 +23,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
     [UsesVerify]
+    [Collection(SqlServerCollection.Name)]
     public class SystemDataSqlClientTests : TracingIntegrationTest
     {
-        public SystemDataSqlClientTests(ITestOutputHelper output)
+        private readonly SqlServerFixture _sqlServerFixture;
+
+        public SystemDataSqlClientTests(ITestOutputHelper output, SqlServerFixture sqlServerFixture)
             : base("SqlServer", output)
         {
+            _sqlServerFixture = sqlServerFixture;
             SetServiceVersion("1.0.0");
+            ConfigureContainers(sqlServerFixture);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsSqlClient(metadataSchemaVersion);
@@ -96,6 +102,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 builder.Clear();
                 builder.Append(filtered);
             });
+
+            if (_sqlServerFixture.HostAndPort is { } hostAndPort)
+            {
+                settings.AddSimpleScrubber($"out.host: {hostAndPort}", "out.host: sqlserver");
+                settings.AddSimpleScrubber($"peer.service: {hostAndPort}", "peer.service: sqlserver");
+            }
 
             settings.AddSimpleScrubber("out.host: localhost", "out.host: sqlserver");
             settings.AddSimpleScrubber("out.host: (localdb)\\MSSQLLocalDB", "out.host: sqlserver");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
@@ -22,6 +22,26 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
     {
         public const string Name = "ServiceStackRedis";
     }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class SqlServerCollection : ICollectionFixture<SqlServerFixture>
+    {
+        public const string Name = "SqlServer";
+    }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class PostgresCollection : ICollectionFixture<PostgresFixture>
+    {
+        public const string Name = "Postgres";
+    }
+
+    // MySQL 8 is shared by the MySql.Data and MySqlConnector tests to avoid restarting the container.
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class MySqlCollection : ICollectionFixture<MySql8Fixture>
+    {
+        public const string Name = "MySql";
+    }
+
 }
 
 #pragma warning restore SA1649 // File name should match first type name

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalMassTransitTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalMassTransitTest.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,11 +13,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(SqlServerCollection.Name)]
     public class ServiceBusMinimalMassTransitTest : SmokeTestBase
     {
-        public ServiceBusMinimalMassTransitTest(ITestOutputHelper output)
+        public ServiceBusMinimalMassTransitTest(ITestOutputHelper output, SqlServerFixture sqlServerFixture)
             : base(output, "ServiceBus.Minimal.MassTransit", maxTestRunSeconds: 60)
         {
+            foreach (var variable in sqlServerFixture.GetEnvironmentVariables())
+            {
+                SetEnvironmentVariable(variable.Key, variable.Value);
+            }
+
             AssumeSuccessOnTimeout = true;
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalNServiceBusTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalNServiceBusTest.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,11 +13,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(SqlServerCollection.Name)]
     public class ServiceBusMinimalNServiceBusTest : SmokeTestBase
     {
-        public ServiceBusMinimalNServiceBusTest(ITestOutputHelper output)
+        public ServiceBusMinimalNServiceBusTest(ITestOutputHelper output, SqlServerFixture sqlServerFixture)
             : base(output, "ServiceBus.Minimal.NServiceBus", maxTestRunSeconds: 90)
         {
+            foreach (var variable in sqlServerFixture.GetEnvironmentVariables())
+            {
+                SetEnvironmentVariable(variable.Key, variable.Value);
+            }
         }
 
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalRebusTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalRebusTest.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -11,11 +13,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(SqlServerCollection.Name)]
     public class ServiceBusMinimalRebusTest : SmokeTestBase
     {
-        public ServiceBusMinimalRebusTest(ITestOutputHelper output)
+        public ServiceBusMinimalRebusTest(ITestOutputHelper output, SqlServerFixture sqlServerFixture)
             : base(output, "ServiceBus.Minimal.Rebus", maxTestRunSeconds: 90)
         {
+            foreach (var variable in sqlServerFixture.GetEnvironmentVariables())
+            {
+                SetEnvironmentVariable(variable.Key, variable.Value);
+            }
         }
 
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/MySql57Fixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/MySql57Fixture.cs
@@ -1,0 +1,67 @@
+// <copyright file="MySql57Fixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class MySql57Fixture : ContainerFixture
+{
+    private const int MySqlPort = 3306;
+    private const string Username = "mysqldb";
+    private const string Password = "mysqldb";
+    private const string Database = "world";
+    private const string Image = "mysql/mysql-server:5.7@sha256:1178cdd375f758968cd834ac4057bae41307e64b7c69a9e145896e7b11f48064";
+
+    private IContainer? _container;
+
+    public string? Host => _container?.Hostname;
+
+    public ushort? Port => _container?.GetMappedPublicPort(MySqlPort);
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        if (Host is { } host && Port is { } port)
+        {
+            yield return new("MYSQL57_HOST", host);
+            yield return new("MYSQL57_PORT", port.ToString());
+        }
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        // The old MySql.Data tests are marked ArmUnsupported, but their collection also contains MySQL 8 tests.
+        if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            return;
+        }
+
+        var container = new ContainerBuilder(Image)
+                       .WithPortBinding(MySqlPort, true)
+                       .WithEnvironment("MYSQL_DATABASE", Database)
+                       .WithEnvironment("MYSQL_ROOT_PASSWORD", Password)
+                       .WithEnvironment("MYSQL_USER", Username)
+                       .WithEnvironment("MYSQL_PASSWORD", Password)
+                       .WithWaitStrategy(
+                            Wait.ForUnixContainer()
+                                // mysqladmin can reach the temporary server used by the image's initialization script.
+                                // Wait for that phase to finish before probing the final server.
+                                .UntilMessageIsLogged("MySQL init process done. Ready for start up.")
+                                .UntilCommandIsCompleted("mysqladmin", "ping", "--silent", "-h", "localhost", "-u", "root", $"-p{Password}"))
+                       .Build();
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+
+        _container = container;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/MySql8Fixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/MySql8Fixture.cs
@@ -1,0 +1,55 @@
+// <copyright file="MySql8Fixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class MySql8Fixture : ContainerFixture
+{
+    private const int MySqlPort = 3306;
+    private const string Username = "mysqldb";
+    private const string Password = "mysqldb";
+    private const string Database = "world";
+    private const string Image = "mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313";
+
+    public string Host => Container.Hostname;
+
+    public ushort Port => Container.GetMappedPublicPort(MySqlPort);
+
+    private IContainer Container => GetResource<IContainer>("container");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("MYSQL_HOST", Host);
+        yield return new("MYSQL_PORT", Port.ToString());
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        var container = new ContainerBuilder(Image)
+                       .WithPortBinding(MySqlPort, true)
+                       .WithEnvironment("MYSQL_DATABASE", Database)
+                       .WithEnvironment("MYSQL_ROOT_PASSWORD", Password)
+                       .WithEnvironment("MYSQL_USER", Username)
+                       .WithEnvironment("MYSQL_PASSWORD", Password)
+                       .WithWaitStrategy(
+                            Wait.ForUnixContainer()
+                                // mysqladmin can reach the temporary server used by the image's initialization script.
+                                // Wait for that phase to finish before probing the final server.
+                                .UntilMessageIsLogged("MySQL init process done. Ready for start up.")
+                                .UntilCommandIsCompleted("mysqladmin", "ping", "--silent", "-h", "localhost", "-u", "root", $"-p{Password}"))
+                       .Build();
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/PostgresFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/PostgresFixture.cs
@@ -1,0 +1,48 @@
+// <copyright file="PostgresFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class PostgresFixture : ContainerFixture
+{
+    private const int PostgresPort = 5432;
+    private const string Username = "postgres";
+    private const string Password = "postgres";
+    private const string Database = "postgres";
+    private const string Image = "postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117";
+
+    public string Host => Container.Hostname;
+
+    public ushort Port => Container.GetMappedPublicPort(PostgresPort);
+
+    private IContainer Container => GetResource<IContainer>("container");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("POSTGRES_CONNECTION_STRING", $"Host={Host};Port={Port};Username={Username};Password={Password};Database={Database}");
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        var container = new ContainerBuilder(Image)
+                       .WithPortBinding(PostgresPort, true)
+                       .WithEnvironment("POSTGRES_USER", Username)
+                       .WithEnvironment("POSTGRES_PASSWORD", Password)
+                       .WithEnvironment("POSTGRES_DB", Database)
+                       .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("pg_isready", "-h", "localhost", "-U", Username))
+                       .Build();
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/SqlServerFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/SqlServerFixture.cs
@@ -1,0 +1,98 @@
+// <copyright file="SqlServerFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Testcontainers.MsSql;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class SqlServerFixture : ContainerFixture
+{
+    private const int SqlServerPort = 1433;
+    private const string Password = "Strong!Passw0rd";
+    private const string SqlServerImage = "mcr.microsoft.com/mssql/server:latest@sha256:2cd0aec4a3bfc3cf9205bed3f7922f4c6208f7c767dc62edcee308d0fd7d56d0";
+    private const string AzureSqlEdgeImage = "mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf";
+
+    private string? _connectionString;
+
+    public string? HostAndPort { get; private set; }
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        if (_connectionString is not null)
+        {
+            yield return new("SQLSERVER_CONNECTION_STRING", _connectionString);
+        }
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        var connectionString = Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING");
+        if (!string.IsNullOrEmpty(connectionString))
+        {
+            _connectionString = connectionString;
+            HostAndPort = GetHost(connectionString);
+            return;
+        }
+
+        // Windows provides LocalDB.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        IContainer container;
+        if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        {
+            // mssql/server has no native arm64 image. Azure SQL Edge does not include the sqlcmd binary
+            // used by MsSqlBuilder's readiness check, so wait for its ready message instead. Explicitly
+            // bound the wait because Testcontainers defaults to one hour.
+            container = new ContainerBuilder(AzureSqlEdgeImage)
+                       .WithPortBinding(SqlServerPort, true)
+                       .WithEnvironment("ACCEPT_EULA", "Y")
+                       .WithEnvironment("MSSQL_SA_PASSWORD", Password)
+                       .WithWaitStrategy(
+                            Wait.ForUnixContainer()
+                                .UntilMessageIsLogged(
+                                     "SQL Server is now ready for client connections",
+                                     strategy => strategy.WithTimeout(TimeSpan.FromMinutes(2))))
+                       .Build();
+        }
+        else
+        {
+            container = new MsSqlBuilder(SqlServerImage)
+                       .WithPassword(Password)
+                       .Build();
+        }
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+
+        HostAndPort = $"{container.Hostname},{container.GetMappedPublicPort(SqlServerPort)}";
+        _connectionString = $"Server={HostAndPort};User=sa;Password={Password};TrustServerCertificate=True";
+    }
+
+    private static string? GetHost(string connectionString)
+    {
+        var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+        foreach (var name in new[] { "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host", "Hostname", "Host Name" })
+        {
+            if (builder.TryGetValue(name, out var value) && value is string host)
+            {
+                return host;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Datadog.Trace.TestHelpers.AutoInstrumentation.csproj
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Datadog.Trace.TestHelpers.AutoInstrumentation.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="SharpPdb" Version="1.0.4" />
     <PackageReference Include="Testcontainers" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

Migrates integration tests that use MySQL, PostreSQL, and SQL Server from using docker compose to use Testcontainers instead via shared fixtures.

## Reason for change

This reduces the number of Docker dependencies running for the entire integration-test job.

These database resources are only consumed while the database tests are running.

## Implementation details

- Added fixtures for: MySQL 5.7, MySQL 8, PostgreSQL, and SQL Server
- Did use the existing Windows DB still 
- Uses Azure SQL Edge for ARM64, where the SQL Server image is unavailable
- Passes dynamically mapped database endpoints to the affected tests and samples
- Removed all the related docker stuff from the compose files.

## Test coverage

Relying on CI for test coverage for this, I ran these initially in https://github.com/DataDog/dd-trace-dotnet/pull/8960.

## Other details
<!-- Fixes #{issue} -->
This is PR 3 of 10 in the Testcontainers migration
The original PR containing the complete set of changes is https://github.com/DataDog/dd-trace-dotnet/pull/8960.
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
