### PR TITLE
Migrate IAST database tests to Testcontainers

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastDbTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastDbTests.cs
@@ -10,17 +10,26 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Security.IntegrationTests.Iast;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests.IAST;
 
 [Trait("RequiresDockerDependency", "true")]
+[Trait("DockerGroup", "1")]
+[Collection(AspNetCore5IastDbTestsCollection.Name)]
 public class AspNetCore5IastDbTests : AspNetCore5IastTests
 {
-    public AspNetCore5IastDbTests(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+    public AspNetCore5IastDbTests(
+        AspNetCoreTestFixture fixture,
+        ITestOutputHelper outputHelper,
+        SqlServerFixture sqlServerFixture,
+        PostgresFixture postgresFixture,
+        MySql8Fixture mySqlFixture)
         : base(fixture, outputHelper, enableIast: true, testName: "AspNetCore5IastDbTestsIastEnabled", samplingRate: 100, vulnerabilitiesPerRequest: 200, isIastDeduplicationEnabled: false, sampleName: "AspNetCore5")
     {
+        ConfigureContainers(sqlServerFixture, postgresFixture, mySqlFixture);
     }
 
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastDbTestsCollection.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastDbTestsCollection.cs
@@ -1,0 +1,19 @@
+// <copyright file="AspNetCore5IastDbTestsCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_0_OR_GREATER
+
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+using Xunit;
+
+namespace Datadog.Trace.Security.IntegrationTests.IAST;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class AspNetCore5IastDbTestsCollection : ICollectionFixture<SqlServerFixture>, ICollectionFixture<PostgresFixture>, ICollectionFixture<MySql8Fixture>
+{
+    public const string Name = "AspNetCore5IastDbTests";
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes

This migrates the IAST integration tests to use the new Testcontainer fixtures for MySQL/PostgreSQL/SQL Server.

> Note that they lacked `[Trait("DockerGroup", "1")]` so they have **not been** running at all before this.

## Reason for change

This reduces the number of Docker dependencies running for the entire integration-test job.

These database resources are only consumed while the database tests are running.

## Implementation details

Just added the xUnit collection along with the new fixtures.

## Test coverage

Relying on CI for test coverage for this, I ran these initially in https://github.com/DataDog/dd-trace-dotnet/pull/8960.

## Other details
<!-- Fixes #{issue} -->

This is PR 4 of 10 in the Testcontainers migration
The original PR containing the complete set of changes is https://github.com/DataDog/dd-trace-dotnet/pull/8960.

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
