### PR TITLE
Migrate RabbitMQ and Kafka tests to Testcontainers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,6 @@ services:
 
   rabbitmq_arm64:
     image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
-    command: rabbitmq-server
-    ports:
-      - "5672"
-      - "15672"
 
   servicestackredis_arm64:
     image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
@@ -70,11 +66,6 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
-    profiles: ["group1"]
-    command: rabbitmq-server
-    ports:
-      - "127.0.0.1:5672:5672"
-      - "127.0.0.1:15672:15672"
 
   servicestackredis:
     image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20
@@ -207,50 +198,11 @@ services:
     ports:
     - "127.0.0.1:8585:8585"
 
-  # See https://github.com/confluentinc/cp-all-in-one/blob/6.1.1-post/cp-all-in-one/docker-compose.yml
-  # For original definitions
   kafka-zookeeper:
     image: confluentinc/cp-zookeeper:6.1.1@sha256:a7c0a20dce46a705300cd464e511e9c70ac55ec7e62c024867470a19ce210563
-    profiles: ["group1"]
-    hostname: kafka-zookeeper
-    container_name: kafka-zookeeper
-    ports:
-      - "2181:2181"
-    restart: unless-stopped
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
 
   kafka-broker:
     image: confluentinc/cp-server:6.1.1@sha256:4a1ff92bd03e361759ba339c97b4c4b7dbb52d7cea478dda22d034261a8991e4
-    profiles: ["group1"]
-    hostname: kafka-broker
-    container_name: kafka-broker
-    depends_on:
-      - kafka-zookeeper
-    ports:
-      - "9092:9092"
-      - "9101:9101"
-    restart: unless-stopped
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'kafka-zookeeper:2181'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9101
-      KAFKA_JMX_HOSTNAME: localhost
-      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: kafka-broker:29092
-      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
-      CONFLUENT_METRICS_ENABLE: 'true'
-      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   openldap:
     image: osixia/openldap:latest@sha256:3f68751292b43564a2586fc29fb7337573e2dad692b92d4e78e49ad5c22e567b
@@ -355,8 +307,6 @@ services:
       - ELASTICSEARCH7_HOST=elasticsearch7:9200
       - ELASTICSEARCH6_HOST=elasticsearch6:9200
       - ELASTICSEARCH5_HOST=elasticsearch5:9200
-      - RABBITMQ_HOST=rabbitmq
-      - KAFKA_BROKER_HOST=kafka-broker:29092
       - AWS_SDK_HOST=localstack:4566
       - ORACLE_HOST=oracle
       - COUCHBASE_HOST=couchbase
@@ -561,14 +511,11 @@ services:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     profiles: ["group1"]
     depends_on:
-      - rabbitmq
-      - kafka-broker
-      - kafka-zookeeper
       - couchbase
       - test-agent
     environment:
       - TIMEOUT_LENGTH=120
-    command: rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 couchbase:11210 test-agent:8126 test-agent:4317 test-agent:4318
+    command: couchbase:11210 test-agent:8126 test-agent:4317 test-agent:4318
 
   StartDependencies.Group2:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
@@ -623,7 +570,6 @@ services:
       - ELASTICSEARCH7_HOST=elasticsearch7_arm64:9200
       - ELASTICSEARCH6_HOST=elasticsearch7_arm64:9200
       - ELASTICSEARCH5_HOST=elasticsearch7_arm64:9200
-      - RABBITMQ_HOST=rabbitmq_arm64
       - AWS_SDK_HOST=localstack_arm64:4566
       - COSMOSDB_ENDPOINT=https://cosmosdb-emulator_arm64:8081
       - DD_LOGGER_DD_API_KEY
@@ -657,7 +603,6 @@ services:
     depends_on:
       - elasticsearch7_arm64
       - mongo_arm64
-      - rabbitmq_arm64
       - localstack_arm64
       - test-agent
       - cosmosdb-emulator_arm64
@@ -667,13 +612,12 @@ services:
     depends_on:
       - elasticsearch7_arm64
       - mongo_arm64
-      - rabbitmq_arm64
       - localstack_arm64
       - test-agent
       - cosmosdb-emulator_arm64
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch7_arm64:9200 mongo_arm64:27017 rabbitmq_arm64:5672 localstack_arm64:4566 test-agent:8126 test-agent:4317 test-agent:4318 cosmosdb-emulator_arm64:8081
+    command: elasticsearch7_arm64:9200 mongo_arm64:27017 localstack_arm64:4566 test-agent:8126 test-agent:4317 test-agent:4318 cosmosdb-emulator_arm64:8081
 
   IntegrationTests.ARM64.Debugger:
     build:
@@ -748,11 +692,10 @@ services:
     depends_on:
       - elasticsearch7_osx_arm64
       - mongo_osx_arm64
-      - rabbitmq_osx_arm64
       - localstack_osx_arm64
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch7_osx_arm64:9200 mongo_osx_arm64:27017 rabbitmq_osx_arm64:5672 localstack_osx_arm64:4566
+    command: elasticsearch7_osx_arm64:9200 mongo_osx_arm64:27017 localstack_osx_arm64:4566
 
   # OSX ARM64 dependencies
 
@@ -791,10 +734,6 @@ services:
 
   rabbitmq_osx_arm64:
     image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
-    command: rabbitmq-server
-    ports:
-      - "5672:5672"
-      - "15672:15672"
 
   servicestackredis_osx_arm64:
     image: redis:4-alpine@sha256:aaf7c123077a5e45ab2328b5ef7e201b5720616efac498d55e65a7afbb96ae20

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -272,7 +272,6 @@ internal static partial class DotNetSettingsExtensions
               .SetProcessEnvironmentVariable("ELASTICSEARCH7_HOST", "localhost:9200")
               .SetProcessEnvironmentVariable("ELASTICSEARCH6_HOST", "localhost:9200")
               .SetProcessEnvironmentVariable("ELASTICSEARCH5_HOST", "localhost:9200")
-              .SetProcessEnvironmentVariable("RABBITMQ_HOST", "localhost")
               .SetProcessEnvironmentVariable("AWS_SDK_HOST", "localhost:4566");
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringKafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringKafkaTests.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -19,15 +21,16 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 
 [UsesVerify]
-[Collection(nameof(KafkaTests.KafkaTestsCollection))]
+[Collection(KafkaCollection.Name)]
 [Trait("RequiresDockerDependency", "true")]
 [Trait("DockerGroup", "1")]
 public class DataStreamsMonitoringKafkaTests : TestHelper
 {
-    public DataStreamsMonitoringKafkaTests(ITestOutputHelper output)
+    public DataStreamsMonitoringKafkaTests(ITestOutputHelper output, KafkaFixture kafkaFixture)
         : base("DataStreams.Kafka", output)
     {
         SetServiceVersion("1.0.0");
+        ConfigureContainers(kafkaFixture);
     }
 
     public static IEnumerable<object[]> GetKafkaTestData()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -22,12 +24,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 [UsesVerify]
 [Trait("RequiresDockerDependency", "true")]
 [Trait("DockerGroup", "1")]
+[Collection(RabbitMqCollection.Name)]
 public class DataStreamsMonitoringRabbitMQTests : TestHelper
 {
-    public DataStreamsMonitoringRabbitMQTests(ITestOutputHelper output)
+    public DataStreamsMonitoringRabbitMQTests(ITestOutputHelper output, RabbitMqFixture rabbitMqFixture)
         : base("DataStreams.RabbitMQ", output)
     {
         SetServiceVersion("1.0.0");
+        ConfigureContainers(rabbitMqFixture);
     }
 
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
@@ -42,6 +42,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
         public const string Name = "MySql";
     }
 
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class RabbitMqCollection : ICollectionFixture<RabbitMqFixture>
+    {
+        public const string Name = "RabbitMq";
+    }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class KafkaCollection : ICollectionFixture<KafkaFixture>
+    {
+        public const string Name = "Kafka";
+    }
 }
 
 #pragma warning restore SA1649 // File name should match first type name

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -9,8 +9,10 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
@@ -18,7 +20,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    [Collection(nameof(KafkaTestsCollection))]
+    [Collection(KafkaCollection.Name)]
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
     public class KafkaTests : TracingIntegrationTest
@@ -38,10 +40,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private const string ErrorProducerResourceName = "Produce Topic INVALID-TOPIC";
 
-        public KafkaTests(ITestOutputHelper output)
+        public KafkaTests(ITestOutputHelper output, KafkaFixture kafkaFixture)
             : base("Kafka", output)
         {
             SetServiceVersion("1.0.0");
+            ConfigureContainers(kafkaFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -208,11 +211,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         private string GetSuccessfulResourceName(string type, string topic)
         {
             return $"{type} Topic {topic}";
-        }
-
-        [CollectionDefinition(nameof(KafkaTestsCollection), DisableParallelization = true)]
-        public class KafkaTestsCollection
-        {
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -9,9 +9,11 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions.Execution;
 using VerifyXunit;
 using Xunit;
@@ -22,12 +24,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     [UsesVerify]
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "1")]
+    [Collection(RabbitMqCollection.Name)]
     public class RabbitMQTests : TracingIntegrationTest
     {
-        public RabbitMQTests(ITestOutputHelper output)
+        private readonly RabbitMqFixture _rabbitMqFixture;
+
+        public RabbitMQTests(ITestOutputHelper output, RabbitMqFixture rabbitMqFixture)
             : base("RabbitMQ", output)
         {
+            _rabbitMqFixture = rabbitMqFixture;
             SetServiceVersion("1.0.0");
+            ConfigureContainers(rabbitMqFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -78,6 +85,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 // We generate a new queue name for the "default" queue with each run
                 settings.AddScrubber(QueueScrubber.ReplaceRabbitMqQueues);
+                settings.AddSimpleScrubber($"out.host: {_rabbitMqFixture.Host}", "out.host: rabbitmq");
+                settings.AddSimpleScrubber($"peer.service: {_rabbitMqFixture.Host}", "peer.service: rabbitmq");
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: rabbitmq");
                 settings.AddSimpleScrubber("out.host: rabbitmq_arm64", "out.host: rabbitmq");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: rabbitmq");

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/KafkaFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/KafkaFixture.cs
@@ -1,0 +1,55 @@
+// <copyright file="KafkaFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Testcontainers.Kafka;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class KafkaFixture : ContainerFixture
+{
+    private const int ZooKeeperPort = 2181;
+    private const string ZooKeeperAlias = "kafka-zookeeper";
+    private const string ZooKeeperImage = "confluentinc/cp-zookeeper:6.1.1@sha256:a7c0a20dce46a705300cd464e511e9c70ac55ec7e62c024867470a19ce210563";
+    private const string KafkaImage = "confluentinc/cp-server:6.1.1@sha256:4a1ff92bd03e361759ba339c97b4c4b7dbb52d7cea478dda22d034261a8991e4";
+
+    private KafkaContainer KafkaContainer => GetResource<KafkaContainer>("container");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("KAFKA_BROKER_HOST", KafkaContainer.GetBootstrapAddress());
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        var network = new NetworkBuilder().Build();
+        var zooKeeperContainer = new ContainerBuilder(ZooKeeperImage)
+                                .WithNetwork(network)
+                                .WithNetworkAliases(ZooKeeperAlias)
+                                .WithEnvironment("ZOOKEEPER_CLIENT_PORT", ZooKeeperPort.ToString())
+                                .WithEnvironment("ZOOKEEPER_TICK_TIME", "2000")
+                                .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(ZooKeeperPort))
+                                .Build();
+        var kafkaContainer = new KafkaBuilder(KafkaImage)
+                            .WithNetwork(network)
+                            .WithZooKeeper($"{ZooKeeperAlias}:{ZooKeeperPort}")
+                            .WithPortBinding(KafkaBuilder.ZooKeeperPort, true)
+                            .WithEnvironment("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+                            .Build();
+
+        registerResource("network", network);
+        registerResource("zookeeper", zooKeeperContainer);
+        registerResource("container", kafkaContainer);
+        await network.CreateAsync().ConfigureAwait(false);
+        await StartContainerAsync(zooKeeperContainer).ConfigureAwait(false);
+        await StartContainerAsync(kafkaContainer).ConfigureAwait(false);
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/RabbitMqFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/RabbitMqFixture.cs
@@ -1,0 +1,45 @@
+// <copyright file="RabbitMqFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Containers;
+using Testcontainers.RabbitMq;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class RabbitMqFixture : ContainerFixture
+{
+    private const string Image = "rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69";
+    private const string Username = "guest";
+    private const string Password = "guest";
+
+    public string Host => Container.Hostname;
+
+    public ushort Port => Container.GetMappedPublicPort(RabbitMqBuilder.RabbitMqPort);
+
+    private IContainer Container => GetResource<IContainer>("container");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("RABBITMQ_HOST", Host);
+        yield return new("RABBITMQ_PORT", Port.ToString());
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        // Preserve the RabbitMQ.Client default credentials used by the samples.
+        var container = new RabbitMqBuilder(Image)
+                       .WithUsername(Username)
+                       .WithPassword(Password)
+                       .Build();
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Datadog.Trace.TestHelpers.AutoInstrumentation.csproj
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Datadog.Trace.TestHelpers.AutoInstrumentation.csproj
@@ -4,7 +4,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="SharpPdb" Version="1.0.4" />
     <PackageReference Include="Testcontainers" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.Kafka" Version="4.11.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.RabbitMQ/Program.cs
@@ -22,12 +22,13 @@ namespace Samples.DataStreams.RabbitMQ
         private static readonly string DirectRoutingKey = nameof(DirectRoutingKey);
         private static readonly string Message = nameof(Message);
         private static readonly string Host = Environment.GetEnvironmentVariable("RABBITMQ_HOST") ?? "localhost";
+        private static readonly int Port = int.TryParse(Environment.GetEnvironmentVariable("RABBITMQ_PORT"), out var port) ? port : 5672;
         
         public static async Task Main(string[] args)
         {
             await SampleHelpers.WaitForDiscoveryService();
 
-            var factory = new ConnectionFactory() { HostName = Host };
+            var factory = new ConnectionFactory() { HostName = Host, Port = Port };
 #if RABBITMQ_7_0
             using var connection = await factory.CreateConnectionAsync();
             using var model = await connection.CreateChannelAsync();

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -35,10 +35,15 @@ namespace Samples.RabbitMQ
             return Environment.GetEnvironmentVariable("RABBITMQ_HOST") ?? "localhost";
         }
 
+        private static int Port()
+        {
+            return int.TryParse(Environment.GetEnvironmentVariable("RABBITMQ_PORT"), out var port) ? port : 5672;
+        }
+
         public static async Task Main(string[] args)
         {
             // connecting takes 2 to 3 seconds, we re-use the connection to save time
-            var factory = new ConnectionFactory() { HostName = Host() };
+            var factory = new ConnectionFactory() { HostName = Host(), Port = Port() };
 #if RABBITMQ_5_0 && !RABBITMQ_7_0
             factory.DispatchConsumersAsync = true;
 #endif
@@ -51,7 +56,7 @@ namespace Samples.RabbitMQ
                 await RunProducersAndConsumers(asyncConnection, useQueue: true, ConsumerType.ExternalExplicit, isAsyncConsumer: true);
             }
 
-            factory = new ConnectionFactory() { HostName = Host() };
+            factory = new ConnectionFactory() { HostName = Host(), Port = Port() };
             using (var syncConnection = await Helper.CreateConnectionAsync(factory))
             {
                 // Test a derived type for the sync consumer from the library


### PR DESCRIPTION
## Summary of changes

Migrates the RabbitMQ and Kafka integration tests, including their Data Streams Monitoring tests, from Docker Compose managed dependencies to shared Testcontainers fixtures.

## Reason for change

This reduces the number of Docker dependencies running for the entire integration-test job.

These docker resources are only consumed while these tests are running.

## Implementation details

- Remove the docker compose stuff
- Add a RabbitMQ fixture to replace
- Add a Kafka fixture to replace

## Test coverage

Relying on CI for test coverage for this, I ran these initially in https://github.com/DataDog/dd-trace-dotnet/pull/8960.

## Other details
<!-- Fixes #{issue} -->

This is PR 5 of 10 in the Testcontainers migration
The original PR containing the complete set of changes is https://github.com/DataDog/dd-trace-dotnet/pull/8960.
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
