### PR TITLE
Fix flaky WhenSupported_WritesAStatsPointAfterDelay test

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -18,6 +18,7 @@ using Datadog.Trace.DataStreamsMonitoring.Hashes;
 using Datadog.Trace.DataStreamsMonitoring.TransactionTracking;
 using Datadog.Trace.DataStreamsMonitoring.Transport;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using Datadog.Trace.Tests.Agent;
 using Datadog.Trace.Util;
@@ -115,6 +116,7 @@ public class DataStreamsWriterTests
     }
 
     [Fact]
+    [Flaky("This timing-dependent test can fail on saturated CI agents")]
     public async Task WhenSupported_WritesAStatsPointAfterDelay()
     {
         var bucketDurationMs = 100;

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -18,7 +18,6 @@ using Datadog.Trace.DataStreamsMonitoring.Hashes;
 using Datadog.Trace.DataStreamsMonitoring.TransactionTracking;
 using Datadog.Trace.DataStreamsMonitoring.Transport;
 using Datadog.Trace.ExtensionMethods;
-using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using Datadog.Trace.Tests.Agent;
 using Datadog.Trace.Util;
@@ -116,7 +115,6 @@ public class DataStreamsWriterTests
     }
 
     [Fact]
-    [Flaky("This timing-dependent test can fail on saturated CI agents")]
     public async Task WhenSupported_WritesAStatsPointAfterDelay()
     {
         var bucketDurationMs = 100;
@@ -124,17 +122,30 @@ public class DataStreamsWriterTests
         var writer = CreateWriter(api, out var discovery, bucketDurationMs);
         TriggerSupportUpdate(discovery, isSupported: true);
 
-        // stats and backlogs will be sent as the same payload
-        writer.Add(CreateStatsPoint());
-        writer.AddBacklog(CreateBacklogPoint());
+        // Keep both points in the same bucket even if the test crosses a bucket boundary.
+        var timestampNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+        var statsPoint = CreateStatsPoint(timestampNs);
+        var backlogPoint = CreateBacklogPoint(timestampNs);
+        writer.Add(statsPoint);
+        writer.AddBacklog(backlogPoint);
 
-        await api.WaitForCount(1, 30_000);
-
-        HasOneOrTwoPoints(api);
+        await api.WaitForSend(30_000);
 
         await writer.DisposeAsync();
 
-        HasOneOrTwoPoints(api);
+        var payloads = await DeserializePayloadsAsync(api);
+        var stats = payloads.SelectMany(x => x.Stats)
+                            .Where(x => x.Stats is not null)
+                            .SelectMany(x => x.Stats)
+                            .ToList();
+        var backlogs = payloads.SelectMany(x => x.Stats)
+                               .Where(x => x.Backlogs is not null)
+                               .SelectMany(x => x.Backlogs)
+                               .ToList();
+
+        stats.Should().ContainSingle(x => x.TimestampType == "current" && x.Hash == statsPoint.Hash.Value && x.ParentHash == statsPoint.ParentHash.Value);
+        stats.Should().ContainSingle(x => x.TimestampType == "origin" && x.Hash == statsPoint.Hash.Value && x.ParentHash == statsPoint.ParentHash.Value);
+        backlogs.Should().ContainSingle(x => x.Value == backlogPoint.Value && x.Tags.Contains(backlogPoint.Tags));
     }
 
     [Fact]
@@ -346,18 +357,7 @@ public class DataStreamsWriterTests
 
         HasOneOrTwoPoints(api);
 
-        var payloads = new List<MockDataStreamsPayload>();
-        foreach (var payload in api.Sent)
-        {
-            using var compressed = new MemoryStream(payload.Array!);
-            using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
-            using var decompressed = new MemoryStream();
-            await gzip.CopyToAsync(decompressed);
-
-            var result = MessagePackSerializer.Deserialize<MockDataStreamsPayload>(decompressed.GetBuffer());
-
-            payloads.Add(result);
-        }
+        var payloads = await DeserializePayloadsAsync(api);
 
         payloads.Should().OnlyContain(x => x.Env == Environment);
         payloads.Should().OnlyContain(x => x.Service == Service);
@@ -454,17 +454,39 @@ public class DataStreamsWriterTests
     }
 
     private static StatsPoint CreateStatsPoint()
+        => CreateStatsPoint(DateTimeOffset.UtcNow.ToUnixTimeNanoseconds());
+
+    private static BacklogPoint CreateBacklogPoint()
+        => CreateBacklogPoint(DateTimeOffset.UtcNow.ToUnixTimeNanoseconds());
+
+    private static StatsPoint CreateStatsPoint(long timestampNs)
         => new StatsPoint(
             edgeTags: new[] { "direction:out", "type:kafka" },
             hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
             parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
-            timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
+            timestampNs,
             pathwayLatencyNs: 5_000_000_000,
             edgeLatencyNs: 2_000_000_000,
             payloadSizeBytes: 1024);
 
-    private static BacklogPoint CreateBacklogPoint()
-        => new BacklogPoint("type:produce", 100, DateTimeOffset.UtcNow.ToUnixTimeNanoseconds());
+    private static BacklogPoint CreateBacklogPoint(long timestampNs)
+        => new BacklogPoint("type:produce", 100, timestampNs);
+
+    private static async Task<List<MockDataStreamsPayload>> DeserializePayloadsAsync(StubApi api)
+    {
+        var payloads = new List<MockDataStreamsPayload>();
+        foreach (var payload in api.Sent)
+        {
+            using var compressed = new MemoryStream(payload.Array!, payload.Offset, payload.Count);
+            using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
+            using var decompressed = new MemoryStream();
+            await gzip.CopyToAsync(decompressed);
+
+            payloads.Add(MessagePackSerializer.Deserialize<MockDataStreamsPayload>(decompressed.ToArray()));
+        }
+
+        return payloads;
+    }
 
     private async Task WaitForFlushCount(int timeout, int flushCount = 2)
     {
@@ -478,6 +500,7 @@ public class DataStreamsWriterTests
     private class StubApi : IDataStreamsApi
     {
         private readonly List<ArraySegment<byte>> _sent = new();
+        private readonly TaskCompletionSource<bool> _firstSend = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public List<ArraySegment<byte>> Sent
         {
@@ -492,12 +515,26 @@ public class DataStreamsWriterTests
 
         public virtual Task<bool> SendAsync(ArraySegment<byte> bytes)
         {
+            // The writer reuses its serialization buffer, so snapshot each request before returning.
+            var copy = new byte[bytes.Count];
+            Buffer.BlockCopy(bytes.Array!, bytes.Offset, copy, 0, bytes.Count);
+
             lock (_sent)
             {
-                _sent.Add(bytes);
+                _sent.Add(new ArraySegment<byte>(copy));
             }
 
+            _firstSend.TrySetResult(true);
             return Task.FromResult(true);
+        }
+
+        public async Task WaitForSend(int timeoutMs)
+        {
+            var completedTask = await Task.WhenAny(_firstSend.Task, Task.Delay(timeoutMs));
+            if (completedTask != _firstSend.Task)
+            {
+                throw new TimeoutException($"Data streams API was not called within {timeoutMs}ms");
+            }
         }
 
         public async Task WaitForCount(int count, int timeoutMs)

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -77,7 +77,7 @@ public class DataStreamsWriterTests
         TriggerSupportUpdate(discovery, isSupported: true);
 
         writer.AddTransaction(new DataStreamsTransactionInfo("id", 1, "checkpoint"));
-        await api.WaitForCount(1, 30_000);
+        await api.WaitForSend(30_000);
 
         HasOneOrTwoPoints(api);
         await writer.DisposeAsync();
@@ -329,7 +329,7 @@ public class DataStreamsWriterTests
 
         writer.Add(CreateStatsPoint());
 
-        await api.WaitForCount(1, 30_000);
+        await api.WaitForSend(30_000);
 
         HasOneOrTwoPoints(api);
 
@@ -534,15 +534,6 @@ public class DataStreamsWriterTests
             if (completedTask != _firstSend.Task)
             {
                 throw new TimeoutException($"Data streams API was not called within {timeoutMs}ms");
-            }
-        }
-
-        public async Task WaitForCount(int count, int timeoutMs)
-        {
-            var end = DateTime.UtcNow.AddMilliseconds(timeoutMs);
-            while (Sent.Count < count && DateTime.UtcNow < end)
-            {
-                await Task.Delay(100);
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

The test flaked [here](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_build/results?buildId=207329&view=logs&j=39c10999-69f9-5df4-5d2a-dbfd23624857&t=8fdc56c1-8334-5ca0-a40e-55d122795a00) so I've attempted to fix it.

## Reason for change

It flaked, and we want CI to pass more consistently.

## Implementation details

Essentially replace polling with a TCS

## Test coverage

Same just just different

## Other details
<!-- Fixes #{issue} -->

#incident-57303
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
