### PR TITLE
[AppSec] Emit appsec.waf.error telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -74,10 +74,16 @@ internal readonly partial struct SecurityCoordinator
                          : additiveContext.Run(args, _security.Settings.WafTimeoutMicroSeconds);
 
             SetErrorInformation(isRasp, result);
-            SecurityReporter.RecordWafTelemetry(result);
+            SecurityReporter.RecordWafTelemetry(result, isRasp);
         }
         catch (Exception ex) when (ex is not BlockException)
         {
+            if (result is null && !isRasp)
+            {
+                // The WAF never ran, so this is our fault rather than ddwaf_run's
+                TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
+            }
+
             var stringBuilder = StringBuilderCache.Acquire();
             foreach (var kvp in args)
             {
@@ -140,7 +146,7 @@ internal readonly partial struct SecurityCoordinator
                 result = additiveContext.Run(userAddresses, _security.Settings.WafTimeoutMicroSeconds);
                 SetErrorInformation(false, result);
                 additiveContext.CommitUserRuns(userAddresses, fromSdk);
-                SecurityReporter.RecordWafTelemetry(result);
+                SecurityReporter.RecordWafTelemetry(result, isRasp: false);
 
                 if (_localRootSpan.Context.TraceContext is not null)
                 {
@@ -150,6 +156,12 @@ internal readonly partial struct SecurityCoordinator
         }
         catch (Exception ex) when (ex is not BlockException)
         {
+            if (result is null)
+            {
+                // The WAF never ran, so this is our fault rather than ddwaf_run's
+                TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
+            }
+
             if (addresses is not null)
             {
                 var stringBuilder = StringBuilderCache.Acquire();

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -80,7 +80,6 @@ internal readonly partial struct SecurityCoordinator
         {
             if (result is null && !isRasp)
             {
-                // The WAF never ran, so this is our fault rather than ddwaf_run's
                 TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
             }
 
@@ -158,7 +157,6 @@ internal readonly partial struct SecurityCoordinator
         {
             if (result is null)
             {
-                // The WAF never ran, so this is our fault rather than ddwaf_run's
                 TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
@@ -143,22 +143,16 @@ internal sealed partial class SecurityReporter
     {
         if (result is null)
         {
-            // The WAF was never run, so the request wasn't analysed. waf.error is reported by whoever
-            // failed to run it, as it needs to distinguish a real failure from a disposed WAF/context.
             return;
         }
 
         if (result.Timeout)
         {
-            // A timeout is explicitly not a WAF error
             metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.WafTimeoutTruncated : MetricTags.WafAnalysis.WafTimeout);
         }
         else if (!isRasp && result.ReturnCode < WafReturnCode.Ok)
         {
-            // waf.requests and waf.error both describe non-RASP runs, so a failed RASP evaluation is
-            // classified below as if it had succeeded, exactly as it was before waf_error existed.
-            // RASP failures are reported separately by rasp.error.
             metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.WafErrorTruncated : MetricTags.WafAnalysis.WafError);
             RecordWafError(metrics, result.ReturnCode);
@@ -182,8 +176,6 @@ internal sealed partial class SecurityReporter
 
     private static void RecordWafError(IMetricsTelemetryCollector metrics, WafReturnCode returnCode)
     {
-        // Unknown negative codes are skipped rather than mislabelled: a new ddwaf error code requires
-        // adding it to WafReturnCode and to MetricTags.WafError.
         switch (returnCode)
         {
             case WafReturnCode.ErrorInternal:

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
@@ -1,4 +1,4 @@
-// <copyright file="SecurityReporter.cs" company="Datadog">
+﻿// <copyright file="SecurityReporter.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -136,32 +136,65 @@ internal sealed partial class SecurityReporter
         }
     }
 
-    internal static void RecordWafTelemetry(IResult? result)
+    internal static void RecordWafTelemetry(IResult? result, bool isRasp)
+        => RecordWafTelemetry(result, isRasp, TelemetryFactory.Metrics);
+
+    internal static void RecordWafTelemetry(IResult? result, bool isRasp, IMetricsTelemetryCollector metrics)
     {
         if (result is null)
         {
+            // The WAF was never run, so the request wasn't analysed. waf.error is reported by whoever
+            // failed to run it, as it needs to distinguish a real failure from a disposed WAF/context.
             return;
         }
 
         if (result.Timeout)
         {
-            TelemetryFactory.Metrics.RecordCountWafRequests(
+            // A timeout is explicitly not a WAF error
+            metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.WafTimeoutTruncated : MetricTags.WafAnalysis.WafTimeout);
+        }
+        else if (!isRasp && result.ReturnCode < WafReturnCode.Ok)
+        {
+            // waf.requests and waf.error both describe non-RASP runs, so a failed RASP evaluation is
+            // classified below as if it had succeeded, exactly as it was before waf_error existed.
+            // RASP failures are reported separately by rasp.error.
+            metrics.RecordCountWafRequests(
+                result.Truncated ? MetricTags.WafAnalysis.WafErrorTruncated : MetricTags.WafAnalysis.WafError);
+            RecordWafError(metrics, result.ReturnCode);
         }
         else if (result.ShouldBlock)
         {
-            TelemetryFactory.Metrics.RecordCountWafRequests(
+            metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.RuleTriggeredAndBlockedTruncated : MetricTags.WafAnalysis.RuleTriggeredAndBlocked);
         }
         else if (result.ShouldReportSecurityResult)
         {
-            TelemetryFactory.Metrics.RecordCountWafRequests(
+            metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.RuleTriggeredTruncated : MetricTags.WafAnalysis.RuleTriggered);
         }
         else
         {
-            TelemetryFactory.Metrics.RecordCountWafRequests(
+            metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.NormalTruncated : MetricTags.WafAnalysis.Normal);
+        }
+    }
+
+    private static void RecordWafError(IMetricsTelemetryCollector metrics, WafReturnCode returnCode)
+    {
+        // Unknown negative codes are skipped rather than mislabelled: a new ddwaf error code requires
+        // adding it to WafReturnCode and to MetricTags.WafError.
+        switch (returnCode)
+        {
+            case WafReturnCode.ErrorInternal:
+                metrics.RecordCountWafError(MetricTags.WafError.Internal);
+                break;
+            case WafReturnCode.ErrorInvalidObject:
+                metrics.RecordCountWafError(MetricTags.WafError.InvalidObject);
+                break;
+            case WafReturnCode.ErrorInvalidArgument:
+                metrics.RecordCountWafError(MetricTags.WafError.InvalidArgument);
+                break;
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityReporter.cs
@@ -155,7 +155,11 @@ internal sealed partial class SecurityReporter
         {
             metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.WafErrorTruncated : MetricTags.WafAnalysis.WafError);
-            RecordWafError(metrics, result.ReturnCode);
+
+            if (result.ReturnCode.ToWafErrorTag() is { } wafError)
+            {
+                metrics.RecordCountWafError(wafError);
+            }
         }
         else if (result.ShouldBlock)
         {
@@ -171,22 +175,6 @@ internal sealed partial class SecurityReporter
         {
             metrics.RecordCountWafRequests(
                 result.Truncated ? MetricTags.WafAnalysis.NormalTruncated : MetricTags.WafAnalysis.Normal);
-        }
-    }
-
-    private static void RecordWafError(IMetricsTelemetryCollector metrics, WafReturnCode returnCode)
-    {
-        switch (returnCode)
-        {
-            case WafReturnCode.ErrorInternal:
-                metrics.RecordCountWafError(MetricTags.WafError.Internal);
-                break;
-            case WafReturnCode.ErrorInvalidObject:
-                metrics.RecordCountWafError(MetricTags.WafError.InvalidObject);
-                break;
-            case WafReturnCode.ErrorInvalidArgument:
-                metrics.RecordCountWafError(MetricTags.WafError.InvalidArgument);
-                break;
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -10,6 +10,8 @@ using System.Diagnostics;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.AppSec.WafEncoding;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.AppSec.Waf;
@@ -108,6 +110,19 @@ internal sealed class Context : IContext
         }
     }
 
+    /// <summary>
+    /// Reports a WAF run that failed before ddwaf_run could be reached, so the error is ours rather
+    /// than the WAF's. Lifecycle failures (a disposed WAF or context) are deliberately not reported:
+    /// they aren't WAF errors, and counting them would drown the metric in shutdown races.
+    /// </summary>
+    private static void RecordBindingError(bool isRasp)
+    {
+        if (!isRasp)
+        {
+            TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
+        }
+    }
+
     private bool ShouldRunWith(IDatadogSecurity security, UserEventsState.UserRecord? previousUserRecord, string? value, string address, bool fromSdk)
     {
         if (value is null || !security.AddressEnabled(address))
@@ -172,6 +187,7 @@ internal sealed class Context : IContext
             if (ephemeral ? addressData is not { Count: > 0 } : addressData is null)
             {
                 Log.Error("The WAF was called without any address data");
+                RecordBindingError(isRasp);
                 return null;
             }
 
@@ -190,6 +206,7 @@ internal sealed class Context : IContext
                 if (subcontextHandle == IntPtr.Zero)
                 {
                     Log.Error("WAF ddwaf_subcontext_init failed, the ephemeral run was skipped");
+                    RecordBindingError(isRasp);
                     args.Dispose();
 
                     // nothing ran, so don't let this call's wall clock leak into the aggregated runtime

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -110,11 +110,6 @@ internal sealed class Context : IContext
         }
     }
 
-    /// <summary>
-    /// Reports a WAF run that failed before ddwaf_run could be reached, so the error is ours rather
-    /// than the WAF's. Lifecycle failures (a disposed WAF or context) are deliberately not reported:
-    /// they aren't WAF errors, and counting them would drown the metric in shutdown races.
-    /// </summary>
     private static void RecordBindingError(bool isRasp)
     {
         if (!isRasp)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -345,9 +345,6 @@ namespace Datadog.Trace.AppSec.Waf
             else
             {
                 Log.Warning("Context couldn't be created as we couldn't acquire a reader lock");
-
-                // Unlike the disposed cases above, this is lock contention on our side rather than a
-                // lifecycle event, so the request goes unanalysed because of the bindings
                 TelemetryFactory.Metrics.RecordCountWafError(Telemetry.Metrics.MetricTags.WafError.BindingError);
                 return null;
             }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -1,4 +1,4 @@
-// <copyright file="Waf.cs" company="Datadog">
+﻿// <copyright file="Waf.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -345,6 +345,10 @@ namespace Datadog.Trace.AppSec.Waf
             else
             {
                 Log.Warning("Context couldn't be created as we couldn't acquire a reader lock");
+
+                // Unlike the disposed cases above, this is lock contention on our side rather than a
+                // lifecycle event, so the request goes unanalysed because of the bindings
+                TelemetryFactory.Metrics.RecordCountWafError(Telemetry.Metrics.MetricTags.WafError.BindingError);
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 60;
+    public const int Length = 61;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -71,6 +71,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "waf.error",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
@@ -132,6 +133,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -107,6 +107,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1);
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 764;
+    private const int CountLength = 770;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -712,25 +712,32 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "success:true" }),
             new(new[] { "waf_version", "event_rules_version", "success:false" }),
             // waf.requests, index = 645
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            // waf.input_truncated, index = 653
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:true" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:true" }),
+            // waf.input_truncated, index = 655
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 656
+            // waf.error, index = 658
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1" }),
+            // rasp.rule.eval, index = 662
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.rule.match, index = 661
+            // rasp.rule.match, index = 667
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:sql_injection" }),
@@ -746,29 +753,29 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.timeout, index = 676
+            // rasp.timeout, index = 682
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 681
+            // instrum.user_auth.missing_user_id, index = 687
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 685
+            // instrum.user_auth.missing_user_login, index = 691
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 689
+            // sdk.event, index = 695
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 694
+            // executed.source, index = 700
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -783,9 +790,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 708
+            // executed.propagation, index = 714
             new(null),
-            // executed.sink, index = 709
+            // executed.sink, index = 715
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -813,9 +820,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 736
+            // request.tainted, index = 742
             new(null),
-            // suppressed.vulnerabilities, index = 737
+            // suppressed.vulnerabilities, index = 743
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -851,7 +858,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 8, 3, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1135,71 +1142,77 @@ internal sealed partial class MetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 653 + (int)tag;
+        var index = 655 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+        var index = 658 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 656 + (int)tag;
+        var index = 662 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1)
     {
-        var index = 661 + (int)tag;
+        var index = 667 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 676 + (int)tag;
+        var index = 682 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 681 + (int)tag;
+        var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 685 + (int)tag;
+        var index = 691 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 689 + (int)tag;
+        var index = 695 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 694 + (int)tag;
+        var index = 700 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[708], increment);
+        Interlocked.Add(ref _buffer.Count[714], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 709 + (int)tag;
+        var index = 715 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[736], increment);
+        Interlocked.Add(ref _buffer.Count[742], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 737 + (int)tag;
+        var index = 743 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 60;
+    public const int Length = 61;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -71,6 +71,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "waf.error",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
@@ -132,6 +133,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -107,6 +107,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1);
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 764;
+    private const int CountLength = 770;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -712,25 +712,32 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "success:true" }),
             new(new[] { "waf_version", "event_rules_version", "success:false" }),
             // waf.requests, index = 645
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            // waf.input_truncated, index = 653
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:true" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:true" }),
+            // waf.input_truncated, index = 655
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 656
+            // waf.error, index = 658
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1" }),
+            // rasp.rule.eval, index = 662
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.rule.match, index = 661
+            // rasp.rule.match, index = 667
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:sql_injection" }),
@@ -746,29 +753,29 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.timeout, index = 676
+            // rasp.timeout, index = 682
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 681
+            // instrum.user_auth.missing_user_id, index = 687
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 685
+            // instrum.user_auth.missing_user_login, index = 691
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 689
+            // sdk.event, index = 695
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 694
+            // executed.source, index = 700
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -783,9 +790,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 708
+            // executed.propagation, index = 714
             new(null),
-            // executed.sink, index = 709
+            // executed.sink, index = 715
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -813,9 +820,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 736
+            // request.tainted, index = 742
             new(null),
-            // suppressed.vulnerabilities, index = 737
+            // suppressed.vulnerabilities, index = 743
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -851,7 +858,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 8, 3, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1135,71 +1142,77 @@ internal sealed partial class MetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 653 + (int)tag;
+        var index = 655 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+        var index = 658 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 656 + (int)tag;
+        var index = 662 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1)
     {
-        var index = 661 + (int)tag;
+        var index = 667 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 676 + (int)tag;
+        var index = 682 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 681 + (int)tag;
+        var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 685 + (int)tag;
+        var index = 691 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 689 + (int)tag;
+        var index = 695 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 694 + (int)tag;
+        var index = 700 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[708], increment);
+        Interlocked.Add(ref _buffer.Count[714], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 709 + (int)tag;
+        var index = 715 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[736], increment);
+        Interlocked.Add(ref _buffer.Count[742], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 737 + (int)tag;
+        var index = 743 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 60;
+    public const int Length = 61;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -71,6 +71,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "waf.error",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
@@ -132,6 +133,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -107,6 +107,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1);
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 764;
+    private const int CountLength = 770;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -712,25 +712,32 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "success:true" }),
             new(new[] { "waf_version", "event_rules_version", "success:false" }),
             // waf.requests, index = 645
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            // waf.input_truncated, index = 653
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:true" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:true" }),
+            // waf.input_truncated, index = 655
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 656
+            // waf.error, index = 658
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1" }),
+            // rasp.rule.eval, index = 662
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.rule.match, index = 661
+            // rasp.rule.match, index = 667
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:sql_injection" }),
@@ -746,29 +753,29 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.timeout, index = 676
+            // rasp.timeout, index = 682
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 681
+            // instrum.user_auth.missing_user_id, index = 687
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 685
+            // instrum.user_auth.missing_user_login, index = 691
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 689
+            // sdk.event, index = 695
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 694
+            // executed.source, index = 700
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -783,9 +790,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 708
+            // executed.propagation, index = 714
             new(null),
-            // executed.sink, index = 709
+            // executed.sink, index = 715
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -813,9 +820,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 736
+            // request.tainted, index = 742
             new(null),
-            // suppressed.vulnerabilities, index = 737
+            // suppressed.vulnerabilities, index = 743
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -851,7 +858,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 8, 3, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1135,71 +1142,77 @@ internal sealed partial class MetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 653 + (int)tag;
+        var index = 655 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+        var index = 658 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 656 + (int)tag;
+        var index = 662 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1)
     {
-        var index = 661 + (int)tag;
+        var index = 667 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 676 + (int)tag;
+        var index = 682 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 681 + (int)tag;
+        var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 685 + (int)tag;
+        var index = 691 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 689 + (int)tag;
+        var index = 695 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 694 + (int)tag;
+        var index = 700 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[708], increment);
+        Interlocked.Add(ref _buffer.Count[714], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 709 + (int)tag;
+        var index = 715 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[736], increment);
+        Interlocked.Add(ref _buffer.Count[742], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 737 + (int)tag;
+        var index = 743 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 60;
+    public const int Length = 61;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -71,6 +71,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "waf.error",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
@@ -132,6 +133,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.WafError => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -107,6 +107,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1);
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 764;
+    private const int CountLength = 770;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -712,25 +712,32 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "success:true" }),
             new(new[] { "waf_version", "event_rules_version", "success:false" }),
             // waf.requests, index = 645
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true" }),
-            // waf.input_truncated, index = 653
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:false" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:true" }),
+            new(new[] { "waf_version", "event_rules_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:true", "waf_error:true" }),
+            // waf.input_truncated, index = 655
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 656
+            // waf.error, index = 658
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1" }),
+            // rasp.rule.eval, index = 662
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.rule.match, index = 661
+            // rasp.rule.match, index = 667
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "block:success", "rule_type:sql_injection" }),
@@ -746,29 +753,29 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "block:irrelevant", "rule_type:command_injection", "rule_variant:exec" }),
-            // rasp.timeout, index = 676
+            // rasp.timeout, index = 682
             new(new[] { "waf_version", "event_rules_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 681
+            // instrum.user_auth.missing_user_id, index = 687
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 685
+            // instrum.user_auth.missing_user_login, index = 691
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 689
+            // sdk.event, index = 695
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 694
+            // executed.source, index = 700
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -783,9 +790,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 708
+            // executed.propagation, index = 714
             new(null),
-            // executed.sink, index = 709
+            // executed.sink, index = 715
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -813,9 +820,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 736
+            // request.tainted, index = 742
             new(null),
-            // suppressed.vulnerabilities, index = 737
+            // suppressed.vulnerabilities, index = 743
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -851,7 +858,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 8, 3, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1135,71 +1142,77 @@ internal sealed partial class MetricsTelemetryCollector
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 653 + (int)tag;
+        var index = 655 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+        var index = 658 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 656 + (int)tag;
+        var index = 662 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeMatch tag, int increment = 1)
     {
-        var index = 661 + (int)tag;
+        var index = 667 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 676 + (int)tag;
+        var index = 682 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 681 + (int)tag;
+        var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 685 + (int)tag;
+        var index = 691 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 689 + (int)tag;
+        var index = 695 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 694 + (int)tag;
+        var index = 700 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[708], increment);
+        Interlocked.Add(ref _buffer.Count[714], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 709 + (int)tag;
+        var index = 715 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[736], increment);
+        Interlocked.Add(ref _buffer.Count[742], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 737 + (int)tag;
+        var index = 743 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -208,6 +208,10 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountWafError(Datadog.Trace.Telemetry.Metrics.MetricTags.WafError tag, int increment = 1)
+    {
+    }
+
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -276,6 +276,11 @@ internal enum Count
     [TelemetryMetric<MetricTags.TruncationReason>("waf.input_truncated", isCommon: true, NS.ASM)] InputTruncated,
 
     /// <summary>
+    /// Number of errors returned by a call to ddwaf_run, tagged by the ddwaf_run return code
+    /// </summary>
+    [TelemetryMetric<MetricTags.WafError>("waf.error", isCommon: true, NS.ASM)] WafError,
+
+    /// <summary>
     /// Counts the number of times a rule type is evaluated.
     /// </summary>
     [TelemetryMetric<RaspRuleType>("rasp.rule.eval", isCommon: true, NS.ASM)] RaspRuleEval,

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -412,18 +412,12 @@ internal static class MetricTags
         [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true;waf_error:false")] RuleTriggeredTruncated,
         [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:true;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true;waf_error:false")] RuleTriggeredAndBlockedTruncated,
         [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:true;block_failure:false;rate_limited:false;input_truncated:true;waf_error:false")] WafTimeoutTruncated,
-        // WAF error (any negative ddwaf_run return code, excluding timeouts)
         [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false;waf_error:true")] WafError,
         [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true;waf_error:true")] WafErrorTruncated,
     }
 
-    /// <summary>
-    /// The ddwaf_run return code of a failed WAF call. -127 is reserved for errors that originate in
-    /// the bindings rather than in ddwaf_run itself.
-    /// </summary>
     public enum WafError
     {
-        // The generator splits on ; to add multiple tags
         // CAUTION: waf_version should aways be placed in first position
         [Description("waf_version;event_rules_version;waf_error:-127")] BindingError,
         [Description("waf_version;event_rules_version;waf_error:-3")] Internal,

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -403,15 +403,32 @@ internal static class MetricTags
         // Note the initial 'waf_version'. This is an optimisation to avoid multiple array allocations
         // It is replaced with the "real" waf_version at runtime
         // CAUTION: waf_version should aways be placed in first position
-        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false")]Normal,
-        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false")]RuleTriggered,
-        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:true;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false")]RuleTriggeredAndBlocked,
-        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:true;block_failure:false;rate_limited:false;input_truncated:false")]WafTimeout,
+        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false;waf_error:false")]Normal,
+        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false;waf_error:false")]RuleTriggered,
+        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:true;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false;waf_error:false")]RuleTriggeredAndBlocked,
+        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:true;block_failure:false;rate_limited:false;input_truncated:false;waf_error:false")]WafTimeout,
         // Input truncated
-        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true")] NormalTruncated,
-        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true")] RuleTriggeredTruncated,
-        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:true;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true")] RuleTriggeredAndBlockedTruncated,
-        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:true;block_failure:false;rate_limited:false;input_truncated:true")] WafTimeoutTruncated,
+        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true;waf_error:false")] NormalTruncated,
+        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true;waf_error:false")] RuleTriggeredTruncated,
+        [Description("waf_version;event_rules_version;rule_triggered:true;request_blocked:true;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true;waf_error:false")] RuleTriggeredAndBlockedTruncated,
+        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:true;block_failure:false;rate_limited:false;input_truncated:true;waf_error:false")] WafTimeoutTruncated,
+        // WAF error (any negative ddwaf_run return code, excluding timeouts)
+        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:false;waf_error:true")] WafError,
+        [Description("waf_version;event_rules_version;rule_triggered:false;request_blocked:false;waf_timeout:false;block_failure:false;rate_limited:false;input_truncated:true;waf_error:true")] WafErrorTruncated,
+    }
+
+    /// <summary>
+    /// The ddwaf_run return code of a failed WAF call. -127 is reserved for errors that originate in
+    /// the bindings rather than in ddwaf_run itself.
+    /// </summary>
+    public enum WafError
+    {
+        // The generator splits on ; to add multiple tags
+        // CAUTION: waf_version should aways be placed in first position
+        [Description("waf_version;event_rules_version;waf_error:-127")] BindingError,
+        [Description("waf_version;event_rules_version;waf_error:-3")] Internal,
+        [Description("waf_version;event_rules_version;waf_error:-2")] InvalidObject,
+        [Description("waf_version;event_rules_version;waf_error:-1")] InvalidArgument,
     }
 
     public enum WafStatus

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/WafReturnCodeExtensions.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/WafReturnCodeExtensions.cs
@@ -1,0 +1,22 @@
+// <copyright file="WafReturnCodeExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.AppSec.Waf;
+
+namespace Datadog.Trace.Telemetry.Metrics;
+
+internal static class WafReturnCodeExtensions
+{
+    public static MetricTags.WafError? ToWafErrorTag(this WafReturnCode returnCode)
+        => returnCode switch
+        {
+            WafReturnCode.ErrorInternal => MetricTags.WafError.Internal,
+            WafReturnCode.ErrorInvalidObject => MetricTags.WafError.InvalidObject,
+            WafReturnCode.ErrorInvalidArgument => MetricTags.WafError.InvalidArgument,
+            _ => null,
+        };
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityReporterWafTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityReporterWafTelemetryTests.cs
@@ -20,7 +20,6 @@ namespace Datadog.Trace.Security.Unit.Tests;
 
 public class SecurityReporterWafTelemetryTests
 {
-    // WafReturnCode is internal, so the codes are passed as ints to keep the theory signatures public
     public static IEnumerable<object[]> ErrorCodes
         => new List<object[]>
         {
@@ -93,8 +92,6 @@ public class SecurityReporterWafTelemetryTests
 
     private static async Task<List<(string Name, string[] Tags)>> RecordAsync(IResult? result, bool isRasp)
     {
-        // A dedicated collector, rather than TelemetryFactory.Metrics, so that concurrently running
-        // tests can't leak their own WAF metrics into these assertions
         var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
         SecurityReporter.RecordWafTelemetry(result, isRasp, collector);
         await collector.DisposeAsync();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityReporterWafTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityReporterWafTelemetryTests.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests;
@@ -32,7 +33,7 @@ public class SecurityReporterWafTelemetryTests
     [MemberData(nameof(ErrorCodes))]
     public async Task GivenAFailedWafRun_WhenTheTelemetryIsRecorded_ThenBothWafErrorAndWafRequestsAreReported(int returnCode, string expectedErrorTag)
     {
-        var metrics = await RecordAsync(new MockResult(returnCode), isRasp: false);
+        var metrics = await RecordAsync(CreateResult(returnCode), isRasp: false);
 
         metrics.Should().ContainSingle(m => m.Name == "waf.error")
                .Which.Tags.Should().Contain(expectedErrorTag);
@@ -46,7 +47,7 @@ public class SecurityReporterWafTelemetryTests
     [InlineData(-1)]
     public async Task GivenAFailedRaspRun_WhenTheTelemetryIsRecorded_ThenNeitherWafErrorNorTheWafRequestsTagIsSet(int returnCode)
     {
-        var metrics = await RecordAsync(new MockResult(returnCode), isRasp: true);
+        var metrics = await RecordAsync(CreateResult(returnCode), isRasp: true);
 
         metrics.Should().NotContain(m => m.Name == "waf.error");
         metrics.Should().ContainSingle(m => m.Name == "waf.requests")
@@ -56,7 +57,7 @@ public class SecurityReporterWafTelemetryTests
     [Fact]
     public async Task GivenAFailedTruncatedWafRun_WhenTheTelemetryIsRecorded_ThenTheTruncatedTagIsUsed()
     {
-        var metrics = await RecordAsync(new MockResult(-3, truncated: true), isRasp: false);
+        var metrics = await RecordAsync(CreateResult(-3, truncated: true), isRasp: false);
 
         metrics.Should().ContainSingle(m => m.Name == "waf.requests")
                .Which.Tags.Should().Contain("waf_error:true").And.Contain("input_truncated:true");
@@ -65,7 +66,7 @@ public class SecurityReporterWafTelemetryTests
     [Fact]
     public async Task GivenATimedOutWafRun_WhenTheTelemetryIsRecorded_ThenItIsNotReportedAsAnError()
     {
-        var metrics = await RecordAsync(new MockResult(0, timeout: true), isRasp: false);
+        var metrics = await RecordAsync(CreateResult(0, timeout: true), isRasp: false);
 
         metrics.Should().NotContain(m => m.Name == "waf.error");
         metrics.Should().ContainSingle(m => m.Name == "waf.requests")
@@ -75,7 +76,7 @@ public class SecurityReporterWafTelemetryTests
     [Fact]
     public async Task GivenASuccessfulWafRun_WhenTheTelemetryIsRecorded_ThenNoErrorIsReported()
     {
-        var metrics = await RecordAsync(new MockResult(0), isRasp: false);
+        var metrics = await RecordAsync(CreateResult(0), isRasp: false);
 
         metrics.Should().NotContain(m => m.Name == "waf.error");
         metrics.Should().ContainSingle(m => m.Name == "waf.requests")
@@ -102,53 +103,12 @@ public class SecurityReporterWafTelemetryTests
             ?? [];
     }
 
-    private class MockResult : IResult
+    private static IResult CreateResult(int returnCode, bool timeout = false, bool truncated = false)
     {
-        public MockResult(int returnCode, bool timeout = false, bool truncated = false)
-        {
-            ReturnCode = (WafReturnCode)returnCode;
-            Timeout = timeout;
-            Truncated = truncated;
-        }
-
-        public WafReturnCode ReturnCode { get; }
-
-        public bool Timeout { get; }
-
-        public bool Truncated { get; }
-
-        public bool ShouldBlock => false;
-
-        public bool ShouldReportSecurityResult => false;
-
-        public Dictionary<string, object?>? BlockInfo => throw new System.NotImplementedException();
-
-        public Dictionary<string, object?>? RedirectInfo => throw new System.NotImplementedException();
-
-        public Dictionary<string, object?>? SendStackInfo => throw new System.NotImplementedException();
-
-        public IReadOnlyCollection<object>? Data => throw new System.NotImplementedException();
-
-        public Dictionary<string, object?>? Actions => throw new System.NotImplementedException();
-
-        public ulong AggregatedTotalRuntime => throw new System.NotImplementedException();
-
-        public ulong AggregatedTotalRuntimeWithBindings => throw new System.NotImplementedException();
-
-        public ulong AggregatedTotalRuntimeRasp => throw new System.NotImplementedException();
-
-        public ulong AggregatedTotalRuntimeWithBindingsRasp => throw new System.NotImplementedException();
-
-        public uint RaspRuleEvaluations => throw new System.NotImplementedException();
-
-        public Dictionary<string, object?>? ExtractSchemaDerivatives => throw new System.NotImplementedException();
-
-        public Dictionary<string, object?>? FingerprintDerivatives => throw new System.NotImplementedException();
-
-        public Dictionary<string, object?>? WafSpanAttributes => throw new System.NotImplementedException();
-
-        public bool Keep => throw new System.NotImplementedException();
-
-        public bool HasKeep => throw new System.NotImplementedException();
+        var result = new Mock<IResult>();
+        result.SetupGet(x => x.ReturnCode).Returns((WafReturnCode)returnCode);
+        result.SetupGet(x => x.Timeout).Returns(timeout);
+        result.SetupGet(x => x.Truncated).Returns(truncated);
+        return result.Object;
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityReporterWafTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityReporterWafTelemetryTests.cs
@@ -1,0 +1,157 @@
+﻿// <copyright file="SecurityReporterWafTelemetryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.AppSec.Coordinator;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+public class SecurityReporterWafTelemetryTests
+{
+    // WafReturnCode is internal, so the codes are passed as ints to keep the theory signatures public
+    public static IEnumerable<object[]> ErrorCodes
+        => new List<object[]>
+        {
+            new object[] { -3, "waf_error:-3" },
+            new object[] { -2, "waf_error:-2" },
+            new object[] { -1, "waf_error:-1" },
+        };
+
+    [Theory]
+    [MemberData(nameof(ErrorCodes))]
+    public async Task GivenAFailedWafRun_WhenTheTelemetryIsRecorded_ThenBothWafErrorAndWafRequestsAreReported(int returnCode, string expectedErrorTag)
+    {
+        var metrics = await RecordAsync(new MockResult(returnCode), isRasp: false);
+
+        metrics.Should().ContainSingle(m => m.Name == "waf.error")
+               .Which.Tags.Should().Contain(expectedErrorTag);
+        metrics.Should().ContainSingle(m => m.Name == "waf.requests")
+               .Which.Tags.Should().Contain("waf_error:true").And.Contain("input_truncated:false");
+    }
+
+    [Theory]
+    [InlineData(-3)]
+    [InlineData(-2)]
+    [InlineData(-1)]
+    public async Task GivenAFailedRaspRun_WhenTheTelemetryIsRecorded_ThenNeitherWafErrorNorTheWafRequestsTagIsSet(int returnCode)
+    {
+        var metrics = await RecordAsync(new MockResult(returnCode), isRasp: true);
+
+        metrics.Should().NotContain(m => m.Name == "waf.error");
+        metrics.Should().ContainSingle(m => m.Name == "waf.requests")
+               .Which.Tags.Should().Contain("waf_error:false");
+    }
+
+    [Fact]
+    public async Task GivenAFailedTruncatedWafRun_WhenTheTelemetryIsRecorded_ThenTheTruncatedTagIsUsed()
+    {
+        var metrics = await RecordAsync(new MockResult(-3, truncated: true), isRasp: false);
+
+        metrics.Should().ContainSingle(m => m.Name == "waf.requests")
+               .Which.Tags.Should().Contain("waf_error:true").And.Contain("input_truncated:true");
+    }
+
+    [Fact]
+    public async Task GivenATimedOutWafRun_WhenTheTelemetryIsRecorded_ThenItIsNotReportedAsAnError()
+    {
+        var metrics = await RecordAsync(new MockResult(0, timeout: true), isRasp: false);
+
+        metrics.Should().NotContain(m => m.Name == "waf.error");
+        metrics.Should().ContainSingle(m => m.Name == "waf.requests")
+               .Which.Tags.Should().Contain("waf_timeout:true").And.Contain("waf_error:false");
+    }
+
+    [Fact]
+    public async Task GivenASuccessfulWafRun_WhenTheTelemetryIsRecorded_ThenNoErrorIsReported()
+    {
+        var metrics = await RecordAsync(new MockResult(0), isRasp: false);
+
+        metrics.Should().NotContain(m => m.Name == "waf.error");
+        metrics.Should().ContainSingle(m => m.Name == "waf.requests")
+               .Which.Tags.Should().Contain("waf_error:false");
+    }
+
+    [Fact]
+    public async Task GivenNoResult_WhenTheTelemetryIsRecorded_ThenNothingIsReported()
+    {
+        var metrics = await RecordAsync(result: null, isRasp: false);
+
+        metrics.Should().BeEmpty();
+    }
+
+    private static async Task<List<(string Name, string[] Tags)>> RecordAsync(IResult? result, bool isRasp)
+    {
+        // A dedicated collector, rather than TelemetryFactory.Metrics, so that concurrently running
+        // tests can't leak their own WAF metrics into these assertions
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        SecurityReporter.RecordWafTelemetry(result, isRasp, collector);
+        await collector.DisposeAsync();
+
+        return collector.GetMetrics().Metrics?
+                        .Select(m => (m.Metric, m.Tags ?? []))
+                        .ToList()
+            ?? [];
+    }
+
+    private class MockResult : IResult
+    {
+        public MockResult(int returnCode, bool timeout = false, bool truncated = false)
+        {
+            ReturnCode = (WafReturnCode)returnCode;
+            Timeout = timeout;
+            Truncated = truncated;
+        }
+
+        public WafReturnCode ReturnCode { get; }
+
+        public bool Timeout { get; }
+
+        public bool Truncated { get; }
+
+        public bool ShouldBlock => false;
+
+        public bool ShouldReportSecurityResult => false;
+
+        public Dictionary<string, object?>? BlockInfo => throw new System.NotImplementedException();
+
+        public Dictionary<string, object?>? RedirectInfo => throw new System.NotImplementedException();
+
+        public Dictionary<string, object?>? SendStackInfo => throw new System.NotImplementedException();
+
+        public IReadOnlyCollection<object>? Data => throw new System.NotImplementedException();
+
+        public Dictionary<string, object?>? Actions => throw new System.NotImplementedException();
+
+        public ulong AggregatedTotalRuntime => throw new System.NotImplementedException();
+
+        public ulong AggregatedTotalRuntimeWithBindings => throw new System.NotImplementedException();
+
+        public ulong AggregatedTotalRuntimeRasp => throw new System.NotImplementedException();
+
+        public ulong AggregatedTotalRuntimeWithBindingsRasp => throw new System.NotImplementedException();
+
+        public uint RaspRuleEvaluations => throw new System.NotImplementedException();
+
+        public Dictionary<string, object?>? ExtractSchemaDerivatives => throw new System.NotImplementedException();
+
+        public Dictionary<string, object?>? FingerprintDerivatives => throw new System.NotImplementedException();
+
+        public Dictionary<string, object?>? WafSpanAttributes => throw new System.NotImplementedException();
+
+        public bool Keep => throw new System.NotImplementedException();
+
+        public bool HasKeep => throw new System.NotImplementedException();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="MetricsTelemetryCollectorTests.cs" company="Datadog">
+﻿// <copyright file="MetricsTelemetryCollectorTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -106,6 +106,7 @@ public class MetricsTelemetryCollectorTests
         collector.RecordCountLogCreated(MetricTags.LogLevel.Debug, 3);
         collector.RecordCountWafInit(MetricTags.WafStatus.Success, 4);
         collector.RecordCountWafRequests(MetricTags.WafAnalysis.Normal, 5);
+        collector.RecordCountWafError(MetricTags.WafError.BindingError, 7);
         collector.RecordCountRaspRuleEval(MetricTags.RaspRuleType.Lfi, 5);
         collector.RecordCountRaspRuleMatch(MetricTags.RaspRuleTypeMatch.LfiSuccess, 3);
         collector.RecordCountRaspTimeout(MetricTags.RaspRuleType.Lfi, 2);
@@ -252,7 +253,16 @@ public class MetricsTelemetryCollectorTests
                 Metric = Count.WafRequests.GetName(),
                 Points = new[] { new { Value = 5 } },
                 Type = TelemetryMetricType.Count,
-                Tags = new[] { expectedWafTag, expectedRulesetTag, "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false" },
+                Tags = new[] { expectedWafTag, expectedRulesetTag, "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "block_failure:false", "rate_limited:false", "input_truncated:false", "waf_error:false" },
+                Common = true,
+                Namespace = NS.ASM,
+            },
+            new
+            {
+                Metric = Count.WafError.GetName(),
+                Points = new[] { new { Value = 7 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { expectedWafTag, expectedRulesetTag, "waf_error:-127" },
                 Common = true,
                 Namespace = NS.ASM,
             },

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/TelemetryMetricExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/TelemetryMetricExtensionsTests.cs
@@ -5,8 +5,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Processors;
@@ -43,6 +46,9 @@ public class TelemetryMetricExtensionsTests
 
     public static IEnumerable<object[]> IntegrationIds
         => IntegrationRegistry.Ids.Values.Select(x => new object[] { x });
+
+    public static IEnumerable<object[]> WafReturnCodes
+        => GetEnums<WafReturnCode>().Select(x => new object[] { (int)x });
 
     [Theory]
     [MemberData(nameof(AllEnums))]
@@ -95,6 +101,37 @@ public class TelemetryMetricExtensionsTests
            .OnlyHaveUniqueItems();
     }
 
+    [Theory]
+    [MemberData(nameof(WafReturnCodes))]
+    public void MustHaveMetricTagForEveryWafErrorCode(int returnCode)
+    {
+        var tag = ((WafReturnCode)returnCode).ToWafErrorTag();
+
+        if (returnCode < (int)WafReturnCode.Ok)
+        {
+            tag.Should().NotBeNull("every WAF error code should map to a metric tag. Add a new entry to WafReturnCodeExtensions");
+            GetWafErrorCode(tag!.Value).Should().Be(returnCode, "the waf_error tag should report the ddwaf_run return code");
+        }
+        else
+        {
+            tag.Should().BeNull("only failed WAF runs are reported by appsec.waf.error");
+        }
+    }
+
+    [Fact]
+    public void MustHaveWafErrorCodeForEveryMetricTag()
+    {
+        var mapped = GetEnums<WafReturnCode>()
+                    .Select(x => x.ToWafErrorTag())
+                    .Where(x => x.HasValue)
+                    .Select(x => x!.Value);
+
+        GetEnums<MetricTags.WafError>()
+           .Except(new[] { MetricTags.WafError.BindingError })
+           .Should()
+           .BeSubsetOf(mapped, "every WAF error tag except the binding error should be reachable from a WafReturnCode");
+    }
+
     [Fact]
     public void MustHaveValidTagsForEveryPublicApi()
     {
@@ -141,6 +178,18 @@ public class TelemetryMetricExtensionsTests
                .OnlyContain(x => x.ToLowerInvariant() == x || (allowDebuggerGuardrailTags && DebuggerGuardrailCamelCaseTags.Contains(x)), "should use lowercase unless the debugger contract requires camelCase")
                .And.OnlyContain(x => x.Trim() == x, "should not have any whitespace")
                .And.OnlyContain(x => TraceUtil.NormalizeTag(x) == x || (allowDebuggerGuardrailTags && DebuggerGuardrailCamelCaseTags.Contains(x)), "should match the normalized version unless the debugger contract requires camelCase");
+
+    private static int GetWafErrorCode(MetricTags.WafError tag)
+    {
+        const string prefix = "waf_error:";
+        var description = typeof(MetricTags.WafError)
+                         .GetField(tag.ToString())!
+                         .GetCustomAttribute<DescriptionAttribute>()!
+                         .Description;
+
+        var value = description.Split(';').Single(x => x.StartsWith(prefix, StringComparison.Ordinal));
+        return int.Parse(value.Substring(prefix.Length), CultureInfo.InvariantCulture);
+    }
 
     private static IEnumerable<T> GetEnums<T>()
         => Enum.GetValues(typeof(T)).Cast<T>();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -842,7 +842,8 @@
         "request_excluded",
         "block_failure",
         "rate_limited",
-        "input_truncated"
+        "input_truncated",
+        "waf_error"
       ],
       "metric_type": "count",
       "data_type": "requests",
@@ -867,6 +868,18 @@
       "metric_type": "distribution",
       "data_type": "bytes",
       "description": "Un-truncated size of truncated WAF inputs",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "waf.error": {
+      "tags": [
+        "waf_version",
+        "event_rules_version",
+        "waf_error"
+      ],
+      "metric_type": "count",
+      "data_type": "errors",
+      "description": "Number of errors returned by a call to ddwaf_run",
       "send_to_user": false,
       "user_tags": []
     },

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -879,7 +879,7 @@
       ],
       "metric_type": "count",
       "data_type": "errors",
-      "description": "Number of errors returned by a call to ddwaf_run",
+      "description": "Counts the number of times the WAF returned an error when evaluating WAF addresses",
       "send_to_user": false,
       "user_tags": []
     },


### PR DESCRIPTION
## Summary of changes

Emit the `appsec.waf.error` telemetry count, and add the `waf_error` tag to `appsec.waf.requests`.

## Reason for change

`appsec.waf.error` is mandatory in the AAP telemetry RFC and the .NET tracer never emitted it, so WAF failures were invisible in telemetry (APPSEC-69702). The `waf_error` tag on `appsec.waf.requests` was missing for the same reason.

## Implementation details

- `MetricTags.WafError` — one member per `ddwaf_run` error code (`-3`, `-2`, `-1`), plus `-127` for failures that originate in the bindings rather than in `ddwaf_run`.
- `Count.WafError` (`waf.error`, namespace `appsec`).
- `MetricTags.WafAnalysis` gains `waf_error` on every member, plus `WafError`/`WafErrorTruncated`.
- `WafReturnCodeExtensions.ToWafErrorTag()` maps a `ddwaf_run` return code to its tag, next to the existing `IntegrationIdExtensions.GetMetricTag()`. It returns `null` for anything that isn't a known error code, so a future libddwaf code can't throw inside the request path; the mapping is kept in sync by tests instead.
- `SecurityReporter.RecordWafTelemetry` reports a negative return code on both metrics. Timeouts are explicitly *not* errors, per the RFC.
- `-127` is reported where the WAF was never reached: no address data, `ddwaf_subcontext_init` failure, a read-lock timeout in `Waf.CreateContext`, and the `RunWaf`/`RunWafForUser` catch blocks. A disposed WAF or context is deliberately **not** counted — that's a lifecycle event, not a WAF error, and counting it would fill the metric with shutdown races (same call as dd-trace-java, see APPSEC-69085).
- RASP runs are excluded from both metrics; `rasp.error` is tracked separately (APPSEC-69544).
- `-127` lives in `MetricTags.WafError` rather than in `WafReturnCode`, which stays a faithful mirror of libddwaf's codes.

## Test coverage

- `TelemetryMetricExtensionsTests` — every `WafReturnCode` error maps to a tag whose `waf_error` value equals the return code, non-error codes map to none, and every `MetricTags.WafError` except the binding error is reachable from a `WafReturnCode`. Verified red by mis-mapping and by deleting a mapping.
- `SecurityReporterWafTelemetryTests` — new; covers each error code, RASP exclusion, truncation, timeouts, success, and the no-result case.
- `MetricsTelemetryCollectorTests` — `waf.error` and the new `waf_error` tag.
- `common_metrics.json` updated so `MetricTests.OnlyAllowedMetricsAreSubmitted` accepts the metric. No dd-go follow-up is needed: `waf.error` and `waf_error` on `waf.requests` are already in the intake allowlist on `prod`; this repo's copy had simply drifted.

## Other details

`appsec.waf.requests` is still recorded once per WAF call rather than once per request, so `waf_error` inherits that pre-existing divergence from the RFC. Out of scope here.
