### PR TITLE
Fix IisCheckTests concurrency

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks;
 
 [Trait("Category", "LinuxUnsupported")]
+[Collection(nameof(GacTestsCollection))]
 public class IisCheckTests : ToolTestHelper
 {
     public IisCheckTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/GacTestsCollection.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/GacTestsCollection.cs
@@ -1,0 +1,14 @@
+// <copyright file="GacTestsCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Xunit;
+
+namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests;
+
+// GAC installation is machine-wide, so these tests cannot overlap any other tests.
+[CollectionDefinition(nameof(GacTestsCollection), DisableParallelization = true)]
+public class GacTestsCollection
+{
+}


### PR DESCRIPTION
## Summary of changes

Prevent the IIS artifact tests from running in parallel with other tests.

## Reason for change

The IIS tests modify the machine-wide GAC. Their setup could remove Datadog.Trace.dll while VersionConflict1X was reading its file version, causing a flaky FileNotFoundException in CI.

[Error](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=207338&view=logs&j=b3c3fdd8-5f52-57f5-d8dc-ef70b96c816b&t=15258d2a-ebbf-52c3-618d-fdfc97db216a&s=f8a5130c-15cd-53f7-2d4c-266e6256db49):

```
12:45:32 [DBG] [xUnit.net 00:00:39.66]     Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks.IisCheckTests.WorkingApp(mixedRuntimes: True) [SKIP]
12:45:32 [DBG]   Failed Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks.ProcessBasicChecksTests.VersionConflict1X [2 s]
12:45:32 [DBG]   Error Message:
12:45:32 [DBG]    Expected errorOutput "Running checks on process 7260 Process name: Samples.VersionConflict.1x  ---- STARTING TRACER SETUP CHECKS ----- Target process is running with .NET Framework 1. Checking Modules Needed so the Tracer Loads:  [SUCCESS]: The native library version 3.52.0.0 is loaded into the process. Error: System.IO.FileNotFoundException: C:\Windows\Microsoft.NET\assembly\GAC_MSIL\Datadog.Trace\v4.0_3.52.0.0__def86d06 1d0d2eeb\Datadog.Trace.dll    at System.Diagnostics.FileVersionInfo.GetVersionInfo(String fileName) + 0x72    at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext() + 0x74    at System.Linq.Enumerable.<DistinctByIterator>d__85`2.MoveNext() + 0x70    at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1) + 0x48    at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1) + 0xa6    at Datadog.Trace.Tools.dd_dotnet.Checks.ProcessBasicCheck.Run(ProcessInfo, IRegistryService) + 0x37f    at Datadog.Trace.Tools.dd_dotnet.CheckProcessCommand.<ExecuteAsync>d__2.MoveNext() + 0x142 --- End of stack trace from previous location ---    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb2    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotificat ion(Task, ConfigureAwaitOptions) + 0x4b    at System.CommandLine.Invocation.AnonymousCommandHandler.<InvokeAsync>d__6.MoveNext () + 0x1ca --- End of stack trace from previous location ---    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb2    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotificat ion(Task, ConfigureAwaitOptions) + 0x4b    at System.CommandLine.Invocation.AnonymousCommandHandler.SyncUsingAsync(InvocationC ontext) + 0x2b    at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInv ocationChain>b__0>d.MoveNext() + 0x100 --- End of stack trace from previous location ---    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb2    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotificat ion(Task, ConfigureAwaitOptions) + 0x4b    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<< UseParseErrorReporting>b__0>d.MoveNext() + 0xf2 --- End of stack trace from previous location ---    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb2    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotificat ion(Task, ConfigureAwaitOptions) + 0x4b    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass12_0.<< UseHelp>b__0>d.MoveNext() + 0xbf --- End of stack trace from previous location ---    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb2    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotificat ion(Task, ConfigureAwaitOptions) + 0x4b    at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<CancelOnProcessTer mination>b__1_0>d.MoveNext() + 0x14d --- End of stack trace from previous location ---    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb2    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotificat ion(Task, ConfigureAwaitOptions) + 0x4b    at System.CommandLine.Invocation.InvocationPipeline.<Invoke>g__FullInvocationChain| 3_0(InvocationContext) + 0x77    at Datadog.Trace.Tools.dd_dotnet.Program.Main(String[] args) + 0x2dc " to contain the strings: {"Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.", "Found multiple instances of Datadog.Trace.dll in the target process. Detected versions: 1.29.0.0 3.52.0.0 "}.
12:45:32 [DBG]   Stack Trace:
12:45:32 [DBG]      at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
12:45:32 [DBG]    at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
12:45:32 [DBG]    at FluentAssertions.Primitives.StringAssertions`1.ContainAll(IEnumerable`1 values, String because
```

## Implementation details

Assign IisCheckTests to a non-parallel xUnit collection so GAC installation and removal cannot overlap other artifact tests.

## Test coverage

Existing IIS and process-check artifact tests cover the affected paths.

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->