### PR TITLE
[Tests] Retry non-application dotnet commands after SIGSEGV

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -99,7 +99,7 @@ namespace Foo
 
             return;
 
-            Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
+            Task<string> RunDotnet(string arguments) => RunDotnetCommandWithSigSegvRetry(workingDir, agent, arguments);
         }
 
         [SkippableTheory]
@@ -139,7 +139,7 @@ namespace Foo
 
             return;
 
-            Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
+            Task<string> RunDotnet(string arguments) => RunDotnetCommandWithSigSegvRetry(workingDir, agent, arguments);
         }
 
         [SkippableTheory]
@@ -178,7 +178,7 @@ namespace Foo
 
             return;
 
-            Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
+            Task<string> RunDotnet(string arguments) => RunDotnetCommandWithSigSegvRetry(workingDir, agent, arguments);
         }
 
         [SkippableFact]
@@ -192,12 +192,12 @@ namespace Foo
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 
-            var logDir = await RunDotnet("new xunit -n instrumentation_test -o . --no-restore");
+            var logDir = await RunDotnetCommandWithSigSegvRetry(workingDir, agent, "new xunit -n instrumentation_test -o . --no-restore");
             AssertNotInstrumented(agent, logDir);
 
             // this _should_ be instrumented so we expect managed data.
             // we also expect telemetry, but we end the app so quickly there's a risk of flake
-            logDir = await RunDotnet("test");
+            logDir = await RunDotnetCommand(workingDir, agent, "test");
 
             using var scope = new AssertionScope();
             var allFiles = Directory.GetFiles(logDir);
@@ -214,8 +214,6 @@ namespace Foo
             agent.Telemetry.Should().NotBeEmpty();
 
             return;
-
-            Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
         }
 #endif
 
@@ -671,6 +669,19 @@ namespace Foo
             // Disable .NET CLI telemetry to prevent extra HTTP spans
             SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
             return RunCommand(workingDirectory, mockTracerAgent, "dotnet", arguments);
+        }
+
+        private async Task<string> RunDotnetCommandWithSigSegvRetry(string workingDirectory, MockTracerAgent mockTracerAgent, string arguments)
+        {
+            try
+            {
+                return await RunDotnetCommand(workingDirectory, mockTracerAgent, arguments);
+            }
+            catch (ExitCodeException ex) when (ex.ActualExitCode == 139)
+            {
+                Output.WriteLine($"dotnet {arguments} exited with SIGSEGV (139). Retrying once.");
+                return await RunDotnetCommand(workingDirectory, mockTracerAgent, arguments);
+            }
         }
 
         private async Task<string> RunCommand(string workingDirectory, MockTracerAgent mockTracerAgent, string exe, string arguments = null)

--- a/tracer/test/Datadog.Trace.TestHelpers/ExitCodeException.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ExitCodeException.cs
@@ -14,7 +14,10 @@ public class ExitCodeException : Exception
                    $"Expected exit code: {expectedExitCode}, actual exit code: {actualExitCode}." :
                    $"Expected exit code: {expectedExitCode}, actual exit code: {actualExitCode}. Message: {message}")
     {
+        ActualExitCode = actualExitCode;
     }
+
+    public int ActualExitCode { get; }
 
     public static void ThrowIfNonZero(int actualExitCode, string message = null)
         => ThrowIfNonExpected(actualExitCode, expectedExitCode: 0, message);


### PR DESCRIPTION
## Summary of changes

Retry non-application `dotnet` SDK commands once when they exit with SIGSEGV (139) in instrumentation tests.

## Reason for change

An intermittent .NET SDK/NuGet crash can fail tests before the generated application runs. The captured dump showed the crash in the `dotnet publish` process, after Datadog instrumentation had opted out, with the faulting stack in NuGet package-signature and X.509 trust-store handling. There were no Datadog instrumentation frames in the faulting path.

## Implementation details

Expose the actual process exit code on `ExitCodeException` and retry `dotnet new`, `restore`, `build`, and `publish` once only for exit code 139. Commands that execute instrumented application code, including `dotnet test` and direct application execution, are not retried. Other failures, including a second SIGSEGV, continue to fail normally.

## Test coverage

- Scoped `git diff --check`
- Attempted a net8.0 build; dependency resolution was blocked by missing authentication for the private Azure NuGet feed

## Other details

[Flaky CI failure](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/207434/logs/15316)
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->