### PR TITLE
LLM validation platform moved to ddoghq

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ stages:
 
 include:
   - local: .gitlab/one-pipeline.locked.yml
-  - project: 'DataDog/llm-validation-platform'
+  - project: 'ddoghq/llm-validation-platform'
     ref: 0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf   # v0.1.1 (immutable SHA; a tag could be retargeted)
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
@@ -43,6 +43,7 @@ variables:
 
 "llm validation":
   variables:
+    LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
     LLMVAL_PLATFORM_REF: "0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf"   # v0.1.1 (must match include ref above)
 
 build-windows-ci-image:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
   - For instance, prefer `is not null` to `!= null`
 - Prefer modern collection expressions (`[]`)
 - Use `StringUtil.IsNullOrEmpty()` instead of `string.IsNullOrEmpty()` for compatibility across all supported runtimes
-- StyleCop: see `tracer/stylecop.json`; address warnings before pushing
+- StyleCop: see `tracer/stylecop.json`; address warnings before pushing.
 - Never manually edit generated files (`.g.` in the file extension). Read the file header for regeneration instructions instead.
 
 **C/C++ style:**


### PR DESCRIPTION
## Summary of changes
Point the LLM validation CI gate at the migrated platform repo: `DataDog/llm-validation-platform` → `ddoghq/llm-validation-platform`.

## Reason for change
`llm-validation-platform` moved to the `ddoghq` org / ddbuild GitLab group; the old path no longer resolves.

## Implementation details
- Pinned ref (`0f48ca3`, v0.1.1) is unchanged; the SHA resolves identically on the new mirror.
- `AGENTS.md`: trivial punctuation fix (also triggers the gate to run on this PR).

## Test coverage

## Other details
