### PR TITLE
[AppSec] Send the real response status to the WAF and stop resending the request addresses

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -53,6 +53,7 @@
    </assembly>
    <assembly fullname="Microsoft.AspNetCore.Http.Features">
       <type fullname="Microsoft.AspNetCore.Http.Features.IFeatureCollection" />
+      <type fullname="Microsoft.AspNetCore.Http.Features.IHttpResponseFeature" />
       <type fullname="Microsoft.AspNetCore.Http.IHeaderDictionary" />
       <type fullname="Microsoft.AspNetCore.Http.IQueryCollection" />
       <type fullname="Microsoft.AspNetCore.Http.IRequestCookieCollection" />

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Logging;
@@ -170,10 +171,29 @@ internal partial class AppSecRequestContext
 
     private bool _isAdditiveContextDisposed;
 
+    private int _requestAddressesSent;
+
+    private int _responseScanned;
+
     private IContext? _context;
 
     internal static AppSecRequestContext CreateWithDisposedAdditiveContext()
         => new() { _isAdditiveContextDisposed = true };
+
+    /// <summary>
+    /// The WAF keeps the addresses it was given for the whole life of the context, so the request address
+    /// set only has to be supplied once: a later run of the same request re-evaluates the rules and
+    /// processors that need them against the values already stored. Returns true only for the first
+    /// caller, which is the one that has to supply them.
+    /// </summary>
+    internal bool ShouldSendRequestAddresses() => Interlocked.CompareExchange(ref _requestAddressesSent, 1, 0) == 0;
+
+    /// <summary>
+    /// Returns true only for the first caller, which is the one that has to send the response addresses.
+    /// The response start hook only exists for Kestrel and IIS, so every other server relies on the
+    /// end of request fallback, which is also what covers a response that never started.
+    /// </summary>
+    internal bool ShouldScanResponse() => Interlocked.CompareExchange(ref _responseScanned, 1, 0) == 0;
 
     /// <summary>
     /// Disposes the WAF's context stored in HttpContext.Items[]. If it doesn't exist, nothing happens, no crash

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -140,7 +140,6 @@ internal readonly partial struct SecurityCoordinator
         var addressesDictionary = new Dictionary<string, object>
         {
             { AddressesConstants.RequestMethod, request.Method },
-            { AddressesConstants.ResponseStatus, request.HttpContext.Response.StatusCode.ToString() },
             { AddressesConstants.RequestUriRaw, request.GetUrlForWaf() },
             { AddressesConstants.RequestClientIp, _localRootSpan.GetHttpClientIp() ?? _localRootSpan.GetNetworkClientIp() }
         };

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -280,6 +280,11 @@ internal readonly partial struct SecurityCoordinator
     {
         var args = new Dictionary<string, object>(3);
 
+        // ASP.NET adds its session cookie to Request.Cookies only once the session id is read, so read it
+        // before the cookies below: a request that arrived without cookies gets one just here, and the
+        // session fingerprint needs it. BlockAndReport reads the same id again to send it to the waf.
+        _ = _httpTransport.Context.Session?.SessionID;
+
         if (_httpTransport.StatusCode is { } statusCode)
         {
             args[AddressesConstants.ResponseStatus] = statusCode.ToString();
@@ -290,8 +295,6 @@ internal readonly partial struct SecurityCoordinator
             args[AddressesConstants.RequestPathParams] = pathParams;
         }
 
-        // ASP.NET adds its session cookie to Request.Cookies only once the session id is read, so a request
-        // that arrived without cookies has them just here, and the session fingerprint needs them.
         if (ExtractCookiesFromRequest(_httpTransport.Context.Request) is { } cookies)
         {
             args[AddressesConstants.RequestCookies] = cookies;

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -274,13 +274,11 @@ internal readonly partial struct SecurityCoordinator
 
     internal object? GetPathParams() => ObjectExtractor.Extract(_httpTransport.Context.Request.RequestContext.RouteData.Values);
 
-    /// <summary>
-    /// Builds the address set for the end of the request, where the response status is finally known.
-    /// The request addresses are only included if BeginRequest didn't already supply them.
-    /// </summary>
+    // The WAF context keeps the request addresses BeginRequest already sent, so this only carries what
+    // wasn't available back then.
     internal Dictionary<string, object> GetEndRequestArgsForWaf()
     {
-        var args = CollectRequestArgsForWaf();
+        var args = new Dictionary<string, object>(3);
 
         if (_httpTransport.StatusCode is { } statusCode)
         {
@@ -292,9 +290,8 @@ internal readonly partial struct SecurityCoordinator
             args[AddressesConstants.RequestPathParams] = pathParams;
         }
 
-        // ASP.NET puts its session cookie in Request.Cookies as soon as the session id is read, which is
-        // what this call itself does, so the cookies of a request that arrived without any are only
-        // available here. They have to be sent again for the session fingerprint to be built out of them.
+        // ASP.NET adds its session cookie to Request.Cookies only once the session id is read, so a request
+        // that arrived without cookies has them just here, and the session fingerprint needs them.
         if (ExtractCookiesFromRequest(_httpTransport.Context.Request) is { } cookies)
         {
             args[AddressesConstants.RequestCookies] = cookies;

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -280,9 +280,10 @@ internal readonly partial struct SecurityCoordinator
     {
         var args = new Dictionary<string, object>(3);
 
-        // ASP.NET adds its session cookie to Request.Cookies only once the session id is read, so read it
-        // before the cookies below: a request that arrived without cookies gets one just here, and the
-        // session fingerprint needs it. BlockAndReport reads the same id again to send it to the waf.
+        // ASP.NET puts its session cookie in Request.Cookies only once the session id is read, which
+        // SessionStateModule normally does at AcquireRequestState, long before this. This read is the guard
+        // for the hosts where that hasn't happened: it has to come before the cookies below, or the cookie
+        // halves of the session fingerprint go empty. BlockAndReport reads the same id again for the waf.
         _ = _httpTransport.Context.Session?.SessionID;
 
         if (_httpTransport.StatusCode is { } statusCode)

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -275,6 +275,35 @@ internal readonly partial struct SecurityCoordinator
     internal object? GetPathParams() => ObjectExtractor.Extract(_httpTransport.Context.Request.RequestContext.RouteData.Values);
 
     /// <summary>
+    /// Builds the address set for the end of the request, where the response status is finally known.
+    /// The request addresses are only included if BeginRequest didn't already supply them.
+    /// </summary>
+    internal Dictionary<string, object> GetEndRequestArgsForWaf()
+    {
+        var args = CollectRequestArgsForWaf();
+
+        if (_httpTransport.StatusCode is { } statusCode)
+        {
+            args[AddressesConstants.ResponseStatus] = statusCode.ToString();
+        }
+
+        if (GetPathParams() is { } pathParams)
+        {
+            args[AddressesConstants.RequestPathParams] = pathParams;
+        }
+
+        // ASP.NET puts its session cookie in Request.Cookies as soon as the session id is read, which is
+        // what this call itself does, so the cookies of a request that arrived without any are only
+        // available here. They have to be sent again for the session fingerprint to be built out of them.
+        if (ExtractCookiesFromRequest(_httpTransport.Context.Request) is { } cookies)
+        {
+            args[AddressesConstants.RequestCookies] = cookies;
+        }
+
+        return args;
+    }
+
+    /// <summary>
     /// Framework can do it all at once, but framework only unfortunately
     /// </summary>
     internal void BlockAndReport(Dictionary<string, object> args, bool lastWafCall = false, bool isInHttpTracingModule = false)
@@ -449,10 +478,9 @@ internal readonly partial struct SecurityCoordinator
             }
         }
 
-        var dict = new Dictionary<string, object>(capacity: 7)
+        var dict = new Dictionary<string, object>(capacity: 6)
         {
             { AddressesConstants.RequestMethod, request.HttpMethod },
-            { AddressesConstants.ResponseStatus, request.RequestContext.HttpContext.Response.StatusCode.ToString() },
             { AddressesConstants.RequestClientIp, _localRootSpan.GetHttpClientIp() ?? _localRootSpan.GetNetworkClientIp() }
         };
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -1,4 +1,4 @@
-// <copyright file="SecurityCoordinator.cs" company="Datadog">
+﻿// <copyright file="SecurityCoordinator.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -43,9 +43,27 @@ internal readonly partial struct SecurityCoordinator
 
     public IResult? Scan(bool lastTime = false)
     {
-        var args = GetBasicRequestArgsForWaf();
-        return RunWaf(args, lastTime);
+        var args = CollectRequestArgsForWaf();
+
+        if (lastTime && _httpTransport.StatusCode is { } statusCode)
+        {
+            args[AddressesConstants.ResponseStatus] = statusCode.ToString();
+        }
+
+        return args.Count > 0 ? RunWaf(args, lastTime) : null;
     }
+
+    /// <summary>
+    /// Returns the request address set the first time it is called for a request, and an empty set
+    /// afterwards, so that a second run doesn't pay for re-evaluating every request rule. The context
+    /// check comes first so the addresses aren't marked as sent when there is no store to keep them.
+    /// </summary>
+    internal Dictionary<string, object> CollectRequestArgsForWaf() =>
+        _appsecRequestContext.GetOrCreateAdditiveContext(_security) is not null && _appsecRequestContext.ShouldSendRequestAddresses()
+            ? GetBasicRequestArgsForWaf()
+            : new Dictionary<string, object>(3);
+
+    internal bool ShouldScanResponse() => _appsecRequestContext.ShouldScanResponse();
 
     public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, string? sessionId = null, string? raspAddress = null)
     {

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -53,8 +53,10 @@ internal readonly partial struct SecurityCoordinator
         return args.Count > 0 ? RunWaf(args, lastTime) : null;
     }
 
-    // Returns the request addresses once per request, an empty set afterwards. The context check comes
-    // first so they aren't marked as sent when there is no store to keep them.
+    // Core request-phase collection: returns the request addresses to the first scan of the request and an
+    // empty set to the following ones (Framework doesn't go through here, it refreshes them on every
+    // BeginRequest). The context check comes first so they aren't marked as sent when there is no store to
+    // keep them.
     internal Dictionary<string, object> CollectRequestArgsForWaf() =>
         _appsecRequestContext.GetOrCreateAdditiveContext(_security) is not null && _appsecRequestContext.ShouldSendRequestAddresses()
             ? GetBasicRequestArgsForWaf()

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -53,11 +53,8 @@ internal readonly partial struct SecurityCoordinator
         return args.Count > 0 ? RunWaf(args, lastTime) : null;
     }
 
-    /// <summary>
-    /// Returns the request address set the first time it is called for a request, and an empty set
-    /// afterwards, so that a second run doesn't pay for re-evaluating every request rule. The context
-    /// check comes first so the addresses aren't marked as sent when there is no store to keep them.
-    /// </summary>
+    // Returns the request addresses once per request, an empty set afterwards. The context check comes
+    // first so they aren't marked as sent when there is no store to keep them.
     internal Dictionary<string, object> CollectRequestArgsForWaf() =>
         _appsecRequestContext.GetOrCreateAdditiveContext(_security) is not null && _appsecRequestContext.ShouldSendRequestAddresses()
             ? GetBasicRequestArgsForWaf()

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -69,13 +69,9 @@ internal static class SecurityCoordinatorHelpers
         }
     }
 
-    /// <summary>
-    /// Last chance to run the WAF against the response for servers where the response start hook doesn't
-    /// exist, like HTTP.sys: without it the real response status never reaches the WAF. The response is
-    /// already on the wire by now, so a block action can only be reported, not applied.
-    /// A response that hasn't started yet is left to the hook, which still gets to run after the pipeline
-    /// and can block, unless the server is known not to have one.
-    /// </summary>
+    // Last chance to send the response status on servers with no response start hook, like HTTP.sys. The
+    // response is already on the wire, so a block can only be reported. A response that hasn't started is
+    // left to the hook, which runs after the pipeline and can still block.
     internal static void CheckResponseAtRequestEnd(this in SecurityCoordinator securityCoordinator, HttpContext httpContext)
     {
         try
@@ -107,11 +103,8 @@ internal static class SecurityCoordinatorHelpers
         }
     }
 
-    /// <summary>
-    /// Only HTTP.sys is checked here, and only positively: FireOnStarting is instrumented for Kestrel and
-    /// IIS, and any other server is left with the previous behaviour rather than risking that this runs
-    /// before a hook that would have been able to block.
-    /// </summary>
+    // Only HTTP.sys, and only positively: any other server keeps the previous behaviour rather than
+    // risking that this runs before a hook that would have been able to block.
     internal static bool HasNoResponseStartHook(string? responseFeatureTypeName) =>
         responseFeatureTypeName?.StartsWith("Microsoft.AspNetCore.Server.HttpSys.", StringComparison.Ordinal) == true;
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Routing;
 
@@ -47,18 +48,12 @@ internal static class SecurityCoordinatorHelpers
                 if (!transport.IsBlocked)
                 {
                     var securityCoordinator = SecurityCoordinator.Get(security, span, transport);
-
-                    var args = new Dictionary<string, object>
+                    if (!securityCoordinator.ShouldScanResponse())
                     {
-                        { AddressesConstants.ResponseStatus, httpContext.Response.StatusCode.ToString() },
-                    };
-
-                    var extractedHeaders = SecurityCoordinator.ExtractHeadersFromRequest(headers);
-                    if (extractedHeaders is not null)
-                    {
-                        args.Add(AddressesConstants.ResponseHeaderNoCookies, extractedHeaders);
+                        return;
                     }
 
+                    var args = BuildResponseArgs(httpContext.Response.StatusCode, headers);
                     var result = securityCoordinator.RunWaf(args, true);
                     securityCoordinator.BlockAndReport(result);
                 }
@@ -72,6 +67,64 @@ internal static class SecurityCoordinatorHelpers
         {
             Log.Error(ex, "Error extracting HTTP headers to create header tags.");
         }
+    }
+
+    /// <summary>
+    /// Last chance to run the WAF against the response for servers where the response start hook doesn't
+    /// exist, like HTTP.sys: without it the real response status never reaches the WAF. The response is
+    /// already on the wire by now, so a block action can only be reported, not applied.
+    /// A response that hasn't started yet is left to the hook, which still gets to run after the pipeline
+    /// and can block, unless the server is known not to have one.
+    /// </summary>
+    internal static void CheckResponseAtRequestEnd(this in SecurityCoordinator securityCoordinator, HttpContext httpContext)
+    {
+        try
+        {
+            if (securityCoordinator.IsBlocked)
+            {
+                return;
+            }
+
+            if (!httpContext.Response.HasStarted && !HasNoResponseStartHook(httpContext.Features.Get<IHttpResponseFeature>()?.GetType().FullName))
+            {
+                return;
+            }
+
+            if (!securityCoordinator.ShouldScanResponse())
+            {
+                return;
+            }
+
+            var args = BuildResponseArgs(httpContext.Response.StatusCode, httpContext.Response.Headers);
+            if (securityCoordinator.RunWaf(args, true) is { } result)
+            {
+                securityCoordinator.Reporter.TryReport(result, blocked: false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error running the security checks on the response at the end of the request.");
+        }
+    }
+
+    /// <summary>
+    /// Only HTTP.sys is checked here, and only positively: FireOnStarting is instrumented for Kestrel and
+    /// IIS, and any other server is left with the previous behaviour rather than risking that this runs
+    /// before a hook that would have been able to block.
+    /// </summary>
+    internal static bool HasNoResponseStartHook(string? responseFeatureTypeName) =>
+        responseFeatureTypeName?.StartsWith("Microsoft.AspNetCore.Server.HttpSys.", StringComparison.Ordinal) == true;
+
+    private static Dictionary<string, object> BuildResponseArgs(int statusCode, IHeaderDictionary headers)
+    {
+        var args = new Dictionary<string, object>(2) { { AddressesConstants.ResponseStatus, statusCode.ToString() } };
+
+        if (SecurityCoordinator.ExtractHeadersFromRequest(headers) is { } extractedHeaders)
+        {
+            args.Add(AddressesConstants.ResponseHeaderNoCookies, extractedHeaders);
+        }
+
+        return args;
     }
 
     internal static void CheckPathParamsAndSessionId(this Security security, HttpContext context, Span span, IDictionary<string, object> pathParams)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -242,7 +242,7 @@ namespace Datadog.Trace.AspNet
                     securityCoordinator.Reporter.ReportWafInitInfoOnce(security.WafInitResult);
 
                     // request args
-                    var args = securityCoordinator.CollectRequestArgsForWaf();
+                    var args = securityCoordinator.GetBasicRequestArgsForWaf();
 
                     // body args
                     if (httpRequest.ContentType?.IndexOf("application/x-www-form-urlencoded", StringComparison.InvariantCultureIgnoreCase) >= 0)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -242,7 +242,7 @@ namespace Datadog.Trace.AspNet
                     securityCoordinator.Reporter.ReportWafInitInfoOnce(security.WafInitResult);
 
                     // request args
-                    var args = securityCoordinator.GetBasicRequestArgsForWaf();
+                    var args = securityCoordinator.CollectRequestArgsForWaf();
 
                     // body args
                     if (httpRequest.ContentType?.IndexOf("application/x-www-form-urlencoded", StringComparison.InvariantCultureIgnoreCase) >= 0)
@@ -320,8 +320,7 @@ namespace Datadog.Trace.AspNet
                         if (security.AppsecEnabled)
                         {
                             var securityCoordinator = SecurityCoordinator.Get(security, rootSpan, app.Context);
-                            var args = securityCoordinator.GetBasicRequestArgsForWaf();
-                            args.Add(AddressesConstants.RequestPathParams, securityCoordinator.GetPathParams());
+                            var args = securityCoordinator.GetEndRequestArgsForWaf();
 
                             if (HttpRuntime.UsingIntegratedPipeline && _canAccessHttpHeaders)
                             {

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -291,6 +291,7 @@ namespace Datadog.Trace.PlatformHelpers
                 if (security.AppsecEnabled)
                 {
                     var securityCoordinator = SecurityCoordinator.Get(security, span, new SecurityCoordinator.HttpTransport(httpContext));
+                    securityCoordinator.CheckResponseAtRequestEnd(httpContext);
                     securityCoordinator.Reporter.AddResponseHeadersToSpan();
                 }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ResponseStartHookTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ResponseStartHookTests.cs
@@ -1,0 +1,30 @@
+// <copyright file="ResponseStartHookTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+#if !NETFRAMEWORK
+using Datadog.Trace.AppSec.Coordinator;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+/// <summary>
+/// The end of the pipeline only scans the response by itself on servers that never fire the instrumented
+/// response start hook, and those are recognised by the type of their IHttpResponseFeature. Getting this
+/// wrong either loses the response status (HTTP.sys) or runs before a hook that could have blocked.
+/// </summary>
+public class ResponseStartHookTests
+{
+    [Theory]
+    [InlineData("Microsoft.AspNetCore.Server.HttpSys.FeatureContext", true)]
+    [InlineData("Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol", false)]
+    [InlineData("Microsoft.AspNetCore.Server.IIS.Core.IISHttpContext", false)]
+    [InlineData("Microsoft.AspNetCore.TestHost.ClientHandler+RequestState", false)]
+    [InlineData(null, false)]
+    public void GivenAResponseFeature_WhenItsServerIsChecked_ThenOnlyHttpSysHasNoStartHook(string? responseFeatureTypeName, bool expected)
+        => SecurityCoordinatorHelpers.HasNoResponseStartHook(responseFeatureTypeName).Should().Be(expected);
+}
+#endif

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorAddressesTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorAddressesTests.cs
@@ -1,0 +1,142 @@
+﻿// <copyright file="SecurityCoordinatorAddressesTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Coordinator;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Security.Unit.Tests.Utils;
+using FluentAssertions;
+#if NETFRAMEWORK
+using System.IO;
+using System.Web;
+using System.Web.Routing;
+#else
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+#endif
+using Moq;
+using Xunit;
+using static Datadog.Trace.AppSec.Coordinator.SecurityCoordinator;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+/// <summary>
+/// Who sends which address to the WAF, and when. The request addresses go out once per request and the
+/// response status only when the response is actually known, so these pin the coordinator side of it
+/// rather than what the WAF makes of it.
+/// </summary>
+public class SecurityCoordinatorAddressesTests : WafLibraryRequiredTest
+{
+    [Fact]
+    public void GivenARequestContext_WhenTheRequestAddressesAreClaimedTwice_ThenOnlyTheFirstCallerSendsThem()
+    {
+        var appsecRequestContext = new AppSecRequestContext();
+
+        appsecRequestContext.ShouldSendRequestAddresses().Should().BeTrue();
+        appsecRequestContext.ShouldSendRequestAddresses().Should().BeFalse();
+    }
+
+    [Fact]
+    public void GivenARequestContext_WhenTheResponseScanIsClaimedTwice_ThenOnlyTheFirstCallerScansIt()
+    {
+        var appsecRequestContext = new AppSecRequestContext();
+
+        appsecRequestContext.ShouldScanResponse().Should().BeTrue();
+        appsecRequestContext.ShouldScanResponse().Should().BeFalse();
+    }
+
+#if !NETFRAMEWORK
+    [Fact]
+    public void GivenACoreRequest_WhenItIsScannedSeveralTimes_ThenTheAddressesGoOutOnceAndTheStatusOnlyAtTheEnd()
+    {
+        var runs = new List<Dictionary<string, object>>();
+        var wafContext = new Mock<IContext>();
+        wafContext.Setup(x => x.Run(It.IsAny<IDictionary<string, object>>(), It.IsAny<ulong>()))
+                  .Callback<IDictionary<string, object>, ulong>((args, _) => runs.Add(new Dictionary<string, object>(args)));
+        var waf = new Mock<IWaf>();
+        waf.Setup(x => x.CreateContext()).Returns(wafContext.Object);
+        waf.Setup(x => x.GetKnownAddresses()).Returns([]);
+
+        using var security = new AppSec.Security(waf: waf.Object);
+        var securityCoordinator = Get(security, CreateWebSpan(), new HttpTransport(CreateCoreHttpContext(statusCode: 404)));
+
+        securityCoordinator.Scan();
+        securityCoordinator.Scan();
+        securityCoordinator.Scan(lastTime: true);
+
+        runs.Should().HaveCount(2);
+        runs[0].Should().Contain(AddressesConstants.RequestMethod, "GET").And.NotContainKey(AddressesConstants.ResponseStatus);
+        runs[1].Should().Contain(AddressesConstants.ResponseStatus, "404").And.NotContainKey(AddressesConstants.RequestMethod);
+    }
+#else
+    [Fact]
+    public void GivenAFrameworkRequest_WhenTheRequestStarts_ThenNoResponseStatusIsSent()
+    {
+        var securityCoordinator = GetFrameworkCoordinator(statusCode: 404, out _);
+
+        securityCoordinator.GetBasicRequestArgsForWaf().Should().NotContainKey(AddressesConstants.ResponseStatus);
+    }
+
+    [Fact]
+    public void GivenAFrameworkRequest_WhenTheRequestEnds_ThenTheRealStatusAndTheLateAddressesAreSent()
+    {
+        var securityCoordinator = GetFrameworkCoordinator(statusCode: 404, out var routeValues);
+        routeValues.Add("controller", "home");
+
+        var args = securityCoordinator.GetEndRequestArgsForWaf();
+
+        args.Should().Contain(AddressesConstants.ResponseStatus, "404");
+        args[AddressesConstants.RequestPathParams].Should().BeEquivalentTo(new Dictionary<string, object> { { "controller", "home" } });
+        args[AddressesConstants.RequestCookies].Should().BeEquivalentTo(new Dictionary<string, object> { { "sid", "abc" } });
+    }
+#endif
+
+    private static Span CreateWebSpan()
+    {
+        var traceContext = new TraceContext(new EmptyDatadogTracer());
+        var spanContext = new SpanContext(parent: null, traceContext, serviceName: "My Service Name", traceId: (TraceId)100, spanId: 200);
+        return new Span(spanContext, DateTimeOffset.Now);
+    }
+
+#if !NETFRAMEWORK
+    private static HttpContext CreateCoreHttpContext(int statusCode)
+    {
+        var headers = new Mock<IHeaderDictionary>();
+        headers.Setup(x => x.Keys).Returns([]);
+
+        var request = new Mock<HttpRequest>();
+        request.Setup(x => x.Method).Returns("GET");
+        request.Setup(x => x.Path).Returns(new PathString("/etc/passwd"));
+        request.Setup(x => x.Headers).Returns(headers.Object);
+
+        var response = new Mock<HttpResponse>();
+        response.Setup(x => x.StatusCode).Returns(statusCode);
+
+        var routing = new Mock<IRoutingFeature>();
+        routing.Setup(x => x.RouteData).Returns(new RouteData());
+
+        var context = new Mock<HttpContext>();
+        context.Setup(x => x.Request).Returns(request.Object);
+        context.Setup(x => x.Response).Returns(response.Object);
+        context.Setup(x => x.Features[typeof(IRoutingFeature)]).Returns(routing.Object);
+        return context.Object;
+    }
+#else
+    private static SecurityCoordinator GetFrameworkCoordinator(int statusCode, out RouteValueDictionary routeValues)
+    {
+        var request = new HttpRequest("file", "http://localhost/benchmarks", "data=param");
+        request.Cookies.Add(new HttpCookie("sid", "abc"));
+        var response = new HttpResponse(new StringWriter()) { StatusCode = statusCode };
+        var context = new HttpContext(request, response);
+        var routeData = new RouteData();
+        routeValues = routeData.Values;
+        request.RequestContext = new RequestContext(new HttpContextWrapper(context), routeData);
+
+        return Get(new AppSec.Security(), CreateWebSpan(), new HttpTransport(context));
+    }
+#endif
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorAddressesTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorAddressesTests.cs
@@ -58,7 +58,9 @@ public class SecurityCoordinatorAddressesTests
         wafContext.Setup(x => x.Run(It.IsAny<IDictionary<string, object>>(), It.IsAny<ulong>()))
                   .Callback<IDictionary<string, object>, ulong>((args, _) => runs.Add(new Dictionary<string, object>(args)));
         var waf = new Mock<IWaf>();
-        waf.Setup(x => x.CreateContext()).Returns(wafContext.Object);
+        // Moq assigns the value the out argument held when the setup was recorded
+        var outcome = WafOutcome.Success;
+        waf.Setup(x => x.CreateContext(out outcome, It.IsAny<bool>())).Returns(wafContext.Object);
         waf.Setup(x => x.GetKnownAddresses()).Returns([]);
 
         using var security = new AppSec.Security(waf: waf.Object);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorAddressesTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorAddressesTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.AppSec.Waf;
-using Datadog.Trace.Security.Unit.Tests.Utils;
 using FluentAssertions;
 #if NETFRAMEWORK
 using System.IO;
@@ -25,11 +24,12 @@ using static Datadog.Trace.AppSec.Coordinator.SecurityCoordinator;
 namespace Datadog.Trace.Security.Unit.Tests;
 
 /// <summary>
-/// Who sends which address to the WAF, and when. The request addresses go out once per request and the
-/// response status only when the response is actually known, so these pin the coordinator side of it
-/// rather than what the WAF makes of it.
+/// Who sends which address to the WAF, and when: on ASP.NET Core the request addresses go out once per
+/// request (Framework refreshes them on every BeginRequest), and the response status only once the
+/// response is actually known. The WAF itself is mocked here, this is the coordinator side of it.
 /// </summary>
-public class SecurityCoordinatorAddressesTests : WafLibraryRequiredTest
+[Collection(nameof(SecuritySequentialTests))]
+public class SecurityCoordinatorAddressesTests
 {
     [Fact]
     public void GivenARequestContext_WhenTheRequestAddressesAreClaimedTwice_ThenOnlyTheFirstCallerSendsThem()

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="WafAddressReuseTests.cs" company="Datadog">
+﻿// <copyright file="WafAddressReuseTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -12,8 +12,9 @@ using Xunit;
 namespace Datadog.Trace.Security.Unit.Tests;
 
 /// <summary>
-/// Pins what a later WAF run of the same request has to re-supply: the tracer sends the whole
-/// request address set again on its last call, and these tests say whether that is necessary.
+/// The tracer now sends each request address to the WAF once, so a later run of the same request only
+/// carries what changed. These tests pin what that costs: what the WAF still derives from the addresses
+/// of an earlier run, and what genuinely has to be re-supplied.
 /// </summary>
 public class WafAddressReuseTests : WafLibraryRequiredTest
 {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
@@ -1,0 +1,101 @@
+// <copyright file="WafAddressReuseTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.Security.Unit.Tests.Utils;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+/// <summary>
+/// Pins what a later WAF run of the same request has to re-supply: the tracer sends the whole
+/// request address set again on its last call, and these tests say whether that is necessary.
+/// </summary>
+public class WafAddressReuseTests : WafLibraryRequiredTest
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenSchemaExtractionOnTheLastRun_WhenRequestAddressesAreNotResupplied_ThenSchemasAreStillProduced(bool resupplyRequestAddresses)
+    {
+        using var waf = CreateWaf().Waf;
+        using var context = waf.CreateContext();
+
+        context.Run(RequestArgs(), TimeoutMicroSeconds).Should().NotBeNull();
+
+        var lastArgs = resupplyRequestAddresses ? RequestArgs() : new Dictionary<string, object>();
+        lastArgs[AddressesConstants.ResponseStatus] = "404";
+        lastArgs[AddressesConstants.WafContextProcessor] = new Dictionary<string, bool> { { "extract-schema", true } };
+
+        var result = context.Run(lastArgs, TimeoutMicroSeconds);
+
+        result.Should().NotBeNull();
+        result.ExtractSchemaDerivatives.Should().ContainKeys(
+            "_dd.appsec.s.req.query",
+            "_dd.appsec.s.req.headers",
+            "_dd.appsec.s.req.cookies",
+            "_dd.appsec.s.req.body");
+    }
+
+    /// <summary>
+    /// ASP.NET only puts its session cookie in Request.Cookies once the session id has been read, which
+    /// happens on the last WAF call of the request, so a request that arrived without cookies has none to
+    /// send at the beginning and does have one to send at the end. Not re-reading them there is what
+    /// empties the cookie halves of the session fingerprint.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GivenARequestWithoutCookies_WhenCookiesShowUpForTheLastRun_ThenOnlySendingThemFillsTheSessionFingerprint(bool sendLateCookies)
+    {
+        using var waf = CreateWaf().Waf;
+        using var context = waf.CreateContext();
+
+        var firstArgs = RequestArgs();
+        firstArgs.Remove(AddressesConstants.RequestCookies);
+        context.Run(firstArgs, TimeoutMicroSeconds).Should().NotBeNull();
+
+        var lastArgs = new Dictionary<string, object> { { AddressesConstants.ResponseStatus, "404" }, { AddressesConstants.UserSessionId, "session-1234" } };
+        if (sendLateCookies)
+        {
+            lastArgs[AddressesConstants.RequestCookies] = new Dictionary<string, string> { { "ASP.NET_SessionId", "session-1234" } };
+        }
+
+        var result = context.Run(lastArgs, TimeoutMicroSeconds);
+
+        result.Should().NotBeNull();
+        result.FingerprintDerivatives.Should().ContainKey("_dd.appsec.fp.session");
+
+        // ssn-<user id hash>-<cookie fields hash>-<cookie values hash>-<session id hash>
+        var parts = result.FingerprintDerivatives["_dd.appsec.fp.session"].ToString().Split('-');
+        parts.Should().HaveCount(5);
+        parts[4].Should().NotBeEmpty("the session id hash comes from usr.session_id");
+
+        if (sendLateCookies)
+        {
+            parts[2].Should().NotBeEmpty("the cookie fields hash comes from server.request.cookies");
+            parts[3].Should().NotBeEmpty("the cookie values hash comes from server.request.cookies");
+        }
+        else
+        {
+            parts[2].Should().BeEmpty();
+            parts[3].Should().BeEmpty();
+        }
+    }
+
+    private static Dictionary<string, object> RequestArgs() =>
+        new()
+        {
+            { AddressesConstants.RequestMethod, "POST" },
+            { AddressesConstants.RequestUriRaw, "http://localhost:54587/api/values" },
+            { AddressesConstants.RequestClientIp, "10.0.0.1" },
+            { AddressesConstants.RequestQuery, new Dictionary<string, string[]> { { "q", ["fun"] } } },
+            { AddressesConstants.RequestHeaderNoCookies, new Dictionary<string, string> { { "content-type", "application/json" } } },
+            { AddressesConstants.RequestCookies, new Dictionary<string, string> { { "sid", "abc" } } },
+            { AddressesConstants.RequestBody, new Dictionary<string, object> { { "property1", "value1" }, { "property2", 3 } } },
+        };
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
@@ -25,7 +25,7 @@ public class WafAddressReuseTests : WafLibraryRequiredTest
     public void GivenSchemaExtractionOnTheLastRun_WhenRequestAddressesAreNotResupplied_ThenSchemasAreStillProduced(bool resupplyRequestAddresses)
     {
         using var waf = CreateWaf().Waf;
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
 
         context.Run(RequestArgs(), TimeoutMicroSeconds).Should().NotBeNull();
 
@@ -54,7 +54,7 @@ public class WafAddressReuseTests : WafLibraryRequiredTest
     public void GivenARequestWithoutCookies_WhenCookiesShowUpForTheLastRun_ThenOnlySendingThemFillsTheSessionFingerprint(bool sendLateCookies)
     {
         using var waf = CreateWaf().Waf;
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
 
         var firstArgs = RequestArgs();
         firstArgs.Remove(AddressesConstants.RequestCookies);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafAddressReuseTests.cs
@@ -12,9 +12,10 @@ using Xunit;
 namespace Datadog.Trace.Security.Unit.Tests;
 
 /// <summary>
-/// The tracer now sends each request address to the WAF once, so a later run of the same request only
-/// carries what changed. These tests pin what that costs: what the WAF still derives from the addresses
-/// of an earlier run, and what genuinely has to be re-supplied.
+/// On ASP.NET Core the tracer now sends each request address to the WAF once, so a later run of the same
+/// request only carries what changed (Framework keeps re-sending them on every BeginRequest). These tests
+/// pin what that costs at the WAF level: what it still derives from the addresses of an earlier run, and
+/// what genuinely has to be re-supplied.
 /// </summary>
 public class WafAddressReuseTests : WafLibraryRequiredTest
 {
@@ -43,10 +44,9 @@ public class WafAddressReuseTests : WafLibraryRequiredTest
     }
 
     /// <summary>
-    /// ASP.NET only puts its session cookie in Request.Cookies once the session id has been read, which
-    /// happens on the last WAF call of the request, so a request that arrived without cookies has none to
-    /// send at the beginning and does have one to send at the end. Not re-reading them there is what
-    /// empties the cookie halves of the session fingerprint.
+    /// A cookie that only becomes available after the first run has to be re-supplied on a later one for
+    /// the session fingerprint to be complete: the WAF doesn't fill the cookie halves of
+    /// _dd.appsec.fp.session from a set of cookies it was never given.
     /// </summary>
     [Theory]
     [InlineData(true)]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafResponseStatusTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafResponseStatusTests.cs
@@ -37,11 +37,22 @@ public class WafResponseStatusTests : WafLibraryRequiredTest
         using var waf = CreateWaf().Waf;
         using var context = waf.CreateContext();
 
-        // the request-phase address set carries HttpContext.Response.StatusCode, still 200 at that point;
-        // re-supplying a persistent address replaces it and re-marks it as new, so the value does not latch
+        // re-supplying a persistent address replaces it and re-marks it as new, so 200 does not latch
         context.Run(RequestArgs(status: "200"), TimeoutMicroSeconds).Should().NotBeNull();
 
         MatchedRules(context.Run(ResponseArgs("404"), TimeoutMicroSeconds)).Should().Contain(ScannerRule);
+    }
+
+    [Fact]
+    public void GivenAScannerRequest_WhenTheStatusIsSentTwice_ThenTheRuleMatchesOnce()
+    {
+        using var waf = CreateWaf().Waf;
+        using var context = waf.CreateContext();
+
+        context.Run(RequestArgs(status: null), TimeoutMicroSeconds).Should().NotBeNull();
+        MatchedRules(context.Run(new Dictionary<string, object> { { AddressesConstants.ResponseStatus, "404" } }, TimeoutMicroSeconds)).Should().Contain(ScannerRule);
+
+        MatchedRules(context.Run(ResponseArgs("404"), TimeoutMicroSeconds)).Should().NotContain(ScannerRule);
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafResponseStatusTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafResponseStatusTests.cs
@@ -1,0 +1,90 @@
+// <copyright file="WafResponseStatusTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
+using Datadog.Trace.Security.Unit.Tests.Utils;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+public class WafResponseStatusTests : WafLibraryRequiredTest
+{
+    private const string ScannerRule = "nfd-000-001";
+    private const string ScannerUrl = "http://localhost:54587/etc/passwd";
+
+    [Fact]
+    public void GivenAScannerRequest_WhenTheStatusIsSentOnlyAtResponseTime_ThenTheRuleMatches()
+    {
+        using var waf = CreateWaf().Waf;
+        using var context = waf.CreateContext();
+
+        context.Run(RequestArgs(status: null), TimeoutMicroSeconds).Should().NotBeNull();
+
+        MatchedRules(context.Run(ResponseArgs("404"), TimeoutMicroSeconds)).Should().Contain(ScannerRule);
+    }
+
+    [Fact]
+    public void GivenAScannerRequest_WhenTheRequestPhaseFabricatesA200Status_ThenTheResponsePhaseStillMatches()
+    {
+        using var waf = CreateWaf().Waf;
+        using var context = waf.CreateContext();
+
+        // the request-phase address set carries HttpContext.Response.StatusCode, still 200 at that point;
+        // re-supplying a persistent address replaces it and re-marks it as new, so the value does not latch
+        context.Run(RequestArgs(status: "200"), TimeoutMicroSeconds).Should().NotBeNull();
+
+        MatchedRules(context.Run(ResponseArgs("404"), TimeoutMicroSeconds)).Should().Contain(ScannerRule);
+    }
+
+    [Fact]
+    public void GivenAScannerRequest_WhenTheRealStatusIsNeverSent_ThenTheRuleNeverMatches()
+    {
+        using var waf = CreateWaf().Waf;
+        using var context = waf.CreateContext();
+
+        MatchedRules(context.Run(RequestArgs(status: "200"), TimeoutMicroSeconds)).Should().NotContain(ScannerRule);
+    }
+
+    private static Dictionary<string, object> RequestArgs(string status)
+    {
+        var args = new Dictionary<string, object>
+        {
+            { AddressesConstants.RequestMethod, "GET" },
+            { AddressesConstants.RequestUriRaw, ScannerUrl },
+            { AddressesConstants.RequestClientIp, "10.0.0.1" },
+        };
+
+        if (status is not null)
+        {
+            args.Add(AddressesConstants.ResponseStatus, status);
+        }
+
+        return args;
+    }
+
+    private static Dictionary<string, object> ResponseArgs(string status) =>
+        new()
+        {
+            { AddressesConstants.ResponseStatus, status },
+            { AddressesConstants.ResponseHeaderNoCookies, new Dictionary<string, string[]> { { "content-type", ["text/html"] } } },
+        };
+
+    private static IEnumerable<string> MatchedRules(IResult result)
+    {
+        if (result?.Data is null)
+        {
+            return [];
+        }
+
+        var matches = JsonConvert.DeserializeObject<WafMatch[]>(JsonConvert.SerializeObject(result.Data));
+        return matches.Select(m => m.Rule.Id).ToList();
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafResponseStatusTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafResponseStatusTests.cs
@@ -24,7 +24,7 @@ public class WafResponseStatusTests : WafLibraryRequiredTest
     public void GivenAScannerRequest_WhenTheStatusIsSentOnlyAtResponseTime_ThenTheRuleMatches()
     {
         using var waf = CreateWaf().Waf;
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
 
         context.Run(RequestArgs(status: null), TimeoutMicroSeconds).Should().NotBeNull();
 
@@ -35,7 +35,7 @@ public class WafResponseStatusTests : WafLibraryRequiredTest
     public void GivenAScannerRequest_WhenTheRequestPhaseFabricatesA200Status_ThenTheResponsePhaseStillMatches()
     {
         using var waf = CreateWaf().Waf;
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
 
         // re-supplying a persistent address replaces it and re-marks it as new, so 200 does not latch
         context.Run(RequestArgs(status: "200"), TimeoutMicroSeconds).Should().NotBeNull();
@@ -47,7 +47,7 @@ public class WafResponseStatusTests : WafLibraryRequiredTest
     public void GivenAScannerRequest_WhenTheStatusIsSentTwice_ThenTheRuleMatchesOnce()
     {
         using var waf = CreateWaf().Waf;
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
 
         context.Run(RequestArgs(status: null), TimeoutMicroSeconds).Should().NotBeNull();
         MatchedRules(context.Run(new Dictionary<string, object> { { AddressesConstants.ResponseStatus, "404" } }, TimeoutMicroSeconds)).Should().Contain(ScannerRule);
@@ -59,7 +59,7 @@ public class WafResponseStatusTests : WafLibraryRequiredTest
     public void GivenAScannerRequest_WhenTheRealStatusIsNeverSent_ThenTheRuleNeverMatches()
     {
         using var waf = CreateWaf().Waf;
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
 
         MatchedRules(context.Run(RequestArgs(status: "200"), TimeoutMicroSeconds)).Should().NotContain(ScannerRule);
     }


### PR DESCRIPTION
## Summary of changes

- `server.response.status` reaches the WAF with the real status code: it is never sent during the request-phase scans, and it is sent once the real response status is known. On ASP.NET Core requests that reach the end of the pipeline without an endpoint, both `Scan(lastTime: true)` and the later response scan can carry it — the WAF doesn't report the same match twice.
- On ASP.NET Core the request address set is collected once per request instead of on every run. ASP.NET Framework keeps refreshing it on each `BeginRequest`, including the second pipeline a `Server.TransferRequest` creates, which is deliberate.
- Responses the WAF never saw get a report-only scan at the end of the pipeline: HTTP.sys, which never fires the instrumented response start hook, and server-generated error responses on Kestrel.

## Reason for change

The status came from the request-phase address set, where `HttpContext.Response.StatusCode` is still the default `200`, so status rules were fed a fabricated value — and on HTTP.sys that was the only status the WAF ever saw. Resending every request address on the later runs also re-evaluated the whole request rule set for no new information.

The same gap existed on Kestrel for responses the server writes itself. On an unhandled exception the 500 is produced by `ProduceEnd()`, after `application.ProcessRequestAsync()` has returned, so the scope set by the diagnostic observer inside that call is no longer visible in the `AsyncLocal`: `FireOnStarting` finds no active span and skips the WAF entirely. Those requests reached the WAF without a response status or response headers at all.

## Implementation details

Two one-shot flags on `AppSecRequestContext`, both driving the Core path. Persistent addresses live for the whole WAF context, so later runs re-evaluate rules, schemas and fingerprints against the stored values.

`server.request.cookies` on ASP.NET Framework is the one address the end-of-request run re-reads. ASP.NET puts `ASP.NET_SessionId` in `Request.Cookies` when the session id is read, which `SessionStateModule` normally does at `AcquireRequestState`, well before `EndRequest`; the explicit `SessionID` read in `GetEndRequestArgsForWaf` is the guard for hosts where the cookie isn't visible yet, and it has to happen before the cookies are snapshotted. Without the re-read the cookie halves of `_dd.appsec.fp.session` go empty.

## Test coverage

New unit tests against the real WAF: status rule matching per phase, schemas surviving a run without resupplied addresses, session fingerprint vs late cookies, server detection. Coordinator-level tests for the one-shot address collection, the omission of the status during the request phase and the real status at the end of the request, on both Core and Framework. Green locally: Security unit tests net8.0/net48, Security integration AspNetCore net8.0 + AspNetMvc5 net48, and system-tests `APPSEC_BLOCKING`, `APPSEC_API_SECURITY`, `APPSEC_WAF_TELEMETRY`, `APPSEC_RASP`, `APPSEC_AUTO_EVENTS_EXTENDED`, `DEFAULT`.

Because error responses now reach the last WAF run, API Security samples them too and error spans can carry `_dd.appsec.s.*` schemas. That breaks the `DEBUGGER_EXCEPTION_REPLAY` span approvals, where the schemas land on a different request every run (the sampler's 30s window against the test's 30s retry interval): DataDog/system-tests#7543 scrubs them like the `_dd.appsec.fp.*` fingerprints already are.

## Other details

Replaces #8856 (rewritten from scratch, not rebased). Left out on purpose: registering `Response.OnStarting(...)` from `BlockingMiddleware` would work on every server and let HTTP.sys block, but it means removing a calltarget and redoing the blocking and ordering story.
