### PR TITLE
[Feature Flags] Send the split serial id on exposure events

### DIFF
--- a/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
@@ -28,7 +28,7 @@ internal sealed class ExposureApi : IDisposable
 
     private const int DefaultCapacity = 1 << 16; // 65536 elements
     public const string ExposurePath = "evp_proxy/v2/api/v2/exposures";
-    private static readonly JsonSerializerSettings SerializerSettings = new()
+    internal static readonly JsonSerializerSettings SerializerSettings = new()
     {
         NullValueHandling = NullValueHandling.Include,
         ContractResolver = new DefaultContractResolver

--- a/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
@@ -17,6 +17,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.FeatureFlags.Exposure.Model;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
 
@@ -28,6 +29,7 @@ internal sealed class ExposureApi : IDisposable
 
     private const int DefaultCapacity = 1 << 16; // 65536 elements
     public const string ExposurePath = "evp_proxy/v2/api/v2/exposures";
+    [TestingAndPrivateOnly]
     internal static readonly JsonSerializerSettings SerializerSettings = new()
     {
         NullValueHandling = NullValueHandling.Include,

--- a/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureCache.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureCache.cs
@@ -108,10 +108,13 @@ internal sealed class ExposureCache
         {
             Variant = exposureEvent.Variant.Key;
             Allocation = exposureEvent.Allocation.Key;
+            SerialId = exposureEvent.SerialId;
         }
 
         public string Variant { get; }
 
         public string Allocation { get; }
+
+        public long? SerialId { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/FeatureFlags/Exposure/Model/ExposureEvent.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Exposure/Model/ExposureEvent.cs
@@ -8,7 +8,16 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.FeatureFlags.Exposure.Model;
 
-internal readonly record struct ExposureEvent(long Timestamp, Allocation Allocation, Flag Flag, Variant Variant, Subject Subject);
+// The serializer includes nulls globally, but the intake reads an absent serial id and an explicit
+// null differently, so this one property has to omit itself instead.
+internal readonly record struct ExposureEvent(
+    long Timestamp,
+    Allocation Allocation,
+    Flag Flag,
+    Variant Variant,
+    Subject Subject,
+    [property: JsonProperty(NullValueHandling = NullValueHandling.Ignore)] long? SerialId = null);

--- a/tracer/src/Datadog.Trace/FeatureFlags/Exposure/Model/ExposureEvent.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Exposure/Model/ExposureEvent.cs
@@ -8,16 +8,19 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.FeatureFlags.Exposure.Model;
 
-// The serializer includes nulls globally, but the intake reads an absent serial id and an explicit
-// null differently, so this one property has to omit itself instead.
 internal readonly record struct ExposureEvent(
     long Timestamp,
     Allocation Allocation,
     Flag Flag,
     Variant Variant,
     Subject Subject,
-    [property: JsonProperty(NullValueHandling = NullValueHandling.Ignore)] long? SerialId = null);
+    long? SerialId = null)
+{
+    // The serializer includes nulls globally, but the intake reads an absent serial id and an
+    // explicit null differently. A JsonProperty named argument cannot do this: the enum lives in
+    // this assembly, which AttributeTests forbids.
+    public bool ShouldSerializeSerialId() => SerialId.HasValue;
+}

--- a/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsEvaluator.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsEvaluator.cs
@@ -720,7 +720,7 @@ namespace Datadog.Trace.FeatureFlags
 
             if (doLog)
             {
-                DispatchExposure(flagKey, evaluation, evalTime, context);
+                DispatchExposure(flagKey, evaluation, evalTime, context, split.SerialId);
             }
 
             return evaluation;
@@ -744,7 +744,8 @@ namespace Datadog.Trace.FeatureFlags
             string flagKey,
             Evaluation evaluation,
             DateTime evalTime,
-            EvaluationContext? context)
+            EvaluationContext? context,
+            long? serialId)
         {
             var allocationKey = AllocationKey(evaluation);
             var variantKey = evaluation.Variant;
@@ -759,7 +760,8 @@ namespace Datadog.Trace.FeatureFlags
                 new Exposure.Model.Allocation(allocationKey),
                 new Exposure.Model.Flag(flagKey),
                 new Exposure.Model.Variant(variantKey),
-                new Exposure.Model.Subject(context?.TargetingKey ?? string.Empty, FlattenContext(context)));
+                new Exposure.Model.Subject(context?.TargetingKey ?? string.Empty, FlattenContext(context)),
+                serialId);
 
             _onExposureEvent?.Invoke(in evt);
         }

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureCacheTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureCacheTests.cs
@@ -202,6 +202,9 @@ public partial class ExposureCacheTests
         Assert.True(cache.Add(CreateSerialIdEvent(340132)));
         Assert.True(cache.Add(CreateSerialIdEvent(340133)));
         Assert.True(cache.Add(CreateSerialIdEvent(340132)));
+
+        // The three events share one flag and subject, so they share one cache key. Each Add
+        // replaces the stored value rather than adding an entry.
         Assert.Equal(1, cache.Size);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureCacheTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureCacheTests.cs
@@ -182,4 +182,59 @@ public partial class ExposureCacheTests
 
         Assert.Equal(size, cache.Size);
     }
+
+    [Fact]
+    public void AppearingSerialIdIsNotDeduplicated()
+    {
+        var cache = new ExposureCache(5);
+
+        Assert.True(cache.Add(CreateSerialIdEvent(null)));
+        Assert.True(cache.Add(CreateSerialIdEvent(340132)));
+        Assert.False(cache.Add(CreateSerialIdEvent(340132)));
+        Assert.Equal(1, cache.Size);
+    }
+
+    [Fact]
+    public void ChangingSerialIdIsNotDeduplicated()
+    {
+        var cache = new ExposureCache(5);
+
+        Assert.True(cache.Add(CreateSerialIdEvent(340132)));
+        Assert.True(cache.Add(CreateSerialIdEvent(340133)));
+        Assert.True(cache.Add(CreateSerialIdEvent(340132)));
+        Assert.Equal(1, cache.Size);
+    }
+
+    [Fact]
+    public void DisappearingSerialIdIsNotDeduplicated()
+    {
+        var cache = new ExposureCache(5);
+
+        Assert.True(cache.Add(CreateSerialIdEvent(340132)));
+        Assert.True(cache.Add(CreateSerialIdEvent(null)));
+        Assert.False(cache.Add(CreateSerialIdEvent(null)));
+        Assert.Equal(1, cache.Size);
+    }
+
+    [Fact]
+    public void SerialIdOfZeroDoesNotMatchAnAbsentSerialId()
+    {
+        var cache = new ExposureCache(5);
+
+        Assert.True(cache.Add(CreateSerialIdEvent(null)));
+        Assert.True(cache.Add(CreateSerialIdEvent(0)));
+        Assert.False(cache.Add(CreateSerialIdEvent(0)));
+        Assert.Equal(1, cache.Size);
+    }
+
+    private static ExposureEvent CreateSerialIdEvent(long? serialId)
+    {
+        return new ExposureEvent(
+            new DateTimeOffset(DateTime.Now).ToUnixTimeMilliseconds(),
+            new Trace.FeatureFlags.Exposure.Model.Allocation("allocation"),
+            new Trace.FeatureFlags.Exposure.Model.Flag("flag"),
+            new Trace.FeatureFlags.Exposure.Model.Variant("variant"),
+            new Subject("subject", new Dictionary<string, object?>()),
+            serialId);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureEventTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureEventTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="ExposureEventTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using Datadog.Trace.FeatureFlags.Exposure;
+using Datadog.Trace.FeatureFlags.Exposure.Model;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.FeatureFlags;
+
+public class ExposureEventTests
+{
+    [Theory]
+    [InlineData(340132)]
+    [InlineData(0)]
+    public void SerializesSerialIdAsATopLevelIntegerField(long serialId)
+    {
+        var serialized = Serialize(CreateEvent(serialId));
+
+        serialized.Value<long?>("serial_id").Should().Be(serialId);
+    }
+
+    [Fact]
+    public void OmitsSerialIdWhenTheSplitCarriesNone()
+    {
+        var serialized = Serialize(CreateEvent(null));
+
+        serialized.ContainsKey("serial_id").Should().BeFalse();
+    }
+
+    private static JObject Serialize(ExposureEvent exposureEvent)
+    {
+        return JObject.Parse(JsonConvert.SerializeObject(exposureEvent, ExposureApi.SerializerSettings));
+    }
+
+    private static ExposureEvent CreateEvent(long? serialId)
+    {
+        return new ExposureEvent(
+            1755000000000,
+            new Trace.FeatureFlags.Exposure.Model.Allocation("allocation-a"),
+            new Trace.FeatureFlags.Exposure.Model.Flag("test-flag"),
+            new Trace.FeatureFlags.Exposure.Model.Variant("variant-a"),
+            new Subject("user-123", new Dictionary<string, object?>()),
+            serialId);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvaluatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvaluatorTests.cs
@@ -279,6 +279,40 @@ public partial class FeatureFlagsEvaluatorTests
         Assert.Single(events);
     }
 
+    [Fact]
+    public void EvaluateExposureFlagSendsTheSplitSerialIdOnTheExposureEvent()
+    {
+        var flags = new FlagCollection
+        {
+            ["exposure-flag"] = FeatureFlagsHelpers.CreateExposureFlag()
+        };
+
+        List<Trace.FeatureFlags.Exposure.Model.ExposureEvent> events = new List<Trace.FeatureFlags.Exposure.Model.ExposureEvent>();
+        var evaluator = new FeatureFlagsEvaluator((in Trace.FeatureFlags.Exposure.Model.ExposureEvent e) => events.Add(e), new ServerConfiguration { Flags = flags });
+
+        evaluator.Evaluate("exposure-flag", Trace.FeatureFlags.ValueType.String, "default", new EvaluationContext("user-123"));
+
+        events.Should().HaveCount(1);
+        events[0].SerialId.Should().Be(FeatureFlagsHelpers.ExposureSerialId);
+    }
+
+    [Fact]
+    public void EvaluateExposureFlagSendsNoSerialIdWhenTheSplitCarriesNone()
+    {
+        var flag = FeatureFlagsHelpers.CreateExposureFlag();
+        flag.Allocations![0].Splits![0].SerialId = null;
+
+        var flags = new FlagCollection { ["exposure-flag"] = flag };
+
+        List<Trace.FeatureFlags.Exposure.Model.ExposureEvent> events = new List<Trace.FeatureFlags.Exposure.Model.ExposureEvent>();
+        var evaluator = new FeatureFlagsEvaluator((in Trace.FeatureFlags.Exposure.Model.ExposureEvent e) => events.Add(e), new ServerConfiguration { Flags = flags });
+
+        evaluator.Evaluate("exposure-flag", Trace.FeatureFlags.ValueType.String, "default", new EvaluationContext("user-123"));
+
+        events.Should().HaveCount(1);
+        events[0].SerialId.Should().BeNull();
+    }
+
     // ---------------------------------------------------------------------
     // ISO 8601 Date Parsing tests
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary of changes

Add an optional `serial_id` field to the feature-flag exposure event, and send it when the split carries a serial id.

## Reason for change

The exposures intake uses the serial id to find the holdout that an allocation comes from. The UFC compiler rewrites a holdout into a usual allocation before the tracer receives the flag configuration, so the exposure event holds no other link back to the holdout.

The tracer already reads the serial id and uses it for APM span enrichment. This change also puts it on the exposure event.

## Implementation details

| File | Change |
|---|---|
| `Exposure/Model/ExposureEvent.cs` | Add the optional `SerialId` property. It goes on the wire as a top-level `serial_id`. |
| `FeatureFlagsEvaluator.cs` | Give the serial id from the split to the exposure dispatch. |
| `Exposure/ExposureCache.cs` | Compare the serial id in the deduplication cache. |
| `Exposure/ExposureApi.cs` | Make `SerializerSettings` internal, so that a test can assert the wire shape. |

`ResolveVariant` gives the serial id to `DispatchExposure` directly. It does not read the value from the flag metadata, because `ResolveVariant` writes that metadata entry only when span enrichment is on.

The serializer includes nulls, so `ExposureEvent` gives `SerialId` a `ShouldSerializeSerialId` method. An event without a serial id omits the key instead of sending `null`. A `JsonProperty` named argument cannot do this, because `AttributeTests` forbids an attribute argument whose type is not in the core assembly, and `NullValueHandling` is an enum in `Datadog.Trace`. `ProbeException.ShouldSerializeStackTrace` solves the same problem the same way.

The tracer does not validate the value. The flag configuration layer validates it.

## Test coverage

Nine new test cases in three classes:

- `ExposureEventTests` — the wire shape: `serial_id` for `340132`, `serial_id` for `0`, and no key when the value is absent.
- `FeatureFlagsEvaluatorTests` — the dispatched event, for a split with a serial id and for a split without one.
- `ExposureCacheTests` — deduplication when the serial id appears, changes, disappears, and when it is `0`.

A serial id of `0` is a usual value. Serial ids start at `0` for each organization, so the first allocation of every organization has one. The tests pin `0` as present, not as absent.

```
dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj -f net10.0 \
  --filter "FullyQualifiedName~Datadog.Trace.Tests.FeatureFlags"
```

378 tests pass.

## Other details

The deduplication cache now compares the serial id. A subject therefore sends one more exposure when its serial id appears or changes while the allocation key and the variant key stay the same. This is intended: a configuration refresh can add or change a serial id without changing either key, and the intake must receive the new value.

Part of the work to send the serial id from every Datadog SDK. `DataDog/dd-trace-py#19753` and `DataDog/dd-trace-go#5214` make the same change.

*This description was generated by Claude.*
