### PR TITLE
Change /tracer/ to be unrooted tracer/ in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,11 @@
 /tools/                                   @DataDog/apm-dotnet
 
 # Tracer
-/tracer/                                  @DataDog/tracing-dotnet
+# FIXME: Keep this unrooted e.g., tracer/ instead of /tracer/
+#       As there appears to be a bug with CI Visibility that causes files
+#       to be listed as ../../../_/tracer/test/ which the rooted version doesn't match on.
+#       We need to update the test logger to fix this.
+tracer/                                   @DataDog/tracing-dotnet
 /tracer/build/                            @DataDog/apm-dotnet
 
 # IDM


### PR DESCRIPTION
## Summary of changes

Changes `/tracer/` to be `tracer/` to fix an issue where CI Visibility isn't properly matching the code owners for tests as it is getting a `../../../_/tracer/` path which causes the previous one to not match.

## Reason for change

Test logger has a bug somewhere with how it does things this is a quick workaround.

We used to have a `*` rule that made everything owned by default, but we had to remove that.

## Implementation details

delete `/`

## Test coverage

Made Codex run this locally and compare with the bundled datadog test logger algorithm that we have and it said that this fixes it.

## Other details
<!-- Fixes #{issue} -->

This doesn't change CODEOWNER in practice.

I hope
<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
