### PR TITLE
[AppSec] Emit rasp.error and rasp.rule.skipped telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -172,6 +172,21 @@ internal partial class AppSecRequestContext
 
     private IContext? _context;
 
+    /// <summary>
+    /// Gets a value indicating whether the WAF context has already been disposed, which means the
+    /// request has ended and no further WAF call can be made for it.
+    /// </summary>
+    internal bool IsAdditiveContextDisposed
+    {
+        get
+        {
+            lock (_contextSync)
+            {
+                return _isAdditiveContextDisposed;
+            }
+        }
+    }
+
     internal static AppSecRequestContext CreateWithDisposedAdditiveContext()
         => new() { _isAdditiveContextDisposed = true };
 

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -11,7 +11,6 @@ using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
-using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
@@ -189,33 +188,35 @@ internal partial class AppSecRequestContext
     }
 
     // raspAddress is set for a RASP run only, and a context that cannot be handed out is then reported
-    // under it: telling an ended request from a failed creation is only reliable while _contextSync is held
+    // under it. The cause is captured while _contextSync is held because it is not observable
+    // afterwards: a concurrent disposal would make an ended request and a failed creation look alike.
     internal IContext? GetOrCreateAdditiveContext(Security security, string? raspAddress = null)
     {
         IContext? context;
-        bool disposed;
+        var outcome = WafOutcome.Success;
 
         lock (_contextSync)
         {
-            disposed = _isAdditiveContextDisposed;
-            context = disposed ? null : _context ??= security.CreateAdditiveContext(raspAddress is not null);
+            if (_isAdditiveContextDisposed)
+            {
+                outcome = WafOutcome.RequestEnded;
+                context = null;
+            }
+            else
+            {
+                // an already created context keeps the Success it was handed out with
+                context = _context ??= security.CreateAdditiveContext(out outcome, raspAddress is not null);
+            }
         }
 
-        if (disposed)
+        if (outcome is WafOutcome.RequestEnded)
         {
             Log.Debug("Additive context was requested when already disposed");
         }
 
-        if (context is null && raspAddress is not null)
+        if (raspAddress is not null)
         {
-            if (disposed)
-            {
-                RaspModule.RecordRaspSkipped(raspAddress, RaspModule.SkipReason.AfterRequest);
-            }
-            else
-            {
-                RaspModule.RecordRaspError(raspAddress, result: null, TelemetryFactory.Metrics);
-            }
+            RaspModule.RecordRaspOutcome(raspAddress, outcome);
         }
 
         return context;

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
@@ -172,21 +173,6 @@ internal partial class AppSecRequestContext
 
     private IContext? _context;
 
-    /// <summary>
-    /// Gets a value indicating whether the WAF context has already been disposed, which means the
-    /// request has ended and no further WAF call can be made for it.
-    /// </summary>
-    internal bool IsAdditiveContextDisposed
-    {
-        get
-        {
-            lock (_contextSync)
-            {
-                return _isAdditiveContextDisposed;
-            }
-        }
-    }
-
     internal static AppSecRequestContext CreateWithDisposedAdditiveContext()
         => new() { _isAdditiveContextDisposed = true };
 
@@ -202,23 +188,36 @@ internal partial class AppSecRequestContext
         }
     }
 
-    internal IContext? GetOrCreateAdditiveContext(Security security)
+    // raspAddress is set for a RASP run only, and a context that cannot be handed out is then reported
+    // under it: telling an ended request from a failed creation is only reliable while _contextSync is held
+    internal IContext? GetOrCreateAdditiveContext(Security security, string? raspAddress = null)
     {
+        IContext? context;
+        bool disposed;
+
         lock (_contextSync)
         {
-            if (_isAdditiveContextDisposed)
-            {
-                Log.Debug("Additive context was requested when already disposed");
-                return null;
-            }
-
-            if (_context is not null)
-            {
-                return _context;
-            }
-
-            _context = security.CreateAdditiveContext();
-            return _context;
+            disposed = _isAdditiveContextDisposed;
+            context = disposed ? null : _context ??= security.CreateAdditiveContext(raspAddress is not null);
         }
+
+        if (disposed)
+        {
+            Log.Debug("Additive context was requested when already disposed");
+        }
+
+        if (context is null && raspAddress is not null)
+        {
+            if (disposed)
+            {
+                RaspModule.RecordRaspSkipped(raspAddress, RaspModule.SkipReason.AfterRequest);
+            }
+            else
+            {
+                RaspModule.RecordRaspError(raspAddress, result: null, TelemetryFactory.Metrics);
+            }
+        }
+
+        return context;
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -47,10 +47,14 @@ internal readonly partial struct SecurityCoordinator
         return RunWaf(args, lastTime);
     }
 
-    public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, bool isRasp = false, string? sessionId = null, string? raspAddress = null)
+    public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, string? sessionId = null, string? raspAddress = null)
     {
         SecurityReporter.LogAddressIfDebugEnabled(args);
         IResult? result = null;
+
+        // a RASP run is exactly a run that has an address to report under, so the execution mode and
+        // the telemetry classification cannot end up disagreeing
+        var isRasp = raspAddress is not null;
 
         try
         {
@@ -72,9 +76,17 @@ internal readonly partial struct SecurityCoordinator
             _security.ApiSecurity.ShouldAnalyzeSchema(lastWafCall, _localRootSpan, args, _httpTransport.StatusCode, _httpTransport.RouteData);
 
             // run the WAF and execute the results
+            var outcome = WafOutcome.Success;
             result = runWithEphemeral
-                         ? additiveContext.RunWithEphemeral(args, _security.Settings.WafTimeoutMicroSeconds, isRasp)
+                         ? additiveContext.RunWithEphemeral(args, _security.Settings.WafTimeoutMicroSeconds, isRasp, out outcome)
                          : additiveContext.Run(args, _security.Settings.WafTimeoutMicroSeconds);
+
+            if (raspAddress is not null)
+            {
+                // the context was handed out, so a run that produced nothing failed or arrived after the
+                // request ended, and only the run knows which: a null here is not classifiable
+                RaspModule.RecordRaspOutcome(raspAddress, outcome);
+            }
 
             SetErrorInformation(isRasp, result);
             SecurityReporter.RecordWafTelemetry(result, isRasp);
@@ -85,9 +97,9 @@ internal readonly partial struct SecurityCoordinator
             {
                 if (raspAddress is not null)
                 {
-                    RaspModule.RecordRaspError(raspAddress, result: null, TelemetryFactory.Metrics);
+                    RaspModule.RecordRaspOutcome(raspAddress, WafOutcome.BindingFailed);
                 }
-                else if (!isRasp)
+                else
                 {
                     TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
                 }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -7,6 +7,7 @@
 #pragma warning disable CS0282
 using System;
 using System.Collections.Generic;
+using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Telemetry;
@@ -46,14 +47,16 @@ internal readonly partial struct SecurityCoordinator
         return RunWaf(args, lastTime);
     }
 
-    public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, bool isRasp = false, string? sessionId = null)
+    public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, bool isRasp = false, string? sessionId = null, string? raspAddress = null)
     {
         SecurityReporter.LogAddressIfDebugEnabled(args);
         IResult? result = null;
 
         try
         {
-            var additiveContext = _appsecRequestContext.GetOrCreateAdditiveContext(_security);
+            // GetOrCreateAdditiveContext reports its own RASP failure: it is the only place that can
+            // tell an ended request from a failed creation without racing a concurrent disposal
+            var additiveContext = _appsecRequestContext.GetOrCreateAdditiveContext(_security, raspAddress);
 
             if (additiveContext is null)
             {
@@ -78,9 +81,16 @@ internal readonly partial struct SecurityCoordinator
         }
         catch (Exception ex) when (ex is not BlockException)
         {
-            if (result is null && !isRasp)
+            if (result is null)
             {
-                TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
+                if (raspAddress is not null)
+                {
+                    RaspModule.RecordRaspError(raspAddress, result: null, TelemetryFactory.Metrics);
+                }
+                else if (!isRasp)
+                {
+                    TelemetryFactory.Metrics.RecordCountWafError(MetricTags.WafError.BindingError);
+                }
             }
 
             var stringBuilder = StringBuilderCache.Acquire();

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -277,9 +277,6 @@ internal static class RaspModule
         RecordRaspError(address, result, metrics);
     }
 
-    internal static void RecordRaspError(string address, IResult? result)
-        => RecordRaspError(address, result, TelemetryFactory.Metrics);
-
     internal static void RecordRaspError(string address, IResult? result, IMetricsTelemetryCollector metrics)
     {
         // a timeout is already reported through rasp.timeout, and takes precedence over the return
@@ -527,11 +524,6 @@ internal static class RaspModule
                 }
 
                 var context = rootSpan.Context.TraceContext.AppSecRequestContext;
-                if (context is null)
-                {
-                    RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.OutOfRequest);
-                    return false;
-                }
 
                 var wafArgs = new Dictionary<string, object>();
                 wafArgs[AddressesConstants.DownstreamUrl] = requestMessage.RequestUri?.ToString() ?? string.Empty;
@@ -589,11 +581,6 @@ internal static class RaspModule
             }
 
             var context = rootSpan.Context.TraceContext.AppSecRequestContext;
-            if (context is null)
-            {
-                RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.OutOfRequest);
-                return;
-            }
 
             var wafArgs = new Dictionary<string, object>();
             wafArgs[AddressesConstants.DownstreamResponseStatus] = responseMessage.StatusCode;

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -15,6 +15,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using static Datadog.Trace.Telemetry.Metrics.MetricTags;
 
 namespace Datadog.Trace.AppSec.Rasp;
@@ -34,6 +35,19 @@ internal static class RaspModule
         Irrelevant = 0,
         Success = 1,
         Failure = 2
+    }
+
+    /// <summary>
+    /// Why a RASP evaluation never reached the WAF. The values are the subset of the reasons defined
+    /// in RFC-1012 that can happen in .NET.
+    /// </summary>
+    internal enum SkipReason
+    {
+        /// <summary>The request this evaluation belongs to has already ended.</summary>
+        AfterRequest = 0,
+
+        /// <summary>The evaluation happened outside of any web request, or its context was not reachable.</summary>
+        OutOfRequest = 1,
     }
 
     private static RaspRuleType? TryGetAddressRuleType(string address)
@@ -88,6 +102,88 @@ internal static class RaspModule
         _ => null,
     };
 
+    private static RaspRuleTypeSkipped? TryGetAddressRuleTypeSkipped(string address, SkipReason reason)
+    => address switch
+    {
+        AddressesConstants.FileAccess => reason switch
+        {
+            SkipReason.AfterRequest => RaspRuleTypeSkipped.LfiAfterRequest,
+            SkipReason.OutOfRequest => RaspRuleTypeSkipped.LfiOutOfRequest,
+            _ => null,
+        },
+        AddressesConstants.DownstreamUrl => reason switch
+        {
+            SkipReason.AfterRequest => RaspRuleTypeSkipped.SsrfAfterRequest,
+            SkipReason.OutOfRequest => RaspRuleTypeSkipped.SsrfOutOfRequest,
+            _ => null,
+        },
+        AddressesConstants.DBStatement => reason switch
+        {
+            SkipReason.AfterRequest => RaspRuleTypeSkipped.SQlIAfterRequest,
+            SkipReason.OutOfRequest => RaspRuleTypeSkipped.SQlIOutOfRequest,
+            _ => null,
+        },
+        AddressesConstants.ShellInjection => reason switch
+        {
+            SkipReason.AfterRequest => RaspRuleTypeSkipped.CommandInjectionShellAfterRequest,
+            SkipReason.OutOfRequest => RaspRuleTypeSkipped.CommandInjectionShellOutOfRequest,
+            _ => null,
+        },
+        AddressesConstants.CommandInjection => reason switch
+        {
+            SkipReason.AfterRequest => RaspRuleTypeSkipped.CommandInjectionExecAfterRequest,
+            SkipReason.OutOfRequest => RaspRuleTypeSkipped.CommandInjectionExecOutOfRequest,
+            _ => null,
+        },
+        _ => null,
+    };
+
+    private static RaspError? TryGetRaspErrorTag(string address, WafError wafError)
+    => address switch
+    {
+        AddressesConstants.FileAccess => wafError switch
+        {
+            WafError.BindingError => RaspError.LfiBindingError,
+            WafError.Internal => RaspError.LfiInternal,
+            WafError.InvalidObject => RaspError.LfiInvalidObject,
+            WafError.InvalidArgument => RaspError.LfiInvalidArgument,
+            _ => null,
+        },
+        AddressesConstants.DownstreamUrl => wafError switch
+        {
+            WafError.BindingError => RaspError.SsrfBindingError,
+            WafError.Internal => RaspError.SsrfInternal,
+            WafError.InvalidObject => RaspError.SsrfInvalidObject,
+            WafError.InvalidArgument => RaspError.SsrfInvalidArgument,
+            _ => null,
+        },
+        AddressesConstants.DBStatement => wafError switch
+        {
+            WafError.BindingError => RaspError.SQlIBindingError,
+            WafError.Internal => RaspError.SQlIInternal,
+            WafError.InvalidObject => RaspError.SQlIInvalidObject,
+            WafError.InvalidArgument => RaspError.SQlIInvalidArgument,
+            _ => null,
+        },
+        AddressesConstants.ShellInjection => wafError switch
+        {
+            WafError.BindingError => RaspError.CommandInjectionShellBindingError,
+            WafError.Internal => RaspError.CommandInjectionShellInternal,
+            WafError.InvalidObject => RaspError.CommandInjectionShellInvalidObject,
+            WafError.InvalidArgument => RaspError.CommandInjectionShellInvalidArgument,
+            _ => null,
+        },
+        AddressesConstants.CommandInjection => wafError switch
+        {
+            WafError.BindingError => RaspError.CommandInjectionExecBindingError,
+            WafError.Internal => RaspError.CommandInjectionExecInternal,
+            WafError.InvalidObject => RaspError.CommandInjectionExecInvalidObject,
+            WafError.InvalidArgument => RaspError.CommandInjectionExecInvalidArgument,
+            _ => null,
+        },
+        _ => null,
+    };
+
     internal static void OnLfi(string file)
     {
         CheckVulnerability(new Dictionary<string, object> { [AddressesConstants.FileAccess] = file }, AddressesConstants.FileAccess);
@@ -134,12 +230,82 @@ internal static class RaspModule
 
         rootSpan??= Tracer.Instance.InternalActiveScope?.Root?.Span;
 
-        if (rootSpan is null || rootSpan.IsFinished || rootSpan.Type != SpanTypes.Web)
+        if (rootSpan is null || rootSpan.Type != SpanTypes.Web)
         {
+            RecordRaspSkipped(address, SkipReason.OutOfRequest);
+            return;
+        }
+
+        if (rootSpan.IsFinished)
+        {
+            RecordRaspSkipped(address, SkipReason.AfterRequest);
             return;
         }
 
         RunWafRasp(arguments, rootSpan, address);
+    }
+
+    internal static void RecordRaspSkipped(string address, SkipReason reason)
+        => RecordRaspSkipped(address, reason, TelemetryFactory.Metrics);
+
+    internal static void RecordRaspSkipped(string address, SkipReason reason, IMetricsTelemetryCollector metrics)
+    {
+        var ruleTypeSkipped = TryGetAddressRuleTypeSkipped(address, reason);
+
+        if (ruleTypeSkipped is null)
+        {
+            Log.Warning("RASP: Rule skipped type not found for address {Address} {Reason}", address, reason);
+            return;
+        }
+
+        metrics.RecordCountRaspRuleSkipped(ruleTypeSkipped.Value);
+    }
+
+    internal static void RecordRaspRunOutcome(string address, IResult? result, Span rootSpan)
+        => RecordRaspRunOutcome(address, result, rootSpan, TelemetryFactory.Metrics);
+
+    internal static void RecordRaspRunOutcome(string address, IResult? result, Span rootSpan, IMetricsTelemetryCollector metrics)
+    {
+        // the request can end between the lifecycle check and the WAF call: the additive context is
+        // then gone and nothing was evaluated, which is a skip rather than a binding error
+        if (result is null && rootSpan.Context.TraceContext?.AppSecRequestContext.IsAdditiveContextDisposed == true)
+        {
+            RecordRaspSkipped(address, SkipReason.AfterRequest, metrics);
+            return;
+        }
+
+        RecordRaspError(address, result, metrics);
+    }
+
+    internal static void RecordRaspError(string address, IResult? result)
+        => RecordRaspError(address, result, TelemetryFactory.Metrics);
+
+    internal static void RecordRaspError(string address, IResult? result, IMetricsTelemetryCollector metrics)
+    {
+        // a timeout is already reported through rasp.timeout, and takes precedence over the return
+        // code, the same way it does in SecurityReporter.RecordWafTelemetry
+        if (result is { Timeout: true })
+        {
+            return;
+        }
+
+        // a null result means the WAF never produced one: the bindings failed, or the context was gone
+        var wafError = result is null ? WafError.BindingError : result.ReturnCode.ToWafErrorTag();
+
+        if (wafError is null)
+        {
+            return;
+        }
+
+        var raspError = TryGetRaspErrorTag(address, wafError.Value);
+
+        if (raspError is null)
+        {
+            Log.Warning("RASP: Error type not found for address {Address} {WafError}", address, wafError);
+            return;
+        }
+
+        metrics.RecordCountRaspError(raspError.Value);
     }
 
     private static void RecordRaspTelemetry(string address, bool isMatch, bool timeOut, BlockType matchType)
@@ -190,10 +356,12 @@ internal static class RaspModule
                 Log.Debug("Tried to run Rasp but security coordinator couldn't be instantiated, probably because of httpcontext missing");
             }
 
+            RecordRaspSkipped(address, SkipReason.OutOfRequest);
             return;
         }
 
         var result = securityCoordinator.Value.RunWaf(arguments, runWithEphemeral: true, isRasp: true);
+        RecordRaspRunOutcome(address, result, rootSpan);
 
         try
         {
@@ -339,19 +507,29 @@ internal static class RaspModule
                 _processDownstreamRequest = false;
                 var security = Security.Instance;
 
-                if (!security.RaspEnabled)
+                // the address check must happen before any telemetry is recorded, otherwise a
+                // ruleset without SSRF rules reports skips for an instrumentation that is not active
+                if (!security.RaspEnabled || !security.AddressEnabled(AddressesConstants.DownstreamUrl))
                 {
                     return false;
                 }
 
-                if (rootSpan is null || rootSpan.IsFinished || rootSpan.Type != SpanTypes.Web)
+                if (rootSpan is null || rootSpan.Type != SpanTypes.Web)
                 {
+                    RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.OutOfRequest);
+                    return false;
+                }
+
+                if (rootSpan.IsFinished)
+                {
+                    RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.AfterRequest);
                     return false;
                 }
 
                 var context = rootSpan.Context.TraceContext.AppSecRequestContext;
                 if (context is null)
                 {
+                    RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.OutOfRequest);
                     return false;
                 }
 
@@ -392,20 +570,28 @@ internal static class RaspModule
             _processDownstreamRequest = false;
             var security = Security.Instance;
 
-            if (!security.RaspEnabled)
+            if (!security.RaspEnabled || !security.AddressEnabled(AddressesConstants.DownstreamUrl))
             {
                 return;
             }
 
             var rootSpan = Tracer.Instance.InternalActiveScope?.Root?.Span;
-            if (rootSpan is null || rootSpan.IsFinished || rootSpan.Type != SpanTypes.Web)
+            if (rootSpan is null || rootSpan.Type != SpanTypes.Web)
             {
+                RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.OutOfRequest);
+                return;
+            }
+
+            if (rootSpan.IsFinished)
+            {
+                RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.AfterRequest);
                 return;
             }
 
             var context = rootSpan.Context.TraceContext.AppSecRequestContext;
             if (context is null)
             {
+                RecordRaspSkipped(AddressesConstants.DownstreamUrl, SkipReason.OutOfRequest);
                 return;
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -343,8 +343,10 @@ internal static class RaspModule
 
         var result = securityCoordinator.Value.RunWaf(arguments, runWithEphemeral: true, isRasp: true, raspAddress: address);
 
-        // a null result is already reported by whoever knows why it is null: GetOrCreateAdditiveContext
-        // for an unavailable context, RunWaf's catch for a binding failure
+        // RecordRaspError needs a result to classify. GetOrCreateAdditiveContext reports the context it
+        // could not hand out and RunWaf's catch a thrown binding failure, but a null out of
+        // Context.RunInternal (empty ephemeral batch, failed SubcontextInit, request context disposed
+        // after hand-out) still reports nothing: RunInternal has to surface its cause first
         if (result is not null)
         {
             RecordRaspError(address, result, TelemetryFactory.Metrics);

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -261,22 +261,6 @@ internal static class RaspModule
         metrics.RecordCountRaspRuleSkipped(ruleTypeSkipped.Value);
     }
 
-    internal static void RecordRaspRunOutcome(string address, IResult? result, Span rootSpan)
-        => RecordRaspRunOutcome(address, result, rootSpan, TelemetryFactory.Metrics);
-
-    internal static void RecordRaspRunOutcome(string address, IResult? result, Span rootSpan, IMetricsTelemetryCollector metrics)
-    {
-        // the request can end between the lifecycle check and the WAF call: the additive context is
-        // then gone and nothing was evaluated, which is a skip rather than a binding error
-        if (result is null && rootSpan.Context.TraceContext?.AppSecRequestContext.IsAdditiveContextDisposed == true)
-        {
-            RecordRaspSkipped(address, SkipReason.AfterRequest, metrics);
-            return;
-        }
-
-        RecordRaspError(address, result, metrics);
-    }
-
     internal static void RecordRaspError(string address, IResult? result, IMetricsTelemetryCollector metrics)
     {
         // a timeout is already reported through rasp.timeout, and takes precedence over the return
@@ -357,8 +341,14 @@ internal static class RaspModule
             return;
         }
 
-        var result = securityCoordinator.Value.RunWaf(arguments, runWithEphemeral: true, isRasp: true);
-        RecordRaspRunOutcome(address, result, rootSpan);
+        var result = securityCoordinator.Value.RunWaf(arguments, runWithEphemeral: true, isRasp: true, raspAddress: address);
+
+        // a null result is already reported by whoever knows why it is null: GetOrCreateAdditiveContext
+        // for an unavailable context, RunWaf's catch for a binding failure
+        if (result is not null)
+        {
+            RecordRaspError(address, result, TelemetryFactory.Metrics);
+        }
 
         try
         {

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -245,6 +245,38 @@ internal static class RaspModule
         RunWafRasp(arguments, rootSpan, address);
     }
 
+    internal static void RecordRaspOutcome(string address, WafOutcome outcome)
+        => RecordRaspOutcome(address, outcome, TelemetryFactory.Metrics);
+
+    /// <summary>
+    /// Turns the cause of a RASP evaluation that produced no result into its metric. This is the only
+    /// place that decides, so that context creation and the run itself cannot classify the same cause
+    /// differently.
+    /// </summary>
+    internal static void RecordRaspOutcome(string address, WafOutcome outcome, IMetricsTelemetryCollector metrics)
+    {
+        switch (outcome)
+        {
+            case WafOutcome.RequestEnded:
+                RecordRaspSkipped(address, SkipReason.AfterRequest, metrics);
+                break;
+
+            case WafOutcome.BindingFailed:
+                RecordRaspError(address, result: null, metrics);
+                break;
+
+            case WafOutcome.WafUnavailable:
+                // a WAF that is gone (disposed, replaced by an update, or never initialized) never got
+                // to evaluate anything, so counting it as a RASP error would turn every remote
+                // configuration update into a burst of phantom binding errors
+                break;
+
+            case WafOutcome.Success:
+                // the result carries the return code, so RecordRaspError classifies it instead
+                break;
+        }
+    }
+
     internal static void RecordRaspSkipped(string address, SkipReason reason)
         => RecordRaspSkipped(address, reason, TelemetryFactory.Metrics);
 
@@ -341,12 +373,11 @@ internal static class RaspModule
             return;
         }
 
-        var result = securityCoordinator.Value.RunWaf(arguments, runWithEphemeral: true, isRasp: true, raspAddress: address);
+        var result = securityCoordinator.Value.RunWaf(arguments, runWithEphemeral: true, raspAddress: address);
 
-        // RecordRaspError needs a result to classify. GetOrCreateAdditiveContext reports the context it
-        // could not hand out and RunWaf's catch a thrown binding failure, but a null out of
-        // Context.RunInternal (empty ephemeral batch, failed SubcontextInit, request context disposed
-        // after hand-out) still reports nothing: RunInternal has to surface its cause first
+        // a null result carries no return code to classify, and RunWaf has already reported it from the
+        // outcome the failing step returned: the context it could not hand out, the run that produced
+        // nothing, or a thrown binding failure
         if (result is not null)
         {
             RecordRaspError(address, result, TelemetryFactory.Metrics);

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -652,7 +652,7 @@ namespace Datadog.Trace.AppSec
             return false;
         }
 
-        internal IContext? CreateAdditiveContext() => _waf?.CreateContext();
+        internal IContext? CreateAdditiveContext(bool isRasp = false) => _waf?.CreateContext(isRasp);
 
         private void RunShutdown(Exception? ex)
         {

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -652,7 +652,17 @@ namespace Datadog.Trace.AppSec
             return false;
         }
 
-        internal IContext? CreateAdditiveContext(bool isRasp = false) => _waf?.CreateContext(isRasp);
+        internal IContext? CreateAdditiveContext(out WafOutcome outcome, bool isRasp = false)
+        {
+            if (_waf is null)
+            {
+                // AppSec is enabled but the WAF never initialized, or an update left us without one
+                outcome = WafOutcome.WafUnavailable;
+                return null;
+            }
+
+            return _waf.CreateContext(out outcome, isRasp);
+        }
 
         private void RunShutdown(Exception? ex)
         {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -64,10 +64,10 @@ internal sealed class Context : IContext
     }
 
     public IResult? Run(IDictionary<string, object> addressData, ulong timeoutMicroSeconds)
-        => RunInternal(addressData, false, timeoutMicroSeconds);
+        => RunInternal(addressData, false, timeoutMicroSeconds, isRasp: false, out _);
 
-    public IResult? RunWithEphemeral(IDictionary<string, object> ephemeralAddressData, ulong timeoutMicroSeconds, bool isRasp)
-        => RunInternal(ephemeralAddressData, true, timeoutMicroSeconds, isRasp);
+    public IResult? RunWithEphemeral(IDictionary<string, object> ephemeralAddressData, ulong timeoutMicroSeconds, bool isRasp, out WafOutcome outcome)
+        => RunInternal(ephemeralAddressData, true, timeoutMicroSeconds, isRasp, out outcome);
 
     public Dictionary<string, object> FilterAddresses(IDatadogSecurity security, string? userId = null, string? userLogin = null, string? userSessionId = null, bool fromSdk = false)
     {
@@ -110,6 +110,8 @@ internal sealed class Context : IContext
         }
     }
 
+    // a RASP run reports its binding errors as rasp.error instead, which its caller does from the
+    // BindingFailed outcome the run returns
     private static void RecordBindingError(bool isRasp)
     {
         if (!isRasp)
@@ -144,13 +146,15 @@ internal sealed class Context : IContext
     /// effects don't outlive the call; this is what RASP relies on</param>
     /// <param name="timeoutMicroSeconds">the WAF budget for this run</param>
     /// <param name="isRasp">whether this run should be reported as a RASP run</param>
-    private unsafe Result? RunInternal(IDictionary<string, object>? addressData, bool ephemeral, ulong timeoutMicroSeconds, bool isRasp = false)
+    /// <param name="outcome">why the run produced no result</param>
+    private unsafe Result? RunInternal(IDictionary<string, object>? addressData, bool ephemeral, ulong timeoutMicroSeconds, bool isRasp, out WafOutcome outcome)
     {
         DdwafObjectStruct retNative = default;
 
         if (_waf.Disposed)
         {
             Log.Warning("Context can't run when waf handle has been disposed. This shouldn't have happened with the locks, check concurrency.");
+            outcome = WafOutcome.WafUnavailable;
             return null;
         }
 
@@ -171,7 +175,10 @@ internal sealed class Context : IContext
         {
             if (_disposed)
             {
+                // the context is disposed when the request it belongs to ends, so a run that gets here
+                // arrived too late rather than failed
                 Log.Information("Can't run WAF when context is disposed");
+                outcome = WafOutcome.RequestEnded;
                 return null;
             }
 
@@ -183,6 +190,7 @@ internal sealed class Context : IContext
             {
                 Log.Error("The WAF was called without any address data");
                 RecordBindingError(isRasp);
+                outcome = WafOutcome.BindingFailed;
                 return null;
             }
 
@@ -206,6 +214,7 @@ internal sealed class Context : IContext
 
                     // nothing ran, so don't let this call's wall clock leak into the aggregated runtime
                     _stopwatch.Stop();
+                    outcome = WafOutcome.BindingFailed;
                     return null;
                 }
 
@@ -235,6 +244,7 @@ internal sealed class Context : IContext
         }
 
         _stopwatch.Stop();
+        outcome = WafOutcome.Success;
         var result = new Result(ref retNative, code, ref _totalRuntimeOverRuns, (ulong)(_stopwatch.Elapsed.TotalMilliseconds * 1000), isRasp, truncated);
 
         // the result was allocated by the WAF with the output allocator given to ddwaf_context_init, which is the default one

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IContext.cs
@@ -14,7 +14,13 @@ internal interface IContext : IDisposable
 {
     IResult? Run(IDictionary<string, object> addressData, ulong timeoutMicroSeconds);
 
-    IResult? RunWithEphemeral(IDictionary<string, object> ephemeralAddressData, ulong timeoutMicroSeconds, bool isRasp);
+    /// <param name="ephemeralAddressData">the addresses to evaluate in their own subcontext</param>
+    /// <param name="timeoutMicroSeconds">the WAF budget for this run</param>
+    /// <param name="isRasp">whether this run should be reported as a RASP run</param>
+    /// <param name="outcome">why the run produced no result. The persistent overload reports its own
+    /// failure and has nothing else to distinguish, but a RASP run has to tell an ended request from a
+    /// binding failure and from a WAF that is gone, and only the run itself knows which happened.</param>
+    IResult? RunWithEphemeral(IDictionary<string, object> ephemeralAddressData, ulong timeoutMicroSeconds, bool isRasp, out WafOutcome outcome);
 
     /// <summary>
     /// Here we compare with potential previous runs, and make sure we don't override previous values provided by the SDK

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
@@ -17,9 +17,11 @@ namespace Datadog.Trace.AppSec.Waf
 
         bool Disposed { get; }
 
+        /// <param name="outcome">Why no context was handed out, so that a caller can tell a binding
+        /// failure from a WAF that is gone without re-reading state a concurrent disposal has moved.</param>
         /// <param name="isRasp">Whether the context serves a RASP evaluation, whose binding errors
         /// are reported as rasp.error instead of the generic waf.error.</param>
-        public IContext? CreateContext(bool isRasp = false);
+        public IContext? CreateContext(out WafOutcome outcome, bool isRasp = false);
 
         /// <summary>
         /// Evaluates persistent data, whose side effects live for the whole context.

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
@@ -17,7 +17,9 @@ namespace Datadog.Trace.AppSec.Waf
 
         bool Disposed { get; }
 
-        public IContext? CreateContext();
+        /// <param name="isRasp">Whether the context serves a RASP evaluation, whose binding errors
+        /// are reported as rasp.error instead of the generic waf.error.</param>
+        public IContext? CreateContext(bool isRasp = false);
 
         /// <summary>
         /// Evaluates persistent data, whose side effects live for the whole context.

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -309,11 +309,12 @@ namespace Datadog.Trace.AppSec.Waf
         /// </summary>
         /// <returns>Context object to perform matching using the provided WAF instance</returns>
         /// <exception cref="Exception">Exception</exception>
-        public IContext? CreateContext(bool isRasp = false)
+        public IContext? CreateContext(out WafOutcome outcome, bool isRasp = false)
         {
             if (Disposed)
             {
                 Log.Warning("Context can't be created as waf instance has been disposed.");
+                outcome = WafOutcome.WafUnavailable;
                 return null;
             }
 
@@ -331,6 +332,7 @@ namespace Datadog.Trace.AppSec.Waf
                     _wafLocker.ExitReadLock();
                     ReleasePendingHandles();
                     Log.Warning("Context can't be created as waf instance has been disposed.");
+                    outcome = WafOutcome.WafUnavailable;
                     return null;
                 }
 
@@ -346,13 +348,14 @@ namespace Datadog.Trace.AppSec.Waf
             {
                 Log.Warning("Context couldn't be created as we couldn't acquire a reader lock");
 
-                // a RASP run reports its binding errors as rasp.error, the same way Context and
-                // SecurityCoordinator suppress the generic metric for it
+                // a RASP run reports its binding errors as rasp.error instead, which the caller does
+                // from the outcome
                 if (!isRasp)
                 {
                     TelemetryFactory.Metrics.RecordCountWafError(Telemetry.Metrics.MetricTags.WafError.BindingError);
                 }
 
+                outcome = WafOutcome.BindingFailed;
                 return null;
             }
 
@@ -362,7 +365,11 @@ namespace Datadog.Trace.AppSec.Waf
                 throw new Exception(InitContextError);
             }
 
-            return Context.GetContext(contextHandle, this, _wafLibraryInvoker, _encoder);
+            // GetContext only drops the handle when it finds the waf disposed under it, so a null here
+            // is a lost race against an update or a shutdown, never a binding failure
+            var context = Context.GetContext(contextHandle, this, _wafLibraryInvoker, _encoder);
+            outcome = context is null ? WafOutcome.WafUnavailable : WafOutcome.Success;
+            return context;
         }
 
         // Doesn't require a non disposed waf handle, but as the WAF instance needs to be valid for the lifetime of the context, if waf is disposed, don't run (unpredictable)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -309,7 +309,7 @@ namespace Datadog.Trace.AppSec.Waf
         /// </summary>
         /// <returns>Context object to perform matching using the provided WAF instance</returns>
         /// <exception cref="Exception">Exception</exception>
-        public IContext? CreateContext()
+        public IContext? CreateContext(bool isRasp = false)
         {
             if (Disposed)
             {
@@ -345,7 +345,14 @@ namespace Datadog.Trace.AppSec.Waf
             else
             {
                 Log.Warning("Context couldn't be created as we couldn't acquire a reader lock");
-                TelemetryFactory.Metrics.RecordCountWafError(Telemetry.Metrics.MetricTags.WafError.BindingError);
+
+                // a RASP run reports its binding errors as rasp.error, the same way Context and
+                // SecurityCoordinator suppress the generic metric for it
+                if (!isRasp)
+                {
+                    TelemetryFactory.Metrics.RecordCountWafError(Telemetry.Metrics.MetricTags.WafError.BindingError);
+                }
+
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/WafOutcome.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/WafOutcome.cs
@@ -1,0 +1,28 @@
+// <copyright file="WafOutcome.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.AppSec.Waf;
+
+/// <summary>
+/// Why a WAF call produced no context or no result. Carrying the cause is what lets a caller tell a
+/// real failure from a WAF that is simply gone: both come back as a null, and the difference is not
+/// observable afterwards because a concurrent disposal can happen in between.
+/// </summary>
+internal enum WafOutcome
+{
+    /// <summary>The call succeeded: a context was handed out, or a run produced a result.</summary>
+    Success = 0,
+
+    /// <summary>The request this call belongs to has already ended, so nothing was evaluated.</summary>
+    RequestEnded = 1,
+
+    /// <summary>The WAF instance is gone: disposed, replaced by an update, or never initialized.</summary>
+    WafUnavailable = 2,
+
+    /// <summary>The addresses or the (sub)context could not be handed to the WAF.</summary>
+    BindingFailed = 3,
+}

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 61;
+    public const int Length = 63;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -75,6 +75,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "rasp.error",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "rasp.rule.skipped",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "sdk.event",
@@ -137,6 +139,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -115,6 +115,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1);
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1);
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 770;
+    private const int CountLength = 800;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -759,23 +759,55 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 687
+            // rasp.error, index = 687
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:exec" }),
+            // rasp.rule.skipped, index = 707
+            new(new[] { "reason:after-request", "rule_type:lfi" }),
+            new(new[] { "reason:after-request", "rule_type:ssrf" }),
+            new(new[] { "reason:after-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "reason:out-of-request", "rule_type:lfi" }),
+            new(new[] { "reason:out-of-request", "rule_type:ssrf" }),
+            new(new[] { "reason:out-of-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:exec" }),
+            // instrum.user_auth.missing_user_id, index = 717
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 691
+            // instrum.user_auth.missing_user_login, index = 721
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 695
+            // sdk.event, index = 725
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 700
+            // executed.source, index = 730
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -790,9 +822,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 714
+            // executed.propagation, index = 744
             new(null),
-            // executed.sink, index = 715
+            // executed.sink, index = 745
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -820,9 +852,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 742
+            // request.tainted, index = 772
             new(null),
-            // suppressed.vulnerabilities, index = 743
+            // suppressed.vulnerabilities, index = 773
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -858,7 +890,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 20, 10, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1170,49 +1202,61 @@ internal sealed partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
     {
         var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+        var index = 707 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 717 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 691 + (int)tag;
+        var index = 721 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 695 + (int)tag;
+        var index = 725 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 700 + (int)tag;
+        var index = 730 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[714], increment);
+        Interlocked.Add(ref _buffer.Count[744], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 715 + (int)tag;
+        var index = 745 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[742], increment);
+        Interlocked.Add(ref _buffer.Count[772], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 743 + (int)tag;
+        var index = 773 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 61;
+    public const int Length = 63;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -75,6 +75,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "rasp.error",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "rasp.rule.skipped",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "sdk.event",
@@ -137,6 +139,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -115,6 +115,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1);
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1);
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 770;
+    private const int CountLength = 800;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -759,23 +759,55 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 687
+            // rasp.error, index = 687
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:exec" }),
+            // rasp.rule.skipped, index = 707
+            new(new[] { "reason:after-request", "rule_type:lfi" }),
+            new(new[] { "reason:after-request", "rule_type:ssrf" }),
+            new(new[] { "reason:after-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "reason:out-of-request", "rule_type:lfi" }),
+            new(new[] { "reason:out-of-request", "rule_type:ssrf" }),
+            new(new[] { "reason:out-of-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:exec" }),
+            // instrum.user_auth.missing_user_id, index = 717
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 691
+            // instrum.user_auth.missing_user_login, index = 721
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 695
+            // sdk.event, index = 725
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 700
+            // executed.source, index = 730
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -790,9 +822,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 714
+            // executed.propagation, index = 744
             new(null),
-            // executed.sink, index = 715
+            // executed.sink, index = 745
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -820,9 +852,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 742
+            // request.tainted, index = 772
             new(null),
-            // suppressed.vulnerabilities, index = 743
+            // suppressed.vulnerabilities, index = 773
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -858,7 +890,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 20, 10, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1170,49 +1202,61 @@ internal sealed partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
     {
         var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+        var index = 707 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 717 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 691 + (int)tag;
+        var index = 721 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 695 + (int)tag;
+        var index = 725 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 700 + (int)tag;
+        var index = 730 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[714], increment);
+        Interlocked.Add(ref _buffer.Count[744], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 715 + (int)tag;
+        var index = 745 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[742], increment);
+        Interlocked.Add(ref _buffer.Count[772], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 743 + (int)tag;
+        var index = 773 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 61;
+    public const int Length = 63;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -75,6 +75,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "rasp.error",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "rasp.rule.skipped",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "sdk.event",
@@ -137,6 +139,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -115,6 +115,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1);
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1);
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 770;
+    private const int CountLength = 800;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -759,23 +759,55 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 687
+            // rasp.error, index = 687
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:exec" }),
+            // rasp.rule.skipped, index = 707
+            new(new[] { "reason:after-request", "rule_type:lfi" }),
+            new(new[] { "reason:after-request", "rule_type:ssrf" }),
+            new(new[] { "reason:after-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "reason:out-of-request", "rule_type:lfi" }),
+            new(new[] { "reason:out-of-request", "rule_type:ssrf" }),
+            new(new[] { "reason:out-of-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:exec" }),
+            // instrum.user_auth.missing_user_id, index = 717
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 691
+            // instrum.user_auth.missing_user_login, index = 721
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 695
+            // sdk.event, index = 725
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 700
+            // executed.source, index = 730
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -790,9 +822,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 714
+            // executed.propagation, index = 744
             new(null),
-            // executed.sink, index = 715
+            // executed.sink, index = 745
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -820,9 +852,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 742
+            // request.tainted, index = 772
             new(null),
-            // suppressed.vulnerabilities, index = 743
+            // suppressed.vulnerabilities, index = 773
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -858,7 +890,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 20, 10, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1170,49 +1202,61 @@ internal sealed partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
     {
         var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+        var index = 707 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 717 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 691 + (int)tag;
+        var index = 721 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 695 + (int)tag;
+        var index = 725 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 700 + (int)tag;
+        var index = 730 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[714], increment);
+        Interlocked.Add(ref _buffer.Count[744], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 715 + (int)tag;
+        var index = 745 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[742], increment);
+        Interlocked.Add(ref _buffer.Count[772], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 743 + (int)tag;
+        var index = 773 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 61;
+    public const int Length = 63;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -75,6 +75,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "rasp.rule.eval",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "rasp.rule.match",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "rasp.timeout",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "rasp.error",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "rasp.rule.skipped",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "instrum.user_auth.missing_user_id",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "instrum.user_auth.missing_user_login",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "sdk.event",
@@ -137,6 +139,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleEval => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspRuleMatch => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.RaspTimeout => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspError => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.RaspRuleSkipped => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserId => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.MissingUserLogin => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.UserEventSdk => "appsec",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -115,6 +115,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1);
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1);
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1);
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);
 
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 770;
+    private const int CountLength = 800;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -759,23 +759,55 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "event_rules_version", "rule_type:sql_injection" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:shell" }),
             new(new[] { "waf_version", "event_rules_version", "rule_type:command_injection", "rule_variant:exec" }),
-            // instrum.user_auth.missing_user_id, index = 687
+            // rasp.error, index = 687
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-127", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-3", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-2", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:lfi" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:ssrf" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:sql_injection" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "waf_version", "event_rules_version", "waf_error:-1", "rule_type:command_injection", "rule_variant:exec" }),
+            // rasp.rule.skipped, index = 707
+            new(new[] { "reason:after-request", "rule_type:lfi" }),
+            new(new[] { "reason:after-request", "rule_type:ssrf" }),
+            new(new[] { "reason:after-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:after-request", "rule_type:command_injection", "rule_variant:exec" }),
+            new(new[] { "reason:out-of-request", "rule_type:lfi" }),
+            new(new[] { "reason:out-of-request", "rule_type:ssrf" }),
+            new(new[] { "reason:out-of-request", "rule_type:sql_injection" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:shell" }),
+            new(new[] { "reason:out-of-request", "rule_type:command_injection", "rule_variant:exec" }),
+            // instrum.user_auth.missing_user_id, index = 717
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // instrum.user_auth.missing_user_login, index = 691
+            // instrum.user_auth.missing_user_login, index = 721
             new(new[] { "framework:aspnetcore_identity", "event_type:login_success" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:login_failure" }),
             new(new[] { "framework:aspnetcore_identity", "event_type:signup" }),
             new(new[] { "framework:unknown", "event_type:signup" }),
-            // sdk.event, index = 695
+            // sdk.event, index = 725
             new(new[] { "event_type:login_success", "sdk_version:v1" }),
             new(new[] { "event_type:login_success", "sdk_version:v2" }),
             new(new[] { "event_type:login_failure", "sdk_version:v1" }),
             new(new[] { "event_type:login_failure", "sdk_version:v2" }),
             new(new[] { "event_type:custom", "sdk_version:v1" }),
-            // executed.source, index = 700
+            // executed.source, index = 730
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -790,9 +822,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 714
+            // executed.propagation, index = 744
             new(null),
-            // executed.sink, index = 715
+            // executed.sink, index = 745
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -820,9 +852,9 @@ internal sealed partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 742
+            // request.tainted, index = 772
             new(null),
-            // suppressed.vulnerabilities, index = 743
+            // suppressed.vulnerabilities, index = 773
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -858,7 +890,7 @@ internal sealed partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 4, 4, 5, 14, 1, 27, 1, 27, };
+        = new int[]{ 4, 85, 1, 3, 7, 2, 2, 7, 1, 1, 1, 22, 3, 2, 5, 5, 4, 1, 1, 22, 3, 34, 90, 90, 4, 4, 4, 4, 2, 44, 6, 1, 1, 85, 1, 22, 3, 8, 2, 10, 8, 4, 12, 4, 16, 2, 2, 10, 3, 4, 5, 15, 5, 20, 10, 4, 4, 5, 14, 1, 27, 1, 27, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -1170,49 +1202,61 @@ internal sealed partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
     {
         var index = 687 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+        var index = 707 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
+    {
+        var index = 717 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountMissingUserLogin(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
-        var index = 691 + (int)tag;
+        var index = 721 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountUserEventSdk(Datadog.Trace.Telemetry.Metrics.MetricTags.UserEventSdk tag, int increment = 1)
     {
-        var index = 695 + (int)tag;
+        var index = 725 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastSourceType tag, int increment = 1)
     {
-        var index = 700 + (int)tag;
+        var index = 730 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[714], increment);
+        Interlocked.Add(ref _buffer.Count[744], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 715 + (int)tag;
+        var index = 745 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[742], increment);
+        Interlocked.Add(ref _buffer.Count[772], increment);
     }
 
     public void RecordCountIastSuppressedVulnerabilities(Datadog.Trace.Telemetry.Metrics.MetricTags.IastVulnerabilityType tag, int increment = 1)
     {
-        var index = 743 + (int)tag;
+        var index = 773 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -224,6 +224,14 @@ internal sealed partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountRaspError(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspError tag, int increment = 1)
+    {
+    }
+
+    public void RecordCountRaspRuleSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleTypeSkipped tag, int increment = 1)
+    {
+    }
+
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFrameworkWithEventType tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -296,6 +296,17 @@ internal enum Count
     [TelemetryMetric<RaspRuleType>("rasp.timeout", isCommon: true, NS.ASM)] RaspTimeout,
 
     /// <summary>
+    /// Counts the number of times the WAF returned an error when evaluating a specific rule type.
+    /// </summary>
+    [TelemetryMetric<MetricTags.RaspError>("rasp.error", isCommon: true, NS.ASM)] RaspError,
+
+    /// <summary>
+    /// Counts the number of times the evaluation of a RASP instrumentation had to be skipped
+    /// because of the request lifecycle, tagged by the rule type and the reason.
+    /// </summary>
+    [TelemetryMetric<RaspRuleTypeSkipped>("rasp.rule.skipped", isCommon: true, NS.ASM)] RaspRuleSkipped,
+
+    /// <summary>
     /// Counts the number of times a user id hasn't been found  as part of the login success, login failure or signup event
     /// </summary>
     [TelemetryMetric<AuthenticationFrameworkWithEventType>("instrum.user_auth.missing_user_id", isCommon: true, NS.ASM)] MissingUserId,

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -470,6 +470,50 @@ internal static class MetricTags
         [Description("waf_version;event_rules_version;block:irrelevant;rule_type:command_injection;rule_variant:exec")] CommandInjectionExecIrrelevant = 14,
     }
 
+    public enum RaspError
+    {
+        // CAUTION: waf_version should aways be placed in first position
+        [Description("waf_version;event_rules_version;waf_error:-127;rule_type:lfi")] LfiBindingError = 0,
+        [Description("waf_version;event_rules_version;waf_error:-127;rule_type:ssrf")] SsrfBindingError = 1,
+        [Description("waf_version;event_rules_version;waf_error:-127;rule_type:sql_injection")] SQlIBindingError = 2,
+        [Description("waf_version;event_rules_version;waf_error:-127;rule_type:command_injection;rule_variant:shell")] CommandInjectionShellBindingError = 3,
+        [Description("waf_version;event_rules_version;waf_error:-127;rule_type:command_injection;rule_variant:exec")] CommandInjectionExecBindingError = 4,
+        [Description("waf_version;event_rules_version;waf_error:-3;rule_type:lfi")] LfiInternal = 5,
+        [Description("waf_version;event_rules_version;waf_error:-3;rule_type:ssrf")] SsrfInternal = 6,
+        [Description("waf_version;event_rules_version;waf_error:-3;rule_type:sql_injection")] SQlIInternal = 7,
+        [Description("waf_version;event_rules_version;waf_error:-3;rule_type:command_injection;rule_variant:shell")] CommandInjectionShellInternal = 8,
+        [Description("waf_version;event_rules_version;waf_error:-3;rule_type:command_injection;rule_variant:exec")] CommandInjectionExecInternal = 9,
+        [Description("waf_version;event_rules_version;waf_error:-2;rule_type:lfi")] LfiInvalidObject = 10,
+        [Description("waf_version;event_rules_version;waf_error:-2;rule_type:ssrf")] SsrfInvalidObject = 11,
+        [Description("waf_version;event_rules_version;waf_error:-2;rule_type:sql_injection")] SQlIInvalidObject = 12,
+        [Description("waf_version;event_rules_version;waf_error:-2;rule_type:command_injection;rule_variant:shell")] CommandInjectionShellInvalidObject = 13,
+        [Description("waf_version;event_rules_version;waf_error:-2;rule_type:command_injection;rule_variant:exec")] CommandInjectionExecInvalidObject = 14,
+        [Description("waf_version;event_rules_version;waf_error:-1;rule_type:lfi")] LfiInvalidArgument = 15,
+        [Description("waf_version;event_rules_version;waf_error:-1;rule_type:ssrf")] SsrfInvalidArgument = 16,
+        [Description("waf_version;event_rules_version;waf_error:-1;rule_type:sql_injection")] SQlIInvalidArgument = 17,
+        [Description("waf_version;event_rules_version;waf_error:-1;rule_type:command_injection;rule_variant:shell")] CommandInjectionShellInvalidArgument = 18,
+        [Description("waf_version;event_rules_version;waf_error:-1;rule_type:command_injection;rule_variant:exec")] CommandInjectionExecInvalidArgument = 19,
+    }
+
+    /// <summary>
+    /// Tags for rasp.rule.skipped. Unlike the other RASP metrics this one carries neither waf_version
+    /// nor event_rules_version: the evaluation is skipped before the WAF is reached, so there isn't
+    /// necessarily a WAF instance to report a version for.
+    /// </summary>
+    public enum RaspRuleTypeSkipped
+    {
+        [Description("reason:after-request;rule_type:lfi")] LfiAfterRequest = 0,
+        [Description("reason:after-request;rule_type:ssrf")] SsrfAfterRequest = 1,
+        [Description("reason:after-request;rule_type:sql_injection")] SQlIAfterRequest = 2,
+        [Description("reason:after-request;rule_type:command_injection;rule_variant:shell")] CommandInjectionShellAfterRequest = 3,
+        [Description("reason:after-request;rule_type:command_injection;rule_variant:exec")] CommandInjectionExecAfterRequest = 4,
+        [Description("reason:out-of-request;rule_type:lfi")] LfiOutOfRequest = 5,
+        [Description("reason:out-of-request;rule_type:ssrf")] SsrfOutOfRequest = 6,
+        [Description("reason:out-of-request;rule_type:sql_injection")] SQlIOutOfRequest = 7,
+        [Description("reason:out-of-request;rule_type:command_injection;rule_variant:shell")] CommandInjectionShellOutOfRequest = 8,
+        [Description("reason:out-of-request;rule_type:command_injection;rule_variant:exec")] CommandInjectionExecOutOfRequest = 9,
+    }
+
     public enum TruncationReason
     {
         [Description("truncation_reason:string_too_long")]StringTooLong = 1,

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ActionChangeTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ActionChangeTests.cs
@@ -30,7 +30,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
         var configurationState = CreateConfigurationState("rasp-rule-set.json");
         var initResult = CreateWaf(configurationState, true);
         var waf = initResult.Waf;
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
         var args = CreateArgs(paramValue);
         var result = context.Run(args, TimeoutMicroSeconds);
         result.Timeout.Should().BeFalse("Timeout should be false");
@@ -41,7 +41,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
         var newAction = CreateNewStatusAction(action, actionType, newStatus);
         UpdateWafWithActions([newAction], waf, configurationState, "update1");
 
-        using var contextNew = waf.CreateContext();
+        using var contextNew = waf.CreateContext(out _);
         result = contextNew.Run(args, TimeoutMicroSeconds);
         result.Timeout.Should().BeFalse("Timeout should be false");
         if (actionType == BlockingAction.BlockRequestType)
@@ -67,7 +67,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
 
         UpdateWafWithActions([CreateNewStatusAction("block", BlockingAction.BlockRequestType, 500)], waf, configurationState, "update1");
 
-        using var context = waf.CreateContext();
+        using var context = waf.CreateContext(out _);
         var result = context.Run(args, TimeoutMicroSeconds);
         result.Timeout.Should().BeFalse("Timeout should be false");
         result.BlockInfo["status_code"].Should().Be(500);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Fingerprint/FingerprintTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Fingerprint/FingerprintTests.cs
@@ -136,7 +136,7 @@ public class FingerprintTests : WafLibraryRequiredTest
     {
         var initResult = CreateWaf(newEncoder, ruleFile);
         waf = initResult.Waf;
-        var context = waf.CreateContext();
+        var context = waf.CreateContext(out _);
         var result = context.Run(args, TimeoutMicroSeconds);
         result.Timeout.Should().BeFalse("Timeout should be false");
         return context;

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspContextFailureTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspContextFailureTelemetryTests.cs
@@ -1,0 +1,171 @@
+// <copyright file="RaspContextFailureTelemetryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Rasp;
+using Datadog.Trace.AppSec.Rcm;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Telemetry;
+using FluentAssertions;
+using Moq;
+using Xunit;
+using AppSecSecurity = Datadog.Trace.AppSec.Security;
+
+namespace Datadog.Trace.Security.Unit.Tests.RASP;
+
+/// <summary>
+/// An unavailable WAF context is classified while _contextSync is held, so the cause cannot be misread
+/// by a concurrent disposal. These tests pin the metric each cause produces, and that a RASP run never
+/// reports the generic waf.error for it.
+/// </summary>
+[Collection(nameof(SecuritySequentialTests))]
+public class RaspContextFailureTelemetryTests
+{
+    [Fact]
+    public async Task GivenADisposedAdditiveContext_WhenARaspRunRequestsIt_ThenAnAfterRequestSkipIsReported()
+    {
+        // the request has ended, so nothing was evaluated: that is a skip, not a binding error
+        var waf = CreateWaf(contextCreated: true);
+        var requestContext = new AppSecRequestContext();
+        requestContext.DisposeAdditiveContext();
+
+        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+
+        var metric = metrics.Should().ContainSingle().Which;
+        metric.Name.Should().Be("rasp.rule.skipped");
+        metric.Tags.Should().Equal("reason:after-request", "rule_type:sql_injection");
+
+        // one request, one skip: reporting twice would show up as a second point or a count of 2
+        metric.Values.Should().Equal(1);
+    }
+
+    [Fact]
+    public async Task GivenAFailedContextCreation_WhenARaspRunRequestsIt_ThenABindingErrorIsReported()
+    {
+        var waf = CreateWaf(contextCreated: false);
+        var requestContext = new AppSecRequestContext();
+
+        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+
+        var metric = metrics.Should().ContainSingle().Which;
+        metric.Name.Should().Be("rasp.error");
+        metric.Tags.Should().Equal("waf_version:unknown", "event_rules_version:unknown", "waf_error:-127", "rule_type:sql_injection");
+        metric.Values.Should().Equal(1);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GivenARaspRun_WhenTheContextIsCreated_ThenTheWafIsToldItServesRasp(bool contextCreated)
+    {
+        // Waf.CreateContext suppresses the generic waf.error for a RASP run, which only works if the
+        // classification actually reaches it
+        var waf = CreateWaf(contextCreated);
+        var requestContext = new AppSecRequestContext();
+
+        await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+
+        waf.Verify(x => x.CreateContext(true), Times.Once);
+        waf.Verify(x => x.CreateContext(false), Times.Never);
+    }
+
+    [Fact]
+    public async Task GivenANonRaspRun_WhenTheContextIsCreated_ThenTheWafIsNotToldItServesRasp()
+    {
+        var waf = CreateWaf(contextCreated: true);
+        var requestContext = new AppSecRequestContext();
+
+        await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security));
+
+        waf.Verify(x => x.CreateContext(false), Times.Once);
+        waf.Verify(x => x.CreateContext(true), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GivenANonRaspRun_WhenTheContextIsUnavailable_ThenNoRaspMetricIsReported(bool disposed)
+    {
+        var waf = CreateWaf(contextCreated: false);
+        var requestContext = new AppSecRequestContext();
+
+        if (disposed)
+        {
+            requestContext.DisposeAdditiveContext();
+        }
+
+        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security));
+
+        metrics.Should().NotContain(m => m.Name.StartsWith("rasp."));
+    }
+
+    [Fact]
+    public async Task GivenARaspRun_WhenTheContextIsCreated_ThenNothingIsReported()
+    {
+        var waf = CreateWaf(contextCreated: true);
+        var requestContext = new AppSecRequestContext();
+
+        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+
+        metrics.Should().BeEmpty();
+    }
+
+    private static Mock<IWaf> CreateWaf(bool contextCreated)
+    {
+        var waf = new Mock<IWaf>();
+        waf.SetupGet(x => x.Version).Returns("1.26.0");
+        waf.Setup(x => x.IsKnowAddressesSuported()).Returns(true);
+        waf.Setup(x => x.GetKnownAddresses()).Returns([AddressesConstants.DBStatement]);
+        waf.Setup(x => x.CreateContext(It.IsAny<bool>())).Returns(contextCreated ? Mock.Of<IContext>() : null);
+        return waf;
+    }
+
+    private static async Task<List<(string Name, string[] Tags, int[] Values)>> RecordAsync(Mock<IWaf> waf, Func<AppSecSecurity, IContext?> run)
+    {
+        var config = new NameValueCollection
+        {
+            { ConfigurationKeys.AppSec.Enabled, "1" },
+            { ConfigurationKeys.AppSec.RaspEnabled, "1" },
+        };
+
+        var settings = new SecuritySettings(new NameValueConfigurationSource(config), NullConfigurationTelemetry.Instance);
+
+        // passing a waf keeps the real init out of the way, but AppsecEnabled is only flipped by that
+        // init, so the configuration state has to be built by hand
+        var configurationState = new ConfigurationState(settings, NullConfigurationTelemetry.Instance, wafIsNull: false) { AppsecEnabled = true };
+
+        using var security = new AppSecSecurity(settings, waf.Object, rcmSubscriptionManager: Mock.Of<IRcmSubscriptionManager>(), configurationState: configurationState);
+
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        var previousMetrics = TelemetryFactory.SetMetricsForTesting(collector);
+
+        try
+        {
+            run(security);
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(previousMetrics);
+        }
+
+        await collector.DisposeAsync();
+
+        return collector.GetMetrics().Metrics?
+                        .Select(m => (m.Metric, m.Tags ?? [], m.Points.Select(p => p.Value).ToArray()))
+                        .ToList()
+            ?? [];
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspContextFailureTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspContextFailureTelemetryTests.cs
@@ -18,6 +18,7 @@ using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Security.Unit.Tests.Utils;
 using Datadog.Trace.Telemetry;
 using FluentAssertions;
 using Moq;
@@ -27,22 +28,22 @@ using AppSecSecurity = Datadog.Trace.AppSec.Security;
 namespace Datadog.Trace.Security.Unit.Tests.RASP;
 
 /// <summary>
-/// An unavailable WAF context is classified while _contextSync is held, so the cause cannot be misread
-/// by a concurrent disposal. These tests pin the metric each cause produces, and that a RASP run never
-/// reports the generic waf.error for it.
+/// A context that cannot be handed out is classified while _contextSync is held, so the cause cannot be
+/// misread by a concurrent disposal. These tests pin the metric each cause produces, and that a RASP run
+/// never reports the generic waf.error for it.
 /// </summary>
 [Collection(nameof(SecuritySequentialTests))]
-public class RaspContextFailureTelemetryTests
+public class RaspContextFailureTelemetryTests : WafLibraryRequiredTest
 {
     [Fact]
     public async Task GivenADisposedAdditiveContext_WhenARaspRunRequestsIt_ThenAnAfterRequestSkipIsReported()
     {
         // the request has ended, so nothing was evaluated: that is a skip, not a binding error
-        var waf = CreateWaf(contextCreated: true);
+        var waf = CreateWafMock(WafOutcome.Success);
         var requestContext = new AppSecRequestContext();
         requestContext.DisposeAdditiveContext();
 
-        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+        var metrics = await RecordAsync(waf.Object, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
 
         var metric = metrics.Should().ContainSingle().Which;
         metric.Name.Should().Be("rasp.rule.skipped");
@@ -55,15 +56,76 @@ public class RaspContextFailureTelemetryTests
     [Fact]
     public async Task GivenAFailedContextCreation_WhenARaspRunRequestsIt_ThenABindingErrorIsReported()
     {
-        var waf = CreateWaf(contextCreated: false);
+        var waf = CreateWafMock(WafOutcome.BindingFailed);
         var requestContext = new AppSecRequestContext();
 
-        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+        var metrics = await RecordAsync(waf.Object, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
 
         var metric = metrics.Should().ContainSingle().Which;
         metric.Name.Should().Be("rasp.error");
         metric.Tags.Should().Equal("waf_version:unknown", "event_rules_version:unknown", "waf_error:-127", "rule_type:sql_injection");
         metric.Values.Should().Equal(1);
+    }
+
+    [Fact]
+    public async Task GivenAnUnavailableWaf_WhenARaspRunRequestsAContext_ThenNoMetricIsReported()
+    {
+        // the WAF was disposed or replaced by a remote configuration update, so nothing was ever handed
+        // to it: counting that as a binding error would turn every update into a burst of phantom errors
+        var waf = CreateWafMock(WafOutcome.WafUnavailable);
+        var requestContext = new AppSecRequestContext();
+
+        var metrics = await RecordAsync(waf.Object, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenARealDisposedWaf_WhenARaspRunRequestsAContext_ThenNoMetricIsReported()
+    {
+        // same cause as above, but reached through the real WAF instead of a mocked outcome: this is the
+        // path a remote configuration update or a shutdown actually takes
+        var initResult = CreateWaf();
+        var waf = initResult.Waf!;
+        waf.Dispose();
+
+        var requestContext = new AppSecRequestContext();
+
+        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+
+        // the WAF logs the refusal, which the collector counts under logs_created: what must not appear
+        // is a RASP error or skip, nor the generic waf.error a RASP run never reports
+        metrics.Should().NotContain(m => m.Name.StartsWith("rasp.") || m.Name == "waf.error");
+    }
+
+    [Fact]
+    public async Task GivenARealWaf_WhenARaspRunRequestsAContext_ThenNoMetricIsReported()
+    {
+        // the counterpart of the disposed case: a healthy WAF hands out a context, so nothing is reported
+        var initResult = CreateWaf();
+        var waf = initResult.Waf!;
+        var requestContext = new AppSecRequestContext();
+        IContext? context = null;
+
+        var metrics = await RecordAsync(waf, security => context = requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+
+        context.Should().NotBeNull();
+        metrics.Should().BeEmpty();
+        requestContext.DisposeAdditiveContext();
+        waf.Dispose();
+    }
+
+    [Fact]
+    public void GivenASecurityWithoutAWaf_WhenAContextIsRequested_ThenTheWafIsReportedUnavailable()
+    {
+        // AppSec is enabled but the WAF never initialized, which is a WAF that is gone rather than a
+        // failure to hand it anything
+        using var security = new AppSecSecurity(waf: null);
+
+        var context = security.CreateAdditiveContext(out var outcome, isRasp: true);
+
+        context.Should().BeNull();
+        outcome.Should().Be(WafOutcome.WafUnavailable);
     }
 
     [Theory]
@@ -73,41 +135,44 @@ public class RaspContextFailureTelemetryTests
     {
         // Waf.CreateContext suppresses the generic waf.error for a RASP run, which only works if the
         // classification actually reaches it
-        var waf = CreateWaf(contextCreated);
+        var waf = CreateWafMock(contextCreated ? WafOutcome.Success : WafOutcome.BindingFailed);
         var requestContext = new AppSecRequestContext();
 
-        await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+        await RecordAsync(waf.Object, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
 
-        waf.Verify(x => x.CreateContext(true), Times.Once);
-        waf.Verify(x => x.CreateContext(false), Times.Never);
+        waf.Verify(x => x.CreateContext(out It.Ref<WafOutcome>.IsAny, true), Times.Once);
+        waf.Verify(x => x.CreateContext(out It.Ref<WafOutcome>.IsAny, false), Times.Never);
     }
 
     [Fact]
     public async Task GivenANonRaspRun_WhenTheContextIsCreated_ThenTheWafIsNotToldItServesRasp()
     {
-        var waf = CreateWaf(contextCreated: true);
+        var waf = CreateWafMock(WafOutcome.Success);
         var requestContext = new AppSecRequestContext();
 
-        await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security));
+        await RecordAsync(waf.Object, security => requestContext.GetOrCreateAdditiveContext(security));
 
-        waf.Verify(x => x.CreateContext(false), Times.Once);
-        waf.Verify(x => x.CreateContext(true), Times.Never);
+        waf.Verify(x => x.CreateContext(out It.Ref<WafOutcome>.IsAny, false), Times.Once);
+        waf.Verify(x => x.CreateContext(out It.Ref<WafOutcome>.IsAny, true), Times.Never);
     }
 
+    // WafOutcome is internal, so a public theory has to carry it as its underlying value
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task GivenANonRaspRun_WhenTheContextIsUnavailable_ThenNoRaspMetricIsReported(bool disposed)
+    [InlineData((int)WafOutcome.BindingFailed)]
+    [InlineData((int)WafOutcome.WafUnavailable)]
+    [InlineData((int)WafOutcome.RequestEnded)]
+    public async Task GivenANonRaspRun_WhenTheContextIsUnavailable_ThenNoRaspMetricIsReported(int outcomeValue)
     {
-        var waf = CreateWaf(contextCreated: false);
+        var outcome = (WafOutcome)outcomeValue;
+        var waf = CreateWafMock(outcome);
         var requestContext = new AppSecRequestContext();
 
-        if (disposed)
+        if (outcome is WafOutcome.RequestEnded)
         {
             requestContext.DisposeAdditiveContext();
         }
 
-        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security));
+        var metrics = await RecordAsync(waf.Object, security => requestContext.GetOrCreateAdditiveContext(security));
 
         metrics.Should().NotContain(m => m.Name.StartsWith("rasp."));
     }
@@ -115,25 +180,30 @@ public class RaspContextFailureTelemetryTests
     [Fact]
     public async Task GivenARaspRun_WhenTheContextIsCreated_ThenNothingIsReported()
     {
-        var waf = CreateWaf(contextCreated: true);
+        var waf = CreateWafMock(WafOutcome.Success);
         var requestContext = new AppSecRequestContext();
 
-        var metrics = await RecordAsync(waf, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
+        var metrics = await RecordAsync(waf.Object, security => requestContext.GetOrCreateAdditiveContext(security, AddressesConstants.DBStatement));
 
         metrics.Should().BeEmpty();
     }
 
-    private static Mock<IWaf> CreateWaf(bool contextCreated)
+    private static Mock<IWaf> CreateWafMock(WafOutcome outcome)
     {
         var waf = new Mock<IWaf>();
         waf.SetupGet(x => x.Version).Returns("1.26.0");
         waf.Setup(x => x.IsKnowAddressesSuported()).Returns(true);
         waf.Setup(x => x.GetKnownAddresses()).Returns([AddressesConstants.DBStatement]);
-        waf.Setup(x => x.CreateContext(It.IsAny<bool>())).Returns(contextCreated ? Mock.Of<IContext>() : null);
+
+        // Moq assigns the value the out argument held when the setup was recorded, so the cause has to
+        // live in a local
+        var creationOutcome = outcome;
+        waf.Setup(x => x.CreateContext(out creationOutcome, It.IsAny<bool>()))
+           .Returns(outcome is WafOutcome.Success ? Mock.Of<IContext>() : null);
         return waf;
     }
 
-    private static async Task<List<(string Name, string[] Tags, int[] Values)>> RecordAsync(Mock<IWaf> waf, Func<AppSecSecurity, IContext?> run)
+    private static async Task<List<(string Name, string[] Tags, int[] Values)>> RecordAsync(IWaf waf, Func<AppSecSecurity, IContext?> run)
     {
         var config = new NameValueCollection
         {
@@ -147,7 +217,7 @@ public class RaspContextFailureTelemetryTests
         // init, so the configuration state has to be built by hand
         var configurationState = new ConfigurationState(settings, NullConfigurationTelemetry.Instance, wafIsNull: false) { AppsecEnabled = true };
 
-        using var security = new AppSecSecurity(settings, waf.Object, rcmSubscriptionManager: Mock.Of<IRcmSubscriptionManager>(), configurationState: configurationState);
+        using var security = new AppSecSecurity(settings, waf, rcmSubscriptionManager: Mock.Of<IRcmSubscriptionManager>(), configurationState: configurationState);
 
         var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
         var previousMetrics = TelemetryFactory.SetMetricsForTesting(collector);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleDownstreamTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleDownstreamTests.cs
@@ -6,15 +6,28 @@
 #nullable enable
 #if NETCOREAPP3_1_OR_GREATER
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
+using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
+using Datadog.Trace.AppSec.Rcm;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Security.Unit.Tests.Utils;
+using Datadog.Trace.Telemetry;
 using FluentAssertions;
+using Moq;
 using Xunit;
+using AppSecSecurity = Datadog.Trace.AppSec.Security;
 
 namespace Datadog.Trace.Security.Unit.Tests.RASP;
 
@@ -265,6 +278,116 @@ public class RaspModuleDownstreamTests : WafLibraryRequiredTest
         await RaspModule.AddBody(chunkedContent, wafArgs, AddressesConstants.DownstreamResponseBody, bodySizeLimit);
 
         wafArgs.Should().NotContainKey(AddressesConstants.DownstreamResponseBody);
+    }
+
+    [Theory]
+    [InlineData(SpanTypes.Custom, false)]
+    [InlineData(SpanTypes.Web, true)]
+    public async Task GivenSsrfIsNotInTheRuleset_WhenADownstreamRequestIsChecked_ThenNothingIsReported(string spanType, bool finished)
+    {
+        // a ruleset without SSRF rules must not report skips for an instrumentation that is not
+        // active: these are the lifecycles that report before CheckVulnerability rechecks the address
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: false, CreateRootSpan(spanType, finished));
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenNoSecurityCoordinator_WhenADownstreamRequestIsChecked_ThenAnOutOfRequestSkipIsReported()
+    {
+        // no ambient HttpContext, so the coordinator cannot be built and the WAF is never reached
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, CreateRootSpan(SpanTypes.Web, finished: false));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
+        tags.Should().Equal("reason:out-of-request", "rule_type:ssrf");
+    }
+
+    [Fact]
+    public async Task GivenANonWebRootSpan_WhenADownstreamRequestIsChecked_ThenAnOutOfRequestSkipIsReported()
+    {
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, CreateRootSpan(SpanTypes.Custom, finished: false));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
+        tags.Should().Equal("reason:out-of-request", "rule_type:ssrf");
+    }
+
+    [Fact]
+    public async Task GivenAFinishedRootSpan_WhenADownstreamRequestIsChecked_ThenAnAfterRequestSkipIsReported()
+    {
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, CreateRootSpan(SpanTypes.Web, finished: true));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
+        tags.Should().Equal("reason:after-request", "rule_type:ssrf");
+    }
+
+    private static Span CreateRootSpan(string spanType, bool finished)
+    {
+        var traceContext = new TraceContext(new EmptyDatadogTracer());
+        var spanContext = new SpanContext(parent: null, traceContext, serviceName: "My Service Name", traceId: (TraceId)100, spanId: 200);
+        var span = new Span(spanContext, DateTimeOffset.UtcNow) { Type = spanType };
+        traceContext.AddSpan(span);
+
+        if (finished)
+        {
+            span.Finish();
+        }
+
+        return span;
+    }
+
+    private static AppSecSecurity CreateSecurity(bool ssrfAddressEnabled)
+    {
+        var waf = new Mock<IWaf>();
+        waf.SetupGet(x => x.Version).Returns("1.26.0");
+        waf.Setup(x => x.IsKnowAddressesSuported()).Returns(true);
+        waf.Setup(x => x.GetKnownAddresses())
+           .Returns(ssrfAddressEnabled ? [AddressesConstants.DownstreamUrl] : [AddressesConstants.FileAccess]);
+
+        var config = new NameValueCollection
+        {
+            { ConfigurationKeys.AppSec.Enabled, "1" },
+            { ConfigurationKeys.AppSec.RaspEnabled, "1" },
+        };
+
+        var settings = new SecuritySettings(new NameValueConfigurationSource(config), NullConfigurationTelemetry.Instance);
+
+        // passing a waf keeps the real init out of the way, but AppsecEnabled is only flipped by that
+        // init, so the configuration state has to be built by hand
+        var configurationState = new ConfigurationState(settings, NullConfigurationTelemetry.Instance, wafIsNull: false) { AppsecEnabled = true };
+
+        return new AppSecSecurity(settings, waf.Object, rcmSubscriptionManager: Mock.Of<IRcmSubscriptionManager>(), configurationState: configurationState);
+    }
+
+    private static async Task<List<(string Name, string[] Tags)>> CheckDownstreamRequestAsync(bool ssrfAddressEnabled, Span rootSpan)
+    {
+        var previousSecurity = AppSecSecurity.Instance;
+        var security = CreateSecurity(ssrfAddressEnabled);
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        var previousMetrics = TelemetryFactory.SetMetricsForTesting(collector);
+
+        try
+        {
+            AppSecSecurity.Instance = security;
+
+            // OnSSRF arms the thread-static flag OnDownstreamRequest checks, so both calls have to
+            // stay on the same thread: no await between them
+            using var request = new HttpRequestMessage(HttpMethod.Get, "http://downstream.example.com/");
+            RaspModule.OnSSRF(request.RequestUri!.ToString());
+            RaspModule.OnDownstreamRequest(request, requestSpanId: 1, rootSpan);
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(previousMetrics);
+            AppSecSecurity.Instance = previousSecurity;
+            security.Dispose();
+        }
+
+        await collector.DisposeAsync();
+
+        return collector.GetMetrics().Metrics?
+                        .Select(m => (m.Metric, m.Tags ?? []))
+                        .ToList()
+            ?? [];
     }
 }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleDownstreamTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleDownstreamTests.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
@@ -24,6 +25,8 @@ using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Security.Unit.Tests.Utils;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.TestTracer;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -287,7 +290,7 @@ public class RaspModuleDownstreamTests : WafLibraryRequiredTest
     {
         // a ruleset without SSRF rules must not report skips for an instrumentation that is not
         // active: these are the lifecycles that report before CheckVulnerability rechecks the address
-        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: false, CreateRootSpan(spanType, finished));
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: false, spanType, finished);
 
         metrics.Should().BeEmpty();
     }
@@ -296,28 +299,78 @@ public class RaspModuleDownstreamTests : WafLibraryRequiredTest
     public async Task GivenNoSecurityCoordinator_WhenADownstreamRequestIsChecked_ThenAnOutOfRequestSkipIsReported()
     {
         // no ambient HttpContext, so the coordinator cannot be built and the WAF is never reached
-        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, CreateRootSpan(SpanTypes.Web, finished: false));
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, SpanTypes.Web, finished: false);
 
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
-        tags.Should().Equal("reason:out-of-request", "rule_type:ssrf");
+        ShouldBeTheSingleSkip(metrics, "reason:out-of-request", "rule_type:ssrf");
     }
 
     [Fact]
     public async Task GivenANonWebRootSpan_WhenADownstreamRequestIsChecked_ThenAnOutOfRequestSkipIsReported()
     {
-        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, CreateRootSpan(SpanTypes.Custom, finished: false));
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, SpanTypes.Custom, finished: false);
 
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
-        tags.Should().Equal("reason:out-of-request", "rule_type:ssrf");
+        ShouldBeTheSingleSkip(metrics, "reason:out-of-request", "rule_type:ssrf");
     }
 
     [Fact]
     public async Task GivenAFinishedRootSpan_WhenADownstreamRequestIsChecked_ThenAnAfterRequestSkipIsReported()
     {
-        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, CreateRootSpan(SpanTypes.Web, finished: true));
+        var metrics = await CheckDownstreamRequestAsync(ssrfAddressEnabled: true, SpanTypes.Web, finished: true);
 
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
-        tags.Should().Equal("reason:after-request", "rule_type:ssrf");
+        ShouldBeTheSingleSkip(metrics, "reason:after-request", "rule_type:ssrf");
+    }
+
+    [Theory]
+    [InlineData(SpanTypes.Custom, false)]
+    [InlineData(SpanTypes.Web, true)]
+    public async Task GivenSsrfIsNotInTheRuleset_WhenADownstreamResponseIsChecked_ThenNothingIsReported(string spanType, bool finished)
+    {
+        var metrics = await CheckDownstreamResponseAsync(ssrfAddressEnabled: false, spanType, finished);
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenNoSecurityCoordinator_WhenADownstreamResponseIsChecked_ThenAnOutOfRequestSkipIsReported()
+    {
+        var metrics = await CheckDownstreamResponseAsync(ssrfAddressEnabled: true, SpanTypes.Web, finished: false);
+
+        ShouldBeTheSingleSkip(metrics, "reason:out-of-request", "rule_type:ssrf");
+    }
+
+    [Fact]
+    public async Task GivenANonWebRootSpan_WhenADownstreamResponseIsChecked_ThenAnOutOfRequestSkipIsReported()
+    {
+        var metrics = await CheckDownstreamResponseAsync(ssrfAddressEnabled: true, SpanTypes.Custom, finished: false);
+
+        ShouldBeTheSingleSkip(metrics, "reason:out-of-request", "rule_type:ssrf");
+    }
+
+    [Fact]
+    public async Task GivenAFinishedRootSpan_WhenADownstreamResponseIsChecked_ThenAnAfterRequestSkipIsReported()
+    {
+        var metrics = await CheckDownstreamResponseAsync(ssrfAddressEnabled: true, SpanTypes.Web, finished: true);
+
+        ShouldBeTheSingleSkip(metrics, "reason:after-request", "rule_type:ssrf");
+    }
+
+    [Fact]
+    public async Task GivenNoActiveScope_WhenASqlQueryIsChecked_ThenTheSkipCarriesItsOwnRuleType()
+    {
+        // the same classifier serves every RASP address, so the rule type has to come from the
+        // address rather than from the SSRF path the downstream tests above exercise
+        var metrics = await RecordAsync([AddressesConstants.DBStatement], _ => RaspModule.OnSqlQuery("SELECT 1", IntegrationId.SqlClient));
+
+        ShouldBeTheSingleSkip(metrics, "reason:out-of-request", "rule_type:sql_injection");
+    }
+
+    private static void ShouldBeTheSingleSkip(List<(string Name, string[] Tags, int[] Values)> metrics, params string[] expectedTags)
+    {
+        var metric = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which;
+        metric.Tags.Should().Equal(expectedTags);
+
+        // one call, one skip: a path reporting twice would show up as a second point or a count of 2
+        metric.Values.Should().Equal(1);
     }
 
     private static Span CreateRootSpan(string spanType, bool finished)
@@ -335,13 +388,12 @@ public class RaspModuleDownstreamTests : WafLibraryRequiredTest
         return span;
     }
 
-    private static AppSecSecurity CreateSecurity(bool ssrfAddressEnabled)
+    private static AppSecSecurity CreateSecurity(string[] knownAddresses)
     {
         var waf = new Mock<IWaf>();
         waf.SetupGet(x => x.Version).Returns("1.26.0");
         waf.Setup(x => x.IsKnowAddressesSuported()).Returns(true);
-        waf.Setup(x => x.GetKnownAddresses())
-           .Returns(ssrfAddressEnabled ? [AddressesConstants.DownstreamUrl] : [AddressesConstants.FileAccess]);
+        waf.Setup(x => x.GetKnownAddresses()).Returns(knownAddresses);
 
         var config = new NameValueCollection
         {
@@ -358,25 +410,61 @@ public class RaspModuleDownstreamTests : WafLibraryRequiredTest
         return new AppSecSecurity(settings, waf.Object, rcmSubscriptionManager: Mock.Of<IRcmSubscriptionManager>(), configurationState: configurationState);
     }
 
-    private static async Task<List<(string Name, string[] Tags)>> CheckDownstreamRequestAsync(bool ssrfAddressEnabled, Span rootSpan)
+    private static Task<List<(string Name, string[] Tags, int[] Values)>> CheckDownstreamRequestAsync(bool ssrfAddressEnabled, string spanType, bool finished)
+        => RecordAsync(
+            ssrfAddressEnabled ? [AddressesConstants.DownstreamUrl] : [AddressesConstants.FileAccess],
+            _ =>
+            {
+                // the root span is built inside the swap so that the test does not rely on its own
+                // span lifecycle metrics landing in somebody else's collector
+                var rootSpan = CreateRootSpan(spanType, finished);
+
+                // OnSSRF arms the thread-static flag OnDownstreamRequest checks, so both calls have to
+                // stay on the same thread: no await between them
+                using var request = new HttpRequestMessage(HttpMethod.Get, "http://downstream.example.com/");
+                RaspModule.OnSSRF(request.RequestUri!.ToString());
+                RaspModule.OnDownstreamRequest(request, requestSpanId: 1, rootSpan);
+            });
+
+    private static Task<List<(string Name, string[] Tags, int[] Values)>> CheckDownstreamResponseAsync(bool ssrfAddressEnabled, string spanType, bool finished)
+        => RecordAsync(
+            ssrfAddressEnabled ? [AddressesConstants.DownstreamUrl] : [AddressesConstants.FileAccess],
+            tracer =>
+            {
+                // unlike the request path, OnDownstreamResponse takes its root span from the ambient
+                // tracer, so the scope has to be active on the global one
+                using var scope = (Scope)tracer.StartActive("test.trace");
+                scope.Span.Type = spanType;
+
+                if (finished)
+                {
+                    scope.Span.Finish();
+                }
+
+                using var response = new HttpResponseMessage(HttpStatusCode.OK);
+                RaspModule.OnDownstreamResponse(response, requestSpanId: 1);
+            });
+
+    private static async Task<List<(string Name, string[] Tags, int[] Values)>> RecordAsync(string[] knownAddresses, Action<ScopedTracer> run)
     {
         var previousSecurity = AppSecSecurity.Instance;
-        var security = CreateSecurity(ssrfAddressEnabled);
+        var previousTracer = Tracer.Instance;
+        var previousTracerManager = previousTracer.TracerManager;
+        var security = CreateSecurity(knownAddresses);
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
         var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
         var previousMetrics = TelemetryFactory.SetMetricsForTesting(collector);
 
         try
         {
             AppSecSecurity.Instance = security;
+            TracerRestorerAttribute.SetTracer(tracer);
 
-            // OnSSRF arms the thread-static flag OnDownstreamRequest checks, so both calls have to
-            // stay on the same thread: no await between them
-            using var request = new HttpRequestMessage(HttpMethod.Get, "http://downstream.example.com/");
-            RaspModule.OnSSRF(request.RequestUri!.ToString());
-            RaspModule.OnDownstreamRequest(request, requestSpanId: 1, rootSpan);
+            run(tracer);
         }
         finally
         {
+            TracerRestorerAttribute.SetTracer(previousTracer, previousTracerManager);
             TelemetryFactory.SetMetricsForTesting(previousMetrics);
             AppSecSecurity.Instance = previousSecurity;
             security.Dispose();
@@ -384,8 +472,11 @@ public class RaspModuleDownstreamTests : WafLibraryRequiredTest
 
         await collector.DisposeAsync();
 
+        // the span lifecycle metrics of the test's own root span are not what these tests assert on,
+        // and filtering them out is what keeps a BeEmpty() expectation meaningful
         return collector.GetMetrics().Metrics?
-                        .Select(m => (m.Metric, m.Tags ?? []))
+                        .Where(m => m.Metric.StartsWith("rasp."))
+                        .Select(m => (m.Metric, m.Tags ?? [], m.Points.Select(p => p.Value).ToArray()))
                         .ToList()
             ?? [];
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
@@ -32,6 +32,27 @@ public class RaspModuleTelemetryTests
             new object[] { AddressesConstants.CommandInjection, new[] { "rule_type:command_injection", "rule_variant:exec" } },
         };
 
+    /// <summary>
+    /// Every address x WAF error combination TryGetRaspErrorTag maps, so that a copy/paste in that
+    /// hand-written table (shell mapped to the exec variant, say) cannot go unnoticed.
+    /// </summary>
+    public static IEnumerable<object[]> RaspErrorMappings
+    {
+        get
+        {
+            // a null return code stands for a null result, which is reported as the binding error
+            int?[] returnCodes = [null, -3, -2, -1];
+
+            foreach (var address in RaspAddresses)
+            {
+                foreach (var returnCode in returnCodes)
+                {
+                    yield return [address[0], (object)returnCode!, $"waf_error:{returnCode?.ToString() ?? "-127"}", address[1]];
+                }
+            }
+        }
+    }
+
     [Theory]
     [MemberData(nameof(RaspAddresses))]
     public async Task GivenASkippedRaspCall_WhenTheReasonIsAfterRequest_ThenTheRuleTypeAndReasonAreReported(string address, string[] expectedRuleTags)
@@ -72,25 +93,16 @@ public class RaspModuleTelemetryTests
     }
 
     [Theory]
-    [MemberData(nameof(RaspAddresses))]
-    public async Task GivenANullResult_WhenTheErrorIsRecorded_ThenABindingErrorIsReported(string address, string[] expectedRuleTags)
+    [MemberData(nameof(RaspErrorMappings))]
+    public async Task GivenAFailedRaspRun_WhenTheErrorIsRecorded_ThenTheAddressAndReturnCodeMapToTheExactTags(string address, int? returnCode, string expectedErrorTag, string[] expectedRuleTags)
     {
-        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(address, result: null, collector));
+        var result = returnCode is null ? null : CreateResult(returnCode.Value);
 
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(address, result, collector));
+
+        var expectedTags = new[] { "waf_version:unknown", "event_rules_version:unknown", expectedErrorTag }.Concat(expectedRuleTags);
         var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
-        tags.Should().Contain("waf_error:-127").And.Contain(expectedRuleTags);
-    }
-
-    [Theory]
-    [InlineData(-3, "waf_error:-3")]
-    [InlineData(-2, "waf_error:-2")]
-    [InlineData(-1, "waf_error:-1")]
-    public async Task GivenAFailedRaspRun_WhenTheErrorIsRecorded_ThenTheReturnCodeIsReported(int returnCode, string expectedErrorTag)
-    {
-        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(AddressesConstants.DBStatement, CreateResult(returnCode), collector));
-
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
-        tags.Should().Contain(expectedErrorTag).And.Contain("rule_type:sql_injection");
+        tags.Should().Equal(expectedTags);
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
@@ -1,0 +1,206 @@
+// <copyright file="RaspModuleTelemetryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Rasp;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Telemetry;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests.RASP;
+
+public class RaspModuleTelemetryTests
+{
+    public static IEnumerable<object[]> RaspAddresses
+        => new List<object[]>
+        {
+            new object[] { AddressesConstants.FileAccess, new[] { "rule_type:lfi" } },
+            new object[] { AddressesConstants.DownstreamUrl, new[] { "rule_type:ssrf" } },
+            new object[] { AddressesConstants.DBStatement, new[] { "rule_type:sql_injection" } },
+            new object[] { AddressesConstants.ShellInjection, new[] { "rule_type:command_injection", "rule_variant:shell" } },
+            new object[] { AddressesConstants.CommandInjection, new[] { "rule_type:command_injection", "rule_variant:exec" } },
+        };
+
+    [Theory]
+    [MemberData(nameof(RaspAddresses))]
+    public async Task GivenASkippedRaspCall_WhenTheReasonIsAfterRequest_ThenTheRuleTypeAndReasonAreReported(string address, string[] expectedRuleTags)
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspSkipped(address, RaspModule.SkipReason.AfterRequest, collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
+        tags.Should().Contain("reason:after-request").And.Contain(expectedRuleTags);
+    }
+
+    [Theory]
+    [MemberData(nameof(RaspAddresses))]
+    public async Task GivenASkippedRaspCall_WhenTheReasonIsOutOfRequest_ThenTheRuleTypeAndReasonAreReported(string address, string[] expectedRuleTags)
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspSkipped(address, RaspModule.SkipReason.OutOfRequest, collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
+        tags.Should().Contain("reason:out-of-request").And.Contain(expectedRuleTags);
+    }
+
+    [Fact]
+    public async Task GivenASkippedRaspCall_WhenTheMetricIsReported_ThenNoWafVersionTagsAreAttached()
+    {
+        // rasp.rule.skipped is specified without waf_version/event_rules_version, and the placeholder
+        // substitution in the collector would leak "unknown" values if they were declared
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspSkipped(AddressesConstants.FileAccess, RaspModule.SkipReason.OutOfRequest, collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
+        tags.Should().NotContain(t => t.StartsWith("waf_version")).And.NotContain(t => t.StartsWith("event_rules_version"));
+    }
+
+    [Fact]
+    public async Task GivenASkippedRaspCall_WhenTheAddressIsUnknown_ThenNothingIsReported()
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspSkipped("server.request.body", RaspModule.SkipReason.OutOfRequest, collector));
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(RaspAddresses))]
+    public async Task GivenANullResult_WhenTheErrorIsRecorded_ThenABindingErrorIsReported(string address, string[] expectedRuleTags)
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(address, result: null, collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
+        tags.Should().Contain("waf_error:-127").And.Contain(expectedRuleTags);
+    }
+
+    [Theory]
+    [InlineData(-3, "waf_error:-3")]
+    [InlineData(-2, "waf_error:-2")]
+    [InlineData(-1, "waf_error:-1")]
+    public async Task GivenAFailedRaspRun_WhenTheErrorIsRecorded_ThenTheReturnCodeIsReported(int returnCode, string expectedErrorTag)
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(AddressesConstants.DBStatement, CreateResult(returnCode), collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
+        tags.Should().Contain(expectedErrorTag).And.Contain("rule_type:sql_injection");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task GivenASuccessfulRaspRun_WhenTheErrorIsRecorded_ThenNothingIsReported(int returnCode)
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(AddressesConstants.DBStatement, CreateResult(returnCode), collector));
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-2)]
+    [InlineData(-3)]
+    public async Task GivenATimedOutRaspRun_WhenTheErrorIsRecorded_ThenItIsNotReportedAsAnError(int returnCode)
+    {
+        // the timeout is already reported through rasp.timeout, so it must win over the return code
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(AddressesConstants.DBStatement, CreateResult(returnCode, timeout: true), collector));
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenAFailedRaspRun_WhenTheAddressIsUnknown_ThenNothingIsReported()
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspError("server.request.body", CreateResult(-3), collector));
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GivenANullResult_WhenTheContextWasAlreadyDisposed_ThenTheRunIsReportedAsSkipped()
+    {
+        // the request can end between the lifecycle check and the WAF call: nothing was evaluated,
+        // so this is a skip rather than a binding error
+        var rootSpan = CreateRootSpan(disposeAdditiveContext: true);
+
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, result: null, rootSpan, collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
+        tags.Should().Contain("reason:after-request").And.Contain("rule_type:sql_injection");
+    }
+
+    [Fact]
+    public async Task GivenANullResult_WhenTheContextIsStillAlive_ThenTheRunIsReportedAsABindingError()
+    {
+        var rootSpan = CreateRootSpan(disposeAdditiveContext: false);
+
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, result: null, rootSpan, collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
+        tags.Should().Contain("waf_error:-127").And.Contain("rule_type:sql_injection");
+    }
+
+    [Fact]
+    public async Task GivenAFailedResult_WhenTheContextWasAlreadyDisposed_ThenTheErrorIsStillReported()
+    {
+        // the WAF did run and did return an error, so the disposal that happened afterwards is irrelevant
+        var rootSpan = CreateRootSpan(disposeAdditiveContext: true);
+
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, CreateResult(-3), rootSpan, collector));
+
+        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
+        tags.Should().Contain("waf_error:-3").And.Contain("rule_type:sql_injection");
+    }
+
+    [Fact]
+    public async Task GivenASuccessfulResult_WhenTheOutcomeIsRecorded_ThenNothingIsReported()
+    {
+        var rootSpan = CreateRootSpan(disposeAdditiveContext: false);
+
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, CreateResult(0), rootSpan, collector));
+
+        metrics.Should().BeEmpty();
+    }
+
+    private static Span CreateRootSpan(bool disposeAdditiveContext)
+    {
+        var traceContext = new TraceContext(new EmptyDatadogTracer());
+
+        if (disposeAdditiveContext)
+        {
+            traceContext.AppSecRequestContext.DisposeAdditiveContext();
+        }
+
+        var spanContext = new SpanContext(parent: null, traceContext, serviceName: "My Service Name", traceId: (TraceId)100, spanId: 200);
+        return new Span(spanContext, DateTimeOffset.Now);
+    }
+
+    private static async Task<List<(string Name, string[] Tags)>> RecordAsync(Action<IMetricsTelemetryCollector> record)
+    {
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        record(collector);
+        await collector.DisposeAsync();
+
+        return collector.GetMetrics().Metrics?
+                        .Select(m => (m.Metric, m.Tags ?? []))
+                        .ToList()
+            ?? [];
+    }
+
+    private static IResult CreateResult(int returnCode, bool timeout = false)
+    {
+        var result = new Mock<IResult>();
+        result.SetupGet(x => x.ReturnCode).Returns((WafReturnCode)returnCode);
+        result.SetupGet(x => x.Timeout).Returns(timeout);
+        return result.Object;
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
@@ -59,8 +59,9 @@ public class RaspModuleTelemetryTests
     {
         var metrics = await RecordAsync(collector => RaspModule.RecordRaspSkipped(address, RaspModule.SkipReason.AfterRequest, collector));
 
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
-        tags.Should().Contain("reason:after-request").And.Contain(expectedRuleTags);
+        var metric = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which;
+        metric.Tags.Should().Contain("reason:after-request").And.Contain(expectedRuleTags);
+        metric.Values.Should().Equal(1);
     }
 
     [Theory]
@@ -69,8 +70,9 @@ public class RaspModuleTelemetryTests
     {
         var metrics = await RecordAsync(collector => RaspModule.RecordRaspSkipped(address, RaspModule.SkipReason.OutOfRequest, collector));
 
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
-        tags.Should().Contain("reason:out-of-request").And.Contain(expectedRuleTags);
+        var metric = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which;
+        metric.Tags.Should().Contain("reason:out-of-request").And.Contain(expectedRuleTags);
+        metric.Values.Should().Equal(1);
     }
 
     [Fact]
@@ -101,8 +103,9 @@ public class RaspModuleTelemetryTests
         var metrics = await RecordAsync(collector => RaspModule.RecordRaspError(address, result, collector));
 
         var expectedTags = new[] { "waf_version:unknown", "event_rules_version:unknown", expectedErrorTag }.Concat(expectedRuleTags);
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
-        tags.Should().Equal(expectedTags);
+        var metric = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which;
+        metric.Tags.Should().Equal(expectedTags);
+        metric.Values.Should().Equal(1);
     }
 
     [Theory]
@@ -137,14 +140,16 @@ public class RaspModuleTelemetryTests
         metrics.Should().BeEmpty();
     }
 
-    private static async Task<List<(string Name, string[] Tags)>> RecordAsync(Action<IMetricsTelemetryCollector> record)
+    private static async Task<List<(string Name, string[] Tags, int[] Values)>> RecordAsync(Action<IMetricsTelemetryCollector> record)
     {
         var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
         record(collector);
         await collector.DisposeAsync();
 
+        // the point values are what make a single report distinguishable from a duplicated one:
+        // two increments of the same series aggregate into one point of value 2, which ContainSingle alone accepts
         return collector.GetMetrics().Metrics?
-                        .Select(m => (m.Metric, m.Tags ?? []))
+                        .Select(m => (m.Metric, m.Tags ?? [], m.Points.Select(p => p.Value).ToArray()))
                         .ToList()
             ?? [];
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
@@ -137,65 +137,6 @@ public class RaspModuleTelemetryTests
         metrics.Should().BeEmpty();
     }
 
-    [Fact]
-    public async Task GivenANullResult_WhenTheContextWasAlreadyDisposed_ThenTheRunIsReportedAsSkipped()
-    {
-        // the request can end between the lifecycle check and the WAF call: nothing was evaluated,
-        // so this is a skip rather than a binding error
-        var rootSpan = CreateRootSpan(disposeAdditiveContext: true);
-
-        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, result: null, rootSpan, collector));
-
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which.Tags;
-        tags.Should().Contain("reason:after-request").And.Contain("rule_type:sql_injection");
-    }
-
-    [Fact]
-    public async Task GivenANullResult_WhenTheContextIsStillAlive_ThenTheRunIsReportedAsABindingError()
-    {
-        var rootSpan = CreateRootSpan(disposeAdditiveContext: false);
-
-        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, result: null, rootSpan, collector));
-
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
-        tags.Should().Contain("waf_error:-127").And.Contain("rule_type:sql_injection");
-    }
-
-    [Fact]
-    public async Task GivenAFailedResult_WhenTheContextWasAlreadyDisposed_ThenTheErrorIsStillReported()
-    {
-        // the WAF did run and did return an error, so the disposal that happened afterwards is irrelevant
-        var rootSpan = CreateRootSpan(disposeAdditiveContext: true);
-
-        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, CreateResult(-3), rootSpan, collector));
-
-        var tags = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which.Tags;
-        tags.Should().Contain("waf_error:-3").And.Contain("rule_type:sql_injection");
-    }
-
-    [Fact]
-    public async Task GivenASuccessfulResult_WhenTheOutcomeIsRecorded_ThenNothingIsReported()
-    {
-        var rootSpan = CreateRootSpan(disposeAdditiveContext: false);
-
-        var metrics = await RecordAsync(collector => RaspModule.RecordRaspRunOutcome(AddressesConstants.DBStatement, CreateResult(0), rootSpan, collector));
-
-        metrics.Should().BeEmpty();
-    }
-
-    private static Span CreateRootSpan(bool disposeAdditiveContext)
-    {
-        var traceContext = new TraceContext(new EmptyDatadogTracer());
-
-        if (disposeAdditiveContext)
-        {
-            traceContext.AppSecRequestContext.DisposeAdditiveContext();
-        }
-
-        var spanContext = new SpanContext(parent: null, traceContext, serviceName: "My Service Name", traceId: (TraceId)100, spanId: 200);
-        return new Span(spanContext, DateTimeOffset.Now);
-    }
-
     private static async Task<List<(string Name, string[] Tags)>> RecordAsync(Action<IMetricsTelemetryCollector> record)
     {
         var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspModuleTelemetryTests.cs
@@ -140,6 +140,42 @@ public class RaspModuleTelemetryTests
         metrics.Should().BeEmpty();
     }
 
+    [Theory]
+    [MemberData(nameof(RaspAddresses))]
+    public async Task GivenAnEndedRequest_WhenTheOutcomeIsRecorded_ThenAnAfterRequestSkipIsReported(string address, string[] expectedRuleTags)
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspOutcome(address, WafOutcome.RequestEnded, collector));
+
+        var metric = metrics.Should().ContainSingle(m => m.Name == "rasp.rule.skipped").Which;
+        metric.Tags.Should().Contain("reason:after-request").And.Contain(expectedRuleTags);
+        metric.Values.Should().Equal(1);
+    }
+
+    [Theory]
+    [MemberData(nameof(RaspAddresses))]
+    public async Task GivenAFailedBinding_WhenTheOutcomeIsRecorded_ThenTheBindingErrorIsReported(string address, string[] expectedRuleTags)
+    {
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspOutcome(address, WafOutcome.BindingFailed, collector));
+
+        var expectedTags = new[] { "waf_version:unknown", "event_rules_version:unknown", "waf_error:-127" }.Concat(expectedRuleTags);
+        var metric = metrics.Should().ContainSingle(m => m.Name == "rasp.error").Which;
+        metric.Tags.Should().Equal(expectedTags);
+        metric.Values.Should().Equal(1);
+    }
+
+    // WafOutcome is internal, so a public theory has to carry it as its underlying value
+    [Theory]
+    [InlineData((int)WafOutcome.Success)]
+    [InlineData((int)WafOutcome.WafUnavailable)]
+    public async Task GivenAnEvaluationThatDidNotFail_WhenTheOutcomeIsRecorded_ThenNothingIsReported(int outcomeValue)
+    {
+        // a successful run is classified from its return code instead, and a WAF that is gone never got
+        // to evaluate anything: neither is a RASP error
+        var metrics = await RecordAsync(collector => RaspModule.RecordRaspOutcome(AddressesConstants.DBStatement, (WafOutcome)outcomeValue, collector));
+
+        metrics.Should().BeEmpty();
+    }
+
     private static async Task<List<(string Name, string[] Tags, int[] Values)>> RecordAsync(Action<IMetricsTelemetryCollector> record)
     {
         var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspRunFailureTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspRunFailureTelemetryTests.cs
@@ -1,0 +1,203 @@
+// <copyright file="RaspRunFailureTelemetryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Security.Unit.Tests.Utils;
+using Datadog.Trace.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+#if NETCOREAPP
+using Datadog.Trace.AppSec.Coordinator;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+#endif
+
+namespace Datadog.Trace.Security.Unit.Tests.RASP;
+
+/// <summary>
+/// A RASP run that produces no result is classified by the run itself, because the cause is not
+/// observable once it has returned: a concurrent disposal would make an ended request, a WAF that is
+/// gone and a genuine binding failure look alike. These tests pin the cause each null carries, and the
+/// metric it turns into on the real call path.
+/// </summary>
+[Collection(nameof(SecuritySequentialTests))]
+public class RaspRunFailureTelemetryTests : WafLibraryRequiredTest
+{
+    private static readonly Dictionary<string, object> VulnerableArgs = new() { { AddressesConstants.DBStatement, "SELECT * FROM users WHERE name = 'John' or '1' = '1'" } };
+
+    [Fact]
+    public void GivenADisposedContext_WhenAnEphemeralRunHappens_ThenTheRequestIsReportedEnded()
+    {
+        // the context is disposed when the request it belongs to ends, so a run that gets here arrived
+        // too late rather than failed
+        var initResult = CreateWaf();
+        var waf = initResult.Waf!;
+        var context = waf.CreateContext(out _)!;
+        context.Dispose();
+
+        var result = context.RunWithEphemeral(VulnerableArgs, TimeoutMicroSeconds, isRasp: true, out var outcome);
+
+        result.Should().BeNull();
+        outcome.Should().Be(WafOutcome.RequestEnded);
+        waf.Dispose();
+    }
+
+    [Fact]
+    public void GivenADisposedWaf_WhenAnEphemeralRunHappens_ThenTheWafIsReportedUnavailable()
+    {
+        // the context outlives a WAF replaced by a remote configuration update, and a run against it
+        // never reaches the WAF at all
+        var initResult = CreateWaf();
+        var waf = initResult.Waf!;
+        var context = waf.CreateContext(out _)!;
+        waf.Dispose();
+
+        var result = context.RunWithEphemeral(VulnerableArgs, TimeoutMicroSeconds, isRasp: true, out var outcome);
+
+        result.Should().BeNull();
+        outcome.Should().Be(WafOutcome.WafUnavailable);
+        context.Dispose();
+    }
+
+    [Fact]
+    public void GivenAnEmptyEphemeralBatch_WhenARunHappens_ThenBindingIsReportedFailed()
+    {
+        // nothing was handed to the WAF, which is a genuine failure of this run rather than a WAF that
+        // is unavailable
+        var initResult = CreateWaf();
+        var waf = initResult.Waf!;
+        var context = waf.CreateContext(out _)!;
+
+        var result = context.RunWithEphemeral(new Dictionary<string, object>(), TimeoutMicroSeconds, isRasp: true, out var outcome);
+
+        result.Should().BeNull();
+        outcome.Should().Be(WafOutcome.BindingFailed);
+        context.Dispose();
+        waf.Dispose();
+    }
+
+    [Fact]
+    public void GivenAHealthyWaf_WhenAnEphemeralRunHappens_ThenSuccessIsReported()
+    {
+        // the counterpart of the three failures: a run that produced a result carries its return code,
+        // so it must not be classified from the outcome
+        var initResult = CreateWaf();
+        var waf = initResult.Waf!;
+        var context = waf.CreateContext(out _)!;
+
+        var result = context.RunWithEphemeral(VulnerableArgs, TimeoutMicroSeconds, isRasp: true, out var outcome);
+
+        result.Should().NotBeNull();
+        outcome.Should().Be(WafOutcome.Success);
+        context.Dispose();
+        waf.Dispose();
+    }
+
+#if NETCOREAPP
+    [Fact]
+    public async Task GivenADisposedWaf_WhenARaspRunHappens_ThenNoMetricIsReported()
+    {
+        // the whole point of the typed outcome: a WAF replaced mid-request must not show up as a burst
+        // of phantom rasp.error:-127
+        var initResult = CreateWaf(ruleFile: "rasp-rule-set.json");
+        var waf = initResult.Waf!;
+        using var security = new AppSec.Security(waf: waf);
+        var coordinator = CreateCoordinator(security);
+
+        // the first run hands out the context, the second one runs against a WAF that is already gone
+        coordinator.RunWaf(VulnerableArgs, runWithEphemeral: true, raspAddress: AddressesConstants.DBStatement);
+        waf.Dispose();
+
+        var metrics = await RecordAsync(() => coordinator.RunWaf(VulnerableArgs, runWithEphemeral: true, raspAddress: AddressesConstants.DBStatement).Should().BeNull());
+
+        metrics.Should().NotContain(m => m.Name.StartsWith("rasp."));
+    }
+
+    [Fact]
+    public async Task GivenAnEmptyEphemeralBatch_WhenARaspRunHappens_ThenABindingErrorIsReported()
+    {
+        var initResult = CreateWaf(ruleFile: "rasp-rule-set.json");
+        var waf = initResult.Waf!;
+        using var security = new AppSec.Security(waf: waf);
+        var coordinator = CreateCoordinator(security);
+
+        var metrics = await RecordAsync(() => coordinator.RunWaf(new Dictionary<string, object>(), runWithEphemeral: true, raspAddress: AddressesConstants.DBStatement).Should().BeNull());
+
+        var metric = metrics.Should().ContainSingle(m => m.Name.StartsWith("rasp.")).Which;
+        metric.Name.Should().Be("rasp.error");
+        metric.Tags.Should().Contain("waf_error:-127").And.Contain("rule_type:sql_injection");
+
+        // reported once: the run classifies the null, and the RASP guard skips a null result
+        metric.Values.Should().Equal(1);
+        waf.Dispose();
+    }
+
+    [Fact]
+    public async Task GivenAMatchingRaspRun_WhenItSucceeds_ThenNoErrorIsReported()
+    {
+        var initResult = CreateWaf(ruleFile: "rasp-rule-set.json");
+        var waf = initResult.Waf!;
+        using var security = new AppSec.Security(waf: waf);
+        var coordinator = CreateCoordinator(security);
+
+        var metrics = await RecordAsync(() => coordinator.RunWaf(VulnerableArgs, runWithEphemeral: true, raspAddress: AddressesConstants.DBStatement).Should().NotBeNull());
+
+        metrics.Should().NotContain(m => m.Name == "rasp.error");
+        metrics.Should().NotContain(m => m.Name == "rasp.rule.skipped");
+        waf.Dispose();
+    }
+
+    private static SecurityCoordinator CreateCoordinator(AppSec.Security security)
+    {
+        var httpContextMock = new Mock<HttpContext>();
+        var httpResponseMock = new Mock<HttpResponse>();
+        httpResponseMock.Setup(x => x.StatusCode).Returns(200);
+        httpContextMock.Setup(x => x.Response).Returns(httpResponseMock.Object);
+        var routingFeature = new Mock<IRoutingFeature>();
+        routingFeature.Setup(x => x.RouteData).Returns(new RouteData());
+        httpContextMock.Setup(x => x.Features[typeof(IRoutingFeature)]).Returns(routingFeature.Object);
+
+        var traceContext = new TraceContext(new EmptyDatadogTracer());
+        var spanContext = new SpanContext(parent: null, traceContext, serviceName: "test", traceId: (TraceId)100, spanId: 200);
+        var span = new Span(spanContext, DateTimeOffset.Now);
+
+        return SecurityCoordinator.Get(security, span, new SecurityCoordinator.HttpTransport(httpContextMock.Object));
+    }
+#endif
+
+    private static async Task<List<(string Name, string[] Tags, int[] Values)>> RecordAsync(Action run)
+    {
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        var previousMetrics = TelemetryFactory.SetMetricsForTesting(collector);
+
+        try
+        {
+            run();
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(previousMetrics);
+        }
+
+        await collector.DisposeAsync();
+
+        // the point values are what make a single report distinguishable from a duplicated one: two
+        // increments of the same series aggregate into one point of value 2
+        return collector.GetMetrics().Metrics?
+                        .Select(m => (m.Metric, m.Tags ?? [], m.Points.Select(p => p.Value).ToArray()))
+                        .ToList()
+            ?? [];
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
@@ -46,7 +46,7 @@ public class RaspWafTests : WafLibraryRequiredTest
         var args = CreateArgs(etcPasswd);
         var context = InitWaf(true, "rasp-rule-set.json", args, out _);
         var argsVulnerable = new Dictionary<string, object> { { AddressesConstants.FileAccess, file } };
-        var resultEph = context.RunWithEphemeral(argsVulnerable, timeout, true);
+        var resultEph = context.RunWithEphemeral(argsVulnerable, timeout, true, out _);
         resultEph.Timeout.Should().Be(shouldRaiseTimeout);
         if (!shouldRaiseTimeout)
         {
@@ -64,7 +64,7 @@ public class RaspWafTests : WafLibraryRequiredTest
 
         // Default config does not block
         var argsVulnerable = new Dictionary<string, object> { { AddressesConstants.FileAccess, value } };
-        var resultEph = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true);
+        var resultEph = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true, out _);
         resultEph.BlockInfo["status_code"].Should().Be(403);
         resultEph.Timeout.Should().BeFalse("Timeout should be false");
         var jsonString = JsonConvert.SerializeObject(resultEph.Data);
@@ -78,7 +78,7 @@ public class RaspWafTests : WafLibraryRequiredTest
         var updateRes1 = UpdateWaf(configurationState, waf, ref context);
         updateRes1.Success.Should().BeTrue();
         context.Run(args, TimeoutMicroSeconds);
-        var resultEph1 = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true);
+        var resultEph1 = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true, out _);
         resultEph1.Timeout.Should().BeFalse("Timeout should be false");
         resultEph1.BlockInfo["status_code"].Should().Be(500);
         resultEph1.AggregatedTotalRuntimeRasp.Should().BeGreaterThan(0);
@@ -150,7 +150,7 @@ public class RaspWafTests : WafLibraryRequiredTest
 
         for (int i = 0; i < runNtimes; i++)
         {
-            var resultEph = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true);
+            var resultEph = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true, out _);
             CheckResult(rule, expectedAction, resultEph, actionType);
         }
     }
@@ -165,7 +165,7 @@ public class RaspWafTests : WafLibraryRequiredTest
     {
         var initResult = CreateWaf(configurationState, newEncoder, wafDebugEnabled: enableDebug);
         waf = initResult.Waf;
-        var context = waf.CreateContext();
+        var context = waf.CreateContext(out _);
         var result = context.Run(args, TimeoutMicroSeconds);
         result.Timeout.Should().BeFalse("Timeout should be false");
         return context;

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecurityCoordinatorTests.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             var security = new AppSec.Security(waf: waf);
             var securityCoordinator = TryGet(security, span);
-            var result = securityCoordinator.Value.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestMethod, "GET" } }, runWithEphemeral: true, isRasp: true);
+            var result = securityCoordinator.Value.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestMethod, "GET" } }, runWithEphemeral: true, raspAddress: AddressesConstants.DBStatement);
             result.Should().BeNull();
         }
 
@@ -137,7 +137,7 @@ namespace Datadog.Trace.Security.Unit.Tests
 
             using var security = new AppSec.Security();
             var securityCoordinator = SecurityCoordinator.Get(security, rootTestScope.Span, new HttpTransport(contextMoq.Object));
-            var result = securityCoordinator.RunWaf(new(), runWithEphemeral: true, isRasp: true);
+            var result = securityCoordinator.RunWaf(new(), runWithEphemeral: true, raspAddress: AddressesConstants.DBStatement);
             result.Should().BeNull();
         }
 
@@ -160,7 +160,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             var security = new AppSec.Security(waf: waf);
             var securityCoordinator = Get(security, span, httpTransport);
-            var result = securityCoordinator.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestMethod, "GET" } }, runWithEphemeral: true, isRasp: true);
+            var result = securityCoordinator.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestMethod, "GET" } }, runWithEphemeral: true, raspAddress: AddressesConstants.DBStatement);
             result.Should().NotBeNull();
         }
 #endif

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/TraceTaggingResultTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/TraceTaggingResultTests.cs
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         {
             var initResult = CreateWaf();
             using var waf = initResult.Waf!;
-            using var context = waf.CreateContext()!;
+            using var context = waf.CreateContext(out _)!;
 
             var result = context.Run(
                 new Dictionary<string, object>
@@ -346,7 +346,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         {
             var initResult = CreateWaf(ruleFile: RuleFile);
             using var waf = initResult.Waf!;
-            using var context = waf.CreateContext()!;
+            using var context = waf.CreateContext(out _)!;
 
             var args = new Dictionary<string, object>
             {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -93,7 +93,7 @@ public class WafLibraryRequiredTest : SettingsTestsBase
     {
         var res = UpdateWaf(configurationState, waf);
         context?.Dispose();
-        context = waf.CreateContext();
+        context = waf.CreateContext(out _);
         return res;
     }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafConcurrencyTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafConcurrencyTests.cs
@@ -162,7 +162,7 @@ public class WafConcurrencyTests : WafLibraryRequiredTest
                     for (var i = 0; i < 100; i++)
                     {
                         var next = r.Next();
-                        using var context = waf.CreateContext();
+                        using var context = waf.CreateContext(out _);
                         if (context == null)
                         {
                             i--;
@@ -262,7 +262,7 @@ public class WafConcurrencyTests : WafLibraryRequiredTest
 
         var threads = new Thread[20];
 
-        var context = waf.CreateContext();
+        var context = waf.CreateContext(out _);
 
         for (var t = 0; t < threads.Length; t++)
         {
@@ -339,7 +339,8 @@ public class WafConcurrencyTests : WafLibraryRequiredTest
 
         try
         {
-            waf!.CreateContext(isRasp).Should().BeNull();
+            waf!.CreateContext(out var outcome, isRasp).Should().BeNull();
+            outcome.Should().Be(WafOutcome.BindingFailed);
         }
         finally
         {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafConcurrencyTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafConcurrencyTests.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 
 #if NETFRAMEWORK
 using System.Web.Routing;
@@ -19,6 +21,7 @@ using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.AppSec.Waf.Initialization;
 using Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
 using Datadog.Trace.Security.Unit.Tests.Utils;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers.FluentAssertionsExtensions.Json;
 using FluentAssertions;
 using Xunit;
@@ -297,6 +300,66 @@ public class WafConcurrencyTests : WafLibraryRequiredTest
         foreach (var thread in threads)
         {
             thread.Join();
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ReaderLockFailureReportsTheGenericBindingErrorOnlyOutsideRasp(bool isRasp)
+    {
+        // a RASP run reports this failure as rasp.error, from GetOrCreateAdditiveContext, so emitting
+        // waf.error here too would count the same failure twice and break the !isRasp convention
+        var initResult = CreateWaf();
+        var waf = initResult.Waf;
+        waf.Should().NotBeNull();
+
+        var locker = (AppSec.Concurrency.ReaderWriterLock)typeof(Waf).GetField("_wafLocker", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(waf)!;
+
+        // hold the write lock so that CreateContext cannot take its read lock
+        using var writeLockTaken = new ManualResetEventSlim(false);
+        using var releaseWriteLock = new ManualResetEventSlim(false);
+        var writer = new Thread(
+            () =>
+            {
+                locker.EnterWriteLock();
+                writeLockTaken.Set();
+                releaseWriteLock.Wait();
+                locker.ExitWriteLock();
+            })
+        {
+            IsBackground = true
+        };
+
+        writer.Start();
+        writeLockTaken.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        var previousMetrics = TelemetryFactory.SetMetricsForTesting(collector);
+
+        try
+        {
+            waf!.CreateContext(isRasp).Should().BeNull();
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(previousMetrics);
+            releaseWriteLock.Set();
+            writer.Join(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            waf!.Dispose();
+        }
+
+        await collector.DisposeAsync();
+
+        var metrics = collector.GetMetrics().Metrics?.Select(m => (Name: m.Metric, Tags: m.Tags ?? [])).ToList() ?? [];
+
+        if (isRasp)
+        {
+            metrics.Should().NotContain(m => m.Name == "waf.error");
+        }
+        else
+        {
+            metrics.Should().ContainSingle(m => m.Name == "waf.error").Which.Tags.Should().Contain("waf_error:-127");
         }
     }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafConcurrencyTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafConcurrencyTests.cs
@@ -351,7 +351,7 @@ public class WafConcurrencyTests : WafLibraryRequiredTest
 
         await collector.DisposeAsync();
 
-        var metrics = collector.GetMetrics().Metrics?.Select(m => (Name: m.Metric, Tags: m.Tags ?? [])).ToList() ?? [];
+        var metrics = collector.GetMetrics().Metrics?.Select(m => (Name: m.Metric, Tags: m.Tags ?? [], Values: m.Points.Select(p => p.Value).ToArray())).ToList() ?? [];
 
         if (isRasp)
         {
@@ -359,7 +359,11 @@ public class WafConcurrencyTests : WafLibraryRequiredTest
         }
         else
         {
-            metrics.Should().ContainSingle(m => m.Name == "waf.error").Which.Tags.Should().Contain("waf_error:-127");
+            var metric = metrics.Should().ContainSingle(m => m.Name == "waf.error").Which;
+            metric.Tags.Should().Contain("waf_error:-127");
+
+            // one failed creation, one increment: a double count aggregates into a single point of value 2
+            metric.Values.Should().Equal(1);
         }
     }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
@@ -102,12 +102,12 @@ namespace Datadog.Trace.Security.Unit.Tests
         {
             var initResult = CreateWaf(newEncoder);
             using var waf = initResult.Waf;
-            using var context = waf.CreateContext();
+            using var context = waf.CreateContext(out _);
 
             for (var i = 0; i < values.Length; i++)
             {
                 var args = MakeDictionary(address, values[i]);
-                var result = context.RunWithEphemeral(args, TimeoutMicroSeconds, false);
+                var result = context.RunWithEphemeral(args, TimeoutMicroSeconds, false, out _);
                 result.Timeout.Should().BeFalse("Timeout should be false");
 
                 // by convention attack is last item in the array

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafIpBlockTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafIpBlockTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var updateRes1 = UpdateWaf(configurationState, waf);
             updateRes1.Success.Should().BeTrue();
             updateRes1.HasRuleErrors.Should().BeFalse();
-            using var context = waf.CreateContext();
+            using var context = waf.CreateContext(out _);
             var result = context!.Run(new Dictionary<string, object> { { AddressesConstants.RequestClientIp, "51.222.158.205" } }, TimeoutMicroSeconds);
             result!.Timeout.Should().BeFalse("Timeout should be false");
             result.Should().NotBeNull();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Security.Unit.Tests
 
             for (int x = 0; x < 1000; x++)
             {
-                using var context = waf.CreateContext();
+                using var context = waf.CreateContext(out _);
                 var result = context.Run(args, TimeoutMicroSeconds);
                 result.Timeout.Should().BeFalse("Timeout should be false");
                 result.ReturnCode.Should().Be(WafReturnCode.Match);
@@ -138,7 +138,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             }
 
             waf.Should().NotBeNull();
-            using var context = waf.CreateContext();
+            using var context = waf.CreateContext(out _);
             var result = context.Run(args, TimeoutMicroSeconds);
             result.Timeout.Should().BeFalse("Timeout should be false");
             if (isAttack)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Security.Unit.Tests
                 var expectedValue = obfuscate ? "<Redacted>" : fullAttack;
 
                 waf.Should().NotBeNull();
-                using var context = waf.CreateContext();
+                using var context = waf.CreateContext(out _);
                 var result = context.Run(args, TimeoutMicroSeconds);
                 result.Timeout.Should().BeFalse("Timeout should be false");
                 result.ReturnCode.Should().Be(WafReturnCode.Match);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -149,7 +149,7 @@ namespace Datadog.Trace.Security.Unit.Tests
 
             var initResult = CreateWaf(useUnsafeEncoder: newEncoder);
             using var waf = initResult.Waf;
-            using var context = waf.CreateContext();
+            using var context = waf.CreateContext(out _);
             var result = context.Run(args, TimeoutMicroSeconds);
             result.Timeout.Should().BeFalse("Timeout should be false");
             if (flow is not null)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             }
 
             waf.Should().NotBeNull();
-            using var context = waf.CreateContext();
+            using var context = waf.CreateContext(out _);
             var result = context.Run(args, TimeoutMicroSeconds);
             result.Timeout.Should().BeFalse("Timeout should be false");
 
@@ -204,7 +204,7 @@ namespace Datadog.Trace.Security.Unit.Tests
                 },
             };
 
-            using var context = waf.CreateContext();
+            using var context = waf.CreateContext(out _);
             var result = context.Run(args, TimeoutMicroSeconds);
             result.Timeout.Should().BeFalse("Timeout should be false");
             result.ReturnCode.Should().Be(WafReturnCode.Match);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var res = initResult.Waf!.Update(configurationStatus);
             res.Success.Should().BeTrue();
             res.HasRuleErrors.Should().BeFalse();
-            using var context = waf.CreateContext()!;
+            using var context = waf.CreateContext(out _)!;
             var result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.UserId, "user3" } },
                 WafTests.TimeoutMicroSeconds);

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -110,6 +110,8 @@ public class MetricsTelemetryCollectorTests
         collector.RecordCountRaspRuleEval(MetricTags.RaspRuleType.Lfi, 5);
         collector.RecordCountRaspRuleMatch(MetricTags.RaspRuleTypeMatch.LfiSuccess, 3);
         collector.RecordCountRaspTimeout(MetricTags.RaspRuleType.Lfi, 2);
+        collector.RecordCountRaspError(MetricTags.RaspError.LfiInternal, 4);
+        collector.RecordCountRaspRuleSkipped(MetricTags.RaspRuleTypeSkipped.LfiAfterRequest, 6);
         collector.RecordGaugeStatsBuckets(234);
         collector.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.Total, 23);
         collector.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.Total, 46);
@@ -290,6 +292,25 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 2 } },
                 Type = TelemetryMetricType.Count,
                 Tags = new[] { expectedWafTag, expectedRulesetTag, "rule_type:lfi" },
+                Common = true,
+                Namespace = NS.ASM,
+            },
+            new
+            {
+                Metric = Count.RaspError.GetName(),
+                Points = new[] { new { Value = 4 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { expectedWafTag, expectedRulesetTag, "waf_error:-3", "rule_type:lfi" },
+                Common = true,
+                Namespace = NS.ASM,
+            },
+            new
+            {
+                // rasp.rule.skipped is specified without the version tags, so they must not be substituted in
+                Metric = Count.RaspRuleSkipped.GetName(),
+                Points = new[] { new { Value = 6 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "reason:after-request", "rule_type:lfi" },
                 Common = true,
                 Namespace = NS.ASM,
             },

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
@@ -59,7 +59,9 @@ public class MetricTests
         { "impacted_tests_detection.response_bytes", ["rs_compressed"] },
         { "rasp.rule.eval", ["rule_variant"] },
         { "rasp.rule.match", ["rule_variant"] },
+        { "rasp.rule.skipped", ["rule_variant"] },
         { "rasp.timeout", ["rule_variant"] },
+        { "rasp.error", ["rule_variant"] },
         // Both dimensions are independently optional: a span can be cardinality-collapsed, oversized-truncated, or both.
         { "stats_collapsed_spans", ["collapsed", "oversized"] },
     };

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -896,6 +896,20 @@
       "send_to_user": false,
       "user_tags": []
     },
+    "rasp.error": {
+      "tags": [
+        "waf_version",
+        "event_rules_version",
+        "waf_error",
+        "rule_type",
+        "rule_variant"
+      ],
+      "metric_type": "count",
+      "data_type": "errors",
+      "description": "Counts the number of times the WAF returned an error when evaluating a specific rule type.",
+      "send_to_user": false,
+      "user_tags": []
+    },
     "rasp.rule.eval": {
       "tags": [
         "waf_version",
@@ -920,6 +934,18 @@
       "metric_type": "count",
       "data_type": "matches",
       "description": "Counts the number of times a rule type has a match",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "rasp.rule.skipped": {
+      "tags": [
+        "reason",
+        "rule_type",
+        "rule_variant"
+      ],
+      "metric_type": "count",
+      "data_type": "events",
+      "description": "Counts the number of times the evaluation of a RASP instrumentation had to be skipped due to issues related to the request lifecycle",
       "send_to_user": false,
       "user_tags": []
     },

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -154,7 +154,7 @@ public class AppSecWafBenchmark
     [Benchmark]
     public void RunWafRealisticBenchmark()
     {
-        var context = _waf.CreateContext();
+        var context = _waf.CreateContext(out _);
         context!.Run(_stage1, TimeoutMicroSeconds);
         context!.Run(_stage2, TimeoutMicroSeconds);
         context!.Run(_stage3, TimeoutMicroSeconds);
@@ -164,7 +164,7 @@ public class AppSecWafBenchmark
     [Benchmark]
     public void RunWafRealisticBenchmarkWithAttack()
     {
-        var context = _waf.CreateContext();
+        var context = _waf.CreateContext(out _);
         context!.Run(_stage1Attack, TimeoutMicroSeconds);
         context.Dispose();
     }


### PR DESCRIPTION
## Summary of changes

Add the two missing RASP telemetry count metrics:

- `appsec.rasp.error` — the WAF returned an error for a RASP evaluation, tagged by `waf_error` and `rule_type`/`rule_variant`.
- `appsec.rasp.rule.skipped` — a RASP evaluation never reached the WAF, tagged by `reason` and `rule_type`/`rule_variant`.

## Reason for change

.NET was the only tracer not emitting these, so RASP errors and lifecycle-skipped evaluations were invisible in telemetry. Fixes APPSEC-69544.

## Implementation details

Both metrics are recorded from `RaspModule`, which is the only place that knows the address (and therefore the rule type) — no rule type has to be plumbed through `SecurityCoordinator`/`Context`.

- **Skipped**: `CheckVulnerability`, `OnDownstreamRequest` and `OnDownstreamResponse` had a combined `rootSpan is null || rootSpan.IsFinished || rootSpan.Type != SpanTypes.Web` guard. It is split so a finished span reports `after-request` and the rest report `out-of-request`. A missing security coordinator also reports `out-of-request`.
- **Error**: recorded from `RunWafRasp` once `RunWaf` produced a result, mapping the return code through the existing `ToWafErrorTag()`. A timeout returns early, since it is already reported by `rasp.timeout` — same precedence as `SecurityReporter.RecordWafTelemetry`.
- A call that produces no context and a run that produces no result both come back as a bare `null`, and the cause is not observable afterwards: a concurrent disposal can move the state between the call and the check. `IWaf.CreateContext` and `IContext.RunWithEphemeral` therefore return a typed `WafOutcome` (`Success` / `RequestEnded` / `WafUnavailable` / `BindingFailed`), and `RaspModule.RecordRaspOutcome` is the single place that turns it into a metric: `RequestEnded` -> `rasp.rule.skipped{after-request}`, `BindingFailed` -> `rasp.error{waf_error:-127}`, `WafUnavailable` -> nothing at all, so a WAF replaced by a remote configuration update never shows up as a burst of phantom errors. `IContext.Run` (persistent, never a RASP run) keeps its signature, so non-RASP `waf.error` behaviour is unchanged.
- `SecurityCoordinator.RunWaf` no longer takes `isRasp`; it derives it from `raspAddress`, so the execution mode and the telemetry classification cannot disagree.
- `OnDownstreamRequest`/`OnDownstreamResponse` now check `AddressEnabled(DownstreamUrl)` up front, so a ruleset without SSRF rules doesn't report skips for instrumentation that isn't active.

Tag shapes follow the intake spec in dd-go rather than another tracer's implementation. Note `rasp.rule.skipped` carries neither `waf_version` nor `event_rules_version` — the evaluation is skipped before the WAF is reached.

The embedded `common_metrics.json` copy used by `MetricTests` is updated; dd-go needs the same two entries after this merges.

## Test coverage

- `RaspModuleTelemetryTests` (52): both reasons across all 5 rule types, every address x WAF error code combination, success codes and timeouts recording nothing, unknown addresses no-op, the absence of `waf_version` tags on the skip, and the metric each `WafOutcome` maps to.
- `RaspContextFailureTelemetryTests` (13): the cause each unavailable context carries, including one that disposes the real WAF rather than mocking `CreateContext() => null`, and that a RASP run tells the WAF it serves RASP so the generic `waf.error` stays suppressed.
- `RaspRunFailureTelemetryTests` (7): the cause each null run carries (disposed context, disposed WAF, empty ephemeral batch) and the success counterpart, both at `Context` level and through `SecurityCoordinator.RunWaf`.
- `RaspModuleDownstreamTests` (31): the skip reason each downstream request/response entry point reports, per span state, plus the rule type carried by a non-downstream address.
- `WafConcurrencyTests` (7): a reader-lock failure reports the generic binding error only outside RASP.

Each assertion pins the metric's exact tags and its point values, so a duplicated increment fails rather than aggregating into one point. `MetricTests` validates both metrics against the intake spec.

## Other details

`rasp.duration` / `rasp.duration_ext` (distributions) are not included and will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



