### PR TITLE
Partially fix runtime metrics memory_load calculation

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/PlatformKeys.DotNet.cs
+++ b/tracer/src/Datadog.Trace/Configuration/PlatformKeys.DotNet.cs
@@ -33,4 +33,18 @@ internal static partial class PlatformKeys
     /// Program data folder
     /// </summary>
     public const string ProgramData = "ProgramData";
+
+    /// <summary>
+    /// Sets the GC's "high memory load" threshold percent (clamped to 99 by the runtime). Parsed as
+    /// <b>hexadecimal</b> by the runtime (see <c>GCToEEInterface::GetIntConfigValue</c>), and takes precedence
+    /// over the <c>System.GC.HighMemoryPercent</c> runtimeconfig knob, which is parsed using C-style base
+    /// detection (<c>0x</c>/<c>0X</c> prefix for hexadecimal, a leading <c>0</c> for octal, otherwise decimal -
+    /// see <c>Configuration::GetKnobULONGLONGValue</c>).
+    /// </summary>
+    public const string DotNetGCHighMemPercent = "DOTNET_GCHighMemPercent";
+
+    /// <summary>
+    /// Legacy alias for <see cref="DotNetGCHighMemPercent"/>, also parsed as hexadecimal.
+    /// </summary>
+    public const string ComPlusGCHighMemPercent = "COMPlus_GCHighMemPercent";
 }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/DiagnosticsMetricsRuntimeMetricsListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/DiagnosticsMetricsRuntimeMetricsListener.cs
@@ -120,25 +120,12 @@ internal sealed class DiagnosticsMetricsRuntimeMetricsListener : IRuntimeMetrics
             }
 
             // memory load
-            // This is attempting to emulate the GcGlobalHeapHistory.MemoryLoad event details
-            // That value is calculated using
-            // - `current_gc_data_global->mem_pressure` (src/coreclr/gc/gc.cpp#L3288)
-            // - which fetches the value set via `history->mem_pressure = entry_memory_load` (src/coreclr/gc/gc.cpp#L7912)
-            // - which is set by calling `gc_heap::get_memory_info()` (src/coreclr/gc/gc.cpp#L29438)
-            // - which then calls GCToOSInterface::GetMemoryStatus(...) which has platform-specific implementations
-            // - On linux, memory_load is calculated differently depending if there's a restriction (src/coreclr/gc/unix/gcenv.unix.cpp#L1191)
-            //   - Physical Memory Used / Limit
-            //   - (g_totalPhysicalMemSize - GetAvailablePhysicalMemory()) / total
-            // - On Windows, memory_load is calculated differently depending if there's a restriction (src/coreclr/gc/unix/gcenv.windows.cpp#L1000)
-            //   - Working Set Size / Limit
-            //   - GlobalMemoryStatusEx -> (ullTotalVirtual - ullAvailVirtual) * 100.0 / (float)ms.ullTotalVirtual
-            //
-            // We try to roughly emulate that using the info in gcInfo:
-            var availableBytes = gcInfo.TotalAvailableMemoryBytes;
-
-            if (availableBytes > 0)
+            // GCMemoryInfo.MemoryLoadBytes and GCMemoryInfo.HighMemoryLoadThresholdBytes are both scaled by the
+            // GC's total_physical_mem, but TotalAvailableMemoryBytes switches to heap_hard_limit whenever a GC
+            // hard limit is in play, so getting the memory load is not simple
+            if (GcMemoryLoadCalculator.TryGetMemoryLoadPercentage(gcInfo) is { } memoryLoad)
             {
-                statsd.Gauge(MetricsNames.GcMemoryLoad, (double)gcInfo.MemoryLoadBytes * 100.0 / availableBytes);
+                statsd.Gauge(MetricsNames.GcMemoryLoad, memoryLoad);
             }
         }
         else

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/GcMemoryLoadCalculator.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/GcMemoryLoadCalculator.cs
@@ -1,0 +1,163 @@
+// <copyright file="GcMemoryLoadCalculator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if NET6_0_OR_GREATER
+
+#nullable enable
+
+using System;
+using System.Threading;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.RuntimeMetrics;
+
+/// <summary>
+/// Tries to recover the true GC memory-load percentage (0-100) from <see cref="GCMemoryInfo"/>.
+/// <see cref="GCMemoryInfo.MemoryLoadBytes"/> and <see cref="GCMemoryInfo.HighMemoryLoadThresholdBytes"/> are both
+/// scaled by the GC's <c>total_physical_mem</c>, but <see cref="GCMemoryInfo.TotalAvailableMemoryBytes"/> switches
+/// to <c>heap_hard_limit</c> whenever a GC hard limit is in play (e.g. a memory-limited container without explicit
+/// GC configuration, where the runtime defaults the limit to 75% of physical memory).
+/// See <c>GCHeap::GetMemoryInfo</c> in src/coreclr/gc/gc.cpp.
+/// </summary>
+internal static class GcMemoryLoadCalculator
+{
+    // gc_heap::compute_memory_settings() only applies its ">= 80GB" branch above this threshold.
+    // The value here is pre-scaled by the default high-memory-load percentage (90%) so the comparison
+    // below is a plain integer comparison, not a division.
+    private const long EightyGiBBytesAt90Percent = 80L * 1024 * 1024 * 1024 * 9 / 10;
+
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(GcMemoryLoadCalculator));
+
+    private static readonly Lazy<bool> HasConfiguredHighMemoryLoadPercent = new(ReadHasConfiguredHighMemoryLoadPercent);
+
+    private static bool _unableToResolveLogged;
+
+    /// <summary>
+    /// Gets the GC memory load as a 0-100 percentage, or <c>null</c> if it cannot be reliably determined.
+    /// </summary>
+    public static double? TryGetMemoryLoadPercentage(in GCMemoryInfo info)
+    {
+        return TryCalculate(
+            info.MemoryLoadBytes,
+            info.HighMemoryLoadThresholdBytes,
+            info.TotalAvailableMemoryBytes,
+            HasConfiguredHighMemoryLoadPercent.Value);
+    }
+
+    [TestingAndPrivateOnly]
+    internal static double? TryCalculate(long memoryLoadBytes, long highMemoryLoadThresholdBytes, long totalAvailableMemoryBytes, bool hasConfiguredHighMemoryLoadPercent)
+    {
+        if (highMemoryLoadThresholdBytes <= 0 || totalAvailableMemoryBytes <= 0)
+        {
+            // HighMemoryLoadThresholdBytes is 0 before the first GC has run, so we can't calculate anything
+            return null;
+        }
+
+        // We need to recreate this flow from the GC: https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/init.cpp#L1488C59-L1519
+        if (hasConfiguredHighMemoryLoadPercent)
+        {
+            // If there's a high memory threshold, then bail out, as we can't reliably calculate without parsing all the values
+            // identically to the GC, which is fragile
+            return UseFallback(memoryLoadBytes, totalAvailableMemoryBytes);
+        }
+
+        // Check if the threshold is within the runtime's "easy" default formula".
+        // Since the resolved percentage is always >= 90, the _implied_ total
+        // here is always >= total_physical_mem, so "implied < 80GiB" implies "total_physical_mem < 80GiB".
+        if (highMemoryLoadThresholdBytes > EightyGiBBytesAt90Percent)
+        {
+            // If we know we're > 80GB, then we can't accurately calculate the high memory load threshold percent without
+            // getting the processors, which is a pain
+            // If that processor count couldn't be reliably determined, we don't guess, we bail out.
+            if (!Volatile.Read(ref _unableToResolveLogged))
+            {
+                Volatile.Write(ref _unableToResolveLogged, true);
+                Log.Warning("Unable to resolve GC memory load percentage: total machine processor count is unknown (HighMemoryLoadThresholdBytes={HighMemoryLoadThresholdBytes})", highMemoryLoadThresholdBytes);
+            }
+
+            return UseFallback(memoryLoadBytes, totalAvailableMemoryBytes);
+        }
+
+        // heap_hard_limit (TotalAvailableMemoryBytes) can never exceed total_physical_mem. If the implied total
+        // from our resolved threshold is smaller than TotalAvailableMemoryBytes, then we got something wrong in our
+        // calculations, so bail out rather than publish a skewed value.
+        // This should never be violated in practice, it's a safety check for our calculations
+        const double highMemoryLoadThresholdPercentage = 90.0;
+        const double highMemoryLoadThresholdRatio = highMemoryLoadThresholdPercentage / 100.0;
+
+        var impliedTotalPhysicalMemoryBytes = highMemoryLoadThresholdBytes / highMemoryLoadThresholdRatio;
+
+        // include some tolerance
+        if (impliedTotalPhysicalMemoryBytes < totalAvailableMemoryBytes * 0.99)
+        {
+            if (!Volatile.Read(ref _unableToResolveLogged))
+            {
+                Volatile.Write(ref _unableToResolveLogged, true);
+                Log.Error(
+                    "Unable to resolve GC memory load percentage, calculated total available bytes {ImpliedTotalAvailableMemoryBytes} is less than provided GC value {TotalAvailableMemoryBytes} (MemoryLoadBytes={MemoryLoadBytes}, HighMemoryLoadThresholdBytes={HighMemoryLoadThresholdBytes})",
+                    [
+                        impliedTotalPhysicalMemoryBytes,
+                        totalAvailableMemoryBytes,
+                        memoryLoadBytes,
+                        highMemoryLoadThresholdBytes
+                    ]);
+            }
+
+            // Something is wrong with our calculation, shouldn't happen
+            return UseFallback(memoryLoadBytes, totalAvailableMemoryBytes);
+        }
+
+        var memoryLoad = Math.Round(memoryLoadBytes * highMemoryLoadThresholdPercentage / highMemoryLoadThresholdBytes);
+        return Math.Min(100d, Math.Max(0d, memoryLoad));
+
+        // Fallback used when we can't reliably invert the threshold back to a total: fall back to the simple
+        // pre-refactor calculation of load relative to TotalAvailableMemoryBytes. This is exactly correct unless a
+        // GC hard limit is in play (TotalAvailableMemoryBytes then reflects heap_hard_limit rather than
+        // total_physical_mem, which can inflate the result) - but that's still a better bet than the alternative.
+        static double UseFallback(long memoryLoadBytes, long totalAvailableMemoryBytes)
+            => Math.Min(100d, Math.Max(0d, memoryLoadBytes * 100.0 / totalAvailableMemoryBytes));
+    }
+
+    [TestingAndPrivateOnly]
+    internal static bool ReadHasConfiguredHighMemoryLoadPercent()
+    {
+        // Check if either of the configs defined here are set, so we can bail out
+        // https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/gcconfig.h#L100
+        try
+        {
+            var envValue = EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHighMemPercent)
+                        ?? EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHighMemPercent);
+
+            // The runtime checks the environment variable first (gcenv.ee.cpp: GetGCHighMemPercent()). If it's
+            // present at all - even "0", which means "unset" - it wins outright and the runtimeconfig knob below is
+            // never consulted, so an explicit-but-unset env var can't fall back to a configured runtimeconfig value.
+            if (envValue is not null)
+            {
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error reading configured GC high memory load percent");
+        }
+
+        try
+        {
+            // The runtimeconfig knob (System.GC.HighMemoryPercent) is only consulted if the environment variable is unset.
+            // runtimeconfig properties always reach AppContext as strings - anything else was set by user code
+            // after startup, so the GC will never see it
+            return AppContext.GetData("System.GC.HighMemoryPercent") is string;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Error reading System.GC.HighMemoryPercent from AppContext");
+        }
+
+        return false;
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -55,6 +55,41 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             EnvironmentHelper.EnableDefaultTransport();
             await RunTest();
         }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [Trait("SupportsInstrumentationVerification", "True")]
+        public async Task DiagnosticsMetricsApiMemoryLoad_StaysWithinValidRange_UnderGcHardLimit()
+        {
+            // DOTNET_GCHeapHardLimitPercent (parsed as hex, so "19" == 0x19 == 25%) sets
+            // gc_heap::heap_hard_limit != 0 (similar to a memory-limited container).
+            SetEnvironmentVariable(ConfigurationKeys.RuntimeMetricsDiagnosticsMetricsApiEnabled, "1");
+            SetEnvironmentVariable("DOTNET_GCHeapHardLimitPercent", "19");
+            EnvironmentHelper.EnableDefaultTransport();
+
+            using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
+            using var processResult = await RunSampleAndWaitForExit(agent);
+            var requests = agent.StatsdRequests;
+            requests.Should().NotBeEmpty();
+
+            var metrics = requests.SelectMany(x => x.Split('\n')).ToList();
+            var memoryLoadSamples = metrics
+                                    .Where(m => m.StartsWith(MetricsNames.GcMemoryLoad + ":", StringComparison.Ordinal))
+                                    .Select(
+                                         m =>
+                                         {
+                                             var separator = m.IndexOf(':');
+                                             var endIndex = m.IndexOf('|', separator + 1);
+                                             return double.Parse(m.Substring(separator + 1, endIndex - separator - 1));
+                                         })
+                                    .ToList();
+
+            memoryLoadSamples.Should().NotBeEmpty();
+            memoryLoadSamples.Should().OnlyContain(v => v <= 100);
+
+            agent.Exceptions.Should().BeEmpty();
+        }
 #endif
 
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
@@ -137,7 +137,6 @@ public class GcMemoryLoadCalculatorTests
         }
     }
 
-
     // AppContext.SetData is public at runtime on every supported TFM, but the net6.0 (and earlier) reference
     // assemblies used to compile this project don't declare it - only GetData, which the product code under test
     // relies on - so a direct call fails to compile for those TargetFrameworks specifically.

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
@@ -137,6 +137,11 @@ public class GcMemoryLoadCalculatorTests
         }
     }
 
+
+    // AppContext.SetData is public at runtime on every supported TFM, but the net6.0 (and earlier) reference
+    // assemblies used to compile this project don't declare it - only GetData, which the product code under test
+    // relies on - so a direct call fails to compile for those TargetFrameworks specifically.
+#if NET7_0_OR_GREATER
     [Fact]
     public void ReadHasConfiguredHighMemoryLoadPercent_NoConfig_ReturnsFalse()
     {
@@ -209,13 +214,19 @@ public class GcMemoryLoadCalculatorTests
             ClearAppContextData();
         }
     }
-
-    private static void ClearAppContextData() => AppContext.SetData("System.GC.HighMemoryPercent", null);
+#endif
 
     // Mirrors how the GC encodes a percentage into bytes (compute_memory_settings, src/coreclr/gc/init.cpp as of
     // writing - see the pinned source reference on GcMemoryLoadCalculator.EightyGiBBytesAt90Percent):
     // `(uint64_t)(pct / 100 * total_physical_mem)`. Each test builds inputs the same way the runtime would, then
     // asserts we decode the original percentage back.
     private static long AsBytes(long total, double percent) => (long)((percent / 100.0) * total);
+
+    // AppContext.SetData is public at runtime on every supported TFM, but the net6.0 (and earlier) reference
+    // assemblies used to compile this project don't declare it. Below net7.0, nothing in this test binary can
+    // set the value in the first place, so clearing it is a no-op.
+#if NET7_0_OR_GREATER
+    private static void ClearAppContextData() => AppContext.SetData("System.GC.HighMemoryPercent", null);
+#endif
 }
 #endif

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
@@ -1,0 +1,221 @@
+// <copyright file="GcMemoryLoadCalculatorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+
+#nullable enable
+
+using System;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.RuntimeMetrics;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.RuntimeMetrics;
+
+[Collection(nameof(EnvironmentVariablesTestCollection))]
+[EnvironmentRestorer(PlatformKeys.DotNetGCHighMemPercent, PlatformKeys.ComPlusGCHighMemPercent)]
+public class GcMemoryLoadCalculatorTests
+{
+    private const long Total8GiB = 8L * 1024 * 1024 * 1024;
+    private const long Total96GiB = 96L * 1024 * 1024 * 1024;
+
+    [Fact]
+    public void TryCalculate_NoHardLimit_RecoversTrueLoad()
+    {
+        var highMemoryLoadThresholdBytes = AsBytes(Total8GiB, 90);
+        var totalAvailableMemoryBytes = Total8GiB;
+        var memoryLoadBytes = AsBytes(Total8GiB, 42);
+
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+
+        result.Should().Be(42);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(42)]
+    [InlineData(80)]
+    [InlineData(99)]
+    [InlineData(100)]
+    public void TryCalculate_DefaultContainerHardLimit_RecoversTrueLoad(int loadPercent)
+    {
+        // e.g. a memory-limited container with no explicit GC hard limit, where the runtime defaults to 75%
+        var highMemoryLoadThresholdBytes = AsBytes(Total8GiB, 90);
+        var totalAvailableMemoryBytes = AsBytes(Total8GiB, 75);
+        var memoryLoadBytes = AsBytes(Total8GiB, loadPercent);
+
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+
+        result.Should().Be(loadPercent);
+    }
+
+    [Theory]
+    // An explicit threshold-percent override (DOTNET_GCHighMemPercent / System.GC.HighMemoryPercent) can't be
+    // reliably inverted without parsing those values identically to the runtime, which is fragile.
+    [InlineData(42, 70, 75, true, 56)]
+    // >= 80GiB, no hard limit: fallback
+    [InlineData(42_000_000_000, 97_000_000_000, 100_000_000_000, false, 42)]
+    // TotalAvailableMemoryBytes (heap_hard_limit) can never exceed total_physical_mem, so a tiny threshold next to
+    // a huge totalAvailableMemoryBytes can never be consistent with that invariant.
+    [InlineData(500, 1000, 2000, false, 25)]
+    // Like the primary calculation, the fallback clamps to [0, 100] - it must not publish a value above 100 just
+    // because the actual load already exceeds TotalAvailableMemoryBytes...
+    [InlineData(90, 70, 75, true, 100)]
+    // ...nor below 0 for a negative load.
+    [InlineData(-1000, 70, 75, true, 0)]
+    public void TryCalculate_WhenItCannotInvertTheThreshold_FallsBackToLoadRelativeToTotalAvailableMemory(
+        long memoryLoadBytes, long highMemoryLoadThresholdBytes, long totalAvailableMemoryBytes, bool hasConfiguredHighMemoryLoadPercent, double expected)
+    {
+        // We can't reliably recover the *true* load percentage relative to the threshold in these cases - so
+        // instead of bailing out, this falls back to the simple pre-refactor calculation of load relative to
+        // TotalAvailableMemoryBytes.
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void TryCalculate_HighMemoryLoadThresholdBytesIsZero_ReturnsNull()
+    {
+        // HighMemoryLoadThresholdBytes is 0 before the first GC has run
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 0, totalAvailableMemoryBytes: Total8GiB, hasConfiguredHighMemoryLoadPercent: false);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryCalculate_TotalAvailableMemoryBytesIsZero_ReturnsNull()
+    {
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 1000, totalAvailableMemoryBytes: 0, hasConfiguredHighMemoryLoadPercent: false);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryCalculate_ClampsResultToUpperBound()
+    {
+        // Defensive clamp: this shouldn't happen for real GC-reported values, but we must never publish
+        // something outside the 0-100 range.
+        var highMemoryLoadThresholdBytes = AsBytes(Total8GiB, 90);
+        var totalAvailableMemoryBytes = Total8GiB;
+        var memoryLoadBytes = AsBytes(Total8GiB, 150);
+
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+
+        result.Should().Be(100);
+    }
+
+    [Fact]
+    public void TryCalculate_ClampsResultToLowerBound()
+    {
+        var highMemoryLoadThresholdBytes = AsBytes(Total8GiB, 90);
+        var totalAvailableMemoryBytes = Total8GiB;
+
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: -1000, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+
+        result.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryGetMemoryLoadPercentage_LiveGcMemoryInfo_ReturnsValueInRangeOrNull()
+    {
+        var info = GC.GetGCMemoryInfo();
+
+        var result = GcMemoryLoadCalculator.TryGetMemoryLoadPercentage(info);
+
+        // Legitimately null if no GC has run yet, a configured override is in play, or the host is >= 80GiB -
+        // but whenever it does resolve, it must be a valid percentage.
+        if (result is { } value)
+        {
+            value.Should().BeInRange(0, 100);
+        }
+    }
+
+    [Fact]
+    public void ReadHasConfiguredHighMemoryLoadPercent_NoConfig_ReturnsFalse()
+    {
+        ClearAppContextData();
+
+        var result = GcMemoryLoadCalculator.ReadHasConfiguredHighMemoryLoadPercent();
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(PlatformKeys.DotNetGCHighMemPercent, "50")]
+    [InlineData(PlatformKeys.DotNetGCHighMemPercent, "")]
+    [InlineData(PlatformKeys.ComPlusGCHighMemPercent, "50")]
+    [InlineData(PlatformKeys.ComPlusGCHighMemPercent, "")]
+    public void ReadHasConfiguredHighMemoryLoadPercent_ComPlusEnvVarSet_ReturnsTrue(string envVar, string value)
+    {
+        if (value.Length == 0 && FrameworkDescription.Instance.IsWindows())
+        {
+            // On Windows, Environment.SetEnvironmentVariable(name, "") deletes the variable instead of setting it
+            // to an empty value (Win32 SetEnvironmentVariable semantics), so we can't construct a "present but
+            // empty" env var this way on this platform.
+            return;
+        }
+
+        ClearAppContextData();
+        Environment.SetEnvironmentVariable(envVar, value);
+
+        var result = GcMemoryLoadCalculator.ReadHasConfiguredHighMemoryLoadPercent();
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadHasConfiguredHighMemoryLoadPercent_RuntimeConfigKnobSetAsString_ReturnsTrue()
+    {
+        ClearAppContextData();
+
+        try
+        {
+            AppContext.SetData("System.GC.HighMemoryPercent", "70");
+
+            var result = GcMemoryLoadCalculator.ReadHasConfiguredHighMemoryLoadPercent();
+
+            result.Should().BeTrue();
+        }
+        finally
+        {
+            ClearAppContextData();
+        }
+    }
+
+    [Fact]
+    public void ReadHasConfiguredHighMemoryLoadPercent_RuntimeConfigKnobSetAsNonString_ReturnsFalse()
+    {
+        // runtimeconfig properties always reach AppContext as strings - anything else was set by user code
+        // after startup, so the GC will never see it
+        ClearAppContextData();
+
+        try
+        {
+            AppContext.SetData("System.GC.HighMemoryPercent", 70);
+
+            var result = GcMemoryLoadCalculator.ReadHasConfiguredHighMemoryLoadPercent();
+
+            result.Should().BeFalse();
+        }
+        finally
+        {
+            ClearAppContextData();
+        }
+    }
+
+    private static void ClearAppContextData() => AppContext.SetData("System.GC.HighMemoryPercent", null);
+
+    // Mirrors how the GC encodes a percentage into bytes (compute_memory_settings, src/coreclr/gc/init.cpp as of
+    // writing - see the pinned source reference on GcMemoryLoadCalculator.EightyGiBBytesAt90Percent):
+    // `(uint64_t)(pct / 100 * total_physical_mem)`. Each test builds inputs the same way the runtime would, then
+    // asserts we decode the original percentage back.
+    private static long AsBytes(long total, double percent) => (long)((percent / 100.0) * total);
+}
+#endif


### PR DESCRIPTION
## Summary of changes

Partially fixes the runtime metrics value of `runtime.dotnet.gc.memory_load` in containers

## Reason for change

#9015 flagged that the calculation we're currently doing for `memory_load` is incorrect. This metric is meant to flag essentially how close you are to an OOM. In the "new" implementation (which avoids using event pipes to prevent crashes) we read GC values using `GC.GetGCMemoryInfo()` which gives some values of interest, e.g.:

- [`MemoryLoadBytes`](https://learn.microsoft.com/en-us/dotnet/api/system.gcmemoryinfo.memoryloadbytes) - This is the amount of physical memory the process is using (in bytes). 
- [`TotalAvailableMemoryBytes`](https://learn.microsoft.com/en-us/dotnet/api/system.gcmemoryinfo.totalavailablememorybytes?view=net-10.0) - This is the amount of physical memory on the machine available for the GC to use. _In containers with memory limits, this is set to 75% of the available memory (this is the bug)_.
- `HighMemoryLoadThresholdBytes` - This is the percentage of total physical memory on the machine, being used, at which point the GC becomes more aggressive.

Our previous implementation assumed that `TotalAvailableMemoryBytes` was... well... the total available memory in bytes, and so we calculated memory_load as a _percentage using (effectively)

```
var memoryLoadPercentage = (MemoryLoadBytes / TotalAvailableMemoryBytes) * 100;
```

However, in containers, the value returned by `TotalAvailableMemoryBytes` is _not_ the total available memory, it's 75% of that, which leads to our memory load calculation being 1/3 too high, and leads to absurdities like memory load being > 100% at high load. That's because `MemoryLoadBytes` maxes out at the _real_ total available memory (before OOMing); i.e. it's the "real" total memory that matters, not the "fake" 75% limit that is provided in `TotalAvailableMemoryBytes`.

The real problem is: there's no simple way for us to get the "real" total available memory from the runtime 🙁 

## Implementation details

I could see essentially two different options:
- Try to parse the values from the system to find the "real" total available memory, in the same way the GC does.
- Use `HighMemoryLoadThresholdBytes` to infer the total memory.

Both have their difficulties, but the second approach (with caveats) is the one I went for, as ultimately there are fewer moving parts.

> Note that this PR does _not_ provide a complete fix, there are edge cases listed below compared to a previous implementation in #9031 and a speculative alternative implementation that [vendors code from `Microsoft.Extensions.Diagnostics.ResourceMonitoring`](https://github.com/dotnet/extensions/blob/b10f9c0a081b5dbb7755b8f5592e1d3c3f550a3a/src/Libraries/Microsoft.Extensions.Diagnostics.ResourceMonitoring/Linux/LinuxUtilizationParserCgroupV1.cs#L184)

We can calculate the real available memory from `HighMemoryLoadThresholdBytes` given that 

```
HighMemoryLoadThresholdBytes = RealAvailableMemoryBytes * (HighMemoryThresholdPercent / 100)
```

Which means we need `HighMemoryLoadThresholdBytes` and `HighMemoryThresholdPercent`. We definitely have the first one, but we also need the threshold. This is [calculated in the GC](https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/init.cpp#L1488) in two steps

- Is there an [explicit config set](https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/gcconfig.h#L100)?
  - This could be the set via the `DOTNET_GCHighMemPercent`/`COM_GCHighMemPercent` variables _or_ the `"System.GC.HighMemoryPercent"` AppContext switch
  - If the config is provided, that's the percentage to use
  - **Parsing these values are not simple, so if we detect this scenario, we fallback to the existing values**. i.e. we _don't_ fix the calculations in this scenario
- If there's no explicit config calculate the threshold [as follows](https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/init.cpp#L1506):
  - If the total available memory is < 80GB - `HighMemoryThresholdPercent = 90%`
  - If the total available memory is >= 80GB - calculate based on [this formula](https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/init.cpp#L1506), which relies on the total number of processors available on the machine)
  - **Unfortunately, grabbing the total number of processors on the machine is not simple, so if we detect this scenario, we fallback to the existing values**. i.e. we _don't_ fix the calculations in this scenario

So _if_ the app has
- No `DOTNET_GCHighMemPercent`/`COM_GCHighMemPercent` configs defined, and
- total available host memory is < 80GB

Then we know that `HighMemoryThresholdPercent = 90` and we can then calculate `RealAvailableMemory` using:

```
RealAvailableMemoryBytes = HighMemoryLoadThresholdBytes / 0.9
```

and from there we can get the memory load:

```
MemoryLoadPercentage = (MemoryLoadBytes / RealAvailableMemoryBytes) * 100
```

## Test coverage

This is kind of tricky, because it naturally relies on how much memory we're using. I mostly limited to unit tests, and added one "smoke test"

## Other details

Partially fixes #9015

An alternative (smaller, simpler, less complete, less risky) version of:
- https://github.com/DataDog/dd-trace-dotnet/pull/9029
- https://github.com/DataDog/dd-trace-dotnet/pull/9031

We are also looking at pushing some fixes for identified gaps upstream to Microsoft.Extensions.Diagnostics.ResourceMonitoring and then using that code instead