### PR TITLE
[Profiler] Raise the crashing-app flag even when crashtracking is disabled

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -196,6 +196,11 @@ char* getSubfolder(const char* path)
 static void check_init();
 
 static char* originalMiniDumpName = NULL;
+// The minidump name configured by the user (DOTNET_DbgMiniDumpName/COMPlus_DbgMiniDumpName),
+// captured before it is potentially replaced by datadogCrashMarker.
+// It is used at execve time to recognize a crash-triggered createdump invocation
+// when the call is not redirected to the Datadog crash handler (ex: crashtracking is disabled).
+static char* userMiniDumpName = NULL;
 static const char* datadogCrashMarker = "datadog_crashtracking";
 #define DD_CRASHTRACKING_ENABLED "DD_CRASHTRACKING_ENABLED"
 #define DD_INTERNAL_CRASHTRACKING_PASSTHROUGH "DD_INTERNAL_CRASHTRACKING_PASSTHROUGH"
@@ -210,6 +215,26 @@ void initLibrary(void)
 {
     check_init();
 
+    // Bash provides its own version of the getenv/setenv functions
+    // Fetch the original ones and use those instead
+    char *(*real_getenv)(const char *) = __dd_dlsym(RTLD_NEXT, "getenv");
+    int (*real_setenv)(const char *, const char *, int) = __dd_dlsym(RTLD_NEXT, "setenv");
+
+    if (real_getenv == NULL || real_setenv == NULL)
+    {
+        return;
+    }
+
+    // Capture the minidump name configured by the user, even when crashtracking is disabled:
+    // the execve interception uses it to detect a crash-triggered createdump invocation
+    // and notify the profiler that the application is crashing.
+    userMiniDumpName = real_getenv(DOTNET_DbgMiniDumpName);
+
+    if (userMiniDumpName == NULL)
+    {
+        userMiniDumpName = real_getenv(COMPlus_DbgMiniDumpName);
+    }
+
     const char* crashHandlerEnabled = getenv(DD_CRASHTRACKING_ENABLED);
 
     if (crashHandlerEnabled != NULL)
@@ -221,16 +246,6 @@ void initLibrary(void)
             // Early nope
             return;
         }
-    }
-
-    // Bash provides its own version of the getenv/setenv functions
-    // Fetch the original ones and use those instead
-    char *(*real_getenv)(const char *) = __dd_dlsym(RTLD_NEXT, "getenv");
-    int (*real_setenv)(const char *, const char *, int) = __dd_dlsym(RTLD_NEXT, "setenv");
-
-    if (real_getenv == NULL || real_setenv == NULL)
-    {
-        return;
     }
 
     // If crashtracking is enabled, check the value of DOTNET_DbgEnableMiniDump
@@ -444,16 +459,22 @@ int dladdr(const void* addr_arg, Dl_info* info)
 static int (*__real_execve)(const char* pathname, char* const argv[], char* const envp[]) = NULL;
 
 __attribute__((visibility("hidden")))
-int ShouldCallCustomCreatedump(const char* pathname, char* const argv[])
+int IsCreatedump(const char* pathname)
 {
-    if (crashHandler == NULL || pathname == NULL)
+    if (pathname == NULL)
     {
         return 0;
     }
 
     size_t length = strlen(pathname);
 
-    if (length < 11 || strcmp(pathname + length - 11, "/createdump") != 0)
+    return length >= 11 && strcmp(pathname + length - 11, "/createdump") == 0;
+}
+
+__attribute__((visibility("hidden")))
+int ShouldCallCustomCreatedump(const char* pathname, char* const argv[])
+{
+    if (crashHandler == NULL || IsCreatedump(pathname) == 0)
     {
         return 0;
     }
@@ -472,6 +493,34 @@ int ShouldCallCustomCreatedump(const char* pathname, char* const argv[])
     return 0;
 }
 
+// Tells whether this createdump invocation was triggered by the runtime handling a crash,
+// when the datadogCrashMarker mechanism is not in place (ex: crashtracking is disabled).
+// Following a crash, the runtime forwards the value of DOTNET_DbgMiniDumpName/COMPlus_DbgMiniDumpName
+// through the --name argument (and passes no --name at all when the variable is not set).
+// Dump generation requests (ex: dotnet-dump) instead carry the file name chosen by the client.
+__attribute__((visibility("hidden")))
+int IsCrashTriggeredCreatedump(const char* pathname, char* const argv[])
+{
+    if (IsCreatedump(pathname) == 0)
+    {
+        return 0;
+    }
+
+    int previousWasNameOpt = 0;
+    for (int i = 0; argv[i] != NULL; i++)
+    {
+        if (previousWasNameOpt != 0)
+        {
+            return userMiniDumpName != NULL && strcmp(argv[i], userMiniDumpName) == 0;
+        }
+        previousWasNameOpt = strncmp(argv[i], "--name", strlen("--name")) == 0;
+    }
+
+    // No --name argument: only the crash path can omit the dump file name
+    // (dump generation requests always specify it)
+    return 1;
+}
+
 int execve(const char* pathname, char* const argv[], char* const envp[])
 {
     check_init();
@@ -480,6 +529,16 @@ int execve(const char* pathname, char* const argv[], char* const envp[])
 
     if (callCustomCreatedump == 0)
     {
+        // Even when the call is not redirected to the Datadog crash handler
+        // (typically because crashtracking is disabled), the runtime spawning createdump
+        // following a crash still means the application is crashing.
+        // Raise the flag so that the profiler stops collecting callstacks in the crashing
+        // (parent) process, then let the original invocation go through unchanged.
+        if (IsCrashTriggeredCreatedump(pathname, argv) != 0 && is_app_crashing != NULL)
+        {
+            *is_app_crashing = 1;
+        }
+
         return __real_execve(pathname, argv, envp);
     }
 

--- a/profiler/test/Datadog.Linux.ApiWrapper.Tests/CrashFlag.cpp
+++ b/profiler/test/Datadog.Linux.ApiWrapper.Tests/CrashFlag.cpp
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gtest/gtest.h"
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char** environ;
+
+// Defined in Datadog.Linux.ApiWrapper (preloaded when running this test suite).
+// Returns non-zero when the "application is crashing" flag is raised.
+extern "C" unsigned long long dd_inside_wrapped_functions() __attribute__((weak));
+
+namespace CrashFlagTest {
+
+// The .NET runtime handles a fatal signal by fork()ing a child which execve()s createdump
+// while the crashing parent waits for it. The wrapper intercepts that execve and raises a
+// flag stored in MAP_SHARED memory, so that the profiler stops collecting callstacks in the
+// crashing parent (see https://github.com/DataDog/dd-trace-dotnet/pull/7657).
+// This must happen even when the call is not redirected to the Datadog crash handler
+// (ex: DD_CRASHTRACKING_ENABLED=false, or dd-dotnet not found next to the wrapper).
+// Note: the flag is sticky for the remaining lifetime of this test process.
+TEST(CrashFlagTest, ExecveOfCreatedumpRaisesTheCrashFlagInTheParent)
+{
+    if (dd_inside_wrapped_functions == nullptr)
+    {
+        GTEST_SKIP() << "Datadog.Linux.ApiWrapper is not preloaded";
+    }
+
+    ASSERT_EQ(0u, dd_inside_wrapped_functions());
+
+    pid_t pid = fork();
+    ASSERT_NE(-1, pid);
+
+    if (pid == 0)
+    {
+        // Mimic the runtime's crash path: no --name argument is passed when
+        // DOTNET_DbgMiniDumpName is not set. The execve itself fails (the path
+        // does not exist), but the interception runs before the real execve.
+        char* const argv[] = {const_cast<char*>("createdump"), const_cast<char*>("1234"), nullptr};
+        execve("/nonexistent_path_for_test/createdump", argv, environ);
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(pid, waitpid(pid, &status, 0));
+
+    // The child shares the MAP_SHARED flag with this process: it must now be raised.
+    ASSERT_NE(0u, dd_inside_wrapped_functions());
+}
+
+} // namespace CrashFlagTest


### PR DESCRIPTION
## Summary of changes

Raise the mmap-shared "application is crashing" flag (introduced in #7657) on the `execve` interception path even when the call is **not** redirected to the Datadog crash handler — i.e. when `DD_CRASHTRACKING_ENABLED=false`, or when `dd-dotnet` is not found next to the wrapper. The original createdump invocation is then passed through unchanged.

## Reason for change

#7657 exists because the profiler's signal-based stack collector can interrupt a process that is in the middle of its crash handling ("crash on a crash"). But the flag is only ever set inside the `ShouldCallCustomCreatedump != 0` branch of the `execve` wrapper, and that branch is unreachable when crashtracking is disabled:

- With `DD_CRASHTRACKING_ENABLED=false`, `initLibrary()` takes the early return, so `crashHandler` stays `NULL` and `ShouldCallCustomCreatedump` returns 0 unconditionally.
- Independently, the `--name datadog_crashtracking` marker is only planted into `DOTNET_DbgMiniDumpName` when crashtracking is enabled, so the marker check can never match either.

Result: disabling crashtracking (a legitimate configuration for users who want the stock runtime `createdump` minidumps) silently re-exposes the exact pre-#7657 behavior — the profiler keeps sending sampling signals throughout the entire crash sequence.

**Production evidence** (dd-trace-dotnet 3.51.1, .NET 10.0.11, Ubuntu 24.04 AKS via k8s single-step injection, all profiler samplers enabled, `DD_CRASHTRACKING_ENABLED=false`, `DOTNET_DbgEnableMiniDump=1`): a process with a 12–17 GB heap crashing on its GC hard limit terminated with **exit code 139 (second SIGSEGV during crash handling)** and **no dump produced**, on 4 consecutive crashes. The final log line each time was the runtime's

```
Problem reading from createdump child_read_pipe: Success (0)
```

which is the fork-handshake in `PROCCreateCrashDump`: `read()` returning 0 with errno 0 means the crashing parent died between `fork()` and writing the go-byte, so createdump was never even exec'd. Disabling the profiler makes dumps reliably appear again.

## Implementation details

`profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c`:

- `initLibrary()` now captures the user-configured `DOTNET_DbgMiniDumpName`/`COMPlus_DbgMiniDumpName` into `userMiniDumpName` **before** the crashtracking-disabled early return (the `real_getenv`/`real_setenv` lookup moved above the check to make that possible; the check itself is unchanged).
- New helper `IsCreatedump()` extracts the existing `/createdump` path-suffix test (now shared with `ShouldCallCustomCreatedump`, which is otherwise unchanged).
- New helper `IsCrashTriggeredCreatedump()` distinguishes a crash-triggered createdump from an on-demand dump request when the `datadog_crashtracking` marker mechanism is not in place: following a crash the runtime forwards the raw value of `DbgMiniDumpName` through `--name` (and passes no `--name` at all when the variable is not set), whereas dump-generation requests (ex: `dotnet-dump collect`) carry a client-chosen file name. This mirrors what the marker check does for the crashtracking-enabled path, and avoids permanently muting the profiler after a live `dotnet-dump collect` (the flag is sticky).
- In `execve()`: when `ShouldCallCustomCreatedump` says no, but `IsCrashTriggeredCreatedump` says yes, set `*is_app_crashing = 1` and fall through to the **original** `execve(pathname, argv, envp)` unchanged — no dd-dotnet substitution, no argv/envp rewriting, so user-visible createdump behavior in this configuration is exactly as before, minus the sampling during the crash window.

No reader-side changes were needed: the shared-memory flag is already mmap'd unconditionally in `init()`, and the profiler consumes it through the weak `dd_inside_wrapped_functions()` symbol (`LinuxStackFramesCollector`, `TimerCreateCpuProfiler`, `SystemCallsShield`) with no crashtracking gating.

Behavior with crashtracking enabled and functioning is unchanged: the crash path still goes through the marker match and the custom-createdump branch. The one intentional extension is the "crashtracking enabled but dd-dotnet binary not found" case, where the flag is now also raised (the guard was equally dead there).

## Test coverage

- New `profiler/test/Datadog.Linux.ApiWrapper.Tests/CrashFlag.cpp` (runs under the existing `RunNativeWrapperNativeTests` target with the wrapper preloaded): forks, execve's a (nonexistent) `.../createdump` the way the runtime's crash path does, and asserts `dd_inside_wrapped_functions()` becomes non-zero in the parent. This fails against master and passes with this change. Note the flag is sticky for the remainder of the test process (documented in the test).
- The existing `CreatedumpTests.DoNothingIfNotEnabled(enableCrashDumps: true)` integration test covers this exact configuration and asserts stock createdump still runs — the pass-through here keeps it intact.
- Manual verification in the `gleocadie/centos7-clang16` CI image (wrapper built and `LD_PRELOAD`ed into a fork/execve harness mimicking `PROCCreateCrashDump`):
  - crashtracking disabled + `--name` matching `DOTNET_DbgMiniDumpName` → flag set (was: not set on master);
  - crashtracking disabled + dotnet-dump-style foreign `--name` → flag not set;
  - `DbgMiniDumpName` unset + no `--name` → flag set;
  - non-createdump exec → flag not set;
  - `COMPlus_` variants → flag set.
- Build verification: `functions_to_wrap.c` compiles clean (`clang 16, -std=c11 -Wall`, glibc and `-DDD_ALPINE`) in the CI image and the full `.so` links; `nm -D` confirms no new exported symbols (the wrapper-symbols snapshot test should be unaffected). I could not run the full Nuke/CMake pipeline locally (macOS host), so relying on CI for the complete build and test matrix.

## Other details

- **Residual gap this does not fix**: the flag is raised at `execve()` interception time, but the vulnerable window opens at `fork()` — the `PROCCreateCrashDump` pipe handshake happens before exec, and in our production crashes the parent died inside that pre-exec window. So even with crashtracking enabled, the current mechanism cannot protect the fork→exec gap; closing it (e.g. raising the flag from the runtime's SIGSEGV handler side, or intercepting the crash-path `fork`) is follow-up material.
- Related known limitation (pre-existing, shared with the marker mechanism): a direct diagnostics-IPC `GenerateCoreDump` request whose target file name happens to equal `DbgMiniDumpName` would be treated as a crash.
- We can readily test candidate builds against the reproducing production workload.

Refs #7657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
