### PR TITLE
Fix broken unit tests in `GcMemoryLoadCalculatorTests`

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
@@ -153,19 +153,21 @@ public class GcMemoryLoadCalculatorTests
 
     [Theory]
     [InlineData(PlatformKeys.DotNetGCHighMemPercent, "50")]
-    [InlineData(PlatformKeys.DotNetGCHighMemPercent, "")]
     [InlineData(PlatformKeys.ComPlusGCHighMemPercent, "50")]
+    [InlineData(PlatformKeys.DotNetGCHighMemPercent, "0")]
+    [InlineData(PlatformKeys.ComPlusGCHighMemPercent, "0")]
+    [InlineData(PlatformKeys.DotNetGCHighMemPercent, " ")]
+    [InlineData(PlatformKeys.ComPlusGCHighMemPercent, " ")]
+    // Below net9.0, Environment.SetEnvironmentVariable(name, "") deletes the variable instead of
+    // setting it to an empty value, on every platform .NET runs on (not just Windows), so we can't
+    // construct a "present but empty" env var there. net9.0 changed this: empty strings
+    // are now persisted everywhere - so on net9.0+ this case runs for real.
+#if NET9_0_OR_GREATER
+    [InlineData(PlatformKeys.DotNetGCHighMemPercent, "")]
     [InlineData(PlatformKeys.ComPlusGCHighMemPercent, "")]
+#endif
     public void ReadHasConfiguredHighMemoryLoadPercent_ComPlusEnvVarSet_ReturnsTrue(string envVar, string value)
     {
-        if (value.Length == 0 && FrameworkDescription.Instance.IsWindows())
-        {
-            // On Windows, Environment.SetEnvironmentVariable(name, "") deletes the variable instead of setting it
-            // to an empty value (Win32 SetEnvironmentVariable semantics), so we can't construct a "present but
-            // empty" env var this way on this platform.
-            return;
-        }
-
         ClearAppContextData();
         Environment.SetEnvironmentVariable(envVar, value);
 


### PR DESCRIPTION
## Summary of changes

Fixes the new unit tests that only fail on master

## Reason for change

The behaviour of `Environment.SetEnvironmentVariable(.., "")` is different on < .NET 9, which causes the new unit tests introduced in #9505 to break only on master, where we run .NET 7 and .NET 8. This fixes those tests

## Implementation details

These tests cases don't work on < .NET 9, because they _don't_ set a `""` variable, they instead delete the variable:

```c#
[InlineData(PlatformKeys.DotNetGCHighMemPercent, "")]
```

In .NET 9+ these tests work, as they _do_ set the variable with the `""` value

## Test coverage

Added a couple of extra cases just to cover other edge cases while I was there.
I'll make sure to do a full TFM run to be sure it's fixed

## Other details

Currently causing failures on master (not PRs) so high urgency