### PR TITLE
[CI Visibility] Fix coverage rewrites with shared framework dependencies

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -797,10 +797,11 @@ namespace Datadog.Trace.Coverage.Collector
             var assemblyDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
             var assemblyFileName = Path.GetFileNameWithoutExtension(assemblyFilePath);
             var stagingBasePath = Path.Combine(assemblyDirectory, $".{assemblyFileName}.{Guid.NewGuid():N}");
-            var stagedAssemblyPath = stagingBasePath + ".tmp.dll";
+            // Keep transaction files on the target volume for File.Replace, but do not let the collector identify them as assemblies.
+            var stagedAssemblyPath = stagingBasePath + ".tmp";
             var stagedSymbolsPath = Path.ChangeExtension(stagedAssemblyPath, ".pdb");
-            var assemblyBackupPath = stagingBasePath + ".backup.dll";
-            var symbolsBackupPath = stagingBasePath + ".backup.pdb";
+            var assemblyBackupPath = stagingBasePath + ".assembly.backup";
+            var symbolsBackupPath = stagingBasePath + ".symbols.backup";
             var symbolsPath = Path.ChangeExtension(assemblyFilePath, ".pdb");
             var published = false;
 
@@ -812,9 +813,7 @@ namespace Datadog.Trace.Coverage.Collector
                     StrongNameKeyBlob = strongNameKeyBlob
                 });
 
-                using (AssemblyDefinition.ReadAssembly(stagedAssemblyPath, new ReaderParameters { ReadSymbols = true, InMemory = true }))
-                {
-                }
+                ValidateStagedAssemblyAndSymbols(stagedAssemblyPath);
 
                 ReplaceTargetFiles(stagedAssemblyPath, stagedSymbolsPath, assemblyFilePath, symbolsPath, assemblyBackupPath, symbolsBackupPath, replaceFile);
                 published = true;
@@ -828,6 +827,15 @@ namespace Datadog.Trace.Coverage.Collector
                     TryDeleteStagedFile(assemblyBackupPath, logger);
                     TryDeleteStagedFile(symbolsBackupPath, logger);
                 }
+            }
+        }
+
+        private static void ValidateStagedAssemblyAndSymbols(string stagedAssemblyPath)
+        {
+            using var stagedAssembly = AssemblyDefinition.ReadAssembly(stagedAssemblyPath, new ReaderParameters { ReadSymbols = true, InMemory = true });
+            if (!stagedAssembly.MainModule.HasSymbols)
+            {
+                throw new InvalidOperationException($"Rewritten symbols could not be read from '{Path.ChangeExtension(stagedAssemblyPath, ".pdb")}'.");
             }
         }
 

--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Coverage.Collector
 {
     internal class AssemblyProcessor
     {
-        internal const string TransactionDirectoryPrefix = ".ddc-";
+        internal const string StagingDirectoryPrefix = ".ddc-";
 
         private static readonly string? ExcludeFromCodeCoverageAttributeFullName = typeof(ExcludeFromCodeCoverageAttribute).FullName;
         private static readonly string? AvoidCoverageAttributeFullName = typeof(AvoidCoverageAttribute).FullName;
@@ -796,14 +796,14 @@ namespace Datadog.Trace.Coverage.Collector
         private static void WriteTargetAssembly(AssemblyDefinition assemblyDefinition, string assemblyFilePath, byte[]? strongNameKeyBlob, Action<string, string, string?> replaceFile, ICollectorLogger? logger)
         {
             using var assemblyLock = CoverageAssemblyPathLock.EnterWrite(assemblyFilePath);
-            var assemblyDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
-            var transactionDirectory = Path.Combine(assemblyDirectory, TransactionDirectoryPrefix + Guid.NewGuid().ToString("N").Substring(0, 12));
-            // Keep transaction files on the target volume for File.Replace and use the final basenames for Cecil's symbol metadata.
-            Directory.CreateDirectory(transactionDirectory);
-            var stagedAssemblyPath = Path.Combine(transactionDirectory, Path.GetFileName(assemblyFilePath));
+            var targetDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
+            var stagingDirectory = Path.Combine(targetDirectory, StagingDirectoryPrefix + Path.GetRandomFileName());
+            // File.Replace requires the same volume, and Cecil writes the PDB basename into the assembly.
+            Directory.CreateDirectory(stagingDirectory);
+            var stagedAssemblyPath = Path.Combine(stagingDirectory, Path.GetFileName(assemblyFilePath));
             var stagedSymbolsPath = Path.ChangeExtension(stagedAssemblyPath, ".pdb");
-            var assemblyBackupPath = Path.Combine(transactionDirectory, ".assembly.backup");
-            var symbolsBackupPath = Path.Combine(transactionDirectory, ".symbols.backup");
+            var assemblyBackupPath = Path.Combine(stagingDirectory, ".assembly.backup");
+            var symbolsBackupPath = Path.Combine(stagingDirectory, ".symbols.backup");
             var symbolsPath = Path.ChangeExtension(assemblyFilePath, ".pdb");
             var published = false;
 
@@ -832,7 +832,7 @@ namespace Datadog.Trace.Coverage.Collector
                     TryDeleteStagedFile(symbolsBackupPath, logger);
                 }
 
-                TryDeleteTransactionDirectory(transactionDirectory, logger);
+                TryDeleteStagingDirectory(stagingDirectory, logger);
             }
         }
 
@@ -925,12 +925,11 @@ namespace Datadog.Trace.Coverage.Collector
             }
             catch (Exception ex)
             {
-                // Staging cleanup must not hide a rewrite or publication failure.
-                logger?.Warning($"Failed to remove coverage rewrite transaction file '{filePath}': {ex}");
+                logger?.Warning($"Failed to remove coverage rewrite staging file '{filePath}': {ex}");
             }
         }
 
-        private static void TryDeleteTransactionDirectory(string directoryPath, ICollectorLogger? logger)
+        private static void TryDeleteStagingDirectory(string directoryPath, ICollectorLogger? logger)
         {
             try
             {
@@ -941,8 +940,7 @@ namespace Datadog.Trace.Coverage.Collector
             }
             catch (Exception ex)
             {
-                // Staging cleanup must not hide a rewrite or publication failure.
-                logger?.Warning($"Failed to remove coverage rewrite transaction directory '{directoryPath}': {ex}");
+                logger?.Warning($"Failed to remove coverage rewrite staging directory '{directoryPath}': {ex}");
             }
         }
 

--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -29,6 +29,8 @@ namespace Datadog.Trace.Coverage.Collector
 {
     internal class AssemblyProcessor
     {
+        internal const string TransactionDirectoryPrefix = ".ddc-";
+
         private static readonly string? ExcludeFromCodeCoverageAttributeFullName = typeof(ExcludeFromCodeCoverageAttribute).FullName;
         private static readonly string? AvoidCoverageAttributeFullName = typeof(AvoidCoverageAttribute).FullName;
         private static readonly string? CoveredAssemblyAttributeFullName = typeof(CoveredAssemblyAttribute).FullName;
@@ -795,18 +797,20 @@ namespace Datadog.Trace.Coverage.Collector
         {
             using var assemblyLock = CoverageAssemblyPathLock.EnterWrite(assemblyFilePath);
             var assemblyDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
-            var assemblyFileName = Path.GetFileNameWithoutExtension(assemblyFilePath);
-            var stagingBasePath = Path.Combine(assemblyDirectory, $".{assemblyFileName}.{Guid.NewGuid():N}");
-            // Keep transaction files on the target volume for File.Replace, but do not let the collector identify them as assemblies.
-            var stagedAssemblyPath = stagingBasePath + ".tmp";
+            var transactionDirectory = Path.Combine(assemblyDirectory, TransactionDirectoryPrefix + Guid.NewGuid().ToString("N").Substring(0, 12));
+            // Keep transaction files on the target volume for File.Replace and use the final basenames for Cecil's symbol metadata.
+            Directory.CreateDirectory(transactionDirectory);
+            var stagedAssemblyPath = Path.Combine(transactionDirectory, Path.GetFileName(assemblyFilePath));
             var stagedSymbolsPath = Path.ChangeExtension(stagedAssemblyPath, ".pdb");
-            var assemblyBackupPath = stagingBasePath + ".assembly.backup";
-            var symbolsBackupPath = stagingBasePath + ".symbols.backup";
+            var assemblyBackupPath = Path.Combine(transactionDirectory, ".assembly.backup");
+            var symbolsBackupPath = Path.Combine(transactionDirectory, ".symbols.backup");
             var symbolsPath = Path.ChangeExtension(assemblyFilePath, ".pdb");
             var published = false;
 
             try
             {
+                // Cecil truncates this copy when writing, preserving the original Unix mode bits for publication.
+                File.Copy(assemblyFilePath, stagedAssemblyPath);
                 assemblyDefinition.Write(stagedAssemblyPath, new WriterParameters
                 {
                     WriteSymbols = true,
@@ -827,6 +831,8 @@ namespace Datadog.Trace.Coverage.Collector
                     TryDeleteStagedFile(assemblyBackupPath, logger);
                     TryDeleteStagedFile(symbolsBackupPath, logger);
                 }
+
+                TryDeleteTransactionDirectory(transactionDirectory, logger);
             }
         }
 
@@ -921,6 +927,22 @@ namespace Datadog.Trace.Coverage.Collector
             {
                 // Staging cleanup must not hide a rewrite or publication failure.
                 logger?.Warning($"Failed to remove coverage rewrite transaction file '{filePath}': {ex}");
+            }
+        }
+
+        private static void TryDeleteTransactionDirectory(string directoryPath, ICollectorLogger? logger)
+        {
+            try
+            {
+                if (Directory.Exists(directoryPath) && !Directory.EnumerateFileSystemEntries(directoryPath).Any())
+                {
+                    Directory.Delete(directoryPath);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Staging cleanup must not hide a rewrite or publication failure.
+                logger?.Warning($"Failed to remove coverage rewrite transaction directory '{directoryPath}': {ex}");
             }
         }
 

--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -744,7 +744,7 @@ namespace Datadog.Trace.Coverage.Collector
                     var tracerAssemblyLocation = CopyRequiredAssemblies(assemblyDefinition, tracerTarget);
                     assemblyResolver.SetTracerAssemblyLocation(tracerAssemblyLocation);
 
-                    WriteTargetAssembly(assemblyDefinition, _assemblyFilePath, _strongNameKeyBlob);
+                    WriteTargetAssembly(assemblyDefinition, _assemblyFilePath, _strongNameKeyBlob, _logger);
                 }
 
                 _logger.Debug($"Done: {_assemblyFilePath} [Modified:{isDirty}]");
@@ -783,13 +783,107 @@ namespace Datadog.Trace.Coverage.Collector
         /// <param name="assemblyFilePath">The assembly path to overwrite.</param>
         /// <param name="strongNameKeyBlob">The optional strong-name key used when rewriting signed assemblies.</param>
         internal static void WriteTargetAssembly(AssemblyDefinition assemblyDefinition, string assemblyFilePath, byte[]? strongNameKeyBlob)
+            => WriteTargetAssembly(assemblyDefinition, assemblyFilePath, strongNameKeyBlob, (source, destination, backup) => File.Replace(source, destination, backup), logger: null);
+
+        private static void WriteTargetAssembly(AssemblyDefinition assemblyDefinition, string assemblyFilePath, byte[]? strongNameKeyBlob, ICollectorLogger logger)
+            => WriteTargetAssembly(assemblyDefinition, assemblyFilePath, strongNameKeyBlob, (source, destination, backup) => File.Replace(source, destination, backup), logger);
+
+        internal static void WriteTargetAssembly(AssemblyDefinition assemblyDefinition, string assemblyFilePath, byte[]? strongNameKeyBlob, Action<string, string, string?> replaceFile)
+            => WriteTargetAssembly(assemblyDefinition, assemblyFilePath, strongNameKeyBlob, replaceFile, logger: null);
+
+        private static void WriteTargetAssembly(AssemblyDefinition assemblyDefinition, string assemblyFilePath, byte[]? strongNameKeyBlob, Action<string, string, string?> replaceFile, ICollectorLogger? logger)
         {
             using var assemblyLock = CoverageAssemblyPathLock.EnterWrite(assemblyFilePath);
-            assemblyDefinition.Write(assemblyFilePath, new WriterParameters
+            var assemblyDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
+            var assemblyFileName = Path.GetFileNameWithoutExtension(assemblyFilePath);
+            var stagingBasePath = Path.Combine(assemblyDirectory, $".{assemblyFileName}.{Guid.NewGuid():N}");
+            var stagedAssemblyPath = stagingBasePath + ".tmp.dll";
+            var stagedSymbolsPath = Path.ChangeExtension(stagedAssemblyPath, ".pdb");
+            var assemblyBackupPath = stagingBasePath + ".backup.dll";
+            var symbolsBackupPath = stagingBasePath + ".backup.pdb";
+            var symbolsPath = Path.ChangeExtension(assemblyFilePath, ".pdb");
+            var published = false;
+
+            try
             {
-                WriteSymbols = true,
-                StrongNameKeyBlob = strongNameKeyBlob
-            });
+                assemblyDefinition.Write(stagedAssemblyPath, new WriterParameters
+                {
+                    WriteSymbols = true,
+                    StrongNameKeyBlob = strongNameKeyBlob
+                });
+
+                using (AssemblyDefinition.ReadAssembly(stagedAssemblyPath, new ReaderParameters { ReadSymbols = true, InMemory = true }))
+                {
+                }
+
+                ReplaceTargetFiles(stagedAssemblyPath, stagedSymbolsPath, assemblyFilePath, symbolsPath, assemblyBackupPath, symbolsBackupPath, replaceFile);
+                published = true;
+            }
+            finally
+            {
+                TryDeleteStagedFile(stagedAssemblyPath, logger);
+                TryDeleteStagedFile(stagedSymbolsPath, logger);
+                if (published)
+                {
+                    TryDeleteStagedFile(assemblyBackupPath, logger);
+                    TryDeleteStagedFile(symbolsBackupPath, logger);
+                }
+            }
+        }
+
+        private static void ReplaceTargetFiles(
+            string stagedAssemblyPath,
+            string stagedSymbolsPath,
+            string assemblyFilePath,
+            string symbolsPath,
+            string assemblyBackupPath,
+            string symbolsBackupPath,
+            Action<string, string, string?> replaceFile)
+        {
+            if (!File.Exists(stagedSymbolsPath))
+            {
+                throw new InvalidOperationException($"Rewritten symbols were not created at '{stagedSymbolsPath}'.");
+            }
+
+            var symbolsReplaced = false;
+            try
+            {
+                replaceFile(stagedSymbolsPath, symbolsPath, symbolsBackupPath);
+                symbolsReplaced = true;
+                replaceFile(stagedAssemblyPath, assemblyFilePath, assemblyBackupPath);
+            }
+            catch (Exception publicationException)
+            {
+                if (symbolsReplaced)
+                {
+                    try
+                    {
+                        replaceFile(symbolsBackupPath, symbolsPath, null);
+                    }
+                    catch (Exception rollbackException)
+                    {
+                        throw new AggregateException("Failed to publish the rewritten assembly and to restore its original symbols.", publicationException, rollbackException);
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        private static void TryDeleteStagedFile(string filePath, ICollectorLogger? logger)
+        {
+            try
+            {
+                if (File.Exists(filePath))
+                {
+                    File.Delete(filePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Staging cleanup must not hide a rewrite or publication failure.
+                logger?.Warning($"Failed to remove coverage rewrite transaction file '{filePath}': {ex}");
+            }
         }
 
         internal static bool IsIgnoredAssembly(string? assemblyFileName)

--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -853,28 +853,58 @@ namespace Datadog.Trace.Coverage.Collector
                 throw new InvalidOperationException($"Rewritten symbols were not created at '{stagedSymbolsPath}'.");
             }
 
-            var symbolsReplaced = false;
             try
             {
                 replaceFile(stagedSymbolsPath, symbolsPath, symbolsBackupPath);
-                symbolsReplaced = true;
                 replaceFile(stagedAssemblyPath, assemblyFilePath, assemblyBackupPath);
             }
             catch (Exception publicationException)
             {
-                if (symbolsReplaced)
+                var assemblyRollbackException = TryRestoreBackup(assemblyBackupPath, assemblyFilePath, replaceFile);
+                var symbolsRollbackException = TryRestoreBackup(symbolsBackupPath, symbolsPath, replaceFile);
+                if (assemblyRollbackException is not null || symbolsRollbackException is not null)
                 {
-                    try
+                    var exceptions = new List<Exception> { publicationException };
+                    if (assemblyRollbackException is not null)
                     {
-                        replaceFile(symbolsBackupPath, symbolsPath, null);
+                        exceptions.Add(assemblyRollbackException);
                     }
-                    catch (Exception rollbackException)
+
+                    if (symbolsRollbackException is not null)
                     {
-                        throw new AggregateException("Failed to publish the rewritten assembly and to restore its original symbols.", publicationException, rollbackException);
+                        exceptions.Add(symbolsRollbackException);
                     }
+
+                    throw new AggregateException("Failed to publish the rewritten assembly and to restore its original files.", exceptions);
                 }
 
                 throw;
+            }
+        }
+
+        private static Exception? TryRestoreBackup(string backupPath, string targetPath, Action<string, string, string?> replaceFile)
+        {
+            if (!File.Exists(backupPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                if (File.Exists(targetPath))
+                {
+                    replaceFile(backupPath, targetPath, null);
+                }
+                else
+                {
+                    File.Move(backupPath, targetPath);
+                }
+
+                return null;
+            }
+            catch (Exception exception)
+            {
+                return exception;
             }
         }
 

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -4,12 +4,15 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Mono.Cecil;
 
 namespace Datadog.Trace.Coverage.Collector;
@@ -21,12 +24,15 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
 {
     private static readonly Assembly TracerAssembly = typeof(CoverageReporter).Assembly;
     private static readonly StringComparison PathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+    private static readonly StringComparer PathComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
     private static readonly string[] ManagedAssemblyExtensions = [".exe", ".dll"];
     private static readonly string[] WindowsRuntimeAssemblyExtensions = [".winmd", ".dll"];
+    private static readonly ConcurrentDictionary<string, Lazy<string[]>> SharedFrameworkDirectories = new(PathComparer);
     private readonly Dictionary<string, AssemblyDefinition> _cache = new(StringComparer.Ordinal);
     private readonly ICollectorLogger _logger;
     private readonly string _assemblyFilePath;
     private readonly string _preferredSearchDirectory;
+    private readonly string? _sharedFrameworkRoot;
     private string _tracerAssemblyLocation;
     private bool _disposed;
 
@@ -36,10 +42,16 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
     /// <param name="logger">Logger used to report resolution failures.</param>
     /// <param name="assemblyFilePath">The target assembly currently being rewritten.</param>
     public CoverageAssemblyResolver(ICollectorLogger logger, string assemblyFilePath)
+        : this(logger, assemblyFilePath, sharedFrameworkRoot: null)
+    {
+    }
+
+    internal CoverageAssemblyResolver(ICollectorLogger logger, string assemblyFilePath, string? sharedFrameworkRoot)
     {
         _logger = logger;
         _assemblyFilePath = assemblyFilePath;
         _preferredSearchDirectory = Path.GetDirectoryName(assemblyFilePath) ?? string.Empty;
+        _sharedFrameworkRoot = sharedFrameworkRoot;
         _tracerAssemblyLocation = string.Empty;
     }
 
@@ -120,6 +132,12 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             return assemblyFromSearchDirectory;
         }
 
+        var assemblyFromSharedFramework = ResolveFromDirectories(name, GetSharedFrameworkDirectories());
+        if (assemblyFromSharedFramework is not null)
+        {
+            return assemblyFromSharedFramework;
+        }
+
         if (IsTracerAssembly(name, tracerAssemblyName))
         {
             return ReadAndCache(name.FullName, TracerAssembly.Location);
@@ -139,9 +157,12 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
     }
 
     private AssemblyDefinition? ResolveFromSearchDirectories(AssemblyNameReference name)
+        => ResolveFromDirectories(name, GetSearchDirectoryCandidates());
+
+    private AssemblyDefinition? ResolveFromDirectories(AssemblyNameReference name, IEnumerable<string> directories)
     {
         var extensions = name.IsWindowsRuntime ? WindowsRuntimeAssemblyExtensions : ManagedAssemblyExtensions;
-        foreach (var directory in GetSearchDirectoryCandidates())
+        foreach (var directory in directories)
         {
             foreach (var extension in extensions)
             {
@@ -164,6 +185,30 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
         }
 
         return null;
+    }
+
+    private IEnumerable<string> GetSharedFrameworkDirectories()
+    {
+        if (string.IsNullOrEmpty(_preferredSearchDirectory))
+        {
+            return [];
+        }
+
+        var sharedFrameworkRoot = _sharedFrameworkRoot ?? SharedFrameworkLocator.TryGetSharedFrameworkRoot();
+        if (string.IsNullOrEmpty(sharedFrameworkRoot) || !Directory.Exists(sharedFrameworkRoot))
+        {
+            return [];
+        }
+
+        var outputDirectory = Path.GetFullPath(_preferredSearchDirectory);
+        sharedFrameworkRoot = Path.GetFullPath(sharedFrameworkRoot);
+        var cacheKey = outputDirectory + "\0" + sharedFrameworkRoot;
+        return SharedFrameworkDirectories.GetOrAdd(
+                                              cacheKey,
+                                              _ => new Lazy<string[]>(
+                                                  () => SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(outputDirectory, sharedFrameworkRoot),
+                                                  LazyThreadSafetyMode.ExecutionAndPublication))
+                                         .Value;
     }
 
     private IEnumerable<string> GetSearchDirectoryCandidates()
@@ -301,6 +346,182 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
         if (_disposed)
         {
             throw new ObjectDisposedException(nameof(CoverageAssemblyResolver));
+        }
+    }
+
+    private static class SharedFrameworkLocator
+    {
+        public static string[] DiscoverSharedFrameworkDirectories(string outputDirectory, string sharedFrameworkRoot)
+        {
+            var directories = new List<string>();
+            var seenDirectories = new HashSet<string>(PathComparer);
+            foreach (var runtimeConfigPath in GetRuntimeConfigPaths(outputDirectory))
+            {
+                foreach (var framework in ReadFrameworkReferences(runtimeConfigPath))
+                {
+                    var frameworkDirectory = FindCompatibleFrameworkDirectory(sharedFrameworkRoot, framework.Name, framework.Version);
+                    if (frameworkDirectory is not null && seenDirectories.Add(frameworkDirectory))
+                    {
+                        directories.Add(frameworkDirectory);
+                    }
+                }
+            }
+
+            return directories.ToArray();
+        }
+
+        public static string? TryGetSharedFrameworkRoot()
+        {
+            var coreLibraryPath = typeof(object).Assembly.Location;
+            if (!string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var versionDirectory = Path.GetDirectoryName(coreLibraryPath);
+            var frameworkDirectory = versionDirectory is null ? null : Path.GetDirectoryName(versionDirectory);
+            var sharedFrameworkRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
+            return sharedFrameworkRoot is not null && string.Equals(Path.GetFileName(sharedFrameworkRoot), "shared", StringComparison.OrdinalIgnoreCase)
+                       ? sharedFrameworkRoot
+                       : null;
+        }
+
+        private static IEnumerable<string> GetRuntimeConfigPaths(string outputDirectory)
+        {
+            try
+            {
+                return Directory.EnumerateFiles(outputDirectory, "*.runtimeconfig.json", SearchOption.TopDirectoryOnly)
+                                .OrderBy(path => path, PathComparer)
+                                .ToArray();
+            }
+            catch (IOException)
+            {
+                return [];
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return [];
+            }
+        }
+
+        private static IEnumerable<FrameworkReference> ReadFrameworkReferences(string runtimeConfigPath)
+        {
+            JObject runtimeConfig;
+            try
+            {
+                runtimeConfig = JObject.Parse(File.ReadAllText(runtimeConfigPath));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or Datadog.Trace.Vendors.Newtonsoft.Json.JsonException)
+            {
+                yield break;
+            }
+
+            if (runtimeConfig["runtimeOptions"] is not JObject runtimeOptions)
+            {
+                yield break;
+            }
+
+            if (TryReadFrameworkReference(runtimeOptions["framework"], out var framework))
+            {
+                yield return framework;
+            }
+
+            foreach (var propertyName in new[] { "frameworks", "includedFrameworks" })
+            {
+                if (runtimeOptions[propertyName] is not JArray frameworks)
+                {
+                    continue;
+                }
+
+                foreach (var frameworkToken in frameworks)
+                {
+                    if (TryReadFrameworkReference(frameworkToken, out framework))
+                    {
+                        yield return framework;
+                    }
+                }
+            }
+        }
+
+        private static bool TryReadFrameworkReference(JToken? token, out FrameworkReference framework)
+        {
+            framework = default;
+            if (token is not JObject frameworkObject ||
+                frameworkObject["name"]?.Value<string>() is not { Length: > 0 } name ||
+                frameworkObject["version"]?.Value<string>() is not { Length: > 0 } version ||
+                Path.IsPathRooted(name) ||
+                name is "." or ".." ||
+                name.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+                name.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+            {
+                return false;
+            }
+
+            framework = new FrameworkReference(name, version);
+            return true;
+        }
+
+        private static string? FindCompatibleFrameworkDirectory(string sharedFrameworkRoot, string frameworkName, string requestedVersionText)
+        {
+            if (!TryParseRuntimeVersion(requestedVersionText, out var requestedVersion, out _))
+            {
+                return null;
+            }
+
+            var frameworkRoot = Path.Combine(sharedFrameworkRoot, frameworkName);
+            if (!Directory.Exists(frameworkRoot))
+            {
+                return null;
+            }
+
+            try
+            {
+                return Directory.EnumerateDirectories(frameworkRoot)
+                                .Select(path => new
+                                {
+                                    Path = path,
+                                    Parsed = TryParseRuntimeVersion(Path.GetFileName(path), out var version, out var isPrerelease),
+                                    Version = version,
+                                    IsPrerelease = isPrerelease
+                                })
+                                .Where(candidate => candidate.Parsed &&
+                                                    candidate.Version.Major == requestedVersion.Major &&
+                                                    candidate.Version.Minor == requestedVersion.Minor &&
+                                                    candidate.Version >= requestedVersion)
+                                .OrderByDescending(candidate => candidate.Version)
+                                .ThenBy(candidate => candidate.IsPrerelease)
+                                .Select(candidate => candidate.Path)
+                                .FirstOrDefault();
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+
+        private static bool TryParseRuntimeVersion(string versionText, out Version version, out bool isPrerelease)
+        {
+            var suffixIndex = versionText.IndexOf('-');
+            isPrerelease = suffixIndex >= 0;
+            var numericVersion = isPrerelease ? versionText.Substring(0, suffixIndex) : versionText;
+            return Version.TryParse(numericVersion, out version!);
+        }
+
+        private readonly struct FrameworkReference
+        {
+            public FrameworkReference(string name, string version)
+            {
+                Name = name;
+                Version = version;
+            }
+
+            public string Name { get; }
+
+            public string Version { get; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -219,11 +219,12 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
         }
 
         var outputDirectory = Path.GetFullPath(_preferredSearchDirectory);
-        var cacheKey = outputDirectory + "\0" + string.Join("\0", sharedFrameworkRoots);
+        var rollForwardToPrerelease = SharedFrameworkLocator.RollForwardToPrerelease();
+        var cacheKey = outputDirectory + "\0" + string.Join("\0", sharedFrameworkRoots) + "\0" + (rollForwardToPrerelease ? "1" : "0");
         return SharedFrameworkDirectories.GetOrAdd(
                                               cacheKey,
                                               _ => new Lazy<string[]>(
-                                                  () => SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(outputDirectory, sharedFrameworkRoots),
+                                                  () => SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(outputDirectory, sharedFrameworkRoots, rollForwardToPrerelease),
                                                   LazyThreadSafetyMode.ExecutionAndPublication))
                                          .Value;
     }
@@ -372,7 +373,7 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
     {
         private static readonly string[] DotnetRootEnvironmentVariables = ["DOTNET_ROOT", "DOTNET_ROOT_X64", "DOTNET_ROOT_X86", "DOTNET_ROOT_ARM64", "DOTNET_ROOT(x86)"];
 
-        public static string[] DiscoverSharedFrameworkDirectories(string outputDirectory, IEnumerable<string> sharedFrameworkRoots)
+        public static string[] DiscoverSharedFrameworkDirectories(string outputDirectory, IEnumerable<string> sharedFrameworkRoots, bool rollForwardToPrerelease)
         {
             var directories = new List<string>();
             var seenDirectories = new HashSet<string>(PathComparer);
@@ -382,7 +383,7 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
                 {
                     foreach (var sharedFrameworkRoot in sharedFrameworkRoots)
                     {
-                        var frameworkDirectory = FindCompatibleFrameworkDirectory(sharedFrameworkRoot, framework.Name, framework.Version);
+                        var frameworkDirectory = FindCompatibleFrameworkDirectory(sharedFrameworkRoot, framework.Name, framework.Version, rollForwardToPrerelease);
                         if (frameworkDirectory is not null && seenDirectories.Add(frameworkDirectory))
                         {
                             directories.Add(frameworkDirectory);
@@ -402,12 +403,10 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             var roots = new List<string>();
             var seenRoots = new HashSet<string>(PathComparer);
 
-            if (string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
+            var dotnetHostPath = getEnvironmentVariable("DOTNET_HOST_PATH");
+            if (!string.IsNullOrEmpty(dotnetHostPath))
             {
-                var versionDirectory = Path.GetDirectoryName(coreLibraryPath);
-                var frameworkDirectory = versionDirectory is null ? null : Path.GetDirectoryName(versionDirectory);
-                var sharedFrameworkRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
-                AddSharedFrameworkRoot(sharedFrameworkRoot, roots, seenRoots);
+                AddDotnetInstallRoot(Path.GetDirectoryName(dotnetHostPath), roots, seenRoots);
             }
 
             foreach (var variableName in DotnetRootEnvironmentVariables)
@@ -415,10 +414,12 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
                 AddDotnetInstallRoot(getEnvironmentVariable(variableName), roots, seenRoots);
             }
 
-            var dotnetHostPath = getEnvironmentVariable("DOTNET_HOST_PATH");
-            if (!string.IsNullOrEmpty(dotnetHostPath))
+            if (string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
             {
-                AddDotnetInstallRoot(Path.GetDirectoryName(dotnetHostPath), roots, seenRoots);
+                var versionDirectory = Path.GetDirectoryName(coreLibraryPath);
+                var frameworkDirectory = versionDirectory is null ? null : Path.GetDirectoryName(versionDirectory);
+                var sharedFrameworkRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
+                AddSharedFrameworkRoot(sharedFrameworkRoot, roots, seenRoots);
             }
 
             if (getEnvironmentVariable("PATH") is { Length: > 0 } path)
@@ -431,6 +432,9 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
 
             return roots.ToArray();
         }
+
+        internal static bool RollForwardToPrerelease()
+            => string.Equals(Environment.GetEnvironmentVariable("DOTNET_ROLL_FORWARD_TO_PRERELEASE"), "1", StringComparison.Ordinal);
 
         private static void AddDotnetInstallRoot(string? dotnetInstallRoot, List<string> roots, HashSet<string> seenRoots)
         {
@@ -538,7 +542,7 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             return true;
         }
 
-        private static string? FindCompatibleFrameworkDirectory(string sharedFrameworkRoot, string frameworkName, string requestedVersionText)
+        private static string? FindCompatibleFrameworkDirectory(string sharedFrameworkRoot, string frameworkName, string requestedVersionText, bool rollForwardToPrerelease)
         {
             if (!TryParseRuntimeVersion(requestedVersionText, out var requestedVersion, out var requestedSemanticVersion))
             {
@@ -553,19 +557,22 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
 
             try
             {
+                var preferStable = requestedVersionText.IndexOf('-') < 0 && !rollForwardToPrerelease;
                 return Directory.EnumerateDirectories(frameworkRoot)
                                 .Select(path => new
                                 {
                                     Path = path,
                                     Parsed = TryParseRuntimeVersion(Path.GetFileName(path), out var version, out var semanticVersion),
                                     Version = version,
-                                    SemanticVersion = semanticVersion
+                                    SemanticVersion = semanticVersion,
+                                    IsPrerelease = Path.GetFileName(path).IndexOf('-') >= 0
                                 })
                                 .Where(candidate => candidate.Parsed &&
                                                     candidate.Version.Major == requestedVersion.Major &&
                                                     candidate.Version.Minor == requestedVersion.Minor &&
                                                     candidate.SemanticVersion.CompareTo(requestedSemanticVersion) >= 0)
-                                .OrderByDescending(candidate => candidate.SemanticVersion)
+                                .OrderBy(candidate => preferStable && candidate.IsPrerelease)
+                                .ThenByDescending(candidate => candidate.SemanticVersion)
                                 .Select(candidate => candidate.Path)
                                 .FirstOrDefault();
             }

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.FeatureFlags;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Mono.Cecil;
 
@@ -463,7 +464,7 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
 
         private static string? FindCompatibleFrameworkDirectory(string sharedFrameworkRoot, string frameworkName, string requestedVersionText)
         {
-            if (!TryParseRuntimeVersion(requestedVersionText, out var requestedVersion, out _))
+            if (!TryParseRuntimeVersion(requestedVersionText, out var requestedVersion, out var requestedSemanticVersion))
             {
                 return null;
             }
@@ -480,16 +481,15 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
                                 .Select(path => new
                                 {
                                     Path = path,
-                                    Parsed = TryParseRuntimeVersion(Path.GetFileName(path), out var version, out var isPrerelease),
+                                    Parsed = TryParseRuntimeVersion(Path.GetFileName(path), out var version, out var semanticVersion),
                                     Version = version,
-                                    IsPrerelease = isPrerelease
+                                    SemanticVersion = semanticVersion
                                 })
                                 .Where(candidate => candidate.Parsed &&
                                                     candidate.Version.Major == requestedVersion.Major &&
                                                     candidate.Version.Minor == requestedVersion.Minor &&
-                                                    candidate.Version >= requestedVersion)
-                                .OrderByDescending(candidate => candidate.Version)
-                                .ThenBy(candidate => candidate.IsPrerelease)
+                                                    candidate.SemanticVersion.CompareTo(requestedSemanticVersion) >= 0)
+                                .OrderByDescending(candidate => candidate.SemanticVersion)
                                 .Select(candidate => candidate.Path)
                                 .FirstOrDefault();
             }
@@ -503,12 +503,11 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             }
         }
 
-        private static bool TryParseRuntimeVersion(string versionText, out Version version, out bool isPrerelease)
+        private static bool TryParseRuntimeVersion(string versionText, out Version version, out SemanticVersion semanticVersion)
         {
             var suffixIndex = versionText.IndexOf('-');
-            isPrerelease = suffixIndex >= 0;
-            var numericVersion = isPrerelease ? versionText.Substring(0, suffixIndex) : versionText;
-            return Version.TryParse(numericVersion, out version!);
+            var numericVersion = suffixIndex >= 0 ? versionText.Substring(0, suffixIndex) : versionText;
+            return Version.TryParse(numericVersion, out version!) && SemanticVersion.TryParse(versionText, out semanticVersion);
         }
 
         private readonly struct FrameworkReference

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -4,16 +4,12 @@
 // </copyright>
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Datadog.Trace.Ci.Coverage;
-using Datadog.Trace.FeatureFlags;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Mono.Cecil;
 
 namespace Datadog.Trace.Coverage.Collector;
@@ -25,10 +21,8 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
 {
     private static readonly Assembly TracerAssembly = typeof(CoverageReporter).Assembly;
     private static readonly StringComparison PathComparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-    private static readonly StringComparer PathComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
     private static readonly string[] ManagedAssemblyExtensions = [".exe", ".dll"];
     private static readonly string[] WindowsRuntimeAssemblyExtensions = [".winmd", ".dll"];
-    private static readonly ConcurrentDictionary<string, Lazy<string[]>> SharedFrameworkDirectories = new(PathComparer);
     private readonly Dictionary<string, AssemblyDefinition> _cache = new(StringComparer.Ordinal);
     private readonly ICollectorLogger _logger;
     private readonly string _assemblyFilePath;
@@ -139,7 +133,8 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             return assemblyFromSearchDirectory;
         }
 
-        var assemblyFromSharedFramework = ResolveFromDirectories(name, GetSharedFrameworkDirectories(), requireMatchingIdentity: true);
+        var sharedFrameworkDirectories = SharedFrameworkLocator.GetDirectories(_preferredSearchDirectory, _sharedFrameworkRoot);
+        var assemblyFromSharedFramework = ResolveFromDirectories(name, sharedFrameworkDirectories, requireMatchingIdentity: true);
         if (assemblyFromSharedFramework is not null)
         {
             return assemblyFromSharedFramework;
@@ -164,9 +159,9 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
     }
 
     private AssemblyDefinition? ResolveFromSearchDirectories(AssemblyNameReference name)
-        => ResolveFromDirectories(name, GetSearchDirectoryCandidates());
+        => ResolveFromDirectories(name, GetSearchDirectoryCandidates(), requireMatchingIdentity: false);
 
-    private AssemblyDefinition? ResolveFromDirectories(AssemblyNameReference name, IEnumerable<string> directories, bool requireMatchingIdentity = false)
+    private AssemblyDefinition? ResolveFromDirectories(AssemblyNameReference name, IEnumerable<string> directories, bool requireMatchingIdentity)
     {
         var extensions = name.IsWindowsRuntime ? WindowsRuntimeAssemblyExtensions : ManagedAssemblyExtensions;
         foreach (var directory in directories)
@@ -199,34 +194,6 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
         }
 
         return null;
-    }
-
-    private IEnumerable<string> GetSharedFrameworkDirectories()
-    {
-        if (string.IsNullOrEmpty(_preferredSearchDirectory))
-        {
-            return [];
-        }
-
-        var sharedFrameworkRoots = (_sharedFrameworkRoot is null ? SharedFrameworkLocator.GetSharedFrameworkRoots() : [_sharedFrameworkRoot])
-                                  .Where(Directory.Exists)
-                                  .Select(Path.GetFullPath)
-                                  .Distinct(PathComparer)
-                                  .ToArray();
-        if (sharedFrameworkRoots.Length == 0)
-        {
-            return [];
-        }
-
-        var outputDirectory = Path.GetFullPath(_preferredSearchDirectory);
-        var rollForwardToPrerelease = SharedFrameworkLocator.RollForwardToPrerelease();
-        var cacheKey = outputDirectory + "\0" + string.Join("\0", sharedFrameworkRoots) + "\0" + (rollForwardToPrerelease ? "1" : "0");
-        return SharedFrameworkDirectories.GetOrAdd(
-                                              cacheKey,
-                                              _ => new Lazy<string[]>(
-                                                  () => SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(outputDirectory, sharedFrameworkRoots, rollForwardToPrerelease),
-                                                  LazyThreadSafetyMode.ExecutionAndPublication))
-                                         .Value;
     }
 
     private IEnumerable<string> GetSearchDirectoryCandidates()
@@ -366,244 +333,6 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
         if (_disposed)
         {
             throw new ObjectDisposedException(nameof(CoverageAssemblyResolver));
-        }
-    }
-
-    internal static class SharedFrameworkLocator
-    {
-        private static readonly string[] DotnetRootEnvironmentVariables = ["DOTNET_ROOT", "DOTNET_ROOT_X64", "DOTNET_ROOT_X86", "DOTNET_ROOT_ARM64", "DOTNET_ROOT(x86)"];
-
-        public static string[] DiscoverSharedFrameworkDirectories(string outputDirectory, IEnumerable<string> sharedFrameworkRoots, bool rollForwardToPrerelease)
-        {
-            var directories = new List<string>();
-            var seenDirectories = new HashSet<string>(PathComparer);
-            foreach (var runtimeConfigPath in GetRuntimeConfigPaths(outputDirectory))
-            {
-                foreach (var framework in ReadFrameworkReferences(runtimeConfigPath))
-                {
-                    foreach (var sharedFrameworkRoot in sharedFrameworkRoots)
-                    {
-                        var frameworkDirectory = FindCompatibleFrameworkDirectory(sharedFrameworkRoot, framework.Name, framework.Version, rollForwardToPrerelease);
-                        if (frameworkDirectory is not null && seenDirectories.Add(frameworkDirectory))
-                        {
-                            directories.Add(frameworkDirectory);
-                        }
-                    }
-                }
-            }
-
-            return directories.ToArray();
-        }
-
-        public static string[] GetSharedFrameworkRoots()
-            => GetSharedFrameworkRoots(typeof(object).Assembly.Location, Environment.GetEnvironmentVariable);
-
-        internal static string[] GetSharedFrameworkRoots(string coreLibraryPath, Func<string, string?> getEnvironmentVariable)
-        {
-            var roots = new List<string>();
-            var seenRoots = new HashSet<string>(PathComparer);
-
-            var dotnetHostPath = getEnvironmentVariable("DOTNET_HOST_PATH");
-            if (!string.IsNullOrEmpty(dotnetHostPath))
-            {
-                AddDotnetInstallRoot(Path.GetDirectoryName(dotnetHostPath), roots, seenRoots);
-            }
-
-            foreach (var variableName in DotnetRootEnvironmentVariables)
-            {
-                AddDotnetInstallRoot(getEnvironmentVariable(variableName), roots, seenRoots);
-            }
-
-            if (string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
-            {
-                var versionDirectory = Path.GetDirectoryName(coreLibraryPath);
-                var frameworkDirectory = versionDirectory is null ? null : Path.GetDirectoryName(versionDirectory);
-                var sharedFrameworkRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
-                AddSharedFrameworkRoot(sharedFrameworkRoot, roots, seenRoots);
-            }
-
-            if (getEnvironmentVariable("PATH") is { Length: > 0 } path)
-            {
-                foreach (var pathEntry in path.Split(Path.PathSeparator))
-                {
-                    AddDotnetInstallRoot(pathEntry, roots, seenRoots);
-                }
-            }
-
-            return roots.ToArray();
-        }
-
-        internal static bool RollForwardToPrerelease()
-            => string.Equals(Environment.GetEnvironmentVariable("DOTNET_ROLL_FORWARD_TO_PRERELEASE"), "1", StringComparison.Ordinal);
-
-        private static void AddDotnetInstallRoot(string? dotnetInstallRoot, List<string> roots, HashSet<string> seenRoots)
-        {
-            try
-            {
-                if (!string.IsNullOrEmpty(dotnetInstallRoot))
-                {
-                    AddSharedFrameworkRoot(Path.Combine(dotnetInstallRoot, "shared"), roots, seenRoots);
-                }
-            }
-            catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException)
-            {
-                // Ignore malformed or inaccessible environment candidates and keep probing other roots.
-            }
-        }
-
-        private static void AddSharedFrameworkRoot(string? sharedFrameworkRoot, List<string> roots, HashSet<string> seenRoots)
-        {
-            if (string.IsNullOrEmpty(sharedFrameworkRoot) ||
-                !string.Equals(Path.GetFileName(sharedFrameworkRoot), "shared", StringComparison.OrdinalIgnoreCase) ||
-                !Directory.Exists(sharedFrameworkRoot))
-            {
-                return;
-            }
-
-            sharedFrameworkRoot = Path.GetFullPath(sharedFrameworkRoot);
-            if (seenRoots.Add(sharedFrameworkRoot))
-            {
-                roots.Add(sharedFrameworkRoot);
-            }
-        }
-
-        private static IEnumerable<string> GetRuntimeConfigPaths(string outputDirectory)
-        {
-            try
-            {
-                return Directory.EnumerateFiles(outputDirectory, "*.runtimeconfig.json", SearchOption.TopDirectoryOnly)
-                                .OrderBy(path => path, PathComparer)
-                                .ToArray();
-            }
-            catch (IOException)
-            {
-                return [];
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return [];
-            }
-        }
-
-        private static IEnumerable<FrameworkReference> ReadFrameworkReferences(string runtimeConfigPath)
-        {
-            JObject runtimeConfig;
-            try
-            {
-                runtimeConfig = JObject.Parse(File.ReadAllText(runtimeConfigPath));
-            }
-            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or Datadog.Trace.Vendors.Newtonsoft.Json.JsonException)
-            {
-                yield break;
-            }
-
-            if (runtimeConfig["runtimeOptions"] is not JObject runtimeOptions)
-            {
-                yield break;
-            }
-
-            if (TryReadFrameworkReference(runtimeOptions["framework"], out var framework))
-            {
-                yield return framework;
-            }
-
-            foreach (var propertyName in new[] { "frameworks", "includedFrameworks" })
-            {
-                if (runtimeOptions[propertyName] is not JArray frameworks)
-                {
-                    continue;
-                }
-
-                foreach (var frameworkToken in frameworks)
-                {
-                    if (TryReadFrameworkReference(frameworkToken, out framework))
-                    {
-                        yield return framework;
-                    }
-                }
-            }
-        }
-
-        private static bool TryReadFrameworkReference(JToken? token, out FrameworkReference framework)
-        {
-            framework = default;
-            if (token is not JObject frameworkObject ||
-                frameworkObject["name"]?.Value<string>() is not { Length: > 0 } name ||
-                frameworkObject["version"]?.Value<string>() is not { Length: > 0 } version ||
-                Path.IsPathRooted(name) ||
-                name is "." or ".." ||
-                name.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
-                name.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
-            {
-                return false;
-            }
-
-            framework = new FrameworkReference(name, version);
-            return true;
-        }
-
-        private static string? FindCompatibleFrameworkDirectory(string sharedFrameworkRoot, string frameworkName, string requestedVersionText, bool rollForwardToPrerelease)
-        {
-            if (!TryParseRuntimeVersion(requestedVersionText, out var requestedVersion, out var requestedSemanticVersion))
-            {
-                return null;
-            }
-
-            var frameworkRoot = Path.Combine(sharedFrameworkRoot, frameworkName);
-            if (!Directory.Exists(frameworkRoot))
-            {
-                return null;
-            }
-
-            try
-            {
-                var preferStable = requestedVersionText.IndexOf('-') < 0 && !rollForwardToPrerelease;
-                return Directory.EnumerateDirectories(frameworkRoot)
-                                .Select(path => new
-                                {
-                                    Path = path,
-                                    Parsed = TryParseRuntimeVersion(Path.GetFileName(path), out var version, out var semanticVersion),
-                                    Version = version,
-                                    SemanticVersion = semanticVersion,
-                                    IsPrerelease = Path.GetFileName(path).IndexOf('-') >= 0
-                                })
-                                .Where(candidate => candidate.Parsed &&
-                                                    candidate.Version.Major == requestedVersion.Major &&
-                                                    candidate.Version.Minor == requestedVersion.Minor &&
-                                                    candidate.SemanticVersion.CompareTo(requestedSemanticVersion) >= 0)
-                                .OrderBy(candidate => preferStable && candidate.IsPrerelease)
-                                .ThenByDescending(candidate => candidate.SemanticVersion)
-                                .Select(candidate => candidate.Path)
-                                .FirstOrDefault();
-            }
-            catch (IOException)
-            {
-                return null;
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return null;
-            }
-        }
-
-        private static bool TryParseRuntimeVersion(string versionText, out Version version, out SemanticVersion semanticVersion)
-        {
-            var suffixIndex = versionText.IndexOf('-');
-            var numericVersion = suffixIndex >= 0 ? versionText.Substring(0, suffixIndex) : versionText;
-            return Version.TryParse(numericVersion, out version!) && SemanticVersion.TryParse(versionText, out semanticVersion);
-        }
-
-        private readonly struct FrameworkReference
-        {
-            public FrameworkReference(string name, string version)
-            {
-                Name = name;
-                Version = version;
-            }
-
-            public string Name { get; }
-
-            public string Version { get; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageAssemblyResolver.cs
@@ -119,6 +119,12 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
         base.Dispose(disposing);
     }
 
+    private static bool AssemblyNamesMatch(AssemblyNameReference requestedName, AssemblyNameDefinition candidateName)
+        => string.Equals(requestedName.Name, candidateName.Name, StringComparison.OrdinalIgnoreCase) &&
+           requestedName.Version == candidateName.Version &&
+           string.Equals(requestedName.Culture ?? string.Empty, candidateName.Culture ?? string.Empty, StringComparison.OrdinalIgnoreCase) &&
+           (requestedName.PublicKeyToken ?? []).SequenceEqual(candidateName.PublicKeyToken ?? []);
+
     private AssemblyDefinition ResolveAndCache(AssemblyNameReference name)
     {
         var tracerAssemblyName = TracerAssembly.GetName();
@@ -133,7 +139,7 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             return assemblyFromSearchDirectory;
         }
 
-        var assemblyFromSharedFramework = ResolveFromDirectories(name, GetSharedFrameworkDirectories());
+        var assemblyFromSharedFramework = ResolveFromDirectories(name, GetSharedFrameworkDirectories(), requireMatchingIdentity: true);
         if (assemblyFromSharedFramework is not null)
         {
             return assemblyFromSharedFramework;
@@ -160,7 +166,7 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
     private AssemblyDefinition? ResolveFromSearchDirectories(AssemblyNameReference name)
         => ResolveFromDirectories(name, GetSearchDirectoryCandidates());
 
-    private AssemblyDefinition? ResolveFromDirectories(AssemblyNameReference name, IEnumerable<string> directories)
+    private AssemblyDefinition? ResolveFromDirectories(AssemblyNameReference name, IEnumerable<string> directories, bool requireMatchingIdentity = false)
     {
         var extensions = name.IsWindowsRuntime ? WindowsRuntimeAssemblyExtensions : ManagedAssemblyExtensions;
         foreach (var directory in directories)
@@ -176,7 +182,14 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
 
                 try
                 {
-                    return ReadAndCache(name.FullName, path);
+                    var assembly = ReadAssembly(path);
+                    if (requireMatchingIdentity && !AssemblyNamesMatch(name, assembly.Name))
+                    {
+                        assembly.Dispose();
+                        continue;
+                    }
+
+                    return CacheAssembly(name.FullName, assembly);
                 }
                 catch (BadImageFormatException)
                 {
@@ -195,19 +208,22 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             return [];
         }
 
-        var sharedFrameworkRoot = _sharedFrameworkRoot ?? SharedFrameworkLocator.TryGetSharedFrameworkRoot();
-        if (string.IsNullOrEmpty(sharedFrameworkRoot) || !Directory.Exists(sharedFrameworkRoot))
+        var sharedFrameworkRoots = (_sharedFrameworkRoot is null ? SharedFrameworkLocator.GetSharedFrameworkRoots() : [_sharedFrameworkRoot])
+                                  .Where(Directory.Exists)
+                                  .Select(Path.GetFullPath)
+                                  .Distinct(PathComparer)
+                                  .ToArray();
+        if (sharedFrameworkRoots.Length == 0)
         {
             return [];
         }
 
         var outputDirectory = Path.GetFullPath(_preferredSearchDirectory);
-        sharedFrameworkRoot = Path.GetFullPath(sharedFrameworkRoot);
-        var cacheKey = outputDirectory + "\0" + sharedFrameworkRoot;
+        var cacheKey = outputDirectory + "\0" + string.Join("\0", sharedFrameworkRoots);
         return SharedFrameworkDirectories.GetOrAdd(
                                               cacheKey,
                                               _ => new Lazy<string[]>(
-                                                  () => SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(outputDirectory, sharedFrameworkRoot),
+                                                  () => SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(outputDirectory, sharedFrameworkRoots),
                                                   LazyThreadSafetyMode.ExecutionAndPublication))
                                          .Value;
     }
@@ -229,10 +245,12 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
     }
 
     private AssemblyDefinition ReadAndCache(string requestedFullName, string assemblyPath)
+        => CacheAssembly(requestedFullName, ReadAssembly(assemblyPath));
+
+    private AssemblyDefinition ReadAssembly(string assemblyPath)
     {
         using var assemblyLock = CoverageAssemblyPathLock.EnterRead(assemblyPath);
-        var assembly = AssemblyDefinition.ReadAssembly(assemblyPath, CreateDependencyReaderParameters());
-        return CacheAssembly(requestedFullName, assembly);
+        return AssemblyDefinition.ReadAssembly(assemblyPath, CreateDependencyReaderParameters());
     }
 
     private AssemblyDefinition CacheAssembly(string requestedFullName, AssemblyDefinition assembly)
@@ -350,9 +368,11 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
         }
     }
 
-    private static class SharedFrameworkLocator
+    internal static class SharedFrameworkLocator
     {
-        public static string[] DiscoverSharedFrameworkDirectories(string outputDirectory, string sharedFrameworkRoot)
+        private static readonly string[] DotnetRootEnvironmentVariables = ["DOTNET_ROOT", "DOTNET_ROOT_X64", "DOTNET_ROOT_X86", "DOTNET_ROOT_ARM64", "DOTNET_ROOT(x86)"];
+
+        public static string[] DiscoverSharedFrameworkDirectories(string outputDirectory, IEnumerable<string> sharedFrameworkRoots)
         {
             var directories = new List<string>();
             var seenDirectories = new HashSet<string>(PathComparer);
@@ -360,10 +380,13 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             {
                 foreach (var framework in ReadFrameworkReferences(runtimeConfigPath))
                 {
-                    var frameworkDirectory = FindCompatibleFrameworkDirectory(sharedFrameworkRoot, framework.Name, framework.Version);
-                    if (frameworkDirectory is not null && seenDirectories.Add(frameworkDirectory))
+                    foreach (var sharedFrameworkRoot in sharedFrameworkRoots)
                     {
-                        directories.Add(frameworkDirectory);
+                        var frameworkDirectory = FindCompatibleFrameworkDirectory(sharedFrameworkRoot, framework.Name, framework.Version);
+                        if (frameworkDirectory is not null && seenDirectories.Add(frameworkDirectory))
+                        {
+                            directories.Add(frameworkDirectory);
+                        }
                     }
                 }
             }
@@ -371,20 +394,73 @@ internal sealed class CoverageAssemblyResolver : BaseAssemblyResolver
             return directories.ToArray();
         }
 
-        public static string? TryGetSharedFrameworkRoot()
+        public static string[] GetSharedFrameworkRoots()
+            => GetSharedFrameworkRoots(typeof(object).Assembly.Location, Environment.GetEnvironmentVariable);
+
+        internal static string[] GetSharedFrameworkRoots(string coreLibraryPath, Func<string, string?> getEnvironmentVariable)
         {
-            var coreLibraryPath = typeof(object).Assembly.Location;
-            if (!string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
+            var roots = new List<string>();
+            var seenRoots = new HashSet<string>(PathComparer);
+
+            if (string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
             {
-                return null;
+                var versionDirectory = Path.GetDirectoryName(coreLibraryPath);
+                var frameworkDirectory = versionDirectory is null ? null : Path.GetDirectoryName(versionDirectory);
+                var sharedFrameworkRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
+                AddSharedFrameworkRoot(sharedFrameworkRoot, roots, seenRoots);
             }
 
-            var versionDirectory = Path.GetDirectoryName(coreLibraryPath);
-            var frameworkDirectory = versionDirectory is null ? null : Path.GetDirectoryName(versionDirectory);
-            var sharedFrameworkRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
-            return sharedFrameworkRoot is not null && string.Equals(Path.GetFileName(sharedFrameworkRoot), "shared", StringComparison.OrdinalIgnoreCase)
-                       ? sharedFrameworkRoot
-                       : null;
+            foreach (var variableName in DotnetRootEnvironmentVariables)
+            {
+                AddDotnetInstallRoot(getEnvironmentVariable(variableName), roots, seenRoots);
+            }
+
+            var dotnetHostPath = getEnvironmentVariable("DOTNET_HOST_PATH");
+            if (!string.IsNullOrEmpty(dotnetHostPath))
+            {
+                AddDotnetInstallRoot(Path.GetDirectoryName(dotnetHostPath), roots, seenRoots);
+            }
+
+            if (getEnvironmentVariable("PATH") is { Length: > 0 } path)
+            {
+                foreach (var pathEntry in path.Split(Path.PathSeparator))
+                {
+                    AddDotnetInstallRoot(pathEntry, roots, seenRoots);
+                }
+            }
+
+            return roots.ToArray();
+        }
+
+        private static void AddDotnetInstallRoot(string? dotnetInstallRoot, List<string> roots, HashSet<string> seenRoots)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(dotnetInstallRoot))
+                {
+                    AddSharedFrameworkRoot(Path.Combine(dotnetInstallRoot, "shared"), roots, seenRoots);
+                }
+            }
+            catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException)
+            {
+                // Ignore malformed or inaccessible environment candidates and keep probing other roots.
+            }
+        }
+
+        private static void AddSharedFrameworkRoot(string? sharedFrameworkRoot, List<string> roots, HashSet<string> seenRoots)
+        {
+            if (string.IsNullOrEmpty(sharedFrameworkRoot) ||
+                !string.Equals(Path.GetFileName(sharedFrameworkRoot), "shared", StringComparison.OrdinalIgnoreCase) ||
+                !Directory.Exists(sharedFrameworkRoot))
+            {
+                return;
+            }
+
+            sharedFrameworkRoot = Path.GetFullPath(sharedFrameworkRoot);
+            if (seenRoots.Add(sharedFrameworkRoot))
+            {
+                roots.Add(sharedFrameworkRoot);
+            }
         }
 
         private static IEnumerable<string> GetRuntimeConfigPaths(string outputDirectory)

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -347,13 +347,15 @@ namespace Datadog.Trace.Coverage.Collector
         internal static bool HasAssemblyExtension(string filePath)
         {
             if (Path.GetDirectoryName(filePath) is { } directory &&
-                Path.GetFileName(directory).StartsWith(AssemblyProcessor.TransactionDirectoryPrefix, StringComparison.Ordinal))
+                Path.GetFileName(directory).StartsWith(AssemblyProcessor.StagingDirectoryPrefix, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            var extension = Path.GetExtension(filePath).ToLowerInvariant();
-            return extension is ".dll" or ".exe" or "";
+            var extension = Path.GetExtension(filePath);
+            return extension is "" ||
+                   string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc />

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -346,6 +346,12 @@ namespace Datadog.Trace.Coverage.Collector
 
         internal static bool HasAssemblyExtension(string filePath)
         {
+            if (Path.GetDirectoryName(filePath) is { } directory &&
+                Path.GetFileName(directory).StartsWith(AssemblyProcessor.TransactionDirectoryPrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
             var extension = Path.GetExtension(filePath).ToLowerInvariant();
             return extension is ".dll" or ".exe" or "";
         }

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -176,8 +176,7 @@ namespace Datadog.Trace.Coverage.Collector
                         return;
                     }
 
-                    var extension = Path.GetExtension(file).ToLowerInvariant();
-                    if (extension is ".dll" or ".exe" or "")
+                    if (HasAssemblyExtension(file))
                     {
                         if (File.Exists(Path.Combine(path, fileWithoutExtension + ".pdb")) || File.Exists(Path.Combine(path, fileWithoutExtension + ".PDB")))
                         {
@@ -343,6 +342,12 @@ namespace Datadog.Trace.Coverage.Collector
             {
                 _logger?.Debug("CoverageCollector.Test session context cannot be found, skipping IPC client and sending injection tags");
             }
+        }
+
+        internal static bool HasAssemblyExtension(string filePath)
+        {
+            var extension = Path.GetExtension(filePath).ToLowerInvariant();
+            return extension is ".dll" or ".exe" or "";
         }
 
         /// <inheritdoc />

--- a/tracer/src/Datadog.Trace.Coverage.collector/SharedFrameworkLocator.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/SharedFrameworkLocator.cs
@@ -1,0 +1,355 @@
+// <copyright file="SharedFrameworkLocator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+
+namespace Datadog.Trace.Coverage.Collector;
+
+internal static class SharedFrameworkLocator
+{
+    private static readonly StringComparer PathComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+    private static readonly string[] DotnetRootEnvironmentVariables = ["DOTNET_ROOT", "DOTNET_ROOT_X64", "DOTNET_ROOT_X86", "DOTNET_ROOT_ARM64", "DOTNET_ROOT(x86)"];
+    private static readonly ConcurrentDictionary<string, Lazy<string[]>> CachedDirectories = new(PathComparer);
+
+    internal static IEnumerable<string> GetDirectories(string outputDirectory, string? sharedFrameworkRoot = null)
+    {
+        if (string.IsNullOrEmpty(outputDirectory))
+        {
+            return [];
+        }
+
+        var roots = (sharedFrameworkRoot is null ? GetSharedFrameworkRoots() : [sharedFrameworkRoot])
+                   .Where(Directory.Exists)
+                   .Select(Path.GetFullPath)
+                   .Distinct(PathComparer)
+                   .ToArray();
+        if (roots.Length == 0)
+        {
+            return [];
+        }
+
+        outputDirectory = Path.GetFullPath(outputDirectory);
+        var rollForwardToPrerelease = RollForwardToPrerelease();
+        var cacheKey = outputDirectory + "\0" + string.Join("\0", roots) + "\0" + (rollForwardToPrerelease ? "1" : "0");
+        return CachedDirectories.GetOrAdd(
+                                    cacheKey,
+                                    _ => new Lazy<string[]>(
+                                        () => DiscoverDirectories(outputDirectory, roots, rollForwardToPrerelease),
+                                        LazyThreadSafetyMode.ExecutionAndPublication))
+                                .Value;
+    }
+
+    internal static string[] DiscoverDirectories(string outputDirectory, IEnumerable<string> sharedFrameworkRoots, bool rollForwardToPrerelease)
+    {
+        var directories = new List<string>();
+        var seenDirectories = new HashSet<string>(PathComparer);
+        foreach (var runtimeConfigPath in GetRuntimeConfigPaths(outputDirectory))
+        {
+            foreach (var framework in ReadFrameworkReferences(runtimeConfigPath))
+            {
+                foreach (var root in sharedFrameworkRoots)
+                {
+                    var directory = FindCompatibleFrameworkDirectory(root, framework.Name, framework.Version, rollForwardToPrerelease);
+                    if (directory is not null && seenDirectories.Add(directory))
+                    {
+                        directories.Add(directory);
+                    }
+                }
+            }
+        }
+
+        return directories.ToArray();
+    }
+
+    internal static string[] GetSharedFrameworkRoots()
+        => GetSharedFrameworkRoots(typeof(object).Assembly.Location, Environment.GetEnvironmentVariable);
+
+    internal static string[] GetSharedFrameworkRoots(string coreLibraryPath, Func<string, string?> getEnvironmentVariable)
+    {
+        var roots = new List<string>();
+        var seenRoots = new HashSet<string>(PathComparer);
+
+        var dotnetHostPath = getEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrEmpty(dotnetHostPath))
+        {
+            AddDotnetInstallRoot(Path.GetDirectoryName(dotnetHostPath), roots, seenRoots);
+        }
+
+        foreach (var variableName in DotnetRootEnvironmentVariables)
+        {
+            AddDotnetInstallRoot(getEnvironmentVariable(variableName), roots, seenRoots);
+        }
+
+        if (string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase))
+        {
+            var versionDirectory = Path.GetDirectoryName(coreLibraryPath);
+            var frameworkDirectory = versionDirectory is null ? null : Path.GetDirectoryName(versionDirectory);
+            var sharedFrameworkRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
+            AddSharedFrameworkRoot(sharedFrameworkRoot, roots, seenRoots);
+        }
+
+        if (getEnvironmentVariable("PATH") is { Length: > 0 } path)
+        {
+            foreach (var pathEntry in path.Split(Path.PathSeparator))
+            {
+                AddDotnetInstallRoot(pathEntry, roots, seenRoots);
+            }
+        }
+
+        return roots.ToArray();
+    }
+
+    private static bool RollForwardToPrerelease()
+        => string.Equals(Environment.GetEnvironmentVariable("DOTNET_ROLL_FORWARD_TO_PRERELEASE"), "1", StringComparison.Ordinal);
+
+    private static void AddDotnetInstallRoot(string? dotnetInstallRoot, List<string> roots, HashSet<string> seenRoots)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(dotnetInstallRoot))
+            {
+                AddSharedFrameworkRoot(Path.Combine(dotnetInstallRoot, "shared"), roots, seenRoots);
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException)
+        {
+            // Environment variables can contain invalid or inaccessible paths. Try the other roots.
+        }
+    }
+
+    private static void AddSharedFrameworkRoot(string? sharedFrameworkRoot, List<string> roots, HashSet<string> seenRoots)
+    {
+        if (string.IsNullOrEmpty(sharedFrameworkRoot) ||
+            !string.Equals(Path.GetFileName(sharedFrameworkRoot), "shared", StringComparison.OrdinalIgnoreCase) ||
+            !Directory.Exists(sharedFrameworkRoot))
+        {
+            return;
+        }
+
+        sharedFrameworkRoot = Path.GetFullPath(sharedFrameworkRoot);
+        if (seenRoots.Add(sharedFrameworkRoot))
+        {
+            roots.Add(sharedFrameworkRoot);
+        }
+    }
+
+    private static IEnumerable<string> GetRuntimeConfigPaths(string outputDirectory)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(outputDirectory, "*.runtimeconfig.json", SearchOption.TopDirectoryOnly)
+                            .OrderBy(path => path, PathComparer)
+                            .ToList();
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    private static IEnumerable<FrameworkReference> ReadFrameworkReferences(string runtimeConfigPath)
+    {
+        JObject runtimeConfig;
+        try
+        {
+            runtimeConfig = JObject.Parse(File.ReadAllText(runtimeConfigPath));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or Datadog.Trace.Vendors.Newtonsoft.Json.JsonException)
+        {
+            yield break;
+        }
+
+        if (runtimeConfig["runtimeOptions"] is not JObject runtimeOptions)
+        {
+            yield break;
+        }
+
+        if (TryReadFrameworkReference(runtimeOptions["framework"], out var framework))
+        {
+            yield return framework;
+        }
+
+        foreach (var propertyName in new[] { "frameworks", "includedFrameworks" })
+        {
+            if (runtimeOptions[propertyName] is not JArray frameworks)
+            {
+                continue;
+            }
+
+            foreach (var frameworkToken in frameworks)
+            {
+                if (TryReadFrameworkReference(frameworkToken, out framework))
+                {
+                    yield return framework;
+                }
+            }
+        }
+    }
+
+    private static bool TryReadFrameworkReference(JToken? token, out FrameworkReference framework)
+    {
+        framework = default;
+        if (token is not JObject frameworkObject ||
+            frameworkObject["name"]?.Value<string>() is not { Length: > 0 } name ||
+            frameworkObject["version"]?.Value<string>() is not { Length: > 0 } version ||
+            Path.IsPathRooted(name) ||
+            name is "." or ".." ||
+            name.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+            name.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+        {
+            return false;
+        }
+
+        framework = new FrameworkReference(name, version);
+        return true;
+    }
+
+    private static string? FindCompatibleFrameworkDirectory(string sharedFrameworkRoot, string frameworkName, string requestedVersionText, bool rollForwardToPrerelease)
+    {
+        if (!RuntimeVersion.TryParse(requestedVersionText, out var requestedVersion))
+        {
+            return null;
+        }
+
+        var frameworkRoot = Path.Combine(sharedFrameworkRoot, frameworkName);
+        if (!Directory.Exists(frameworkRoot))
+        {
+            return null;
+        }
+
+        try
+        {
+            var preferStable = !requestedVersion.IsPrerelease && !rollForwardToPrerelease;
+            return Directory.EnumerateDirectories(frameworkRoot)
+                            .Select(path => new
+                            {
+                                Path = path,
+                                Parsed = RuntimeVersion.TryParse(Path.GetFileName(path), out var version),
+                                Version = version
+                            })
+                            .Where(candidate => candidate.Parsed &&
+                                                candidate.Version.Major == requestedVersion.Major &&
+                                                candidate.Version.Minor == requestedVersion.Minor &&
+                                                candidate.Version.CompareTo(requestedVersion) >= 0)
+                            .OrderBy(candidate => preferStable && candidate.Version.IsPrerelease)
+                            .ThenByDescending(candidate => candidate.Version)
+                            .Select(candidate => candidate.Path)
+                            .FirstOrDefault();
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    private readonly struct FrameworkReference
+    {
+        public FrameworkReference(string name, string version)
+        {
+            Name = name;
+            Version = version;
+        }
+
+        public string Name { get; }
+
+        public string Version { get; }
+    }
+
+    private readonly struct RuntimeVersion : IComparable<RuntimeVersion>
+    {
+        private readonly Version _version;
+        private readonly string[] _prerelease;
+
+        private RuntimeVersion(Version version, string[] prerelease)
+        {
+            _version = version;
+            _prerelease = prerelease;
+        }
+
+        public int Major => _version.Major;
+
+        public int Minor => _version.Minor;
+
+        public bool IsPrerelease => _prerelease.Length > 0;
+
+        public static bool TryParse(string value, out RuntimeVersion runtimeVersion)
+        {
+            runtimeVersion = default;
+            var separator = value.IndexOf('-');
+            var versionText = separator < 0 ? value : value.Substring(0, separator);
+            if (!Version.TryParse(versionText, out var version))
+            {
+                return false;
+            }
+
+            var prerelease = separator < 0 ? [] : value.Substring(separator + 1).Split('.');
+            if (prerelease.Any(identifier => identifier.Length == 0))
+            {
+                return false;
+            }
+
+            runtimeVersion = new RuntimeVersion(version, prerelease);
+            return true;
+        }
+
+        public int CompareTo(RuntimeVersion other)
+        {
+            var result = _version.CompareTo(other._version);
+            if (result != 0)
+            {
+                return result;
+            }
+
+            if (_prerelease.Length == 0 || other._prerelease.Length == 0)
+            {
+                return other._prerelease.Length.CompareTo(_prerelease.Length);
+            }
+
+            var count = Math.Min(_prerelease.Length, other._prerelease.Length);
+            for (var i = 0; i < count; i++)
+            {
+                result = ComparePrereleaseIdentifier(_prerelease[i], other._prerelease[i]);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            return _prerelease.Length.CompareTo(other._prerelease.Length);
+        }
+
+        private static int ComparePrereleaseIdentifier(string left, string right)
+        {
+            var leftIsNumeric = ulong.TryParse(left, out var leftNumber);
+            var rightIsNumeric = ulong.TryParse(right, out var rightNumber);
+            if (leftIsNumeric && rightIsNumeric)
+            {
+                return leftNumber.CompareTo(rightNumber);
+            }
+
+            if (leftIsNumeric != rightIsNumeric)
+            {
+                return leftIsNumeric ? -1 : 1;
+            }
+
+            return string.CompareOrdinal(left, right);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.PortableExecutable;
+using System.Runtime.Versioning;
 using System.Threading;
 using Datadog.Trace.Coverage.Collector;
 using Datadog.Trace.TestHelpers;
@@ -70,8 +72,8 @@ public class CoverageResolverTests
         Directory.CreateDirectory(outputDirectory);
         Directory.CreateDirectory(olderFrameworkDirectory);
         Directory.CreateDirectory(latestFrameworkDirectory);
-        _ = CreateAssembly(olderFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 8, 0));
-        var dependencyPath = CreateAssembly(latestFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 10, 0));
+        _ = CreateAssembly(olderFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
+        var dependencyPath = CreateAssembly(latestFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
         const string RuntimeConfig = """
                                      {
                                        "runtimeOptions": {
@@ -91,7 +93,7 @@ public class CoverageResolverTests
         using (var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot))
         {
             var assembly = resolver.Resolve(assemblyName);
-            assembly.Name.Version.Should().Be(new Version(10, 0, 10, 0));
+            assembly.MainModule.FileName.Should().Be(dependencyPath);
         }
 
         if (EnvironmentTools.IsWindows())
@@ -101,7 +103,25 @@ public class CoverageResolverTests
 
         File.Delete(runtimeConfigPath);
         using var cachedResolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot);
-        cachedResolver.Resolve(assemblyName).Name.Version.Should().Be(new Version(10, 0, 10, 0));
+        cachedResolver.Resolve(assemblyName).MainModule.FileName.Should().Be(dependencyPath);
+    }
+
+    /// <summary>
+    /// Verifies that shared frameworks can be found when the collector itself is hosted by .NET Framework.
+    /// </summary>
+    [Fact]
+    public void SharedFrameworkRootsUseDotnetRootOutsideCoreClr()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var dotnetRoot = Path.Combine(directory.Path, "dotnet");
+        var sharedFrameworkRoot = Path.Combine(dotnetRoot, "shared");
+        Directory.CreateDirectory(sharedFrameworkRoot);
+
+        var roots = CoverageAssemblyResolver.SharedFrameworkLocator.GetSharedFrameworkRoots(
+            Path.Combine(directory.Path, "mscorlib.dll"),
+            name => name == "DOTNET_ROOT" ? dotnetRoot : null);
+
+        roots.Should().Equal(sharedFrameworkRoot);
     }
 
     /// <summary>
@@ -118,14 +138,40 @@ public class CoverageResolverTests
         var frameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
         Directory.CreateDirectory(outputDirectory);
         Directory.CreateDirectory(frameworkDirectory);
-        _ = CreateAssembly(frameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 8, 0));
+        _ = CreateAssembly(frameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
         File.WriteAllText(Path.Combine(outputDirectory, "Repro.Tests.runtimeconfig.json"), CreateRuntimeConfig(propertyName, "Microsoft.AspNetCore.App", "10.0.0"));
         var targetPath = Path.Combine(outputDirectory, "Repro.Library.dll");
         using var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot);
 
         var assembly = resolver.Resolve(new AssemblyNameReference("SharedFrameworkDependency", new Version(10, 0, 0, 0)));
 
-        assembly.Name.Version.Should().Be(new Version(10, 0, 8, 0));
+        assembly.Name.Version.Should().Be(new Version(10, 0, 0, 0));
+    }
+
+    /// <summary>
+    /// Verifies that a candidate from one runtimeconfig cannot satisfy a different requested assembly identity.
+    /// </summary>
+    [Fact]
+    public void ResolveAssemblySkipsSharedFrameworkCandidateWithDifferentIdentity()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var outputDirectory = Path.Combine(directory.Path, "output");
+        var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
+        var net8FrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "8.0.10");
+        var net9FrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "9.0.10");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(net8FrameworkDirectory);
+        Directory.CreateDirectory(net9FrameworkDirectory);
+        _ = CreateAssembly(net8FrameworkDirectory, "SharedFrameworkDependency", new Version(8, 0, 0, 0));
+        _ = CreateAssembly(net9FrameworkDirectory, "SharedFrameworkDependency", new Version(9, 0, 0, 0));
+        File.WriteAllText(Path.Combine(outputDirectory, "A.runtimeconfig.json"), CreateRuntimeConfig("framework", "Microsoft.AspNetCore.App", "8.0.0"));
+        File.WriteAllText(Path.Combine(outputDirectory, "B.runtimeconfig.json"), CreateRuntimeConfig("framework", "Microsoft.AspNetCore.App", "9.0.0"));
+        var targetPath = Path.Combine(outputDirectory, "Repro.Library.dll");
+        using var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot);
+
+        var assembly = resolver.Resolve(new AssemblyNameReference("SharedFrameworkDependency", new Version(9, 0, 0, 0)));
+
+        assembly.Name.Version.Should().Be(new Version(9, 0, 0, 0));
     }
 
     /// <summary>
@@ -324,6 +370,7 @@ public class CoverageResolverTests
         using var unchangedAssembly = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters { ReadSymbols = true });
         unchangedAssembly.Name.Name.Should().Be("CoverageRewriterAssembly");
         Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
+        Directory.GetDirectories(directory.Path).Should().BeEmpty();
     }
 
     /// <summary>
@@ -338,10 +385,16 @@ public class CoverageResolverTests
         using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
         assembly.MainModule.Types.Add(new TypeDefinition("CoverageRewriterAssembly", "AddedByTest", Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class, assembly.MainModule.TypeSystem.Object));
         var transactionPaths = new List<string>();
+        string stagedAssemblyPath = null;
 
         AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null, (source, destination, backup) =>
         {
             transactionPaths.Add(source);
+            if (destination == assemblyPath)
+            {
+                stagedAssemblyPath = source;
+            }
+
             if (backup is not null)
             {
                 transactionPaths.Add(backup);
@@ -352,9 +405,41 @@ public class CoverageResolverTests
 
         using var rewrittenAssembly = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters { ReadSymbols = true });
         rewrittenAssembly.MainModule.GetType("CoverageRewriterAssembly.AddedByTest").Should().NotBeNull();
+        Path.GetFileName(stagedAssemblyPath).Should().Be(Path.GetFileName(assemblyPath));
+        (stagedAssemblyPath.Length - assemblyPath.Length).Should().BeLessOrEqualTo(20);
         transactionPaths.Where(CoverageCollector.HasAssemblyExtension).Should().BeEmpty();
         Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
+        Directory.GetDirectories(directory.Path).Should().BeEmpty();
+
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var codeViewEntry = peReader.ReadDebugDirectory().Single(entry => entry.Type == DebugDirectoryEntryType.CodeView);
+        var codeViewData = peReader.ReadCodeViewDebugDirectoryData(codeViewEntry);
+        Path.GetFileName(codeViewData.Path).Should().Be(Path.GetFileName(Path.ChangeExtension(assemblyPath, ".pdb")));
     }
+
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// Verifies that replacing the assembly does not drop Unix mode bits from the original file.
+    /// </summary>
+    [SkippableFact]
+    [UnsupportedOSPlatform("windows")]
+    public void WriteTargetAssemblyPreservesUnixMode()
+    {
+        SkipOn.Platform(SkipOn.PlatformValue.Windows);
+
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path, "CoverageRewriterAssembly");
+        var expectedMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead;
+        File.SetUnixFileMode(assemblyPath, expectedMode);
+        using var resolver = CreateResolver(directory.Path);
+        using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
+
+        AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null);
+
+        File.GetUnixFileMode(assemblyPath).Should().Be(expectedMode);
+    }
+#endif
 
     /// <summary>
     /// Verifies that both original files are restored when publishing the DLL reports a failure after replacement.
@@ -395,6 +480,7 @@ public class CoverageResolverTests
         File.ReadAllBytes(assemblyPath).Should().Equal(originalAssembly);
         File.ReadAllBytes(symbolsPath).Should().Equal(originalSymbols);
         Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
+        Directory.GetDirectories(directory.Path).Should().BeEmpty();
     }
 
     /// <summary>

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -151,6 +151,28 @@ public class CoverageResolverTests
     }
 
     /// <summary>
+    /// Verifies that an older prerelease framework is not considered compatible with a newer requested prerelease.
+    /// </summary>
+    [Fact]
+    public void ResolveAssemblyDoesNotRollBackToOlderPrereleaseFramework()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var outputDirectory = Path.Combine(directory.Path, "output");
+        var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
+        var frameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "11.0.0-preview.6");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(frameworkDirectory);
+        _ = CreateAssembly(frameworkDirectory, "SharedFrameworkDependency", new Version(11, 0, 0, 6));
+        File.WriteAllText(Path.Combine(outputDirectory, "Repro.Tests.runtimeconfig.json"), CreateRuntimeConfig("framework", "Microsoft.AspNetCore.App", "11.0.0-preview.8"));
+        var targetPath = Path.Combine(outputDirectory, "Repro.Library.dll");
+        using var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot);
+
+        var action = () => resolver.Resolve(new AssemblyNameReference("SharedFrameworkDependency", new Version(11, 0, 0, 0)));
+
+        action.Should().Throw<AssemblyResolutionException>();
+    }
+
+    /// <summary>
     /// Verifies the Windows failure mode from issue 8592: resolved dependency handles are released.
     /// </summary>
     [SkippableFact]
@@ -335,10 +357,12 @@ public class CoverageResolverTests
     }
 
     /// <summary>
-    /// Verifies that replacing the PDB is rolled back when publishing the DLL fails.
+    /// Verifies that both original files are restored when publishing the DLL reports a failure after replacement.
     /// </summary>
-    [Fact]
-    public void WriteTargetAssemblyPublicationFailureRestoresOriginalFiles()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WriteTargetAssemblyPublicationFailureRestoresOriginalFiles(bool replacementWasPublished)
     {
         using var directory = TemporaryDirectory.Create();
         var assemblyPath = CopyCoverageFixture(directory.Path);
@@ -355,7 +379,13 @@ public class CoverageResolverTests
             replaceCallCount++;
             if (replaceCallCount == 2)
             {
-                throw new IOException("Injected DLL publication failure.");
+                File.Move(destination, backup!);
+                if (replacementWasPublished)
+                {
+                    File.Move(source, destination);
+                }
+
+                throw new IOException("Injected DLL publication failure during replacement.");
             }
 
             File.Replace(source, destination, backup);

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -104,6 +104,25 @@ public class CoverageResolverTests
     }
 
     /// <summary>
+    /// Verifies that the resolver follows the shared framework selected for the current test process.
+    /// </summary>
+    [SkippableFact]
+    public void ResolveAssemblyFromCurrentSharedFrameworkSucceeds()
+    {
+        var coreLibraryPath = typeof(object).Assembly.Location;
+        Skip.IfNot(
+            string.Equals(Path.GetFileName(coreLibraryPath), "System.Private.CoreLib.dll", StringComparison.OrdinalIgnoreCase),
+            "The current test process does not use a .NET shared framework.");
+        var targetPath = typeof(CoverageResolverTests).Assembly.Location;
+        using var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath);
+        var assemblyName = AssemblyNameReference.Parse(typeof(object).Assembly.FullName);
+
+        var assembly = resolver.Resolve(assemblyName);
+
+        Path.GetFullPath(assembly.MainModule.FileName).Should().Be(Path.GetFullPath(coreLibraryPath));
+    }
+
+    /// <summary>
     /// Verifies that shared frameworks can be found when the collector itself is hosted by .NET Framework.
     /// </summary>
     [Fact]
@@ -114,7 +133,7 @@ public class CoverageResolverTests
         var sharedFrameworkRoot = Path.Combine(dotnetRoot, "shared");
         Directory.CreateDirectory(sharedFrameworkRoot);
 
-        var roots = CoverageAssemblyResolver.SharedFrameworkLocator.GetSharedFrameworkRoots(
+        var roots = SharedFrameworkLocator.GetSharedFrameworkRoots(
             Path.Combine(directory.Path, "mscorlib.dll"),
             name => name == "DOTNET_ROOT" ? dotnetRoot : null);
 
@@ -138,7 +157,7 @@ public class CoverageResolverTests
         Directory.CreateDirectory(collectorSharedFrameworkRoot);
         var configuredPath = variableName == "DOTNET_HOST_PATH" ? Path.Combine(targetDotnetRoot, "dotnet") : targetDotnetRoot;
 
-        var roots = CoverageAssemblyResolver.SharedFrameworkLocator.GetSharedFrameworkRoots(
+        var roots = SharedFrameworkLocator.GetSharedFrameworkRoots(
             coreLibraryPath,
             name => name == variableName ? configuredPath : null);
 
@@ -163,7 +182,7 @@ public class CoverageResolverTests
         Directory.CreateDirectory(prereleaseFrameworkDirectory);
         File.WriteAllText(Path.Combine(outputDirectory, "Repro.Tests.runtimeconfig.json"), CreateRuntimeConfig("framework", "Microsoft.AspNetCore.App", "10.0.0"));
 
-        var directories = CoverageAssemblyResolver.SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(
+        var directories = SharedFrameworkLocator.DiscoverDirectories(
             outputDirectory,
             [sharedFrameworkRoot],
             rollForwardToPrerelease);
@@ -431,12 +450,12 @@ public class CoverageResolverTests
         using var resolver = CreateResolver(directory.Path);
         using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
         assembly.MainModule.Types.Add(new TypeDefinition("CoverageRewriterAssembly", "AddedByTest", Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class, assembly.MainModule.TypeSystem.Object));
-        var transactionPaths = new List<string>();
+        var stagingPaths = new List<string>();
         string stagedAssemblyPath = null;
 
         AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null, (source, destination, backup) =>
         {
-            transactionPaths.Add(source);
+            stagingPaths.Add(source);
             if (destination == assemblyPath)
             {
                 stagedAssemblyPath = source;
@@ -444,7 +463,7 @@ public class CoverageResolverTests
 
             if (backup is not null)
             {
-                transactionPaths.Add(backup);
+                stagingPaths.Add(backup);
             }
 
             File.Replace(source, destination, backup);
@@ -454,7 +473,7 @@ public class CoverageResolverTests
         rewrittenAssembly.MainModule.GetType("CoverageRewriterAssembly.AddedByTest").Should().NotBeNull();
         Path.GetFileName(stagedAssemblyPath).Should().Be(Path.GetFileName(assemblyPath));
         (stagedAssemblyPath.Length - assemblyPath.Length).Should().BeLessOrEqualTo(20);
-        transactionPaths.Where(CoverageCollector.HasAssemblyExtension).Should().BeEmpty();
+        stagingPaths.Where(CoverageCollector.HasAssemblyExtension).Should().BeEmpty();
         Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
         Directory.GetDirectories(directory.Path).Should().BeEmpty();
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -314,11 +315,22 @@ public class CoverageResolverTests
         using var resolver = CreateResolver(directory.Path);
         using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
         assembly.MainModule.Types.Add(new TypeDefinition("CoverageRewriterAssembly", "AddedByTest", Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class, assembly.MainModule.TypeSystem.Object));
+        var transactionPaths = new List<string>();
 
-        AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null);
+        AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null, (source, destination, backup) =>
+        {
+            transactionPaths.Add(source);
+            if (backup is not null)
+            {
+                transactionPaths.Add(backup);
+            }
+
+            File.Replace(source, destination, backup);
+        });
 
         using var rewrittenAssembly = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters { ReadSymbols = true });
         rewrittenAssembly.MainModule.GetType("CoverageRewriterAssembly.AddedByTest").Should().NotBeNull();
+        transactionPaths.Where(CoverageCollector.HasAssemblyExtension).Should().BeEmpty();
         Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
     }
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -5,12 +5,14 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using Datadog.Trace.Coverage.Collector;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 using Xunit;
 
 namespace Datadog.Trace.Tools.Runner.Tests;
@@ -51,6 +53,100 @@ public class CoverageResolverTests
         var second = resolver.Resolve(assemblyName);
 
         second.Should().BeSameAs(first);
+    }
+
+    /// <summary>
+    /// Verifies that dependencies supplied by a declared shared framework can be resolved outside the test output directory.
+    /// </summary>
+    [Fact]
+    public void ResolveAssemblyFromDeclaredSharedFrameworkSucceeds()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var outputDirectory = Path.Combine(directory.Path, "output");
+        var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
+        var olderFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
+        var latestFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.10-servicing.1");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(olderFrameworkDirectory);
+        Directory.CreateDirectory(latestFrameworkDirectory);
+        _ = CreateAssembly(olderFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 8, 0));
+        var dependencyPath = CreateAssembly(latestFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 10, 0));
+        const string RuntimeConfig = """
+                                     {
+                                       "runtimeOptions": {
+                                         "frameworks": [
+                                           { "name": "Microsoft.NETCore.App", "version": "10.0.0" },
+                                           { "name": "Microsoft.AspNetCore.App", "version": "10.0.0" }
+                                         ]
+                                       }
+                                     }
+                                     """;
+        var runtimeConfigPath = Path.Combine(outputDirectory, "Repro.Tests.runtimeconfig.json");
+        File.WriteAllText(Path.Combine(outputDirectory, "Malformed.runtimeconfig.json"), "{");
+        File.WriteAllText(runtimeConfigPath, RuntimeConfig);
+        var targetPath = Path.Combine(outputDirectory, "Repro.Library.dll");
+        var assemblyName = new AssemblyNameReference("SharedFrameworkDependency", new Version(10, 0, 0, 0));
+
+        using (var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot))
+        {
+            var assembly = resolver.Resolve(assemblyName);
+            assembly.Name.Version.Should().Be(new Version(10, 0, 10, 0));
+        }
+
+        if (EnvironmentTools.IsWindows())
+        {
+            AssertCanOpenExclusively(dependencyPath);
+        }
+
+        File.Delete(runtimeConfigPath);
+        using var cachedResolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot);
+        cachedResolver.Resolve(assemblyName).Name.Version.Should().Be(new Version(10, 0, 10, 0));
+    }
+
+    /// <summary>
+    /// Verifies all runtimeconfig framework declaration shapes used by the host.
+    /// </summary>
+    [Theory]
+    [InlineData("framework")]
+    [InlineData("includedFrameworks")]
+    public void ResolveAssemblySupportsRuntimeConfigFrameworkShape(string propertyName)
+    {
+        using var directory = TemporaryDirectory.Create();
+        var outputDirectory = Path.Combine(directory.Path, "output");
+        var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
+        var frameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(frameworkDirectory);
+        _ = CreateAssembly(frameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 8, 0));
+        File.WriteAllText(Path.Combine(outputDirectory, "Repro.Tests.runtimeconfig.json"), CreateRuntimeConfig(propertyName, "Microsoft.AspNetCore.App", "10.0.0"));
+        var targetPath = Path.Combine(outputDirectory, "Repro.Library.dll");
+        using var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot);
+
+        var assembly = resolver.Resolve(new AssemblyNameReference("SharedFrameworkDependency", new Version(10, 0, 0, 0)));
+
+        assembly.Name.Version.Should().Be(new Version(10, 0, 8, 0));
+    }
+
+    /// <summary>
+    /// Verifies that installed frameworks are not probed unless a runtimeconfig declares them.
+    /// </summary>
+    [Fact]
+    public void ResolveAssemblyDoesNotProbeUndeclaredSharedFramework()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var outputDirectory = Path.Combine(directory.Path, "output");
+        var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
+        var frameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(frameworkDirectory);
+        _ = CreateAssembly(frameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 8, 0));
+        File.WriteAllText(Path.Combine(outputDirectory, "Repro.Tests.runtimeconfig.json"), CreateRuntimeConfig("framework", "Microsoft.NETCore.App", "10.0.0"));
+        var targetPath = Path.Combine(outputDirectory, "Repro.Library.dll");
+        using var resolver = new CoverageAssemblyResolver(new ConsoleCollectorLogger(), targetPath, sharedFrameworkRoot);
+
+        var action = () => resolver.Resolve(new AssemblyNameReference("SharedFrameworkDependency", new Version(10, 0, 0, 0)));
+
+        action.Should().Throw<AssemblyResolutionException>();
     }
 
     /// <summary>
@@ -182,6 +278,84 @@ public class CoverageResolverTests
     }
 
     /// <summary>
+    /// Verifies that a Cecil write failure cannot damage the original assembly or symbols.
+    /// </summary>
+    [Fact]
+    public void WriteTargetAssemblyFailurePreservesOriginalFiles()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+        var symbolsPath = Path.ChangeExtension(assemblyPath, ".pdb");
+        var originalAssembly = File.ReadAllBytes(assemblyPath);
+        var originalSymbols = File.ReadAllBytes(symbolsPath);
+        using var resolver = CreateResolver(directory.Path);
+        using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
+
+        AddOptionalParameterWithUnresolvableEnum(assembly.MainModule);
+
+        var action = () => AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null);
+
+        action.Should().Throw<AssemblyResolutionException>();
+        File.ReadAllBytes(assemblyPath).Should().Equal(originalAssembly);
+        File.ReadAllBytes(symbolsPath).Should().Equal(originalSymbols);
+        using var unchangedAssembly = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters { ReadSymbols = true });
+        unchangedAssembly.Name.Name.Should().Be("CoverageRewriterAssembly");
+        Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
+    }
+
+    /// <summary>
+    /// Verifies that a successful staged write publishes readable matching assembly and symbol files.
+    /// </summary>
+    [Fact]
+    public void WriteTargetAssemblySuccessPublishesRewrittenFiles()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+        using var resolver = CreateResolver(directory.Path);
+        using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
+        assembly.MainModule.Types.Add(new TypeDefinition("CoverageRewriterAssembly", "AddedByTest", Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class, assembly.MainModule.TypeSystem.Object));
+
+        AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null);
+
+        using var rewrittenAssembly = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters { ReadSymbols = true });
+        rewrittenAssembly.MainModule.GetType("CoverageRewriterAssembly.AddedByTest").Should().NotBeNull();
+        Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
+    }
+
+    /// <summary>
+    /// Verifies that replacing the PDB is rolled back when publishing the DLL fails.
+    /// </summary>
+    [Fact]
+    public void WriteTargetAssemblyPublicationFailureRestoresOriginalFiles()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var assemblyPath = CopyCoverageFixture(directory.Path);
+        var symbolsPath = Path.ChangeExtension(assemblyPath, ".pdb");
+        var originalAssembly = File.ReadAllBytes(assemblyPath);
+        var originalSymbols = File.ReadAllBytes(symbolsPath);
+        using var resolver = CreateResolver(directory.Path);
+        using var assembly = AssemblyProcessor.ReadTargetAssembly(assemblyPath, resolver);
+        assembly.MainModule.Types.Add(new TypeDefinition("CoverageRewriterAssembly", "AddedByTest", Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class, assembly.MainModule.TypeSystem.Object));
+        var replaceCallCount = 0;
+
+        var action = () => AssemblyProcessor.WriteTargetAssembly(assembly, assemblyPath, strongNameKeyBlob: null, (source, destination, backup) =>
+        {
+            replaceCallCount++;
+            if (replaceCallCount == 2)
+            {
+                throw new IOException("Injected DLL publication failure.");
+            }
+
+            File.Replace(source, destination, backup);
+        });
+
+        action.Should().Throw<IOException>();
+        File.ReadAllBytes(assemblyPath).Should().Equal(originalAssembly);
+        File.ReadAllBytes(symbolsPath).Should().Equal(originalSymbols);
+        Directory.GetFiles(directory.Path).Select(Path.GetFileName).Should().BeEquivalentTo("CoverageRewriterAssembly.dll", "CoverageRewriterAssembly.pdb");
+    }
+
+    /// <summary>
     /// Verifies that multiple dependency reads for the same path can proceed together.
     /// </summary>
     [Fact]
@@ -236,12 +410,38 @@ public class CoverageResolverTests
         return resolver;
     }
 
+    private static void AddOptionalParameterWithUnresolvableEnum(ModuleDefinition module)
+    {
+        var missingAssembly = new AssemblyNameReference("Missing.Enums", new Version(1, 0, 0, 0));
+        module.AssemblyReferences.Add(missingAssembly);
+        var missingEnum = new TypeReference("Missing.Enums", "MissingEnum", module, missingAssembly, true);
+        var method = new MethodDefinition("MethodWithMissingEnumDefault", Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.Static, module.TypeSystem.Void);
+        method.Parameters.Add(new ParameterDefinition("value", Mono.Cecil.ParameterAttributes.Optional | Mono.Cecil.ParameterAttributes.HasDefault, missingEnum) { Constant = 0 });
+        method.Body.Instructions.Add(Instruction.Create(OpCodes.Ret));
+        module.Types.First(type => type.Name != "<Module>").Methods.Add(method);
+    }
+
     private static string CopyCoverageFixture(string directory, string fileName = "CoverageRewriterAssembly.dll")
     {
         var targetPath = Path.Combine(directory, fileName);
         File.Copy("CoverageRewriterAssembly.dll", targetPath, overwrite: true);
         File.Copy("CoverageRewriterAssembly.pdb", Path.ChangeExtension(targetPath, ".pdb"), overwrite: true);
         return targetPath;
+    }
+
+    private static string CreateAssembly(string directory, string assemblyName, Version version)
+    {
+        var assemblyPath = Path.Combine(directory, assemblyName + ".dll");
+        using var assembly = AssemblyDefinition.CreateAssembly(new AssemblyNameDefinition(assemblyName, version), assemblyName, ModuleKind.Dll);
+        assembly.Write(assemblyPath);
+        return assemblyPath;
+    }
+
+    private static string CreateRuntimeConfig(string propertyName, string frameworkName, string version)
+    {
+        var framework = $"{{ \"name\": \"{frameworkName}\", \"version\": \"{version}\" }}";
+        var value = propertyName == "framework" ? framework : $"[{framework}]";
+        return $"{{ \"runtimeOptions\": {{ \"{propertyName}\": {value} }} }}";
     }
 
     private static Exception CaptureExceptionFromThread(ThreadStart action)

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -67,13 +67,13 @@ public class CoverageResolverTests
         using var directory = TemporaryDirectory.Create();
         var outputDirectory = Path.Combine(directory.Path, "output");
         var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
-        var olderFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
-        var latestFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.10-servicing.1");
+        var stableFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
+        var prereleaseFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.10-servicing.1");
         Directory.CreateDirectory(outputDirectory);
-        Directory.CreateDirectory(olderFrameworkDirectory);
-        Directory.CreateDirectory(latestFrameworkDirectory);
-        _ = CreateAssembly(olderFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
-        var dependencyPath = CreateAssembly(latestFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
+        Directory.CreateDirectory(stableFrameworkDirectory);
+        Directory.CreateDirectory(prereleaseFrameworkDirectory);
+        var dependencyPath = CreateAssembly(stableFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
+        _ = CreateAssembly(prereleaseFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
         const string RuntimeConfig = """
                                      {
                                        "runtimeOptions": {
@@ -122,6 +122,54 @@ public class CoverageResolverTests
             name => name == "DOTNET_ROOT" ? dotnetRoot : null);
 
         roots.Should().Equal(sharedFrameworkRoot);
+    }
+
+    /// <summary>
+    /// Verifies that an explicitly configured target runtime is searched before the collector runtime.
+    /// </summary>
+    [Theory]
+    [InlineData("DOTNET_HOST_PATH")]
+    [InlineData("DOTNET_ROOT")]
+    public void SharedFrameworkRootsPreferConfiguredTargetRuntime(string variableName)
+    {
+        using var directory = TemporaryDirectory.Create();
+        var targetDotnetRoot = Path.Combine(directory.Path, "target-dotnet");
+        var targetSharedFrameworkRoot = Path.Combine(targetDotnetRoot, "shared");
+        var collectorSharedFrameworkRoot = Path.Combine(directory.Path, "collector-dotnet", "shared");
+        var coreLibraryPath = Path.Combine(collectorSharedFrameworkRoot, "Microsoft.NETCore.App", "10.0.0", "System.Private.CoreLib.dll");
+        Directory.CreateDirectory(targetSharedFrameworkRoot);
+        Directory.CreateDirectory(collectorSharedFrameworkRoot);
+        var configuredPath = variableName == "DOTNET_HOST_PATH" ? Path.Combine(targetDotnetRoot, "dotnet") : targetDotnetRoot;
+
+        var roots = CoverageAssemblyResolver.SharedFrameworkLocator.GetSharedFrameworkRoots(
+            coreLibraryPath,
+            name => name == variableName ? configuredPath : null);
+
+        roots.Should().Equal(targetSharedFrameworkRoot, collectorSharedFrameworkRoot);
+    }
+
+    /// <summary>
+    /// Verifies that explicit prerelease roll-forward can select a newer prerelease over a stable patch.
+    /// </summary>
+    [Fact]
+    public void SharedFrameworkDiscoveryHonorsPrereleaseRollForward()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var outputDirectory = Path.Combine(directory.Path, "output");
+        var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
+        var stableFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
+        var prereleaseFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.10-servicing.1");
+        Directory.CreateDirectory(outputDirectory);
+        Directory.CreateDirectory(stableFrameworkDirectory);
+        Directory.CreateDirectory(prereleaseFrameworkDirectory);
+        File.WriteAllText(Path.Combine(outputDirectory, "Repro.Tests.runtimeconfig.json"), CreateRuntimeConfig("framework", "Microsoft.AspNetCore.App", "10.0.0"));
+
+        var directories = CoverageAssemblyResolver.SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(
+            outputDirectory,
+            [sharedFrameworkRoot],
+            rollForwardToPrerelease: true);
+
+        directories.Should().Equal(prereleaseFrameworkDirectory);
     }
 
     /// <summary>

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageResolverTests.cs
@@ -68,12 +68,9 @@ public class CoverageResolverTests
         var outputDirectory = Path.Combine(directory.Path, "output");
         var sharedFrameworkRoot = Path.Combine(directory.Path, "shared");
         var stableFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.8");
-        var prereleaseFrameworkDirectory = Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", "10.0.10-servicing.1");
         Directory.CreateDirectory(outputDirectory);
         Directory.CreateDirectory(stableFrameworkDirectory);
-        Directory.CreateDirectory(prereleaseFrameworkDirectory);
         var dependencyPath = CreateAssembly(stableFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
-        _ = CreateAssembly(prereleaseFrameworkDirectory, "SharedFrameworkDependency", new Version(10, 0, 0, 0));
         const string RuntimeConfig = """
                                      {
                                        "runtimeOptions": {
@@ -149,10 +146,12 @@ public class CoverageResolverTests
     }
 
     /// <summary>
-    /// Verifies that explicit prerelease roll-forward can select a newer prerelease over a stable patch.
+    /// Verifies stable and explicit prerelease roll-forward framework selection.
     /// </summary>
-    [Fact]
-    public void SharedFrameworkDiscoveryHonorsPrereleaseRollForward()
+    [Theory]
+    [InlineData(false, "10.0.8")]
+    [InlineData(true, "10.0.10-servicing.1")]
+    public void SharedFrameworkDiscoveryHonorsPrereleaseRollForward(bool rollForwardToPrerelease, string expectedVersion)
     {
         using var directory = TemporaryDirectory.Create();
         var outputDirectory = Path.Combine(directory.Path, "output");
@@ -167,9 +166,9 @@ public class CoverageResolverTests
         var directories = CoverageAssemblyResolver.SharedFrameworkLocator.DiscoverSharedFrameworkDirectories(
             outputDirectory,
             [sharedFrameworkRoot],
-            rollForwardToPrerelease: true);
+            rollForwardToPrerelease);
 
-        directories.Should().Equal(prereleaseFrameworkDirectory);
+        directories.Should().Equal(Path.Combine(sharedFrameworkRoot, "Microsoft.AspNetCore.App", expectedVersion));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary of changes

- resolve coverage rewrite dependencies from runtimeconfig-declared .NET shared frameworks
- stage and validate rewritten DLL/PDB files before replacing the originals
- restore the original assembly and symbols if publication fails

## Reason for change

The coverage collector could not resolve assemblies that were available only through an installed shared framework, such as `Microsoft.Extensions.Logging.Abstractions` from `Microsoft.AspNetCore.App`. If Mono.Cecil encountered that dependency while writing metadata, it had already truncated the assembly under test and left a damaged DLL on disk.

## Implementation details

- discover `framework`, `frameworks`, and `includedFrameworks` entries from sibling `*.runtimeconfig.json` files
- derive the installed shared-framework root from `System.Private.CoreLib` and select the highest compatible patch version using full semantic-version ordering
- cache immutable shared-framework search directories per output directory while keeping Cecil assemblies resolver-owned
- write DLL/PDB output to unique sibling transaction files with non-assembly extensions, validate both by reopening them, then publish with `File.Replace` backups and rollback
- restore both backups after partial publication failures, including when the target assembly is missing or already replaced

## Test coverage

- `CoverageResolverTests` on net10.0 and net8.0
- `CoverageRewriteTests` on net10.0
- `Datadog.Trace.Coverage.collector` project build
- net10.0 three-project reproduction with `Microsoft.AspNetCore.App` and an optional `LogLevel` parameter

## Other details

Windows and Linux CI provide the remaining platform coverage for replacement and locking semantics.

Fixes #9023
