### PR TITLE
Consolidate and fix bugs in GitLab "download from Azure" scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -286,7 +286,7 @@ publish:
 download-nuget-packages-to-sign:
   stage: package
   image: registry.ddbuild.io/images/ci/images:1.2.6
-  timeout: 1h
+  timeout: 2h15m # based on 3 attempts x40min
   tags: [ "arch:amd64" ]
   needs:
     - job: build
@@ -357,7 +357,7 @@ sign-nuget-packages:
 download-single-step-artifacts:
   stage: package
   image: registry.ddbuild.io/images/ci/images:1.2.6
-  timeout: 45m
+  timeout: 2h15m # based on 3 attempts x40min
   tags: [ "arch:amd64" ]
   needs:
     - job: build
@@ -404,6 +404,7 @@ deploy_to_reliability_env:
 download-serverless-artifacts:
   stage: package
   image: registry.ddbuild.io/images/ci/images:1.2.6
+  timeout: 2h15m # based on 3 attempts x40min
   tags: [ "arch:amd64" ]
   needs: []
   rules:

--- a/.gitlab/download-azure-artifacts-helper.sh
+++ b/.gitlab/download-azure-artifacts-helper.sh
@@ -13,13 +13,31 @@
 # Provides:
 #   resolve_azure_build_id                                  - sets the global `buildId`, or exits 1
 #   download_azure_artifact <buildId> <artifactName> <dir>   - polls for and unzips one artifact
-#                                                               into <dir>/<artifactName>, or exits 1
+#                                                               into <dir>/<artifactName>. Bails out
+#                                                               (after trying to recover onto a
+#                                                               different build of the same commit)
+#                                                               as soon as Azure DevOps reports the
+#                                                               artifact can no longer be produced,
+#                                                               rather than always waiting the full
+#                                                               timeout. Exits 1 if the artifact
+#                                                               can't be obtained.
 #   flatten_azure_artifact <dir> <artifactName>               - moves <dir>/<artifactName>/* up into
 #                                                               <dir> and removes the now-empty folder
+#
+# The remaining functions in this file (azure_stage_for_artifact, azure_build_state,
+# azure_stage_state, is_azure_artifact_doomed, switch_to_better_azure_build,
+# azure_artifact_failure) are implementation details of download_azure_artifact, not a stable
+# interface for callers.
 
+AZDO_API="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build"
 AZDO_BUILD_DEFINITION=54
 ARTIFACT_TIMEOUT=2400 # 40 minutes
 ARTIFACT_POLL_INTERVAL=100
+STAGE_CHECK_INTERVAL=300 # how often to re-read the (multi-MB) build timeline while polling
+
+declare -A AZ_STAGE_CACHE    # "buildId:stageName" -> "state|result"
+declare -A AZ_STAGE_CACHE_AT # "buildId:stageName" -> unix time of the last timeline fetch
+AZ_TRIED_BUILDS=""           # space-separated build ids already rejected by switch_to_better_azure_build
 
 # Resolves the Azure DevOps build id for $CI_COMMIT_SHA / $CI_COMMIT_BRANCH and sets the global
 # `buildId`. Exits 1 if no build can be found.
@@ -39,13 +57,13 @@ resolve_azure_build_id() {
   echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
 
   # 1. PR build for this branch + commit
-  local allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
+  local allBuildsForPrUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
   buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
 
   # 2. Standalone (manual/individualCI) build for this branch + commit
   if [ -z "${buildId}" ]; then
     echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
-    local allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
+    local allBuildsForBranchUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
     buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
   fi
 
@@ -56,7 +74,7 @@ resolve_azure_build_id() {
   # back to an in-progress build if no successful one is found.
   if [ -z "${buildId}" ]; then
     echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
-    local allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=200&queryOrder=queueTimeDescending"
+    local allBuildsUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=200&queryOrder=queueTimeDescending"
     buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
       [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
       | ( map(select(.reason != "schedule" and .result == "succeeded"))
@@ -74,46 +92,246 @@ resolve_azure_build_id() {
   echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
 }
 
-# Polls for the named artifact on the given build for up to $ARTIFACT_TIMEOUT seconds, then
-# downloads and unzips it into <targetDir>/<artifactName>. Exits 1 on timeout.
-download_azure_artifact() {
+# Maps an artifact name to the Azure DevOps pipeline stage (see .azure-pipelines/ultimate-pipeline.yml)
+# that publishes it, so download_azure_artifact can tell "not ready yet" apart from "never coming".
+# Artifacts with no known stage fall back to the whole-build status only (see is_azure_artifact_doomed).
+azure_stage_for_artifact() {
+  case "$1" in
+    ssi-artifacts) echo "store_ssi_artifacts" ;;
+    serverless-artifacts) echo "store_serverless_artifacts" ;;
+    runner-dotnet-tool | bundle-nuget-package | azurefunctions-nuget-package) echo "dotnet_tool" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Sets the globals AZ_BUILD_STATUS / AZ_BUILD_RESULT for the given build. Cheap (a few KB), so
+# unlike azure_stage_state this is not throttled or cached.
+azure_build_state() {
   local buildId="$1"
+  local response
+  response=$(curl -sS "${AZDO_API}/builds/${buildId}?api-version=7.1")
+  AZ_BUILD_STATUS=$(echo "$response" | jq -r '.status // "unknown"')
+  AZ_BUILD_RESULT=$(echo "$response" | jq -r '.result // "none"')
+}
+
+# Sets the globals AZ_STAGE_STATE / AZ_STAGE_RESULT for the named stage's latest attempt on the
+# given build, by reading the build timeline. Returns 1 (leaving both globals empty) if the stage
+# isn't present in the timeline at all.
+#
+# The timeline can be several MB (16k+ records on a full build), so this is throttled to at most
+# one fetch per $STAGE_CHECK_INTERVAL seconds per (buildId, stageName), and skipped entirely once a
+# stage has already been observed to succeed - at that point there's nothing left to learn.
+azure_stage_state() {
+  local buildId="$1"
+  local stageName="$2"
+  local cacheKey="${buildId}:${stageName}"
+  local cached="${AZ_STAGE_CACHE[$cacheKey]:-}"
+
+  if [ "$cached" = "completed|succeeded" ] || [ "$cached" = "completed|succeededWithIssues" ]; then
+    AZ_STAGE_STATE="completed"
+    AZ_STAGE_RESULT="${cached##*|}"
+    return 0
+  fi
+
+  local now lastCheck
+  now=$(date +%s)
+  lastCheck="${AZ_STAGE_CACHE_AT[$cacheKey]:-0}"
+  if [ -n "$cached" ] && (( now - lastCheck < STAGE_CHECK_INTERVAL )); then
+    AZ_STAGE_STATE="${cached%%|*}"
+    AZ_STAGE_RESULT="${cached##*|}"
+    return 0
+  fi
+
+  local response stateResult
+  response=$(curl -sS --compressed "${AZDO_API}/builds/${buildId}/timeline?api-version=7.1")
+  stateResult=$(echo "$response" | jq -r --arg s "$stageName" '
+    [ .records[]? | select(.type == "Stage" and .identifier == $s) ]
+    | sort_by(.attempt) | last
+    | if . == null then "" else "\(.state)|\(.result // "none")" end')
+
+  AZ_STAGE_CACHE_AT[$cacheKey]=$now
+
+  if [ -z "$stateResult" ]; then
+    AZ_STAGE_CACHE[$cacheKey]=""
+    AZ_STAGE_STATE=""
+    AZ_STAGE_RESULT=""
+    return 1
+  fi
+
+  AZ_STAGE_CACHE[$cacheKey]="$stateResult"
+  AZ_STAGE_STATE="${stateResult%%|*}"
+  AZ_STAGE_RESULT="${stateResult##*|}"
+  return 0
+}
+
+# Returns 0 (doomed - the artifact will never appear) if the stage that publishes $artifactName has
+# finished without succeeding, or - when that stage can't be resolved, e.g. an unmapped artifact or
+# a pipeline rename that made the stage name stale - if the whole build has completed. The whole-
+# build check is a deliberately lenient backstop: build `result` (succeeded/failed/canceled) is NOT
+# a reliable signal on its own (failed builds routinely still publish every artifact), only
+# `status == completed` combined with "the artifact still isn't there" is.
+#
+# Also refreshes AZ_BUILD_STATUS / AZ_BUILD_RESULT as a side effect, so callers always have current
+# values to log even when this returns "not doomed".
+is_azure_artifact_doomed() {
+  local buildId="$1"
+  local stageName="$2"
+
+  azure_build_state "$buildId"
+
+  if [ -n "$stageName" ] && azure_stage_state "$buildId" "$stageName"; then
+    if [ "$AZ_STAGE_STATE" = "completed" ]; then
+      case "$AZ_STAGE_RESULT" in
+        succeeded | succeededWithIssues) return 1 ;;
+        *) return 0 ;;
+      esac
+    fi
+    return 1
+  fi
+
+  if [ -n "$stageName" ] && [ -z "${AZ_STAGE_WARNED:-}" ]; then
+    echo "  WARNING: stage '$stageName' not found in build $buildId's timeline; falling back to whole-build status to decide whether the artifact is still coming"
+    AZ_STAGE_WARNED=1
+  fi
+
+  [ "$AZ_BUILD_STATUS" = "completed" ]
+}
+
+# Looks for a different Azure DevOps build of the same commit that can still supply $artifactName,
+# for when $currentBuildId turns out to be doomed - e.g. a newer build was queued for the same
+# commit and failed, while an earlier one for that commit already succeeded. Only ever matches
+# builds by exact commit SHA (never branch alone), so this can never switch onto artifacts built
+# from different code. On success sets the global `buildId` to the replacement and returns 0;
+# returns 1 (leaving `buildId` unchanged) if no better candidate exists.
+switch_to_better_azure_build() {
+  local currentBuildId="$1"
+  local artifactName="$2"
+
+  echo "  Build $currentBuildId can no longer produce '$artifactName'. Looking for another build of commit '$CI_COMMIT_SHA'..."
+  AZ_TRIED_BUILDS="$AZ_TRIED_BUILDS $currentBuildId"
+
+  local allBuildsUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=200&queryOrder=queueTimeDescending"
+  local -a candidates=()
+  local candidate
+  while IFS= read -r candidate; do
+    [ -z "$candidate" ] && continue
+    case " $AZ_TRIED_BUILDS " in
+      *" $candidate "*) continue ;;
+    esac
+    candidates+=("$candidate")
+  done < <(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
+    [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
+    | .[] | select(.status != "completed" or .result == "succeeded" or .result == "partiallySucceeded")
+    | .id')
+
+  # Prefer a candidate that already has the artifact, whether it is still running or completed.
+  local downloadUrl
+  for candidate in "${candidates[@]}"; do
+    downloadUrl=$(curl -sS "${AZDO_API}/builds/${candidate}/artifacts?api-version=7.1&artifactName=${artifactName}" | jq -r '.resource.downloadUrl | select( . != null )')
+    if [ -n "$downloadUrl" ]; then
+      echo "  Switching to build $candidate, which already has '$artifactName'"
+      buildId="$candidate"
+      return 0
+    fi
+  done
+
+  # Otherwise, fall back to the first still-running candidate; it may yet publish the artifact.
+  for candidate in "${candidates[@]}"; do
+    azure_build_state "$candidate"
+    if [ "$AZ_BUILD_STATUS" != "completed" ]; then
+      echo "  Switching to build $candidate, which is still running"
+      buildId="$candidate"
+      return 0
+    fi
+  done
+
+  echo "  No alternative build of commit '$CI_COMMIT_SHA' can supply '$artifactName'"
+  return 1
+}
+
+# Prints the diagnostics block shared by every failure path (doomed with no recovery, timeout).
+azure_artifact_failure() {
+  local buildId="$1"
+  local artifactName="$2"
+  local reason="$3"
+  local response="$4"
+
+  echo "ERROR: '$artifactName' will not be downloaded from build $buildId (commit '$CI_COMMIT_SHA' on branch 'refs/heads/$CI_COMMIT_BRANCH')"
+  echo "  Reason: $reason"
+  echo "Last API response:"
+  echo "$response" | jq '.'
+  echo ""
+  echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
+}
+
+# Polls for the named artifact for up to $ARTIFACT_TIMEOUT seconds, then downloads and unzips it
+# into <targetDir>/<artifactName>.
+#
+# As soon as the artifact's publishing stage finishes without succeeding (or, failing that, once
+# the whole build completes) with the artifact still absent, this tries to switch to a different
+# build of the same commit rather than waiting out the rest of the timeout. Exits 1 if the
+# artifact can't be obtained, either because no build can supply it or because of a genuine timeout.
+download_azure_artifact() {
+  local currentBuildId="$1"
   local artifactName="$2"
   local targetDir="$3"
 
   echo ""
   echo "=== Downloading artifact '$artifactName' ==="
 
-  local artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"
+  local stageName
+  stageName=$(azure_stage_for_artifact "$artifactName")
 
-  # Keep trying to get the artifact for 40 minutes
-  local downloadUrl=""
-  local response=""
-  local STARTED=0
-  until (( STARTED == ARTIFACT_TIMEOUT )) || [ ! -z "${downloadUrl}" ] ; do
-      echo "Checking for artifacts at: ${artifactsUrl}"
-      # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
+  local artifactsUrl="${AZDO_API}/builds/${currentBuildId}/artifacts?api-version=7.1&artifactName=${artifactName}"
+  local downloadUrl="" response="" elapsed=0
+
+  while true; do
+    echo "Checking for artifacts at: ${artifactsUrl}"
+    # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
+    response=$(curl -s "${artifactsUrl}")
+    downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
+
+    if [ -n "${downloadUrl}" ]; then
+      break
+    fi
+
+    if is_azure_artifact_doomed "$currentBuildId" "$stageName"; then
+      # The status read above and the artifact publish can race - re-check once before giving up.
       response=$(curl -s "${artifactsUrl}")
       downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
-
-      if [ -z "${downloadUrl}" ]; then
-          local buildStatus
-          buildStatus=$(echo "$response" | jq -r '.message // "Artifact not yet available"')
-          echo "  Status: ${buildStatus} (elapsed: ${STARTED}s / ${ARTIFACT_TIMEOUT}s)"
-
-          sleep "$ARTIFACT_POLL_INTERVAL"
-          (( STARTED += ARTIFACT_POLL_INTERVAL ))
+      if [ -n "${downloadUrl}" ]; then
+        break
       fi
-  done
 
-  if [ -z "${downloadUrl}" ]; then
-    echo "ERROR: No downloadUrl found after 40 minutes for artifact '$artifactName' (commit '$CI_COMMIT_SHA' on branch 'refs/heads/$CI_COMMIT_BRANCH')"
-    echo "Last API response:"
-    echo "$response" | jq '.'
-    echo ""
-    echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
-    exit 1
-  fi
+      if switch_to_better_azure_build "$currentBuildId" "$artifactName"; then
+        currentBuildId="$buildId"
+        artifactsUrl="${AZDO_API}/builds/${currentBuildId}/artifacts?api-version=7.1&artifactName=${artifactName}"
+        continue
+      fi
+
+      local reason
+      if [ -n "$stageName" ] && [ "$AZ_STAGE_STATE" = "completed" ]; then
+        reason="build $currentBuildId's stage '$stageName' finished as '$AZ_STAGE_RESULT'"
+      else
+        reason="build $currentBuildId finished as '$AZ_BUILD_STATUS'/'$AZ_BUILD_RESULT'"
+      fi
+      azure_artifact_failure "$currentBuildId" "$artifactName" \
+        "$reason and no alternative build was found. If the Azure DevOps stage was retried, re-run this job." \
+        "$response"
+      exit 1
+    fi
+
+    if (( elapsed >= ARTIFACT_TIMEOUT )); then
+      azure_artifact_failure "$currentBuildId" "$artifactName" \
+        "timed out after ${ARTIFACT_TIMEOUT}s waiting for the artifact" \
+        "$response"
+      exit 1
+    fi
+
+    echo "  Waiting for '$artifactName' - build $currentBuildId is $AZ_BUILD_STATUS${AZ_STAGE_STATE:+, stage $stageName is $AZ_STAGE_STATE} (elapsed: ${elapsed}s / ${ARTIFACT_TIMEOUT}s)"
+    sleep "$ARTIFACT_POLL_INTERVAL"
+    (( elapsed += ARTIFACT_POLL_INTERVAL ))
+  done
 
   echo "Downloading artifact '$artifactName' from ${downloadUrl}"
   curl -o "$targetDir/artifact.zip" "$downloadUrl"

--- a/.gitlab/download-azure-artifacts-helper.sh
+++ b/.gitlab/download-azure-artifacts-helper.sh
@@ -11,7 +11,7 @@
 #   source "$SCRIPT_DIR/download-azure-artifacts-helper.sh"
 #
 # Provides:
-#   resolve_azure_build_id                                    - sets the global `buildId`, or
+#   resolve_azure_build_id                                    - sets the global `AZDO_BUILD_ID`, or
 #                                                                 exits 1 if no untried build for
 #                                                                 the commit can be found
 #   download_azure_artifact <buildId> <artifactName> <dir>    - polls for and unzips one artifact
@@ -19,9 +19,11 @@
 #                                                                 Returns 0 on success,
 #                                                                 $AZDO_ARTIFACT_UNAVAILABLE if the
 #                                                                 build finished without publishing
-#                                                                 it, or 1 on a genuine timeout.
+#                                                                 it, or 1 on a genuine timeout or
+#                                                                 an unrecoverable download/unzip
+#                                                                 failure (retried a few times first).
 #                                                                 Never exits and never changes
-#                                                                 `buildId` itself.
+#                                                                 `AZDO_BUILD_ID` itself.
 #   download_azure_artifacts_from_one_build <dir> <name>...   - the caller-facing entry point:
 #                                                                 downloads every named artifact
 #                                                                 from a single build, discarding
@@ -38,13 +40,32 @@ AZDO_API="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build"
 AZDO_BUILD_DEFINITION=54
 ARTIFACT_TIMEOUT=2400 # 40 minutes
 ARTIFACT_POLL_INTERVAL=100
+AZDO_BUILD_STATE_POLL_INTERVAL=300 # only re-check build status every 3rd artifact-poll tick
 AZDO_ARTIFACT_UNAVAILABLE=2 # download_azure_artifact: build finished, artifact never published
 AZDO_MAX_BUILD_ATTEMPTS=3
+AZDO_DOWNLOAD_ATTEMPTS=3 # retries for the final curl+unzip step, unrelated to the polling timeout above
 AZDO_TRIED_BUILDS="" # space-separated build ids resolve_azure_build_id should no longer offer
 
+# Curls $1 (an Azure DevOps builds-list URL) and echoes the response, or a `{"value":[]}`
+# placeholder (with a warning to stderr) if the request itself failed - so a transient network
+# error is treated as "no builds found" for this tier and falls through to the next one, instead
+# of aborting the whole script via `set -o pipefail`.
+_azure_curl_builds_or_empty() {
+  local url="$1"
+  local response
+  if ! response=$(curl -sS "$url"); then
+    echo "  WARNING: failed to query Azure DevOps builds (network error) - treating as no results for this tier" >&2
+    echo '{"value":[]}'
+    return
+  fi
+  echo "$response"
+}
+
 # Echoes the first id on stdin that isn't in $AZDO_TRIED_BUILDS. Always returns 0, even when every
-# candidate is excluded and nothing is echoed, so `set -o pipefail` doesn't abort the
-# `buildId=$(... | _azure_first_untried)` assignment in resolve_azure_build_id.
+# candidate is excluded and nothing is echoed, so it never trips `set -o pipefail` as the LAST stage
+# of the `AZDO_BUILD_ID=$(... | _azure_first_untried)` pipelines in resolve_azure_build_id. The
+# curl/jq stages ahead of it in those pipelines are a separate concern - see
+# _azure_curl_builds_or_empty above, which protects those.
 _azure_first_untried() {
   local id
   while IFS= read -r id; do
@@ -59,8 +80,8 @@ _azure_first_untried() {
 }
 
 # Resolves the Azure DevOps build id for $CI_COMMIT_SHA / $CI_COMMIT_BRANCH and sets the global
-# `buildId`, skipping any build already listed in $AZDO_TRIED_BUILDS. Exits 1 if no such build can
-# be found.
+# `AZDO_BUILD_ID`, skipping any build already listed in $AZDO_TRIED_BUILDS. Exits 1 if no such build
+# can be found.
 #
 # Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
 # builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
@@ -78,13 +99,13 @@ resolve_azure_build_id() {
 
   # 1. PR build for this branch + commit
   local allBuildsForPrUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | _azure_first_untried)
+  AZDO_BUILD_ID=$(_azure_curl_builds_or_empty "$allBuildsForPrUrl" | jq -r --arg version "$CI_COMMIT_SHA" --arg branch "$CI_COMMIT_BRANCH" '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | _azure_first_untried)
 
   # 2. Standalone (manual/individualCI) build for this branch + commit
-  if [ -z "${buildId}" ]; then
+  if [ -z "${AZDO_BUILD_ID}" ]; then
     echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
     local allBuildsForBranchUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
-    buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | _azure_first_untried)
+    AZDO_BUILD_ID=$(_azure_curl_builds_or_empty "$allBuildsForBranchUrl" | jq -r --arg version "$CI_COMMIT_SHA" '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | _azure_first_untried)
   fi
 
   # 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
@@ -92,10 +113,10 @@ resolve_azure_build_id() {
   # tier 3's commit is already built elsewhere, so we prefer a completed-successful build to avoid
   # locking onto a queued/canceled/failed newer build and polling it for 40 minutes; we still fall
   # back to an in-progress build if no successful one is found.
-  if [ -z "${buildId}" ]; then
+  if [ -z "${AZDO_BUILD_ID}" ]; then
     echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
     local allBuildsUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=200&queryOrder=queueTimeDescending"
-    buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
+    AZDO_BUILD_ID=$(_azure_curl_builds_or_empty "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
       [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
       | ( map(select(.reason != "schedule" and .result == "succeeded"))
         + map(select(.reason == "schedule"  and .result == "succeeded"))
@@ -104,7 +125,7 @@ resolve_azure_build_id() {
       | .[].id' | _azure_first_untried)
   fi
 
-  if [ -z "${buildId}" ]; then
+  if [ -z "${AZDO_BUILD_ID}" ]; then
     if [ -n "$AZDO_TRIED_BUILDS" ]; then
       echo "No usable build found for commit '$CI_COMMIT_SHA' (branch '$branchName'): already tried and rejected build(s):$AZDO_TRIED_BUILDS"
     else
@@ -113,16 +134,36 @@ resolve_azure_build_id() {
     exit 1
   fi
 
-  echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
+  echo "Found build with id '$AZDO_BUILD_ID' for commit '$CI_COMMIT_SHA'"
 }
 
-# Sets the globals AZ_BUILD_STATUS / AZ_BUILD_RESULT for the given build.
+# Sets the globals AZDO_BUILD_STATUS / AZDO_BUILD_RESULT for the given build.
 azure_build_state() {
   local buildId="$1"
   local response
-  response=$(curl -sS "${AZDO_API}/builds/${buildId}?api-version=7.1")
-  AZ_BUILD_STATUS=$(echo "$response" | jq -r '.status // "unknown"')
-  AZ_BUILD_RESULT=$(echo "$response" | jq -r '.result // "none"')
+  if ! response=$(curl -fsS "${AZDO_API}/builds/${buildId}?api-version=7.1"); then
+    echo "  WARNING: failed to query status for build $buildId" >&2
+    AZDO_BUILD_STATUS="unknown"
+    AZDO_BUILD_RESULT="unknown"
+    return
+  fi
+  AZDO_BUILD_STATUS=$(jq -r '.status // "unknown"' <<<"$response" 2>/dev/null || echo "unknown")
+  AZDO_BUILD_RESULT=$(jq -r '.result // "none"' <<<"$response" 2>/dev/null || echo "none")
+}
+
+# Fetches the artifacts-list response for $1, or echoes an empty string (with a warning to stderr)
+# on a hard curl failure. HTTP error status codes are NOT curl failures here (no `-f`): Azure
+# returns a normal JSON body with no `resource` when the named artifact doesn't exist yet, and the
+# ordinary "not published yet" polling case relies on that body being readable.
+_azure_fetch_artifacts_response() {
+  local url="$1"
+  local response
+  if ! response=$(curl -sS "$url"); then
+    echo "  WARNING: failed to query artifacts at $url (network error)" >&2
+    echo ""
+    return
+  fi
+  echo "$response"
 }
 
 # Polls for the named artifact on the given build for up to $ARTIFACT_TIMEOUT seconds, then
@@ -134,10 +175,11 @@ azure_build_state() {
 #                                (build `result` alone is NOT used for this: failed builds
 #                                routinely still publish every artifact, so only
 #                                "status == completed and the artifact still isn't there" counts)
-#   1                          - genuine timeout: the build is still running after $ARTIFACT_TIMEOUT
+#   1                          - genuine timeout (the build is still running after $ARTIFACT_TIMEOUT)
+#                                or the download/unzip step failed after $AZDO_DOWNLOAD_ATTEMPTS retries
 #
-# Never calls `exit` and never reassigns `buildId` - switching to a different build is entirely up
-# to the caller (see download_azure_artifacts_from_one_build below).
+# Never calls `exit` and never reassigns `AZDO_BUILD_ID` - switching to a different build is entirely
+# up to the caller (see download_azure_artifacts_from_one_build below).
 download_azure_artifact() {
   local buildId="$1"
   local artifactName="$2"
@@ -148,27 +190,32 @@ download_azure_artifact() {
 
   local artifactsUrl="${AZDO_API}/builds/${buildId}/artifacts?api-version=7.1&artifactName=${artifactName}"
   local downloadUrl="" response="" elapsed=0
+  AZDO_BUILD_STATUS="unknown"
 
   while true; do
     echo "Checking for artifacts at: ${artifactsUrl}"
     # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
-    response=$(curl -s "${artifactsUrl}")
+    response=$(_azure_fetch_artifacts_response "${artifactsUrl}")
     downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
 
     if [ -n "${downloadUrl}" ]; then
       break
     fi
 
-    azure_build_state "$buildId"
-    if [ "$AZ_BUILD_STATUS" = "completed" ]; then
+    # Checking build status is a second API call, so only do it every 3rd tick (~5 minutes) instead
+    # of every tick - except the very first, so an already-completed build is caught immediately.
+    if (( elapsed % AZDO_BUILD_STATE_POLL_INTERVAL == 0 )); then
+      azure_build_state "$buildId"
+    fi
+    if [ "$AZDO_BUILD_STATUS" = "completed" ]; then
       # The status read above and the artifact publish can race - re-check once before giving up.
-      response=$(curl -s "${artifactsUrl}")
+      response=$(_azure_fetch_artifacts_response "${artifactsUrl}")
       downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
       if [ -n "${downloadUrl}" ]; then
         break
       fi
 
-      echo "  Build $buildId finished as '$AZ_BUILD_RESULT' without publishing '$artifactName'"
+      echo "  Build $buildId finished as '$AZDO_BUILD_RESULT' without publishing '$artifactName'"
       return "$AZDO_ARTIFACT_UNAVAILABLE"
     fi
 
@@ -181,22 +228,37 @@ download_azure_artifact() {
       return 1
     fi
 
-    echo "  Waiting for '$artifactName' - build $buildId is $AZ_BUILD_STATUS (elapsed: ${elapsed}s / ${ARTIFACT_TIMEOUT}s)"
+    echo "  Waiting for '$artifactName' - build $buildId is $AZDO_BUILD_STATUS (elapsed: ${elapsed}s / ${ARTIFACT_TIMEOUT}s)"
     sleep "$ARTIFACT_POLL_INTERVAL"
     (( elapsed += ARTIFACT_POLL_INTERVAL ))
   done
 
   echo "Downloading artifact '$artifactName' from ${downloadUrl}"
-  curl -o "$targetDir/artifact.zip" "$downloadUrl"
-  unzip -o "$targetDir/artifact.zip" -d "$targetDir"
-  rm -f "$targetDir/artifact.zip"
+  # download_azure_artifact runs with `set -e` suppressed (it's invoked as `if download_azure_artifact
+  # ...; then` by its caller), so every command below must check its own exit status explicitly.
+  # A curl/unzip failure here is a one-off transient error (network blip, truncated write), not a
+  # build problem, so retry a few times before giving up - unlike the poll loop above, this is not
+  # a "genuine timeout" and doesn't warrant discarding the build and starting over.
+  local downloadAttempt
+  for (( downloadAttempt = 1; downloadAttempt <= AZDO_DOWNLOAD_ATTEMPTS; downloadAttempt++ )); do
+    if curl -fsS -o "$targetDir/artifact.zip" "$downloadUrl" && unzip -o "$targetDir/artifact.zip" -d "$targetDir"; then
+      rm -f "$targetDir/artifact.zip"
+      return 0
+    fi
+    echo "  WARNING: failed to download/unzip '$artifactName' (attempt $downloadAttempt/$AZDO_DOWNLOAD_ATTEMPTS)" >&2
+    rm -f "$targetDir/artifact.zip"
+    (( downloadAttempt < AZDO_DOWNLOAD_ATTEMPTS )) && sleep 5
+  done
+
+  echo "ERROR: failed to download/unzip artifact '$artifactName' after $AZDO_DOWNLOAD_ATTEMPTS attempts" >&2
+  return 1
 }
 
 # Downloads every named artifact from a SINGLE Azure DevOps build into <targetDir>/<artifactName>
 # each. If that build turns out never to publish one of them, discards everything downloaded for
 # this attempt and starts over against a different build of the same commit (bounded by
 # $AZDO_MAX_BUILD_ATTEMPTS) - artifacts from two different builds are never mixed together. On
-# return, the global `buildId` holds the build every artifact actually came from.
+# return, the global `AZDO_BUILD_ID` holds the build every artifact actually came from.
 #
 # resolve_azure_build_id exits 1 as soon as it has no untried build left to offer, so "there's no
 # better build available" fails fast instead of waiting out a doomed poll.
@@ -207,12 +269,12 @@ download_azure_artifacts_from_one_build() {
 
   local attempt
   for (( attempt = 1; attempt <= AZDO_MAX_BUILD_ATTEMPTS; attempt++ )); do
-    buildId=""
+    AZDO_BUILD_ID=""
     resolve_azure_build_id
 
     local artifactName ok=1 rc
     for artifactName in "${artifactNames[@]}"; do
-      if download_azure_artifact "$buildId" "$artifactName" "$targetDir"; then
+      if download_azure_artifact "$AZDO_BUILD_ID" "$artifactName" "$targetDir"; then
         rc=0
       else
         rc=$?
@@ -227,7 +289,8 @@ download_azure_artifacts_from_one_build() {
         break
       fi
 
-      # Genuine timeout - not recoverable by trying a different build.
+      # Genuine timeout, or a download/unzip failure that survived retries - not recoverable by
+      # trying a different build.
       exit 1
     done
 
@@ -235,8 +298,8 @@ download_azure_artifacts_from_one_build() {
       return 0
     fi
 
-    echo "Discarding partial downloads from build $buildId and trying a different build (attempt $attempt/$AZDO_MAX_BUILD_ATTEMPTS)"
-    AZDO_TRIED_BUILDS="$AZDO_TRIED_BUILDS $buildId"
+    echo "Discarding partial downloads from build $AZDO_BUILD_ID and trying a different build (attempt $attempt/$AZDO_MAX_BUILD_ATTEMPTS)"
+    AZDO_TRIED_BUILDS="$AZDO_TRIED_BUILDS $AZDO_BUILD_ID"
     find "${targetDir:?}" -mindepth 1 -delete
   done
 

--- a/.gitlab/download-azure-artifacts-helper.sh
+++ b/.gitlab/download-azure-artifacts-helper.sh
@@ -11,36 +11,56 @@
 #   source "$SCRIPT_DIR/download-azure-artifacts-helper.sh"
 #
 # Provides:
-#   resolve_azure_build_id                                  - sets the global `buildId`, or exits 1
-#   download_azure_artifact <buildId> <artifactName> <dir>   - polls for and unzips one artifact
-#                                                               into <dir>/<artifactName>. Bails out
-#                                                               (after trying to recover onto a
-#                                                               different build of the same commit)
-#                                                               as soon as Azure DevOps reports the
-#                                                               artifact can no longer be produced,
-#                                                               rather than always waiting the full
-#                                                               timeout. Exits 1 if the artifact
-#                                                               can't be obtained.
+#   resolve_azure_build_id                                    - sets the global `buildId`, or
+#                                                                 exits 1 if no untried build for
+#                                                                 the commit can be found
+#   download_azure_artifact <buildId> <artifactName> <dir>    - polls for and unzips one artifact
+#                                                                 into <dir>/<artifactName>.
+#                                                                 Returns 0 on success,
+#                                                                 $AZDO_ARTIFACT_UNAVAILABLE if the
+#                                                                 build finished without publishing
+#                                                                 it, or 1 on a genuine timeout.
+#                                                                 Never exits and never changes
+#                                                                 `buildId` itself.
+#   download_azure_artifacts_from_one_build <dir> <name>...   - the caller-facing entry point:
+#                                                                 downloads every named artifact
+#                                                                 from a single build, discarding
+#                                                                 and retrying against a different
+#                                                                 build of the same commit if the
+#                                                                 chosen one turns out unable to
+#                                                                 publish one of them. Exits 1 if
+#                                                                 no build can supply all of them.
 #   flatten_azure_artifact <dir> <artifactName>               - moves <dir>/<artifactName>/* up into
-#                                                               <dir> and removes the now-empty folder
-#
-# The remaining functions in this file (azure_stage_for_artifact, azure_build_state,
-# azure_stage_state, is_azure_artifact_doomed, switch_to_better_azure_build,
-# azure_artifact_failure) are implementation details of download_azure_artifact, not a stable
-# interface for callers.
+#                                                                 <dir> and removes the now-empty
+#                                                                 folder
 
 AZDO_API="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build"
 AZDO_BUILD_DEFINITION=54
 ARTIFACT_TIMEOUT=2400 # 40 minutes
 ARTIFACT_POLL_INTERVAL=100
-STAGE_CHECK_INTERVAL=300 # how often to re-read the (multi-MB) build timeline while polling
+AZDO_ARTIFACT_UNAVAILABLE=2 # download_azure_artifact: build finished, artifact never published
+AZDO_MAX_BUILD_ATTEMPTS=3
+AZDO_TRIED_BUILDS="" # space-separated build ids resolve_azure_build_id should no longer offer
 
-declare -A AZ_STAGE_CACHE    # "buildId:stageName" -> "state|result"
-declare -A AZ_STAGE_CACHE_AT # "buildId:stageName" -> unix time of the last timeline fetch
-AZ_TRIED_BUILDS=""           # space-separated build ids already rejected by switch_to_better_azure_build
+# Echoes the first id on stdin that isn't in $AZDO_TRIED_BUILDS. Always returns 0, even when every
+# candidate is excluded and nothing is echoed, so `set -o pipefail` doesn't abort the
+# `buildId=$(... | _azure_first_untried)` assignment in resolve_azure_build_id.
+_azure_first_untried() {
+  local id
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    case " $AZDO_TRIED_BUILDS " in
+      *" $id "*) continue ;;
+    esac
+    echo "$id"
+    return 0
+  done
+  return 0
+}
 
 # Resolves the Azure DevOps build id for $CI_COMMIT_SHA / $CI_COMMIT_BRANCH and sets the global
-# `buildId`. Exits 1 if no build can be found.
+# `buildId`, skipping any build already listed in $AZDO_TRIED_BUILDS. Exits 1 if no such build can
+# be found.
 #
 # Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
 # builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
@@ -58,13 +78,13 @@ resolve_azure_build_id() {
 
   # 1. PR build for this branch + commit
   local allBuildsForPrUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | _azure_first_untried)
 
   # 2. Standalone (manual/individualCI) build for this branch + commit
   if [ -z "${buildId}" ]; then
     echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
     local allBuildsForBranchUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
-    buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
+    buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | _azure_first_untried)
   fi
 
   # 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
@@ -81,31 +101,22 @@ resolve_azure_build_id() {
         + map(select(.reason == "schedule"  and .result == "succeeded"))
         + map(select(.reason != "schedule"))
         + map(select(.reason == "schedule")) )
-      | .[0].id // empty')
+      | .[].id' | _azure_first_untried)
   fi
 
   if [ -z "${buildId}" ]; then
-    echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
+    if [ -n "$AZDO_TRIED_BUILDS" ]; then
+      echo "No usable build found for commit '$CI_COMMIT_SHA' (branch '$branchName'): already tried and rejected build(s):$AZDO_TRIED_BUILDS"
+    else
+      echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
+    fi
     exit 1
   fi
 
   echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
 }
 
-# Maps an artifact name to the Azure DevOps pipeline stage (see .azure-pipelines/ultimate-pipeline.yml)
-# that publishes it, so download_azure_artifact can tell "not ready yet" apart from "never coming".
-# Artifacts with no known stage fall back to the whole-build status only (see is_azure_artifact_doomed).
-azure_stage_for_artifact() {
-  case "$1" in
-    ssi-artifacts) echo "store_ssi_artifacts" ;;
-    serverless-artifacts) echo "store_serverless_artifacts" ;;
-    runner-dotnet-tool | bundle-nuget-package | azurefunctions-nuget-package) echo "dotnet_tool" ;;
-    *) echo "" ;;
-  esac
-}
-
-# Sets the globals AZ_BUILD_STATUS / AZ_BUILD_RESULT for the given build. Cheap (a few KB), so
-# unlike azure_stage_state this is not throttled or cached.
+# Sets the globals AZ_BUILD_STATUS / AZ_BUILD_RESULT for the given build.
 azure_build_state() {
   local buildId="$1"
   local response
@@ -114,175 +125,28 @@ azure_build_state() {
   AZ_BUILD_RESULT=$(echo "$response" | jq -r '.result // "none"')
 }
 
-# Sets the globals AZ_STAGE_STATE / AZ_STAGE_RESULT for the named stage's latest attempt on the
-# given build, by reading the build timeline. Returns 1 (leaving both globals empty) if the stage
-# isn't present in the timeline at all.
+# Polls for the named artifact on the given build for up to $ARTIFACT_TIMEOUT seconds, then
+# downloads and unzips it into <targetDir>/<artifactName>.
 #
-# The timeline can be several MB (16k+ records on a full build), so this is throttled to at most
-# one fetch per $STAGE_CHECK_INTERVAL seconds per (buildId, stageName), and skipped entirely once a
-# stage has already been observed to succeed - at that point there's nothing left to learn.
-azure_stage_state() {
-  local buildId="$1"
-  local stageName="$2"
-  local cacheKey="${buildId}:${stageName}"
-  local cached="${AZ_STAGE_CACHE[$cacheKey]:-}"
-
-  if [ "$cached" = "completed|succeeded" ] || [ "$cached" = "completed|succeededWithIssues" ]; then
-    AZ_STAGE_STATE="completed"
-    AZ_STAGE_RESULT="${cached##*|}"
-    return 0
-  fi
-
-  local now lastCheck
-  now=$(date +%s)
-  lastCheck="${AZ_STAGE_CACHE_AT[$cacheKey]:-0}"
-  if [ -n "$cached" ] && (( now - lastCheck < STAGE_CHECK_INTERVAL )); then
-    AZ_STAGE_STATE="${cached%%|*}"
-    AZ_STAGE_RESULT="${cached##*|}"
-    return 0
-  fi
-
-  local response stateResult
-  response=$(curl -sS --compressed "${AZDO_API}/builds/${buildId}/timeline?api-version=7.1")
-  stateResult=$(echo "$response" | jq -r --arg s "$stageName" '
-    [ .records[]? | select(.type == "Stage" and .identifier == $s) ]
-    | sort_by(.attempt) | last
-    | if . == null then "" else "\(.state)|\(.result // "none")" end')
-
-  AZ_STAGE_CACHE_AT[$cacheKey]=$now
-
-  if [ -z "$stateResult" ]; then
-    AZ_STAGE_CACHE[$cacheKey]=""
-    AZ_STAGE_STATE=""
-    AZ_STAGE_RESULT=""
-    return 1
-  fi
-
-  AZ_STAGE_CACHE[$cacheKey]="$stateResult"
-  AZ_STAGE_STATE="${stateResult%%|*}"
-  AZ_STAGE_RESULT="${stateResult##*|}"
-  return 0
-}
-
-# Returns 0 (doomed - the artifact will never appear) if the stage that publishes $artifactName has
-# finished without succeeding, or - when that stage can't be resolved, e.g. an unmapped artifact or
-# a pipeline rename that made the stage name stale - if the whole build has completed. The whole-
-# build check is a deliberately lenient backstop: build `result` (succeeded/failed/canceled) is NOT
-# a reliable signal on its own (failed builds routinely still publish every artifact), only
-# `status == completed` combined with "the artifact still isn't there" is.
+# Returns:
+#   0                          - downloaded successfully
+#   $AZDO_ARTIFACT_UNAVAILABLE - the build has finished and will never publish this artifact
+#                                (build `result` alone is NOT used for this: failed builds
+#                                routinely still publish every artifact, so only
+#                                "status == completed and the artifact still isn't there" counts)
+#   1                          - genuine timeout: the build is still running after $ARTIFACT_TIMEOUT
 #
-# Also refreshes AZ_BUILD_STATUS / AZ_BUILD_RESULT as a side effect, so callers always have current
-# values to log even when this returns "not doomed".
-is_azure_artifact_doomed() {
-  local buildId="$1"
-  local stageName="$2"
-
-  azure_build_state "$buildId"
-
-  if [ -n "$stageName" ] && azure_stage_state "$buildId" "$stageName"; then
-    if [ "$AZ_STAGE_STATE" = "completed" ]; then
-      case "$AZ_STAGE_RESULT" in
-        succeeded | succeededWithIssues) return 1 ;;
-        *) return 0 ;;
-      esac
-    fi
-    return 1
-  fi
-
-  if [ -n "$stageName" ] && [ -z "${AZ_STAGE_WARNED:-}" ]; then
-    echo "  WARNING: stage '$stageName' not found in build $buildId's timeline; falling back to whole-build status to decide whether the artifact is still coming"
-    AZ_STAGE_WARNED=1
-  fi
-
-  [ "$AZ_BUILD_STATUS" = "completed" ]
-}
-
-# Looks for a different Azure DevOps build of the same commit that can still supply $artifactName,
-# for when $currentBuildId turns out to be doomed - e.g. a newer build was queued for the same
-# commit and failed, while an earlier one for that commit already succeeded. Only ever matches
-# builds by exact commit SHA (never branch alone), so this can never switch onto artifacts built
-# from different code. On success sets the global `buildId` to the replacement and returns 0;
-# returns 1 (leaving `buildId` unchanged) if no better candidate exists.
-switch_to_better_azure_build() {
-  local currentBuildId="$1"
-  local artifactName="$2"
-
-  echo "  Build $currentBuildId can no longer produce '$artifactName'. Looking for another build of commit '$CI_COMMIT_SHA'..."
-  AZ_TRIED_BUILDS="$AZ_TRIED_BUILDS $currentBuildId"
-
-  local allBuildsUrl="${AZDO_API}/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=200&queryOrder=queueTimeDescending"
-  local -a candidates=()
-  local candidate
-  while IFS= read -r candidate; do
-    [ -z "$candidate" ] && continue
-    case " $AZ_TRIED_BUILDS " in
-      *" $candidate "*) continue ;;
-    esac
-    candidates+=("$candidate")
-  done < <(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
-    [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-    | .[] | select(.status != "completed" or .result == "succeeded" or .result == "partiallySucceeded")
-    | .id')
-
-  # Prefer a candidate that already has the artifact, whether it is still running or completed.
-  local downloadUrl
-  for candidate in "${candidates[@]}"; do
-    downloadUrl=$(curl -sS "${AZDO_API}/builds/${candidate}/artifacts?api-version=7.1&artifactName=${artifactName}" | jq -r '.resource.downloadUrl | select( . != null )')
-    if [ -n "$downloadUrl" ]; then
-      echo "  Switching to build $candidate, which already has '$artifactName'"
-      buildId="$candidate"
-      return 0
-    fi
-  done
-
-  # Otherwise, fall back to the first still-running candidate; it may yet publish the artifact.
-  for candidate in "${candidates[@]}"; do
-    azure_build_state "$candidate"
-    if [ "$AZ_BUILD_STATUS" != "completed" ]; then
-      echo "  Switching to build $candidate, which is still running"
-      buildId="$candidate"
-      return 0
-    fi
-  done
-
-  echo "  No alternative build of commit '$CI_COMMIT_SHA' can supply '$artifactName'"
-  return 1
-}
-
-# Prints the diagnostics block shared by every failure path (doomed with no recovery, timeout).
-azure_artifact_failure() {
-  local buildId="$1"
-  local artifactName="$2"
-  local reason="$3"
-  local response="$4"
-
-  echo "ERROR: '$artifactName' will not be downloaded from build $buildId (commit '$CI_COMMIT_SHA' on branch 'refs/heads/$CI_COMMIT_BRANCH')"
-  echo "  Reason: $reason"
-  echo "Last API response:"
-  echo "$response" | jq '.'
-  echo ""
-  echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
-}
-
-# Polls for the named artifact for up to $ARTIFACT_TIMEOUT seconds, then downloads and unzips it
-# into <targetDir>/<artifactName>.
-#
-# As soon as the artifact's publishing stage finishes without succeeding (or, failing that, once
-# the whole build completes) with the artifact still absent, this tries to switch to a different
-# build of the same commit rather than waiting out the rest of the timeout. Exits 1 if the
-# artifact can't be obtained, either because no build can supply it or because of a genuine timeout.
+# Never calls `exit` and never reassigns `buildId` - switching to a different build is entirely up
+# to the caller (see download_azure_artifacts_from_one_build below).
 download_azure_artifact() {
-  local currentBuildId="$1"
+  local buildId="$1"
   local artifactName="$2"
   local targetDir="$3"
 
   echo ""
   echo "=== Downloading artifact '$artifactName' ==="
 
-  local stageName
-  stageName=$(azure_stage_for_artifact "$artifactName")
-
-  local artifactsUrl="${AZDO_API}/builds/${currentBuildId}/artifacts?api-version=7.1&artifactName=${artifactName}"
+  local artifactsUrl="${AZDO_API}/builds/${buildId}/artifacts?api-version=7.1&artifactName=${artifactName}"
   local downloadUrl="" response="" elapsed=0
 
   while true; do
@@ -295,7 +159,8 @@ download_azure_artifact() {
       break
     fi
 
-    if is_azure_artifact_doomed "$currentBuildId" "$stageName"; then
+    azure_build_state "$buildId"
+    if [ "$AZ_BUILD_STATUS" = "completed" ]; then
       # The status read above and the artifact publish can race - re-check once before giving up.
       response=$(curl -s "${artifactsUrl}")
       downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
@@ -303,32 +168,20 @@ download_azure_artifact() {
         break
       fi
 
-      if switch_to_better_azure_build "$currentBuildId" "$artifactName"; then
-        currentBuildId="$buildId"
-        artifactsUrl="${AZDO_API}/builds/${currentBuildId}/artifacts?api-version=7.1&artifactName=${artifactName}"
-        continue
-      fi
-
-      local reason
-      if [ -n "$stageName" ] && [ "$AZ_STAGE_STATE" = "completed" ]; then
-        reason="build $currentBuildId's stage '$stageName' finished as '$AZ_STAGE_RESULT'"
-      else
-        reason="build $currentBuildId finished as '$AZ_BUILD_STATUS'/'$AZ_BUILD_RESULT'"
-      fi
-      azure_artifact_failure "$currentBuildId" "$artifactName" \
-        "$reason and no alternative build was found. If the Azure DevOps stage was retried, re-run this job." \
-        "$response"
-      exit 1
+      echo "  Build $buildId finished as '$AZ_BUILD_RESULT' without publishing '$artifactName'"
+      return "$AZDO_ARTIFACT_UNAVAILABLE"
     fi
 
     if (( elapsed >= ARTIFACT_TIMEOUT )); then
-      azure_artifact_failure "$currentBuildId" "$artifactName" \
-        "timed out after ${ARTIFACT_TIMEOUT}s waiting for the artifact" \
-        "$response"
-      exit 1
+      echo "ERROR: No downloadUrl found after ${ARTIFACT_TIMEOUT}s for artifact '$artifactName' (commit '$CI_COMMIT_SHA' on branch 'refs/heads/$CI_COMMIT_BRANCH')"
+      echo "Last API response:"
+      echo "$response" | jq '.'
+      echo ""
+      echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
+      return 1
     fi
 
-    echo "  Waiting for '$artifactName' - build $currentBuildId is $AZ_BUILD_STATUS${AZ_STAGE_STATE:+, stage $stageName is $AZ_STAGE_STATE} (elapsed: ${elapsed}s / ${ARTIFACT_TIMEOUT}s)"
+    echo "  Waiting for '$artifactName' - build $buildId is $AZ_BUILD_STATUS (elapsed: ${elapsed}s / ${ARTIFACT_TIMEOUT}s)"
     sleep "$ARTIFACT_POLL_INTERVAL"
     (( elapsed += ARTIFACT_POLL_INTERVAL ))
   done
@@ -337,6 +190,58 @@ download_azure_artifact() {
   curl -o "$targetDir/artifact.zip" "$downloadUrl"
   unzip -o "$targetDir/artifact.zip" -d "$targetDir"
   rm -f "$targetDir/artifact.zip"
+}
+
+# Downloads every named artifact from a SINGLE Azure DevOps build into <targetDir>/<artifactName>
+# each. If that build turns out never to publish one of them, discards everything downloaded for
+# this attempt and starts over against a different build of the same commit (bounded by
+# $AZDO_MAX_BUILD_ATTEMPTS) - artifacts from two different builds are never mixed together. On
+# return, the global `buildId` holds the build every artifact actually came from.
+#
+# resolve_azure_build_id exits 1 as soon as it has no untried build left to offer, so "there's no
+# better build available" fails fast instead of waiting out a doomed poll.
+download_azure_artifacts_from_one_build() {
+  local targetDir="$1"
+  shift
+  local artifactNames=("$@")
+
+  local attempt
+  for (( attempt = 1; attempt <= AZDO_MAX_BUILD_ATTEMPTS; attempt++ )); do
+    buildId=""
+    resolve_azure_build_id
+
+    local artifactName ok=1 rc
+    for artifactName in "${artifactNames[@]}"; do
+      if download_azure_artifact "$buildId" "$artifactName" "$targetDir"; then
+        rc=0
+      else
+        rc=$?
+      fi
+
+      if [ "$rc" -eq 0 ]; then
+        continue
+      fi
+
+      if [ "$rc" -eq "$AZDO_ARTIFACT_UNAVAILABLE" ]; then
+        ok=0
+        break
+      fi
+
+      # Genuine timeout - not recoverable by trying a different build.
+      exit 1
+    done
+
+    if [ "$ok" -eq 1 ]; then
+      return 0
+    fi
+
+    echo "Discarding partial downloads from build $buildId and trying a different build (attempt $attempt/$AZDO_MAX_BUILD_ATTEMPTS)"
+    AZDO_TRIED_BUILDS="$AZDO_TRIED_BUILDS $buildId"
+    find "${targetDir:?}" -mindepth 1 -delete
+  done
+
+  echo "ERROR: exhausted $AZDO_MAX_BUILD_ATTEMPTS build attempt(s) for commit '$CI_COMMIT_SHA' without obtaining: ${artifactNames[*]}"
+  exit 1
 }
 
 # Moves the contents of <targetDir>/<artifactName>/ up into <targetDir> and removes the now-empty

--- a/.gitlab/download-azure-artifacts-helper.sh
+++ b/.gitlab/download-azure-artifacts-helper.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# Shared helpers for locating an Azure DevOps build for the current commit and downloading its
+# published artifacts. Used by download-serverless-artifacts.sh, download-single-step-artifacts.sh
+# and download-nuget-packages-to-sign.sh: each of those needs a different artifact (or set of
+# artifacts) from the build and has its own fallback/post-download logic, but the "find the build,
+# then poll it for an artifact" core is identical.
+#
+# This file is sourced by other scripts, not executed directly:
+#   SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+#   source "$SCRIPT_DIR/download-azure-artifacts-helper.sh"
+#
+# Provides:
+#   resolve_azure_build_id                                  - sets the global `buildId`, or exits 1
+#   download_azure_artifact <buildId> <artifactName> <dir>   - polls for and unzips one artifact
+#                                                               into <dir>/<artifactName>, or exits 1
+#   flatten_azure_artifact <dir> <artifactName>               - moves <dir>/<artifactName>/* up into
+#                                                               <dir> and removes the now-empty folder
+
+AZDO_BUILD_DEFINITION=54
+ARTIFACT_TIMEOUT=2400 # 40 minutes
+ARTIFACT_POLL_INTERVAL=100
+
+# Resolves the Azure DevOps build id for $CI_COMMIT_SHA / $CI_COMMIT_BRANCH and sets the global
+# `buildId`. Exits 1 if no build can be found.
+#
+# Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
+# builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
+# necessarily identical — so we match from most-specific to least-specific, and only broaden
+# when the precise build can't be found:
+#   1. the PR build for this branch + commit (most likely a "full" build)
+#   2. a standalone (manual/individualCI) build for this branch + commit
+#   3. as a last resort, ANY build carrying this commit on any branch. This rescues pipelines
+#      that the GitLab mirror attributed to a ref that merely *contains* the commit (e.g. a
+#      feature branch rebased onto this master commit), where no (branch, SHA) build exists.
+resolve_azure_build_id() {
+  local branchName="refs/heads/$CI_COMMIT_BRANCH"
+
+  echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
+
+  # 1. PR build for this branch + commit
+  local allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
+  buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+
+  # 2. Standalone (manual/individualCI) build for this branch + commit
+  if [ -z "${buildId}" ]; then
+    echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
+    local allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
+    buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
+  fi
+
+  # 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
+  # Unlike tiers 1-2 (which intentionally wait on an in-progress build for this exact branch),
+  # tier 3's commit is already built elsewhere, so we prefer a completed-successful build to avoid
+  # locking onto a queued/canceled/failed newer build and polling it for 40 minutes; we still fall
+  # back to an in-progress build if no successful one is found.
+  if [ -z "${buildId}" ]; then
+    echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
+    local allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=${AZDO_BUILD_DEFINITION}&\$top=200&queryOrder=queueTimeDescending"
+    buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
+      [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
+      | ( map(select(.reason != "schedule" and .result == "succeeded"))
+        + map(select(.reason == "schedule"  and .result == "succeeded"))
+        + map(select(.reason != "schedule"))
+        + map(select(.reason == "schedule")) )
+      | .[0].id // empty')
+  fi
+
+  if [ -z "${buildId}" ]; then
+    echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
+    exit 1
+  fi
+
+  echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
+}
+
+# Polls for the named artifact on the given build for up to $ARTIFACT_TIMEOUT seconds, then
+# downloads and unzips it into <targetDir>/<artifactName>. Exits 1 on timeout.
+download_azure_artifact() {
+  local buildId="$1"
+  local artifactName="$2"
+  local targetDir="$3"
+
+  echo ""
+  echo "=== Downloading artifact '$artifactName' ==="
+
+  local artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"
+
+  # Keep trying to get the artifact for 40 minutes
+  local downloadUrl=""
+  local response=""
+  local STARTED=0
+  until (( STARTED == ARTIFACT_TIMEOUT )) || [ ! -z "${downloadUrl}" ] ; do
+      echo "Checking for artifacts at: ${artifactsUrl}"
+      # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
+      response=$(curl -s "${artifactsUrl}")
+      downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
+
+      if [ -z "${downloadUrl}" ]; then
+          local buildStatus
+          buildStatus=$(echo "$response" | jq -r '.message // "Artifact not yet available"')
+          echo "  Status: ${buildStatus} (elapsed: ${STARTED}s / ${ARTIFACT_TIMEOUT}s)"
+      fi
+
+      sleep "$ARTIFACT_POLL_INTERVAL"
+      (( STARTED += ARTIFACT_POLL_INTERVAL ))
+  done
+  (( STARTED < ARTIFACT_TIMEOUT ))
+
+  if [ -z "${downloadUrl}" ]; then
+    echo "ERROR: No downloadUrl found after 40 minutes for artifact '$artifactName' (commit '$CI_COMMIT_SHA' on branch 'refs/heads/$CI_COMMIT_BRANCH')"
+    echo "Last API response:"
+    echo "$response" | jq '.'
+    echo ""
+    echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
+    exit 1
+  fi
+
+  echo "Downloading artifact '$artifactName' from ${downloadUrl}"
+  curl -o "$targetDir/artifact.zip" "$downloadUrl"
+  unzip -o "$targetDir/artifact.zip" -d "$targetDir"
+  rm -f "$targetDir/artifact.zip"
+}
+
+# Moves the contents of <targetDir>/<artifactName>/ up into <targetDir> and removes the now-empty
+# <artifactName> folder.
+flatten_azure_artifact() {
+  local targetDir="$1"
+  local artifactName="$2"
+
+  mv "$targetDir/$artifactName"/* "$targetDir"
+  rmdir "$targetDir/$artifactName"
+}

--- a/.gitlab/download-azure-artifacts-helper.sh
+++ b/.gitlab/download-azure-artifacts-helper.sh
@@ -100,12 +100,11 @@ download_azure_artifact() {
           local buildStatus
           buildStatus=$(echo "$response" | jq -r '.message // "Artifact not yet available"')
           echo "  Status: ${buildStatus} (elapsed: ${STARTED}s / ${ARTIFACT_TIMEOUT}s)"
-      fi
 
-      sleep "$ARTIFACT_POLL_INTERVAL"
-      (( STARTED += ARTIFACT_POLL_INTERVAL ))
+          sleep "$ARTIFACT_POLL_INTERVAL"
+          (( STARTED += ARTIFACT_POLL_INTERVAL ))
+      fi
   done
-  (( STARTED < ARTIFACT_TIMEOUT ))
 
   if [ -z "${downloadUrl}" ]; then
     echo "ERROR: No downloadUrl found after 40 minutes for artifact '$artifactName' (commit '$CI_COMMIT_SHA' on branch 'refs/heads/$CI_COMMIT_BRANCH')"

--- a/.gitlab/download-nuget-packages-to-sign.sh
+++ b/.gitlab/download-nuget-packages-to-sign.sh
@@ -6,107 +6,29 @@
 # artifacts that can only be built there - so unlike the other 5 NuGet packages (which GitLab builds
 # and signs itself), these 3 have to be pulled in as a finished .nupkg and signed in place.
 #
-# This is a parameterised copy of download-single-step-artifacts.sh, generalised to fetch several
-# named artifacts from the same Azure DevOps build instead of one. It intentionally does not
-# replicate that script's CI_COMMIT_TAG/GitHub-release fallback path: this job always resolves a
-# live Azure DevOps build for the current commit, on every pipeline.
+# Shares its Azure DevOps build-resolution and artifact-polling logic with
+# download-single-step-artifacts.sh and download-serverless-artifacts.sh via
+# download-azure-artifacts-helper.sh. Unlike those two, it intentionally does not replicate their
+# CI_COMMIT_TAG/GitHub-release fallback path: this job always resolves a live Azure DevOps build
+# for the current commit, on every pipeline.
 
 set -eo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "$SCRIPT_DIR/download-azure-artifacts-helper.sh"
 
 target_dir=packages-to-sign
 mkdir -p $target_dir
 
-branchName="refs/heads/$CI_COMMIT_BRANCH"
 artifactNames=("runner-dotnet-tool" "bundle-nuget-package" "azurefunctions-nuget-package")
 
-echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
-
-# Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
-# builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
-# necessarily identical — and this job publishes the "real" artifacts, so we match from
-# most-specific to least-specific, and only broaden when the precise build can't be found:
-#   1. the PR build for this branch + commit (most likely a "full" build)
-#   2. a standalone (manual/individualCI) build for this branch + commit
-#   3. as a last resort, ANY build carrying this commit on any branch. This rescues pipelines
-#      that the GitLab mirror attributed to a ref that merely *contains* the commit (e.g. a
-#      feature branch rebased onto this master commit), where no (branch, SHA) build exists.
-
-# 1. PR build for this branch + commit
-allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
-
-# 2. Standalone (manual/individualCI) build for this branch + commit
-if [ -z "${buildId}" ]; then
-  echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
-  allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
-  buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
-fi
-
-# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
-# Unlike tiers 1-2 (which intentionally wait on an in-progress build for this exact branch),
-# tier 3's commit is already built elsewhere, so we prefer a completed-successful build to avoid
-# locking onto a queued/canceled/failed newer build and polling it for 40 minutes; we still fall
-# back to an in-progress build if no successful one is found.
-if [ -z "${buildId}" ]; then
-  echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
-  allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
-  buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
-    [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-    | ( map(select(.reason != "schedule" and .result == "succeeded"))
-      + map(select(.reason == "schedule"  and .result == "succeeded"))
-      + map(select(.reason != "schedule"))
-      + map(select(.reason == "schedule")) )
-    | .[0].id // empty')
-fi
-
-if [ -z "${buildId}" ]; then
-  echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
-  exit 1
-fi
-
-echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
+buildId=""
+resolve_azure_build_id
 
 # Download each artifact in turn. They're all produced by the same Azure DevOps build's
 # `dotnet_tool` stage, but stages finish at different times, so each gets its own poll loop.
 for artifactName in "${artifactNames[@]}"; do
-  echo ""
-  echo "=== Downloading artifact '$artifactName' ==="
-
-  artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"
-
-  # Keep trying to get the artifact for 40 minutes
-  downloadUrl=""
-  TIMEOUT=2400
-  STARTED=0
-  until (( STARTED == TIMEOUT )) || [ ! -z "${downloadUrl}" ] ; do
-      echo "Checking for artifacts at: ${artifactsUrl}"
-      # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
-      response=$(curl -s "${artifactsUrl}")
-      downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
-
-      if [ -z "${downloadUrl}" ]; then
-          buildStatus=$(echo "$response" | jq -r '.message // "Artifact not yet available"')
-          echo "  Status: ${buildStatus} (elapsed: ${STARTED}s / ${TIMEOUT}s)"
-      fi
-
-      sleep 100
-      (( STARTED += 100 ))
-  done
-  (( STARTED < TIMEOUT ))
-
-  if [ -z "${downloadUrl}" ]; then
-    echo "ERROR: No downloadUrl found after 40 minutes for artifact '$artifactName' (commit '$CI_COMMIT_SHA' on branch '$branchName')"
-    echo "Last API response:"
-    echo "$response" | jq '.'
-    echo ""
-    echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
-    exit 1
-  fi
-
-  echo "Downloading artifact '$artifactName' from ${downloadUrl}"
-  curl -o $target_dir/artifact.zip "$downloadUrl"
-  unzip -o $target_dir/artifact.zip -d $target_dir
-  rm -f $target_dir/artifact.zip
+  download_azure_artifact "$buildId" "$artifactName" "$target_dir"
 done
 
 # Flatten every .nupkg found (regardless of which artifact/subfolder it came from) directly into

--- a/.gitlab/download-nuget-packages-to-sign.sh
+++ b/.gitlab/download-nuget-packages-to-sign.sh
@@ -21,15 +21,7 @@ target_dir=packages-to-sign
 mkdir -p $target_dir
 
 artifactNames=("runner-dotnet-tool" "bundle-nuget-package" "azurefunctions-nuget-package")
-
-buildId=""
-resolve_azure_build_id
-
-# Download each artifact in turn. They're all produced by the same Azure DevOps build's
-# `dotnet_tool` stage, but stages finish at different times, so each gets its own poll loop.
-for artifactName in "${artifactNames[@]}"; do
-  download_azure_artifact "$buildId" "$artifactName" "$target_dir"
-done
+download_azure_artifacts_from_one_build "$target_dir" "${artifactNames[@]}"
 
 # Flatten every .nupkg found (regardless of which artifact/subfolder it came from) directly into
 # $target_dir, so the sign-nuget-packages job can copy it straight into ArtifactsDirectory/"packages-to-sign".

--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -6,6 +6,9 @@
 
 set -eo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "$SCRIPT_DIR/download-azure-artifacts-helper.sh"
+
 # Create a directory to store the files
 target_dir=artifacts
 mkdir -p $target_dir
@@ -24,91 +27,11 @@ if [ -n "$CI_COMMIT_TAG" ] && [ -n "$CI_COMMIT_SHA" ]; then
   exit 0
 fi
 
-branchName="refs/heads/$CI_COMMIT_BRANCH"
 artifactName="serverless-artifacts"
 
-echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
-
-# Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
-# builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
-# necessarily identical — so we match from most-specific to least-specific, and only broaden
-# when the precise build can't be found:
-#   1. the PR build for this branch + commit (most likely a "full" build)
-#   2. a standalone (manual/individualCI) build for this branch + commit
-#   3. as a last resort, ANY build carrying this commit on any branch. This rescues pipelines
-#      that the GitLab mirror attributed to a ref that merely *contains* the commit (e.g. a
-#      feature branch rebased onto this master commit), where no (branch, SHA) build exists.
-
-# 1. PR build for this branch + commit
-allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
-
-# 2. Standalone (manual/individualCI) build for this branch + commit
-if [ -z "${buildId}" ]; then
-  echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
-  allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
-  buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
-fi
-
-# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
-# Unlike tiers 1-2 (which intentionally wait on an in-progress build for this exact branch),
-# tier 3's commit is already built elsewhere, so we prefer a completed-successful build to avoid
-# locking onto a queued/canceled/failed newer build and polling it for 40 minutes; we still fall
-# back to an in-progress build if no successful one is found.
-if [ -z "${buildId}" ]; then
-  echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
-  allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
-  buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
-    [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-    | ( map(select(.reason != "schedule" and .result == "succeeded"))
-      + map(select(.reason == "schedule"  and .result == "succeeded"))
-      + map(select(.reason != "schedule"))
-      + map(select(.reason == "schedule")) )
-    | .[0].id // empty')
-fi
-
-if [ -z "${buildId}" ]; then
-  echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
-  exit 1
-fi
-
-echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
-
-# Now try to download the artifacts from the build
-artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"
-
-# Keep trying to get the artifact for 40 minutes
-TIMEOUT=2400
-STARTED=0
-until (( STARTED == TIMEOUT )) || [ ! -z "${downloadUrl}" ] ; do
-    echo "Checking for artifacts at: ${artifactsUrl}"
-    # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
-    response=$(curl -s "${artifactsUrl}")
-    downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
-
-    if [ -z "${downloadUrl}" ]; then
-        buildStatus=$(echo "$response" | jq -r '.message // "Artifact not yet available"')
-        echo " Status: ${buildStatus} (elapsed: ${STARTED}s / ${TIMEOUT}s)"
-    fi
-
-    sleep 100
-    (( STARTED += 100 ))
-done
-(( STARTED < TIMEOUT ))
-
-if [ -z "${downloadUrl}" ]; then
-  echo "ERROR: No downloadUrl found after 40 minutes for commit '$CI_COMMIT_SHA' on branch '$branchName'"
-  echo "Last API response:"
-  echo "$response" | jq '.'
-  echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
-  exit 1
-fi
-
-echo "Downloading artifacts from: ${downloadUrl}"
-curl -o $target_dir/artifacts.zip "$downloadUrl"
-unzip $target_dir/artifacts.zip -d $target_dir
-mv $target_dir/$artifactName/* $target_dir
-rm -rf $target_dir/artifacts.zip
-rmdir $target_dir/$artifactName
+buildId=""
+resolve_azure_build_id
+download_azure_artifact "$buildId" "$artifactName" "$target_dir"
+flatten_azure_artifact "$target_dir" "$artifactName"
 
 ls -l $target_dir

--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -14,6 +14,7 @@ target_dir=artifacts
 mkdir -p $target_dir
 
 if [ -n "$CI_COMMIT_TAG" ] && [ -n "$CI_COMMIT_SHA" ]; then
+  # Release pipeline
   echo "Downloading artifacts from Azure"
   curl --location --fail \
     --output $target_dir/serverless-artifacts.zip \
@@ -27,11 +28,10 @@ if [ -n "$CI_COMMIT_TAG" ] && [ -n "$CI_COMMIT_SHA" ]; then
   exit 0
 fi
 
+# Standard build pipeline
 artifactName="serverless-artifacts"
 
-buildId=""
-resolve_azure_build_id
-download_azure_artifact "$buildId" "$artifactName" "$target_dir"
+download_azure_artifacts_from_one_build "$target_dir" "$artifactName"
 flatten_azure_artifact "$target_dir" "$artifactName"
 
 ls -l $target_dir

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -2,6 +2,9 @@
 
 set -eo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+source "$SCRIPT_DIR/download-azure-artifacts-helper.sh"
+
 #Create a directory to store the files
 target_dir=artifacts
 mkdir -p $target_dir
@@ -43,93 +46,11 @@ if [ -n "$CI_COMMIT_TAG" ] || [ -n "$DOTNET_PACKAGE_VERSION" ]; then
   exit 0
 fi
 
-branchName="refs/heads/$CI_COMMIT_BRANCH"
 artifactName="ssi-artifacts"
 
-echo "Looking for an azure devops build for commit '$CI_COMMIT_SHA' (branch '$branchName') to start"
-
-# Prefer the build that was actually triggered for this exact (branch, commit). Azure DevOps
-# builds can be parameterized (e.g. debug mode), so two builds of the same commit are not
-# necessarily identical — and this job publishes the "real" artifacts, so we match from
-# most-specific to least-specific, and only broaden when the precise build can't be found:
-#   1. the PR build for this branch + commit (most likely a "full" build)
-#   2. a standalone (manual/individualCI) build for this branch + commit
-#   3. as a last resort, ANY build carrying this commit on any branch. This rescues pipelines
-#      that the GitLab mirror attributed to a ref that merely *contains* the commit (e.g. a
-#      feature branch rebased onto this master commit), where no (branch, SHA) build exists.
-
-# 1. PR build for this branch + commit
-allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=100&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
-buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
-
-# 2. Standalone (manual/individualCI) build for this branch + commit
-if [ -z "${buildId}" ]; then
-  echo "No PR build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for standalone builds..."
-  allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
-  buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
-fi
-
-# 3. Last resort: any build carrying this commit, regardless of branch (prefer non-scheduled).
-# Unlike tiers 1-2 (which intentionally wait on an in-progress build for this exact branch),
-# tier 3's commit is already built elsewhere, so we prefer a completed-successful build to avoid
-# locking onto a queued/canceled/failed newer build and polling it for 40 minutes; we still fall
-# back to an in-progress build if no successful one is found.
-if [ -z "${buildId}" ]; then
-  echo "No build found on branch '$branchName' for commit '$CI_COMMIT_SHA'. Falling back to any build carrying this commit..."
-  allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=200&queryOrder=queueTimeDescending"
-  buildId=$(curl -sS "$allBuildsUrl" | jq -r --arg version "$CI_COMMIT_SHA" '
-    [ .value[] | select((.triggerInfo["pr.sourceSha"] == $version) or (.sourceVersion == $version)) ]
-    | ( map(select(.reason != "schedule" and .result == "succeeded"))
-      + map(select(.reason == "schedule"  and .result == "succeeded"))
-      + map(select(.reason != "schedule"))
-      + map(select(.reason == "schedule")) )
-    | .[0].id // empty')
-fi
-
-if [ -z "${buildId}" ]; then
-  echo "No build found for commit '$CI_COMMIT_SHA' (branch '$branchName') in the recent build history"
-  exit 1
-fi
-
-echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA'"
-
-# Now try to download the ssi artifacts from the build
-artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"
-
-# Keep trying to get the artifact for 40 minutes
-TIMEOUT=2400
-STARTED=0
-until (( STARTED == TIMEOUT )) || [ ! -z "${downloadUrl}" ] ; do
-    echo "Checking for artifacts at: ${artifactsUrl}"
-    # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
-    response=$(curl -s "${artifactsUrl}")
-    downloadUrl=$(echo "$response" | jq -r '.resource.downloadUrl | select( . != null )')
-
-    if [ -z "${downloadUrl}" ]; then
-        # Check if the build exists and show status
-        buildStatus=$(echo "$response" | jq -r '.message // "Artifact not yet available"')
-        echo "  Status: ${buildStatus} (elapsed: ${STARTED}s / ${TIMEOUT}s)"
-    fi
-
-    sleep 100
-    (( STARTED += 100 ))
-done
-(( STARTED < TIMEOUT ))
-
-if [ -z "${downloadUrl}" ]; then
-  echo "ERROR: No downloadUrl found after 40 minutes for commit '$CI_COMMIT_SHA' on branch '$branchName'"
-  echo "Last API response:"
-  echo "$response" | jq '.'
-  echo ""
-  echo "Build URL: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$buildId"
-  exit 1
-fi
-
-echo "Downloading artifacts from ${downloadUrl}"
-curl -o $target_dir/artifacts.zip "$downloadUrl"
-unzip $target_dir/artifacts.zip -d $target_dir
-mv $target_dir/$artifactName/* $target_dir
-rm -rf $target_dir/artifacts.zip
-rmdir $target_dir/$artifactName
+buildId=""
+resolve_azure_build_id
+download_azure_artifact "$buildId" "$artifactName" "$target_dir"
+flatten_azure_artifact "$target_dir" "$artifactName"
 
 ls -l $target_dir

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -10,6 +10,7 @@ target_dir=artifacts
 mkdir -p $target_dir
 
 if [ -n "$CI_COMMIT_TAG" ] || [ -n "$DOTNET_PACKAGE_VERSION" ]; then
+  # Release pipeline
   echo "Downloading artifacts from Github"
   VERSION=${DOTNET_PACKAGE_VERSION:-${CI_COMMIT_TAG##v}} # Use DOTNET_PACKAGE_VERSION if it exists, otherwise use CI_COMMIT_TAG without the v
 
@@ -46,11 +47,10 @@ if [ -n "$CI_COMMIT_TAG" ] || [ -n "$DOTNET_PACKAGE_VERSION" ]; then
   exit 0
 fi
 
+# Standard build pipeline
 artifactName="ssi-artifacts"
 
-buildId=""
-resolve_azure_build_id
-download_azure_artifact "$buildId" "$artifactName" "$target_dir"
+download_azure_artifacts_from_one_build "$target_dir" "$artifactName"
 flatten_azure_artifact "$target_dir" "$artifactName"
 
 ls -l $target_dir


### PR DESCRIPTION
## Summary of changes

- Consolidates the 3 "wait for build and download artifacts from Azure" scripts into one helper
- Fixes several minor bugs in the download logic

## Reason for change

As part of #9083, @NachoEchevarria flagged some potential improvements to the scripts, for example a cancelled build today would cause flakiness for the download scripts. We now also have 3 copies of essentially the same code, and AI spotted several other bugs, all fixed here

## Implementation details

- Extracted shared logic into a helper bash script
  - Arguably we could/should make this a Nuke target given the bash complexity, but given this all goes away completely when we move to GitLab fully, I think the current approach is fine. It's largely copy+paste with some generalisation.
- Fixed missing diagnostics when the loop timed out.
- Fixed an unnecessary 100s wait on each _successful_ run
- Fixed a cancelled build causing the jobs to sit waiting for artifacts that will never run, before eventually timing out.
- Added retries for cancelled/failed builds, looking for "better" candidate builds
  - Can happen if there are multiple builds running against the same commit (e.g. manual builds)
  - Only checks a given build once, so bounded

## Test coverage

This is the test

## Other details

Note that the `.gitlab/download-serverless-artifacts.sh` and `.gitlab/download-single-step-artifacts.sh` have different paths they take when running against tags (during release). `.gitlab/download-nuget-packages-to-sign.sh` does not have this path, as it does not need to run on tags (there may be an edge case there where we _are_ running - need to check)