### PR TITLE
Don't need to download and sign when pushing a tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -230,6 +230,7 @@ publish:
     variables:
       - $DEPLOY_TO_REL_ENV == "true"
       - $CI_COMMIT_TAG # We don't need to build/publish when building a release tag
+      - $DOTNET_PACKAGE_VERSION
   stage: publish-artifacts
   tags: ["windows-v2:2022"]
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -293,6 +293,10 @@ download-nuget-packages-to-sign:
       optional: true
       artifacts: false
   rules:
+    - if: $DOTNET_PACKAGE_VERSION
+      when: never
+    - if: $CI_COMMIT_TAG
+      when: never      # We don't need to build/publish when building a release tag
     - when: on_success # Artifacts come from the Azure pipeline, but as we already depend on build, we already have a delayed start
   script:
     - .gitlab/download-nuget-packages-to-sign.sh
@@ -305,6 +309,12 @@ sign-nuget-packages:
   stage: sign-nuget
   timeout: 15m
   tags: ["windows-v2:2022"]
+  rules:
+    - if: $DOTNET_PACKAGE_VERSION
+      when: never
+    - if: $CI_COMMIT_TAG
+      when: never      # We don't need to build/publish when building a release tag
+    - when: on_success
   needs:
     - job: build
       optional: true


### PR DESCRIPTION
## Summary of changes

Fix benign failures during release

## Reason for change

When a release is published, we push a tag, which triggers a gitlab build. This triggers _Some_ workflows (OCI/lib-injection images) but we _don't_ need to build or publish. Currently we are trying to download from an Azure DevOps pipeline that never exists, so ultimately we fail.

## Implementation details

Don't try to download/sign nuget packages on release (tag)

## Test coverage

Can't test this until the next release, but it's hopefully pretty simple

## Other details

Copied the syntax from the `publish-artifacts` stage