### PR TITLE
Reduce locking in `AgentWriter` to avoid contention

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -42,7 +42,6 @@ src/Datadog.Trace/Agent/IStatsAggregator.cs
 src/Datadog.Trace/Agent/IStreamFactory.cs
 src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
 src/Datadog.Trace/Agent/NullStatsAggregator.cs
-src/Datadog.Trace/Agent/SpanBuffer.cs
 src/Datadog.Trace/Agent/StatsAggregator.cs
 src/Datadog.Trace/Agent/StatsBucket.cs
 src/Datadog.Trace/Agent/StatsBuffer.cs

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -61,6 +61,12 @@ namespace Datadog.Trace.Agent
 
         private byte[] _temporaryBuffer = new byte[1024];
 
+        /// <summary>
+        /// The array handed to <see cref="SpanBuffer.Detach"/> to swap when grabbing the data to flush.
+        /// Only ever touched by the flush loop, which flushes buffers one at a time.
+        /// </summary>
+        private byte[]? _spareBuffer;
+
         private TaskCompletionSource<bool> _forceFlush;
         private TaskCompletionSource<bool>? _pendingFlushRequest;
         private bool _flushLoopStopped;
@@ -287,8 +293,8 @@ namespace Datadog.Trace.Agent
 
         /// <summary>
         /// Asks the flush loop to flush both buffers, and waits for that flush to complete. Buffers are
-        /// only ever locked and flushed by the flush loop, so that at most one buffer is unavailable to
-        /// the serialization thread at a time. Concurrent requests share a single flush pass.
+        /// only ever flushed by the flush loop, so at most one payload is in flight at a time.
+        /// Concurrent requests share a single flush pass.
         /// </summary>
         private Task RequestFullFlushAsync()
         {
@@ -390,9 +396,7 @@ namespace Datadog.Trace.Agent
         }
 
         /// <summary>
-        /// Flush the active buffer, and the fallback buffer if full. Buffers are flushed (and so locked)
-        /// one at a time, and only from <see cref="FlushBuffersTaskLoopAsync"/>, so that the serialization
-        /// thread always has a buffer available to write to.
+        /// Flush the active buffer, and the fallback buffer if full.
         /// </summary>
         /// <param name="flushAllBuffers">If set to true, then flush the back buffer even if not full</param>
         /// <returns>Async operation</returns>
@@ -420,12 +424,24 @@ namespace Datadog.Trace.Agent
 
         private async Task FlushBuffer(SpanBuffer buffer)
         {
-            // Wait for write operations to complete, then prevent further modifications
-            if (!buffer.Lock())
+            // Make sure the replacement array is big enough before taking the buffer's lock.
+            // This deliberately happens outside the critical section so that the serialization thread
+            // never waits on an allocation.
+            var requiredBufferLength = buffer.CurrentLength;
+            if (_spareBuffer is null || _spareBuffer.Length < requiredBufferLength)
             {
-                // The flush loop is the only thing that locks buffers, and it never runs two flushes
-                // at once, so this should be unreachable in production
-                return;
+                _spareBuffer = new byte[requiredBufferLength];
+            }
+
+            // Take the payload and hand the buffer a fresh array, so that the serialization thread
+            // can keep writing to it for the whole of the send below. Nothing is ever locked across
+            // the network call, which is what makes "buffer unavailable" drops impossible.
+            var payload = buffer.Detach(_spareBuffer);
+
+            if (payload.Array is not null)
+            {
+                // The buffer took the spare, and we get it back once the payload has been sent
+                _spareBuffer = null;
             }
 
             try
@@ -435,8 +451,8 @@ namespace Datadog.Trace.Agent
                     using var lease = _statsd.TryGetClientLease();
                     if (lease.Client is { } statsd)
                     {
-                        statsd.Increment(TracerMetricNames.Queue.DequeuedTraces, buffer.TraceCount);
-                        statsd.Increment(TracerMetricNames.Queue.DequeuedSpans, buffer.SpanCount);
+                        statsd.Increment(TracerMetricNames.Queue.DequeuedTraces, payload.TraceCount);
+                        statsd.Increment(TracerMetricNames.Queue.DequeuedSpans, payload.SpanCount);
                     }
                 }
 
@@ -459,7 +475,7 @@ namespace Datadog.Trace.Agent
                         });
                 }
 
-                if (buffer.TraceCount > 0)
+                if (payload.TraceCount > 0)
                 {
                     long droppedP0Traces = 0;
                     long droppedP0Spans = 0;
@@ -468,40 +484,45 @@ namespace Datadog.Trace.Agent
                     {
                         droppedP0Traces = Interlocked.Exchange(ref _droppedP0Traces, 0);
                         droppedP0Spans = Interlocked.Exchange(ref _droppedP0Spans, 0);
-                        Log.Debug("Flushing {Spans} spans across {Traces} traces. CanComputeStats is enabled with {DroppedP0Traces} droppedP0Traces and {DroppedP0Spans} droppedP0Spans", buffer.SpanCount, buffer.TraceCount, droppedP0Traces, droppedP0Spans);
+                        Log.Debug("Flushing {Spans} spans across {Traces} traces. CanComputeStats is enabled with {DroppedP0Traces} droppedP0Traces and {DroppedP0Spans} droppedP0Spans", payload.SpanCount, payload.TraceCount, droppedP0Traces, droppedP0Spans);
                         // Metrics for unsampled traces/spans already recorded
                     }
                     else
                     {
-                        Log.Debug<int, int>("Flushing {Spans} spans across {Traces} traces. CanComputeStats is disabled.", buffer.SpanCount, buffer.TraceCount);
+                        Log.Debug<int, int>("Flushing {Spans} spans across {Traces} traces. CanComputeStats is disabled.", payload.SpanCount, payload.TraceCount);
                     }
 
-                    var success = await _api.SendTracesAsync(buffer.Data, buffer.TraceCount, CanComputeStats, droppedP0Traces, droppedP0Spans, _apmTracingEnabled).ConfigureAwait(false);
+                    var success = await _api.SendTracesAsync(payload.Data, payload.TraceCount, CanComputeStats, droppedP0Traces, droppedP0Spans, _apmTracingEnabled).ConfigureAwait(false);
 
-                    TelemetryFactory.Metrics.RecordCountTraceChunkSent(buffer.TraceCount);
+                    TelemetryFactory.Metrics.RecordCountTraceChunkSent(payload.TraceCount);
                     if (success)
                     {
-                        _traceKeepRateCalculator.IncrementKeeps(buffer.TraceCount);
+                        _traceKeepRateCalculator.IncrementKeeps(payload.TraceCount);
                     }
                     else
                     {
-                        TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, buffer.TraceCount);
-                        TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, buffer.SpanCount);
-                        _traceKeepRateCalculator.IncrementDrops(buffer.TraceCount);
+                        TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, payload.TraceCount);
+                        TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, payload.SpanCount);
+                        _traceKeepRateCalculator.IncrementDrops(payload.TraceCount);
                     }
                 }
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "An unhandled error occurred while flushing a buffer");
-                _traceKeepRateCalculator.IncrementDrops(buffer.TraceCount);
-                TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, buffer.TraceCount);
-                TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, buffer.SpanCount);
+                _traceKeepRateCalculator.IncrementDrops(payload.TraceCount);
+                TelemetryFactory.Metrics.RecordCountTraceChunkDropped(MetricTags.DropReason.ApiError, payload.TraceCount);
+                TelemetryFactory.Metrics.RecordCountSpanDropped(MetricTags.DropReason.ApiError, payload.SpanCount);
             }
             finally
             {
-                // Clear and unlock the buffer
-                buffer.Clear();
+                if (payload.Array is { } sentBuffer)
+                {
+                    // Recycle the array we just sent as the next replacement. Safe only now that
+                    // the send has completed: the API retries re-send the same segment, so the
+                    // bytes have to stay untouched for the whole of the awaited call.
+                    _spareBuffer = sentBuffer;
+                }
             }
         }
 
@@ -652,11 +673,16 @@ namespace Datadog.Trace.Agent
 
                 if (writeStatus == SpanBuffer.WriteStatus.Locked)
                 {
+                    // Both probes wait the full timeout. Giving the second one a shorter deadline
+                    // would recreate the original bug, where a buffer that was merely busy for an
+                    // instant was reported as unavailable.
                     lockedBufferCount++;
                 }
             }
 
-            // Both buffers are full or at least one is locked, so drop the trace
+            // Both buffers are full, or a write waited out the lock timeout. The latter should not
+            // happen: flushing detaches the payload rather than holding the buffer across the send,
+            // so contention only ever lasts nanoseconds.
             var dropReason = lockedBufferCount switch
             {
                 0 => TraceDropReason.BuffersFull,

--- a/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Threading;
 using Datadog.Trace.Agent.MessagePack;
@@ -22,7 +24,6 @@ namespace Datadog.Trace.Agent
         private readonly int _maxBufferSize;
 
         private byte[] _buffer;
-        private bool _locked;
         private int _offset;
 
         public SpanBuffer(int maxBufferSize, ISpanBufferSerializer serializer)
@@ -48,20 +49,6 @@ namespace Datadog.Trace.Agent
             Locked = 3
         }
 
-        public ArraySegment<byte> Data
-        {
-            get
-            {
-                if (!_locked)
-                {
-                    // Sanity check - headers are written when the buffer is locked
-                    ThrowHelper.ThrowInvalidOperationException("Data was extracted from the buffer without locking");
-                }
-
-                return new ArraySegment<byte>(_buffer, 0, _offset);
-            }
-        }
-
         public int TraceCount { get; private set; }
 
         public int SpanCount { get; private set; }
@@ -70,11 +57,25 @@ namespace Datadog.Trace.Agent
 
         internal int MaxBufferSize => _maxBufferSize;
 
+        /// <summary>
+        /// Gets the length of the array currently backing the buffer, so that callers of
+        /// <see cref="Detach"/> can size the replacement array without holding the lock.
+        /// Read without synchronization: the serialization thread may replace the array at any
+        /// time, but both the old and the new reference are valid arrays, so the worst case is a
+        /// replacement that is one growth generation behind and grows on its next write.
+        /// </summary>
+        internal int CurrentLength => _buffer.Length;
+
+        /// <summary>
+        /// Gets the raw contents of the buffer, without finalizing the payload. Only useful for
+        /// asserting on what a write did or didn't put in the buffer; production code takes the
+        /// payload from <see cref="Detach"/> instead.
+        /// </summary>
         [TestingOnly]
-        internal bool IsLocked => _locked;
+        internal ArraySegment<byte> RawData => new(_buffer, 0, _offset);
 
         [TestingOnly]
-        internal bool IsEmpty => !_locked && !IsFull && TraceCount == 0 && SpanCount == 0 && _offset == _serializer.HeaderSize;
+        internal bool IsEmpty => !IsFull && TraceCount == 0 && SpanCount == 0 && _offset == _serializer.HeaderSize;
 
         public WriteStatus TryWrite(in SpanCollection spans, ref byte[] temporaryBuffer, int? samplingPriority = null)
         {
@@ -82,11 +83,17 @@ namespace Datadog.Trace.Agent
 
             try
             {
-                Monitor.TryEnter(_syncRoot, ref lockTaken);
+                // Wait, rather than giving up immediately as this used to. Flushing doesn't
+                // hold the buffer across a network send, so contention should be very small
+                // and waiting it out costs nothing. The bounded timeout only exists so
+                // that a pathological holder can never stall the serialization thread for good.
+                const int lockTimeoutMs = 100;
+                Monitor.TryEnter(_syncRoot, lockTimeoutMs, ref lockTaken);
 
-                if (!lockTaken || _locked)
+                if (!lockTaken)
                 {
-                    // A flush operation is in progress
+                    // This should be very rare, and only happen in pathological/overload cases where
+                    // the flushing thread is rescheduled in the middle of the lock()
                     return WriteStatus.Locked;
                 }
 
@@ -106,6 +113,8 @@ namespace Datadog.Trace.Agent
                     return WriteStatus.Overflow;
                 }
 
+                // Reserve room for whatever FinishBody will append, which ensures
+                // the payload in Detach doesn't grow the array while the lock is held.
                 if (!EnsureCapacity(size + _offset + _serializer.TrailerSize))
                 {
                     if (TraceCount == 0)
@@ -135,34 +144,43 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        public bool Lock()
+        /// <summary>
+        /// Finalizes the current payload and hands it to the caller, swapping
+        /// <paramref name="replacement"/> in as the new backing array so that the buffer is
+        /// immediately writable again, minimizing the duration the buffer is locked.
+        /// </summary>
+        /// <param name="replacement">
+        /// The array to write into from now on. Only consumed if there was something to detach.
+        /// Must not be the array currently backing the buffer.
+        /// </param>
+        /// <returns>
+        /// The detached payload, or <c>default</c> if the buffer held no traces, in which case
+        /// <paramref name="replacement"/> is unused.
+        /// </returns>
+        public Payload Detach(byte[] replacement)
         {
             lock (_syncRoot)
             {
-                if (_locked)
+                if (TraceCount == 0)
                 {
-                    return false;
+                    // Nothing to send, so don't consume the caller's replacement array
+                    return default;
                 }
 
                 // Use a fixed-size header
                 _serializer.WriteHeader(ref _buffer, 0, TraceCount);
                 int addedBytes = _serializer.FinishBody(ref _buffer, _offset, _maxBufferSize);
                 _offset += addedBytes;
-                _locked = true;
 
-                return true;
-            }
-        }
+                var payload = new Payload(new ArraySegment<byte>(_buffer, 0, count: _offset), TraceCount, SpanCount);
 
-        public void Clear()
-        {
-            lock (_syncRoot)
-            {
+                _buffer = replacement;
                 _offset = _serializer.HeaderSize;
                 TraceCount = 0;
                 SpanCount = 0;
                 IsFull = false;
-                _locked = false;
+
+                return payload;
             }
         }
 
@@ -200,6 +218,25 @@ namespace Datadog.Trace.Agent
             _buffer = newBuffer;
 
             return true;
+        }
+
+        public readonly struct Payload
+        {
+            public readonly ArraySegment<byte> Data;
+            public readonly int TraceCount;
+            public readonly int SpanCount;
+
+            public Payload(ArraySegment<byte> data, int traceCount, int spanCount)
+            {
+                Data = data;
+                TraceCount = traceCount;
+                SpanCount = spanCount;
+            }
+
+            /// <summary>
+            /// Gets the detached array, or <c>null</c> if there was nothing to detach.
+            /// </summary>
+            public byte[]? Array => Data.Array;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -74,13 +74,13 @@ namespace Datadog.Trace.Tests.Agent
         public async Task SpanSampling_ShouldSend_SingleMatchedSpan_WhenStatsDrops()
         {
             var api = new Mock<IApi>();
-            ArraySegment<byte> actualData = default;
+            byte[] actualData = [];
             var actualDroppedP0Traces = 0L;
             var actualDroppedP0Spans = 0L;
             api.Setup(x => x.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
                 .Callback((ArraySegment<byte> traces, int _, bool _, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans, bool _) =>
                 {
-                    actualData = traces;
+                    actualData = CopyPayload(traces);
                     actualDroppedP0Traces = numberOfDroppedP0Traces;
                     actualDroppedP0Spans = numberOfDroppedP0Spans;
                 })
@@ -119,13 +119,13 @@ namespace Datadog.Trace.Tests.Agent
         public async Task SpanSampling_ShouldSend_MultipleMatchedSpans_WhenStatsDrops()
         {
             var api = new Mock<IApi>();
-            ArraySegment<byte> actualData = default;
+            byte[] actualData = [];
             var actualDroppedP0Traces = 0L;
             var actualDroppedP0Spans = 0L;
             api.Setup(x => x.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
                 .Callback((ArraySegment<byte> traces, int _, bool _, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans, bool _) =>
                 {
-                    actualData = traces;
+                    actualData = CopyPayload(traces);
                     actualDroppedP0Traces = numberOfDroppedP0Traces;
                     actualDroppedP0Spans = numberOfDroppedP0Spans;
                 })
@@ -223,11 +223,11 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public async Task WriteTrace_2Traces_SendToApi()
         {
-            ArraySegment<byte> actualPayload = default;
+            byte[] actualPayload = [];
             _api.Setup(x => x.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
                 .Callback((ArraySegment<byte> traces, int _, bool _, long _, long _, bool _) =>
                 {
-                    actualPayload = traces;
+                    actualPayload = CopyPayload(traces);
                 })
                 .ReturnsAsync(true);
 
@@ -242,7 +242,7 @@ namespace Datadog.Trace.Tests.Agent
             AssertPayloadEqual(actualPayload, expectedData1);
 
             _api.Invocations.Clear();
-            actualPayload = default;
+            actualPayload = [];
 
             spans = CreateTraceChunk(1, 2);
             traceChunk = new TraceChunkModel(spans);
@@ -288,57 +288,58 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public Task SwitchBuffer()
+        public async Task BufferStaysWritableWhileItsPayloadIsBeingSent()
         {
-            // Make sure that the agent is able to switch to the secondary buffer when the primary is full/busy
+            // Flushing detaches the payload instead of holding the buffer for the duration of the
+            // send, so the serialization thread can keep writing to the very buffer being flushed.
+            // Before that change the buffer was locked across the send, and a trace arriving at the
+            // wrong moment could find both buffers unavailable and be dropped.
             var api = new Mock<IApi>();
             var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp);
 
-            var barrier = new Barrier(2);
+            using var sendStarted = new ManualResetEventSlim();
+            using var releaseSend = new ManualResetEventSlim();
+            var alreadyBlocked = 0;
 
             api.Setup(a => a.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
-                .Callback(() =>
+               .Callback(() =>
                 {
-                    barrier.SignalAndWait();
-                    barrier.SignalAndWait();
+                    // Only stall the first send, so that shutdown isn't blocked
+                    if (Interlocked.Exchange(ref alreadyBlocked, 1) == 0)
+                    {
+                        sendStarted.Set();
+                        releaseSend.Wait(30_000);
+                    }
                 })
-                .Returns(Task.FromResult(true));
+               .Returns(Task.FromResult(true));
 
             agent.WriteTrace(CreateTraceChunk(1));
 
-            // Wait for the flush operation
-            barrier.SignalAndWait();
+            sendStarted.Wait(30_000).Should().BeTrue("the flush loop should have started sending the first trace");
 
-            // At this point, the flush thread is stuck in Api.SendTracesAsync, and the frontBuffer should be active and locked
+            // The flush thread is stuck inside SendTracesAsync, but it took the payload with it,
+            // so the active buffer is empty and immediately writable again
             agent.ActiveBuffer.Should().BeSameAs(agent.FrontBuffer);
-            agent.FrontBuffer.IsLocked.Should().BeTrue();
+            agent.FrontBuffer.IsEmpty.Should().BeTrue();
+
+            WriteTraceAndWait(agent, CreateTraceChunk(2));
+
+            // No swap was needed, because the buffer was never unavailable
+            agent.ActiveBuffer.Should().BeSameAs(agent.FrontBuffer);
             agent.FrontBuffer.TraceCount.Should().Be(1);
-            agent.FrontBuffer.SpanCount.Should().Be(1);
+            agent.FrontBuffer.SpanCount.Should().Be(2);
+            agent.BackBuffer.IsEmpty.Should().BeTrue();
 
-            agent.WriteTrace(CreateTraceChunk(2));
+            // Nothing was dropped while the send was in flight, and nothing timed out waiting
+            // for the buffer either
+            agent.DroppedTracesBufferFull.Should().Be(0);
+            agent.DroppedTracesBufferFullAndLocked.Should().Be(0);
+            agent.DroppedTracesBuffersLocked.Should().Be(0);
+            agent.DroppedTracesTooLarge.Should().Be(0);
 
-            // Wait for the trace to be dequeued
-            WaitForDequeue(agent);
+            releaseSend.Set();
 
-            // Since the frontBuffer was locked, the buffers should have been swapped
-            agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
-            agent.BackBuffer.TraceCount.Should().Be(1);
-            agent.BackBuffer.SpanCount.Should().Be(2);
-
-            // Unblock the flush thread
-            barrier.SignalAndWait();
-
-            // Wait for the next flush operation
-            barrier.SignalAndWait();
-
-            // Back buffer should still be active and being flushed
-            agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
-            agent.BackBuffer.IsLocked.Should().BeTrue();
-            agent.FrontBuffer.IsLocked.Should().BeFalse();
-
-            // Unblock and exit
-            barrier.Dispose();
-            return agent.FlushAndCloseAsync();
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -426,8 +427,6 @@ namespace Datadog.Trace.Tests.Agent
             agent.BackBuffer.SpanCount.Should().Be(1);
 
             agent.DroppedTracesBufferFull.Should().Be(1);
-            agent.DroppedTracesBufferFullAndLocked.Should().Be(0);
-            agent.DroppedTracesBuffersLocked.Should().Be(0);
             agent.DroppedTracesTooLarge.Should().Be(0);
 
             // Dropped trace should have been reported to statsd
@@ -436,44 +435,6 @@ namespace Datadog.Trace.Tests.Agent
             statsd.Verify(s => s.Increment(TracerMetricNames.Queue.DroppedTraces, 1, 1, null), Times.Once);
             statsd.Verify(s => s.Increment(TracerMetricNames.Queue.DroppedSpans, 2, 1, null), Times.Once);
             statsd.VerifyNoOtherCalls();
-
-            await agent.FlushAndCloseAsync();
-        }
-
-        [Fact]
-        public async Task DropTraceWhenBothBuffersAreLocked()
-        {
-            var agent = AgentWriterHelper.CreateWithManualFlush(Mock.Of<IApi>());
-
-            agent.FrontBuffer.Lock().Should().BeTrue();
-            agent.BackBuffer.Lock().Should().BeTrue();
-
-            WriteTraceAndWait(agent, CreateTraceChunk(1));
-
-            agent.DroppedTracesBufferFull.Should().Be(0);
-            agent.DroppedTracesBufferFullAndLocked.Should().Be(0);
-            agent.DroppedTracesBuffersLocked.Should().Be(1);
-            agent.DroppedTracesTooLarge.Should().Be(0);
-
-            await agent.FlushAndCloseAsync();
-        }
-
-        [Fact]
-        public async Task DropTraceWhenOneBufferIsFullAndOneIsLocked()
-        {
-            var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
-            var agent = AgentWriterHelper.CreateWithManualFlush(
-                Mock.Of<IApi>(),
-                maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1);
-
-            agent.FrontBuffer.Lock().Should().BeTrue();
-            WriteTraceAndWait(agent, CreateTraceChunk(1));
-            WriteTraceAndWait(agent, CreateTraceChunk(2));
-
-            agent.DroppedTracesBufferFull.Should().Be(0);
-            agent.DroppedTracesBufferFullAndLocked.Should().Be(1);
-            agent.DroppedTracesBuffersLocked.Should().Be(0);
-            agent.DroppedTracesTooLarge.Should().Be(0);
 
             await agent.FlushAndCloseAsync();
         }
@@ -505,26 +466,6 @@ namespace Datadog.Trace.Tests.Agent
 
             agent.DroppedTracesBufferFull.Should().Be(0);
             agent.DroppedTracesTooLarge.Should().Be(0);
-
-            await agent.FlushAndCloseAsync();
-        }
-
-        [Fact]
-        public async Task DropTraceThatExceedsBufferSizeWhenActiveBufferIsLocked()
-        {
-            var agent = AgentWriterHelper.CreateWithManualFlush(
-                Mock.Of<IApi>(),
-                maxBufferSize: SpanBufferMessagePackSerializer.HeaderSizeConst);
-
-            agent.ActiveBuffer.Lock().Should().BeTrue();
-
-            WriteTraceAndWait(agent, CreateTraceChunk(2));
-
-            agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
-            agent.FrontBuffer.IsLocked.Should().BeTrue();
-            agent.BackBuffer.IsEmpty.Should().BeTrue();
-            agent.DroppedTracesBufferFull.Should().Be(0);
-            agent.DroppedTracesTooLarge.Should().Be(1);
 
             await agent.FlushAndCloseAsync();
         }
@@ -828,18 +769,31 @@ namespace Datadog.Trace.Tests.Agent
             return mutex.Wait(delay);
         }
 
-        private static void AssertPayloadEqual(ArraySegment<byte> data, byte[] expectedData)
+        /// <summary>
+        /// Takes a copy of the payload handed to the API. Copying matters: once the send completes,
+        /// the flush loop recycles that array as a buffer's backing store, so the bytes are only
+        /// guaranteed to be intact for the duration of the call. Deliberately assertion-free —
+        /// it runs on the flush thread, where a failed assertion would be swallowed rather than
+        /// failing the test.
+        /// </summary>
+        private static byte[] CopyPayload(ArraySegment<byte> data)
         {
-            data.Array.Should().NotBeNull();
-            data.Count.Should().BeGreaterOrEqualTo(SpanBufferMessagePackSerializer.HeaderSizeConst);
+            if (data.Array is null)
+            {
+                return [];
+            }
 
-            var actualPayload = data.Array!
-                .Skip(data.Offset)
-                .Take(data.Count)
-                .Skip(SpanBufferMessagePackSerializer.HeaderSizeConst)
-                .ToArray();
+            var copy = new byte[data.Count];
+            Array.Copy(data.Array, data.Offset, copy, 0, data.Count);
+            return copy;
+        }
 
-            actualPayload.Should().Equal(expectedData);
+        private static void AssertPayloadEqual(byte[] data, byte[] expectedData)
+        {
+            data.Length.Should().BeGreaterOrEqualTo(SpanBufferMessagePackSerializer.HeaderSizeConst);
+
+            data.Skip(SpanBufferMessagePackSerializer.HeaderSizeConst)
+                .Should().Equal(expectedData);
         }
 
         private static int ComputeSize(SpanCollection spans)

--- a/tracer/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
@@ -6,8 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
+using Datadog.Trace.OpenTelemetry.Traces;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Vendors.MessagePack.Formatters;
 using FluentAssertions;
@@ -34,12 +36,12 @@ namespace Datadog.Trace.Tests.Agent
                 buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
             }
 
-            buffer.Lock();
+            var payload = buffer.Detach(new byte[SpanBuffer.InitialBufferSize]);
 
-            buffer.TraceCount.Should().Be(traceCount);
-            buffer.SpanCount.Should().Be(traceCount * spanCount);
+            payload.TraceCount.Should().Be(traceCount);
+            payload.SpanCount.Should().Be(traceCount * spanCount);
 
-            var content = buffer.Data;
+            var content = payload.Data;
             var mockTraceChunks = MessagePackSerializer.Deserialize<MockSpan[][]>(content);
             var resized = content.Count > SpanBuffer.InitialBufferSize;
 
@@ -65,43 +67,143 @@ namespace Datadog.Trace.Tests.Agent
             buffer.TraceCount.Should().Be(0);
             buffer.IsFull.Should().BeFalse();
 
-            buffer.Lock();
-            var innerBuffer = buffer.Data;
+            var innerBuffer = buffer.RawData;
 
             innerBuffer.Array!.Skip(SpanBufferMessagePackSerializer.HeaderSizeConst).All(b => b == 0x0).Should().BeTrue("No data should have been written to the buffer");
         }
 
         [Fact]
-        public void LockingBuffer()
+        public void DetachingBuffer_HandsOverThePayloadAndResetsTheBuffer()
         {
             var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanBufferMessagePackSerializer(SpanFormatterResolver.Instance));
-            var spans = CreateTraceChunk(1);
 
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
-            buffer.Lock();
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Locked);
-            buffer.Clear();
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            buffer.TryWrite(CreateTraceChunk(3), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            buffer.TryWrite(CreateTraceChunk(3), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+
+            var payload = buffer.Detach(new byte[SpanBuffer.InitialBufferSize]);
+
+            payload.Array.Should().NotBeNull();
+            payload.TraceCount.Should().Be(2);
+            payload.SpanCount.Should().Be(6);
+
+            var chunks = MessagePackSerializer.Deserialize<MockSpan[][]>(payload.Data);
+            chunks.Length.Should().Be(2);
+            chunks.Sum(t => t.Length).Should().Be(6);
+
+            // The buffer handed everything over, so it's empty again
+            buffer.IsEmpty.Should().BeTrue();
         }
 
         [Fact]
-        public void ClearingBuffer()
+        public void DetachingBuffer_LeavesThePayloadIntactWhileTheBufferIsWrittenTo()
         {
             var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanBufferMessagePackSerializer(SpanFormatterResolver.Instance));
-            var spans = CreateTraceChunk(3);
 
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
-            buffer.TraceCount.Should().Be(1);
-            buffer.SpanCount.Should().Be(3);
+            buffer.TryWrite(CreateTraceChunk(3), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
 
-            buffer.Clear();
+            var payload = buffer.Detach(new byte[SpanBuffer.InitialBufferSize]);
 
-            buffer.TraceCount.Should().Be(0);
-            buffer.SpanCount.Should().Be(0);
+            // The whole point of detaching: the buffer is writable straight away, and none of
+            // those writes may touch the payload that is still being sent
+            for (var i = 0; i < 10; i++)
+            {
+                buffer.TryWrite(CreateTraceChunk(5), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            }
 
-            buffer.Lock();
+            var chunks = MessagePackSerializer.Deserialize<MockSpan[][]>(payload.Data);
+            chunks.Length.Should().Be(1);
+            chunks[0].Length.Should().Be(3);
+        }
 
-            buffer.Data.Count.Should().Be(SpanBufferMessagePackSerializer.HeaderSizeConst);
+        [Fact]
+        public void DetachingBuffer_InstallsTheReplacementArray()
+        {
+            var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanBufferMessagePackSerializer(SpanFormatterResolver.Instance));
+            var replacement = new byte[SpanBuffer.InitialBufferSize];
+
+            buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            var first = buffer.Detach(replacement);
+
+            buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            var second = buffer.Detach(first.Array!);
+
+            first.Array.Should().NotBeSameAs(replacement);
+            second.Array.Should().BeSameAs(replacement, "the replacement handed to the first detach becomes the backing array");
+        }
+
+        [Fact]
+        public void DetachingEmptyBuffer_ReturnsNothingAndDoesNotConsumeTheReplacement()
+        {
+            var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanBufferMessagePackSerializer(SpanFormatterResolver.Instance));
+            var replacement = new byte[SpanBuffer.InitialBufferSize];
+
+            var payload = buffer.Detach(replacement);
+
+            payload.Array.Should().BeNull();
+            payload.TraceCount.Should().Be(0);
+            payload.SpanCount.Should().Be(0);
+
+            // The replacement wasn't taken, so the caller can still use it for the next flush
+            buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            buffer.Detach(replacement).Array.Should().NotBeSameAs(replacement);
+        }
+
+        [Fact]
+        public void DetachingFullBuffer_ClearsTheFullFlag()
+        {
+            var buffer = new SpanBuffer(512, new SpanBufferMessagePackSerializer(SpanFormatterResolver.Instance));
+
+            SpanBuffer.WriteStatus status;
+
+            do
+            {
+                status = buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer);
+            }
+            while (status == SpanBuffer.WriteStatus.Success);
+
+            status.Should().Be(SpanBuffer.WriteStatus.Full);
+            buffer.IsFull.Should().BeTrue();
+
+            buffer.Detach(new byte[512]);
+
+            buffer.IsFull.Should().BeFalse();
+            buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+        }
+
+        [Fact]
+        public void JsonSerializer_CanAlwaysCloseThePayload_EvenWhenTheBufferFillsUp()
+        {
+            // FinishBody appends the closing brackets when the payload is detached, and that runs
+            // while the buffer's lock is held. Every write reserves TrailerSize bytes for them, so
+            // finalizing can never need to grow the array there -- and the payload can never come
+            // out unterminated.
+            var serializer = new OtlpTracesJsonSerializer();
+
+            // Measure two chunks, then size the real buffer so that without the reservation it
+            // would fill to within fewer bytes than the closing brackets need. That is the case
+            // where finalizing used to silently give up and emit unterminated JSON.
+            var probe = new SpanBuffer(64 * 1024, new OtlpTracesJsonSerializer());
+            probe.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            probe.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+
+            var buffer = new SpanBuffer(probe.RawData.Count + serializer.TrailerSize - 1, serializer);
+
+            SpanBuffer.WriteStatus status;
+
+            do
+            {
+                status = buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer);
+            }
+            while (status == SpanBuffer.WriteStatus.Success);
+
+            status.Should().Be(SpanBuffer.WriteStatus.Full, "the buffer should fill up rather than reject the first chunk");
+
+            var payload = buffer.Detach(new byte[64 * 1024]);
+
+            payload.Array.Should().NotBeNull();
+
+            var json = Encoding.UTF8.GetString(payload.Data.Array!, payload.Data.Offset, payload.Data.Count);
+            json.Should().EndWith("]}]}]}", "the closing brackets must always fit");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Update `AgentWriter` to reduce chance of locked buffers

## Reason for change

In #9007 (and related PRs) we updated the `AgentWriter` flush loop to avoid simultaneous flushes. The intention was to avoid the "both buffers locked" failure scenario we have seen in CI.

However, there were still several edge cases that could lead to the serialization thread seeing _both_ buffers as locked _despite_ the fact we only ever locked one at a time (during flushing). 
The serialization thread can "chase" the lock from one buffer to the other and
see `Locked` twice even though the two buffers _were never locked simultaneously_. #9007 prevented _simultaneous_ locking, but it doesn't prevent this scenario.

What's worse, we kind of cause it ourselves, because of how we call `WakeFlushLoop` from the serialization thread. For example

1. Flush loop is running, and is locking the front buffer (currently active buffer)
2. Serialization thread tries to write, but finds the buffer locked, so it calls `SwapBuffers()` and `WakeFlushLoop`
3. Flush Loop finishes, doesn't sleep because of the trigger, and so immediately locks the back buffer (the currently active buffer, again)
4. Serialization thread tries to write, finds the buffer locked again, and drops the trace (two buffers locked)

There are various other factors that also make this worse:
- In `SpanBuffer.TryWrite` we call `Monitor.TryEnter` with _zero_ timeout. Even if the flush loop is locking for a tiny time (e.g. if `TraceCount == 0`) the write will fail. In other words, we don't _actually_ have to be flushing to report `Locked`
- `FlushBuffer` locks the _active_ buffer _at least_ once every second (more when there's heavy load/contention/forced flushing).

There's also a latent bug where a locked-but-not-full buffer can end up skipped and sitting in the background and not being flushed until shutdown. I'll address that in a follow up PR

## Implementation details

The key fix I implemented in the end is to _not_ lock the buffer for the whole duration of the flush. Instead, we use a third buffer that we "swap in", so that we can reset the buffer, and keep the contention period to a minimum.

_Technically_, this _should_ mean that we can now _block_ on `SpanBuffer.TryWrite`, instead of trying to aquire the lock, and bailing if we can't. Given that the critical section during a flush is now just "write the header + trailer, then reset the buffer", this _should_ be tiny. However, I was too much of a coward to go this route, and instead opted for `Monitor.TryEnter` with a 100ms timeout. We _shouldn't_ hit it (though I'm interested to see if we do in CI). And if we do, we decide the best way to handle it, but I just wanted to avoid the chance of stalling indefinitely, with the queue building up, and would rather lose traces in that case.

One thing to note is that #9115 is required so that we don't accidentally try to do allocation while holding the lock on the buffer, as that could increase the duration we hold it for.

## Test coverage

Mostly just unit tests, as this is an internal refactoring. Hopefully it reduces our instances of double-lock in CI

## Other details

Depends on https://github.com/DataDog/dd-trace-dotnet/pull/9115