### PR TITLE
Run Azure messaging emulators with Testcontainers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,48 +152,19 @@ services:
 
   sqledge:
     image: mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf
-    profiles: ["group2"]
-    environment:
-    - ACCEPT_EULA=Y
-    - MSSQL_SA_PASSWORD=Strong!Passw0rd
+    profiles: ["testcontainers"]
 
   azureservicebus-emulator:
     image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2@sha256:353913ece3d9124cebd40f4b91d00dd197846b8cf86eae9a4790698709c64a1d
-    profiles: ["group2"]
-    depends_on:
-      - sqledge
-    ports:
-      - "127.0.0.1:5672:5672"
-    environment:
-      - ACCEPT_EULA=Y
-      - SQL_SERVER=sqledge:1433
-      - MSSQL_SA_PASSWORD=Strong!Passw0rd
-    volumes:
-      - ./docker/servicebus-emulator-config.json:/ServiceBus_Emulator/ConfigFiles/Config.json:ro
+    profiles: ["testcontainers"]
 
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite:latest@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37
-    profiles: ["group2"]
-    hostname: azurite
-    container_name: azurite
-    ports:
-      - "10000:10000"
-      - "10001:10001"
-      - "10002:10002"
+    profiles: ["testcontainers"]
 
   azure-eventhubs-emulator:
     image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest@sha256:2c8e0d4dd93a5fc078df2721eeb3e211442d555d61293ac3972df931c6d9333a
-    profiles: ["group2"]
-    depends_on:
-      - azurite
-    ports:
-      - "127.0.0.1:5673:5672"
-    environment:
-      - ACCEPT_EULA=Y
-      - BLOB_SERVER=azurite
-      - METADATA_SERVER=azurite
-    volumes:
-      - ./docker/eventhubs-emulator-config.json:/Eventhubs_Emulator/ConfigFiles/Config.json:ro
+    profiles: ["testcontainers"]
 
   cosmosdb-emulator:
     image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview@sha256:54d7bc334494c50cea867c270880671a7db080626a9732832b34c0d69342f9b0
@@ -326,8 +297,6 @@ services:
       - ELASTICSEARCH5_HOST=elasticsearch5:9200
       - AWS_SDK_HOST=localstack:4566
       - ORACLE_HOST=oracle
-      - ASB_CONNECTION_STRING=Endpoint=sb://azureservicebus-emulator:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
-      - EVENTHUBS_CONNECTION_STRING=Endpoint=sb://azure-eventhubs-emulator:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
       - COSMOSDB_ENDPOINT=https://cosmosdb-emulator:8081
       - TEST_AGENT_HOST=test-agent
       - CONTAINER_HOSTNAME=http://integrationtests
@@ -540,15 +509,11 @@ services:
       - elasticsearch5
       - mongo
       - localstack
-      - sqledge
-      - azureservicebus-emulator
-      - azurite
-      - azure-eventhubs-emulator
       - cosmosdb-emulator
       - test-agent
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch5:9200 elasticsearch6:9200 elasticsearch7:9200 mongo:27017 localstack:4566 sqledge:1433 azureservicebus-emulator:5672 azure-eventhubs-emulator:5672 cosmosdb-emulator:8081 test-agent:8126 test-agent:4317 test-agent:4318
+    command: elasticsearch5:9200 elasticsearch6:9200 elasticsearch7:9200 mongo:27017 localstack:4566 cosmosdb-emulator:8081 test-agent:8126 test-agent:4317 test-agent:4318
 
   IntegrationTests.ARM64:
     build:

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventHubsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureEventHubsTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
@@ -22,9 +23,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
     [Collection(AzureMessagingEmulatorTestsCollection.Name)]
     public class AzureEventHubsTests : TracingIntegrationTest
     {
-        public AzureEventHubsTests(ITestOutputHelper output)
+        public AzureEventHubsTests(ITestOutputHelper output, AzureEventHubsFixture eventHubsFixture)
             : base("AzureEventHubs", output)
         {
+            ConfigureContainers(eventHubsFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureMessagingEmulatorTestsCollection.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureMessagingEmulatorTestsCollection.cs
@@ -3,12 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure;
 
 [CollectionDefinition(Name, DisableParallelization = true)]
-public class AzureMessagingEmulatorTestsCollection
+public class AzureMessagingEmulatorTestsCollection : ICollectionFixture<AzureEventHubsFixture>, ICollectionFixture<AzureServiceBusFixture>
 {
     public const string Name = nameof(AzureMessagingEmulatorTestsCollection);
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusAPMTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusAPMTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using VerifyXunit;
@@ -27,9 +28,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
     [Collection(AzureMessagingEmulatorTestsCollection.Name)]
     public class AzureServiceBusAPMTests : TracingIntegrationTest
     {
-        public AzureServiceBusAPMTests(ITestOutputHelper output)
+        public AzureServiceBusAPMTests(ITestOutputHelper output, AzureServiceBusFixture serviceBusFixture)
             : base("AzureServiceBus.APM", output)
         {
+            ConfigureContainers(serviceBusFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsMessagingTriggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsMessagingTriggerTests.cs
@@ -12,11 +12,11 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Azure.Messaging.EventHubs;
 using Azure.Messaging.ServiceBus;
 using Azure.Storage.Blobs;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Azure;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using VerifyTests;
 using VerifyXunit;
 using Xunit;
@@ -39,19 +39,18 @@ public class AzureFunctionsMessagingTriggerTests : AzureFunctionsTests
     private const string EventHubConsumerGroup = "cg1";
     private const string TestIdEnvironmentVariable = "DD_AZURE_FUNCTIONS_MESSAGING_TEST_ID";
     private const string TestModeEnvironmentVariable = "DD_AZURE_FUNCTIONS_MESSAGING_TEST_MODE";
-    private const string LocalServiceBusConnectionString = "Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
-    private const string LocalEventHubsConnectionString = "Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
-    private const string AzuriteAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    private readonly AzureEventHubsFixture _eventHubsFixture;
+    private readonly AzureServiceBusFixture _serviceBusFixture;
 
-    public AzureFunctionsMessagingTriggerTests(ITestOutputHelper output)
+    public AzureFunctionsMessagingTriggerTests(ITestOutputHelper output, AzureEventHubsFixture eventHubsFixture, AzureServiceBusFixture serviceBusFixture)
         : base("AzureFunctions.V4Isolated.Messaging", output)
     {
+        _eventHubsFixture = eventHubsFixture;
+        _serviceBusFixture = serviceBusFixture;
+        ConfigureContainers(eventHubsFixture, serviceBusFixture);
         SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "dotnet-isolated");
         SetEnvironmentVariable("FUNCTIONS_EXTENSION_VERSION", "~4");
         SetEnvironmentVariable("WEBSITE_SITE_NAME", nameof(AzureFunctionsMessagingTriggerTests));
-        SetEnvironmentVariable("ASB_CONNECTION_STRING", GetServiceBusConnectionString());
-        SetEnvironmentVariable("EVENTHUBS_CONNECTION_STRING", GetEventHubsConnectionString());
-        SetEnvironmentVariable("AzureWebJobsStorage", GetAzuriteConnectionString());
     }
 
     private static int ExpectedFuncKillExitCode
@@ -69,7 +68,7 @@ public class AzureFunctionsMessagingTriggerTests : AzureFunctionsTests
         SetEnvironmentVariable("AzureWebJobs.ServiceBusTrigger.Disabled", "false");
         SetEnvironmentVariable("AzureWebJobs.EventHubTrigger.Disabled", "true");
 
-        await using (var client = new ServiceBusClient(GetServiceBusConnectionString()))
+        await using (var client = new ServiceBusClient(_serviceBusFixture.ServiceBusConnectionString))
         await using (var receiver = client.CreateReceiver(ServiceBusQueueName))
         {
             await PurgeQueue(receiver);
@@ -136,23 +135,6 @@ public class AzureFunctionsMessagingTriggerTests : AzureFunctionsTests
         }
     }
 
-    private static VerifySettings GetMessagingTriggerSettings()
-    {
-        var settings = VerifyHelper.GetSpanVerifierSettings();
-        settings.AddSimpleScrubber("aas.environment.runtime: .NET Core", "aas.environment.runtime: .NET");
-        // Normalize emulator hostnames so snapshots are consistent across local and CI (Docker) environments
-        settings.AddSimpleScrubber("network.destination.name: azure-eventhubs-emulator", "network.destination.name: localhost");
-        settings.AddSimpleScrubber("network.destination.name: azureservicebus-emulator", "network.destination.name: localhost");
-        settings.AddSimpleScrubber("server.address: azure-eventhubs-emulator", "server.address: localhost");
-        settings.AddSimpleScrubber("server.address: azureservicebus-emulator", "server.address: localhost");
-        // SpanLinks contain raw 128-bit trace IDs and trace state that change between runs
-        settings.AddRegexScrubber(new Regex(@"TraceIdLow: \d+"), "TraceIdLow: 0");
-        settings.AddRegexScrubber(new Regex(@"TraceIdHigh: \d+"), "TraceIdHigh: 0");
-        settings.AddRegexScrubber(new Regex(@"TraceFlags: \d+"), "TraceFlags: 0");
-        settings.AddRegexScrubber(new Regex(@"TraceState: [^\r\n]+"), "TraceState: scrubbed");
-        return settings;
-    }
-
     private static async Task SeedViaHttpAsync(string route)
     {
         // Retry on 404: the host may accept connections before all function routes are registered.
@@ -202,42 +184,40 @@ public class AzureFunctionsMessagingTriggerTests : AzureFunctionsTests
         }
     }
 
-    private static async Task ResetEventHubCheckpointStore()
-    {
-        var container = new BlobContainerClient(GetAzuriteConnectionString(), "azure-webjobs-eventhub");
-        await container.CreateIfNotExistsAsync();
-
-        var prefix = $"{GetEventHubsCheckpointNamespace()}/{EventHubName}/{EventHubConsumerGroup}/";
-        await foreach (var blob in container.GetBlobsAsync(prefix: prefix))
-        {
-            await container.DeleteBlobIfExistsAsync(blob.Name);
-        }
-    }
-
-    private static string GetServiceBusConnectionString()
-        => Environment.GetEnvironmentVariable("ASB_CONNECTION_STRING") ?? LocalServiceBusConnectionString;
-
-    private static string GetEventHubsConnectionString()
-        => Environment.GetEnvironmentVariable("EVENTHUBS_CONNECTION_STRING") ?? LocalEventHubsConnectionString;
-
-    private static string GetAzuriteConnectionString()
-    {
-        var host = UseDockerHostnames() ? "azurite" : "127.0.0.1";
-        return $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={AzuriteAccountKey};BlobEndpoint=http://{host}:10000/devstoreaccount1;QueueEndpoint=http://{host}:10001/devstoreaccount1;TableEndpoint=http://{host}:10002/devstoreaccount1;";
-    }
-
-    private static bool UseDockerHostnames()
-        => (Environment.GetEnvironmentVariable("ASB_CONNECTION_STRING")?.Contains("azureservicebus-emulator", StringComparison.OrdinalIgnoreCase) ?? false)
-        || (Environment.GetEnvironmentVariable("EVENTHUBS_CONNECTION_STRING")?.Contains("azure-eventhubs-emulator", StringComparison.OrdinalIgnoreCase) ?? false);
-
-    private static string GetEventHubsCheckpointNamespace()
-        => EventHubsConnectionStringProperties.Parse(GetEventHubsConnectionString()).Endpoint.Host;
-
     private static string CreateTestId()
         => Guid.NewGuid().ToString("N");
 
     private static string CreateHostId(string testId)
         => "afmsg" + testId.Substring(0, 27);
+
+    private VerifySettings GetMessagingTriggerSettings()
+    {
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddSimpleScrubber("aas.environment.runtime: .NET Core", "aas.environment.runtime: .NET");
+        // Normalize emulator hostnames so snapshots are consistent across local and CI (Docker) environments
+        settings.AddSimpleScrubber($"network.destination.name: {_eventHubsFixture.EventHubsHostname}", "network.destination.name: localhost");
+        settings.AddSimpleScrubber($"network.destination.name: {_serviceBusFixture.ServiceBusHostname}", "network.destination.name: localhost");
+        settings.AddSimpleScrubber($"server.address: {_eventHubsFixture.EventHubsHostname}", "server.address: localhost");
+        settings.AddSimpleScrubber($"server.address: {_serviceBusFixture.ServiceBusHostname}", "server.address: localhost");
+        // SpanLinks contain raw 128-bit trace IDs and trace state that change between runs
+        settings.AddRegexScrubber(new Regex(@"TraceIdLow: \d+"), "TraceIdLow: 0");
+        settings.AddRegexScrubber(new Regex(@"TraceIdHigh: \d+"), "TraceIdHigh: 0");
+        settings.AddRegexScrubber(new Regex(@"TraceFlags: \d+"), "TraceFlags: 0");
+        settings.AddRegexScrubber(new Regex(@"TraceState: [^\r\n]+"), "TraceState: scrubbed");
+        return settings;
+    }
+
+    private async Task ResetEventHubCheckpointStore()
+    {
+        var container = new BlobContainerClient(_eventHubsFixture.AzuriteConnectionString, "azure-webjobs-eventhub");
+        await container.CreateIfNotExistsAsync();
+
+        var prefix = $"{_eventHubsFixture.EventHubsHostname}/{EventHubName}/{EventHubConsumerGroup}/";
+        await foreach (var blob in container.GetBlobsAsync(prefix: prefix))
+        {
+            await container.DeleteBlobIfExistsAsync(blob.Name);
+        }
+    }
 }
 
 #endif

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/AzureEventHubsFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/AzureEventHubsFixture.cs
@@ -1,0 +1,119 @@
+// <copyright file="AzureEventHubsFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class AzureEventHubsFixture : ContainerFixture
+{
+    private const int AzuriteBlobPort = 10000;
+    private const int AzuriteQueuePort = 10001;
+    private const int AzuriteTablePort = 10002;
+    private const int EventHubsAmqpPort = 5672;
+    private const int EventHubsHealthPort = 5300;
+    private const string AzuriteAlias = "azurite";
+    private const string AzuriteAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    private const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:latest@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37";
+    private const string EventHubsImage = "mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest@sha256:2c8e0d4dd93a5fc078df2721eeb3e211442d555d61293ac3972df931c6d9333a";
+    private const string EventHubsConfigContainerPath = "/Eventhubs_Emulator/ConfigFiles/Config.json";
+
+    public string EventHubsConnectionString
+        => $"Endpoint=sb://{EventHubsHostname}:{EventHubsContainer.GetMappedPublicPort(EventHubsAmqpPort)};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+    public string AzuriteConnectionString
+        => $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={AzuriteAccountKey};BlobEndpoint=http://{AzuriteContainer.Hostname}:{AzuriteContainer.GetMappedPublicPort(AzuriteBlobPort)}/devstoreaccount1;QueueEndpoint=http://{AzuriteContainer.Hostname}:{AzuriteContainer.GetMappedPublicPort(AzuriteQueuePort)}/devstoreaccount1;TableEndpoint=http://{AzuriteContainer.Hostname}:{AzuriteContainer.GetMappedPublicPort(AzuriteTablePort)}/devstoreaccount1;";
+
+    public string EventHubsHostname => EventHubsContainer.Hostname;
+
+    private IContainer AzuriteContainer => GetResource<IContainer>("azurite");
+
+    private IContainer EventHubsContainer => GetResource<IContainer>("eventhubs");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("EVENTHUBS_CONNECTION_STRING", EventHubsConnectionString);
+        yield return new("AzureWebJobsStorage", AzuriteConnectionString);
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        // Keep image versions synchronized with docker-compose.yml.
+        var network = new NetworkBuilder().Build();
+        var azuriteContainer = new ContainerBuilder(AzuriteImage)
+                              .WithNetwork(network)
+                              .WithNetworkAliases(AzuriteAlias)
+                              .WithPortBinding(AzuriteBlobPort, true)
+                              .WithPortBinding(AzuriteQueuePort, true)
+                              .WithPortBinding(AzuriteTablePort, true)
+                              .WithWaitStrategy(
+                                   Wait.ForUnixContainer()
+                                       .UntilInternalTcpPortIsAvailable(AzuriteBlobPort)
+                                       .UntilInternalTcpPortIsAvailable(AzuriteQueuePort)
+                                       .UntilInternalTcpPortIsAvailable(AzuriteTablePort))
+                              .Build();
+
+        var configPath = Path.Combine(TestHelpers.EnvironmentTools.GetSolutionDirectory(), "docker", "eventhubs-emulator-config.json");
+        var configBytes = File.ReadAllBytes(configPath);
+        var eventHubsContainer = new ContainerBuilder(EventHubsImage)
+                                .WithNetwork(network)
+                                .WithEnvironment("ACCEPT_EULA", "Y")
+                                .WithEnvironment("BLOB_SERVER", AzuriteAlias)
+                                .WithEnvironment("METADATA_SERVER", AzuriteAlias)
+                                .WithResourceMapping(configBytes, EventHubsConfigContainerPath)
+                                .WithPortBinding(EventHubsAmqpPort, true)
+                                .WithPortBinding(EventHubsHealthPort, true)
+                                .WithWaitStrategy(
+                                     Wait.ForUnixContainer()
+                                         .AddCustomWaitStrategy(new EventHubsHealthWaitStrategy()))
+                                .Build();
+
+        registerResource("network", network);
+        registerResource("azurite", azuriteContainer);
+        registerResource("eventhubs", eventHubsContainer);
+
+        await network.CreateAsync().ConfigureAwait(false);
+        await StartContainerAsync(azuriteContainer).ConfigureAwait(false);
+        await StartContainerAsync(eventHubsContainer).ConfigureAwait(false);
+    }
+
+    private sealed class EventHubsHealthWaitStrategy : IWaitUntil
+    {
+        public async Task<bool> UntilAsync(IContainer container)
+        {
+            using var handler = new HttpClientHandler { UseProxy = false };
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(2) };
+            var healthEndpoint = new UriBuilder(
+                Uri.UriSchemeHttp,
+                container.Hostname,
+                container.GetMappedPublicPort(EventHubsHealthPort),
+                "/health").Uri;
+
+            try
+            {
+                using var response = await client.GetAsync(healthEndpoint).ConfigureAwait(false);
+                return response.IsSuccessStatusCode;
+            }
+            catch (HttpRequestException)
+            {
+                return false;
+            }
+            catch (TaskCanceledException)
+            {
+                // The emulator accepts connections before the health endpoint is ready to respond.
+                return false;
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/AzureServiceBusFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/AzureServiceBusFixture.cs
@@ -1,0 +1,110 @@
+// <copyright file="AzureServiceBusFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class AzureServiceBusFixture : ContainerFixture
+{
+    private const int ServiceBusAmqpPort = 5672;
+    private const int ServiceBusHealthPort = 5300;
+    private const int SqlServerPort = 1433;
+    private const string Password = "Strong!Passw0rd";
+    private const string SqlEdgeAlias = "sqledge";
+    private const string SqlEdgeImage = "mcr.microsoft.com/azure-sql-edge:latest@sha256:902628a8be89e35dfb7895ca31d602974c7bafde4d583a0d0873844feb1c42cf";
+    private const string ServiceBusImage = "mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2@sha256:353913ece3d9124cebd40f4b91d00dd197846b8cf86eae9a4790698709c64a1d";
+    private const string ServiceBusConfigContainerPath = "/ServiceBus_Emulator/ConfigFiles/Config.json";
+
+    public string ServiceBusConnectionString
+        => $"Endpoint=sb://{ServiceBusHostname}:{ServiceBusContainer.GetMappedPublicPort(ServiceBusAmqpPort)};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+    public string ServiceBusHostname => ServiceBusContainer.Hostname;
+
+    private IContainer ServiceBusContainer => GetResource<IContainer>("servicebus");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("ASB_CONNECTION_STRING", ServiceBusConnectionString);
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        // Keep image versions synchronized with docker-compose.yml.
+        var network = new NetworkBuilder().Build();
+        var sqlEdgeContainer = new ContainerBuilder(SqlEdgeImage)
+                              .WithNetwork(network)
+                              .WithNetworkAliases(SqlEdgeAlias)
+                              .WithEnvironment("ACCEPT_EULA", "Y")
+                              .WithEnvironment("MSSQL_SA_PASSWORD", Password)
+                              .WithWaitStrategy(
+                                   Wait.ForUnixContainer()
+                                       .UntilMessageIsLogged(
+                                            "SQL Server is now ready for client connections",
+                                            strategy => strategy.WithTimeout(TimeSpan.FromMinutes(2))))
+                              .Build();
+
+        var configPath = Path.Combine(TestHelpers.EnvironmentTools.GetSolutionDirectory(), "docker", "servicebus-emulator-config.json");
+        var configBytes = File.ReadAllBytes(configPath);
+        var serviceBusContainer = new ContainerBuilder(ServiceBusImage)
+                                 .WithNetwork(network)
+                                 .WithEnvironment("ACCEPT_EULA", "Y")
+                                 .WithEnvironment("SQL_SERVER", $"{SqlEdgeAlias}:{SqlServerPort}")
+                                 .WithEnvironment("MSSQL_SA_PASSWORD", Password)
+                                 .WithResourceMapping(configBytes, ServiceBusConfigContainerPath)
+                                 .WithPortBinding(ServiceBusAmqpPort, true)
+                                 .WithPortBinding(ServiceBusHealthPort, true)
+                                 .WithWaitStrategy(
+                                      Wait.ForUnixContainer()
+                                          .AddCustomWaitStrategy(new ServiceBusHealthWaitStrategy()))
+                                 .Build();
+
+        registerResource("network", network);
+        registerResource("sqledge", sqlEdgeContainer);
+        registerResource("servicebus", serviceBusContainer);
+
+        await network.CreateAsync().ConfigureAwait(false);
+        await StartContainerAsync(sqlEdgeContainer).ConfigureAwait(false);
+        await StartContainerAsync(serviceBusContainer).ConfigureAwait(false);
+    }
+
+    private sealed class ServiceBusHealthWaitStrategy : IWaitUntil
+    {
+        public async Task<bool> UntilAsync(IContainer container)
+        {
+            using var handler = new HttpClientHandler { UseProxy = false };
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(2) };
+            var healthEndpoint = new UriBuilder(
+                Uri.UriSchemeHttp,
+                container.Hostname,
+                container.GetMappedPublicPort(ServiceBusHealthPort),
+                "/health").Uri;
+
+            try
+            {
+                using var response = await client.GetAsync(healthEndpoint).ConfigureAwait(false);
+                return response.IsSuccessStatusCode;
+            }
+            catch (HttpRequestException)
+            {
+                return false;
+            }
+            catch (TaskCanceledException)
+            {
+                // The emulator accepts connections before the health endpoint is ready to respond.
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Migrates the Azure Event Hubs and Azure Service Bus emulator dependencies from Docker Compose to shared Testcontainers fixtures.

## Reason for change

The messaging emulators and their supporting Azurite and SQL Edge containers should only run while the Azure messaging tests need them to help reduce CI load.

## Implementation details

- Adds an Event Hubs fixture that manages the Event Hubs emulator, Azurite, and their shared network.
- Adds a Service Bus fixture that manages the Service Bus emulator, SQL Edge, and their shared network.
- Copies the emulator configuration files into the containers and waits for their health endpoints.
- Passes dynamically generated connection strings to the integration and Azure Functions messaging tests.
- Removes the migrated emulator dependencies from Docker Compose startup.

## Test coverage

Relying on CI for test coverage for this, I ran these initially in https://github.com/DataDog/dd-trace-dotnet/pull/8960.

## Other details
<!-- Fixes #{issue} -->

This is PR 7 of 10 in the Testcontainers migration
The original PR containing the complete set of changes is https://github.com/DataDog/dd-trace-dotnet/pull/8960.


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
