### PR TITLE
Migrate MongoDB and Elasticsearch tests to Testcontainers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,18 +14,11 @@ services:
 
   elasticsearch7_arm64:
     image: elasticsearch:7.10.1@sha256:7cd88158f6ac75d43b447fdd98c4eb69483fa7bf1be5616a85fe556262dc864a
-    ports:
-    - "9200"
-    - "9300"
-    environment:
-    - discovery.type=single-node
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    profiles: ["testcontainers"]
 
   mongo_arm64:
     image: mongo:5.0.31@sha256:54bcd8da3ea5eec561b68c605046c55c6b304387dc4c2bf5b3a5f5064fbb7495
-    ports:
-      - "27017"
-    command: mongod
+    profiles: ["testcontainers"]
 
   mysql_arm64:
     image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313
@@ -95,10 +88,7 @@ services:
 
   mongo:
     image: mongo:5.0.31@sha256:54bcd8da3ea5eec561b68c605046c55c6b304387dc4c2bf5b3a5f5064fbb7495
-    profiles: ["group2"]
-    ports:
-      - "127.0.0.1:27017:27017"
-    command: mongod
+    profiles: ["testcontainers"]
 
   couchbase:
     image: couchbase:community-6.6.0@sha256:43103efdd4b562366c7a48afa977c4ad148e09c877da28a83a86b2c5ee2daa97
@@ -106,33 +96,15 @@ services:
 
   elasticsearch7:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.14.1@sha256:2dcd2f31e246a8b13995ba24922da2edc3d88e65532ff301d0b92cb1be358af5
-    profiles: ["group2"]
-    ports:
-    - "127.0.0.1:9210:9200"
-    - "127.0.0.1:9310:9300"
-    environment:
-    - discovery.type=single-node
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    profiles: ["testcontainers"]
 
   elasticsearch6:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2@sha256:3da16b2f3b1d4e151c44f1a54f4f29d8be64884a64504b24ebcbdb4e14c80aa1
-    profiles: ["group2"]
-    ports:
-    - "127.0.0.1:9200:9200"
-    - "127.0.0.1:9300:9300"
-    environment:
-    - discovery.type=single-node
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    profiles: ["testcontainers"]
 
   elasticsearch5:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16@sha256:9ffbb6d9d0f383d70b8249117e5758dcf9c628a5ab3a78fd6a520ef1d0f416a2
-    profiles: ["group2"]
-    ports:
-    - "127.0.0.1:9205:9200"
-    - "127.0.0.1:9305:9300"
-    environment:
-    - discovery.type=single-node
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    profiles: ["testcontainers"]
 
   postgres:
     image: postgres:10.5-alpine@sha256:295a08ddd9efa1612c46033f0b96c3976f80f49c7ce29e05916b0af557806117
@@ -291,10 +263,6 @@ services:
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
       - IncludeAllTestFrameworks
-      - MONGO_HOST=mongo
-      - ELASTICSEARCH7_HOST=elasticsearch7:9200
-      - ELASTICSEARCH6_HOST=elasticsearch6:9200
-      - ELASTICSEARCH5_HOST=elasticsearch5:9200
       - AWS_SDK_HOST=localstack:4566
       - ORACLE_HOST=oracle
       - COSMOSDB_ENDPOINT=https://cosmosdb-emulator:8081
@@ -504,16 +472,12 @@ services:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     profiles: ["group2"]
     depends_on:
-      - elasticsearch7
-      - elasticsearch6
-      - elasticsearch5
-      - mongo
       - localstack
       - cosmosdb-emulator
       - test-agent
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch5:9200 elasticsearch6:9200 elasticsearch7:9200 mongo:27017 localstack:4566 cosmosdb-emulator:8081 test-agent:8126 test-agent:4317 test-agent:4318
+    command: localstack:4566 cosmosdb-emulator:8081 test-agent:8126 test-agent:4317 test-agent:4318
 
   IntegrationTests.ARM64:
     build:
@@ -545,10 +509,6 @@ services:
       - TESTCONTAINERS_RYUK_CONTAINER_IMAGE
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - IncludeAllTestFrameworks
-      - MONGO_HOST=mongo_arm64
-      - ELASTICSEARCH7_HOST=elasticsearch7_arm64:9200
-      - ELASTICSEARCH6_HOST=elasticsearch7_arm64:9200
-      - ELASTICSEARCH5_HOST=elasticsearch7_arm64:9200
       - AWS_SDK_HOST=localstack_arm64:4566
       - COSMOSDB_ENDPOINT=https://cosmosdb-emulator_arm64:8081
       - DD_LOGGER_DD_API_KEY
@@ -580,8 +540,6 @@ services:
       - RANDOM_SEED
       - TEST_AGENT_HOST=test-agent
     depends_on:
-      - elasticsearch7_arm64
-      - mongo_arm64
       - localstack_arm64
       - test-agent
       - cosmosdb-emulator_arm64
@@ -589,14 +547,12 @@ services:
   StartDependencies.ARM64:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
-      - elasticsearch7_arm64
-      - mongo_arm64
       - localstack_arm64
       - test-agent
       - cosmosdb-emulator_arm64
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch7_arm64:9200 mongo_arm64:27017 localstack_arm64:4566 test-agent:8126 test-agent:4317 test-agent:4318 cosmosdb-emulator_arm64:8081
+    command: localstack_arm64:4566 test-agent:8126 test-agent:4317 test-agent:4318 cosmosdb-emulator_arm64:8081
 
   IntegrationTests.ARM64.Debugger:
     build:
@@ -669,12 +625,10 @@ services:
   StartDependencies.OSXARM64:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
-      - elasticsearch7_osx_arm64
-      - mongo_osx_arm64
       - localstack_osx_arm64
     environment:
       - TIMEOUT_LENGTH=120
-    command: elasticsearch7_osx_arm64:9200 mongo_osx_arm64:27017 localstack_osx_arm64:4566
+    command: localstack_osx_arm64:4566
 
   # OSX ARM64 dependencies
 
@@ -692,18 +646,11 @@ services:
 
   elasticsearch7_osx_arm64:
     image: elasticsearch:7.10.1@sha256:7cd88158f6ac75d43b447fdd98c4eb69483fa7bf1be5616a85fe556262dc864a
-    ports:
-      - "9200:9200"
-      - "9300:9300"
-    environment:
-      - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    profiles: ["testcontainers"]
 
   mongo_osx_arm64:
     image: mongo:5.0.31@sha256:54bcd8da3ea5eec561b68c605046c55c6b304387dc4c2bf5b3a5f5064fbb7495
-    ports:
-      - "27017:27017"
-    command: mongod
+    profiles: ["testcontainers"]
 
   mysql_osx_arm64:
     image: mysql/mysql-server:8.0@sha256:d6c8301b7834c5b9c2b733b10b7e630f441af7bc917c74dba379f24eeeb6a313

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -268,10 +268,6 @@ internal static partial class DotNetSettingsExtensions
         where T : ToolSettings
     {
         return toolSettings
-              .SetProcessEnvironmentVariable("MONGO_HOST", "localhost")
-              .SetProcessEnvironmentVariable("ELASTICSEARCH7_HOST", "localhost:9200")
-              .SetProcessEnvironmentVariable("ELASTICSEARCH6_HOST", "localhost:9200")
-              .SetProcessEnvironmentVariable("ELASTICSEARCH5_HOST", "localhost:9200")
               .SetProcessEnvironmentVariable("AWS_SDK_HOST", "localhost:4566");
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsElasticsearchTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsElasticsearchTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="AspNetWebFormsElasticsearchTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [Trait("RequiresDockerDependency", "true")]
+    [Trait("DockerGroup", "2")]
+    [Collection(Elasticsearch6Collection.Name)]
+    public class AspNetWebFormsElasticsearchTests : TracingIntegrationTest, IClassFixture<IisFixture>, IAsyncLifetime
+    {
+        private readonly IisFixture _iisFixture;
+
+        public AspNetWebFormsElasticsearchTests(IisFixture iisFixture, Elasticsearch6Fixture elasticsearchFixture, ITestOutputHelper output)
+            : base("WebForms", @"test\test-applications\aspnet", output)
+        {
+            SetServiceVersion("1.0.0");
+            ConfigureContainers(elasticsearchFixture);
+
+            _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/account/login?shutdown=1";
+        }
+
+        public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) =>
+            span.Name switch
+            {
+                "aspnet.request" => span.IsAspNet(metadataSchemaVersion),
+                "aspnet-mvc.request" => span.IsAspNetMvc(metadataSchemaVersion),
+                _ => Result.DefaultSuccess,
+            };
+
+        [Fact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
+        [Trait("SkipInCI", "True")] // This local-only Windows test requires a Linux Elasticsearch container.
+        public async Task NestedAsyncElasticCallSubmitsTrace()
+        {
+            var testStart = DateTime.UtcNow;
+            using (var httpClient = new HttpClient())
+            {
+                // disable tracing for this HttpClient request
+                httpClient.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+
+                var response = await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}" + "/Database/Elasticsearch");
+                var content = await response.Content.ReadAsStringAsync();
+                Output.WriteLine($"[http] {response.StatusCode} {content}");
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+
+            var allSpans = (await _iisFixture.Agent.WaitForSpansAsync(3, minDateTime: testStart))
+                                   .OrderBy(s => s.Start)
+                                   .ToList();
+
+            Assert.True(allSpans.Count > 0, "Expected there to be spans.");
+            ValidateIntegrationSpans(allSpans, metadataSchemaVersion: "v0", expectedServiceName: "sample", isExternalSpan: false);
+
+            var elasticSpans = allSpans
+                             .Where(s => s.Type == "elasticsearch")
+                             .ToList();
+
+            Assert.True(elasticSpans.Count > 0, "Expected elasticsearch spans.");
+
+            foreach (var span in elasticSpans)
+            {
+                Assert.Equal("elasticsearch.query", span.Name);
+                Assert.Equal("Development Web Site-elasticsearch", span.Service);
+                Assert.Equal("elasticsearch", span.Type);
+            }
+        }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
+
+        public Task DisposeAsync() => Task.CompletedTask;
+    }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -5,10 +5,7 @@
 
 #if NETFRAMEWORK
 
-using System;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -61,46 +58,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 SpanTypes.Web,
                 expectedResourceName,
                 "1.0.0");
-        }
-
-        [Fact]
-        [Trait("Category", "EndToEnd")]
-        [Trait("RunOnWindows", "True")]
-        [Trait("LoadFromGAC", "True")]
-        [Trait("SkipInCI", "True")] // This test requires Elasticsearch to be running on the host, which is not currently enabled in CI.
-        public async Task NestedAsyncElasticCallSubmitsTrace()
-        {
-            var testStart = DateTime.UtcNow;
-            using (var httpClient = new HttpClient())
-            {
-                // disable tracing for this HttpClient request
-                httpClient.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
-
-                var response = await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}" + "/Database/Elasticsearch");
-                var content = await response.Content.ReadAsStringAsync();
-                Output.WriteLine($"[http] {response.StatusCode} {content}");
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            }
-
-            var allSpans = (await _iisFixture.Agent.WaitForSpansAsync(3, minDateTime: testStart))
-                                   .OrderBy(s => s.Start)
-                                   .ToList();
-
-            Assert.True(allSpans.Count > 0, "Expected there to be spans.");
-            ValidateIntegrationSpans(allSpans, metadataSchemaVersion: "v0", expectedServiceName: "sample", isExternalSpan: false);
-
-            var elasticSpans = allSpans
-                             .Where(s => s.Type == "elasticsearch")
-                             .ToList();
-
-            Assert.True(elasticSpans.Count > 0, "Expected elasticsearch spans.");
-
-            foreach (var span in elasticSpans)
-            {
-                Assert.Equal("elasticsearch.query", span.Name);
-                Assert.Equal("Development Web Site-elasticsearch", span.Service);
-                Assert.Equal("elasticsearch", span.Type);
-            }
         }
 
         public Task InitializeAsync() => _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,16 +19,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(Elasticsearch5Collection.Name)]
     [UsesVerify]
     public class Elasticsearch5Tests : TracingIntegrationTest
     {
         private const string ServiceName = "Samples.Elasticsearch";
+        private readonly Elasticsearch5Fixture _elasticsearchFixture;
 
-        public Elasticsearch5Tests(ITestOutputHelper output)
+        public Elasticsearch5Tests(ITestOutputHelper output, Elasticsearch5Fixture elasticsearchFixture)
             : base("Elasticsearch.V5", output)
         {
+            _elasticsearchFixture = elasticsearchFixture;
             SetServiceName(ServiceName);
             SetServiceVersion("1.0.0");
+            ConfigureContainers(elasticsearchFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -151,20 +156,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  .OrderBy(s => s.Start)
                                  .ToList();
 
-                var host = Environment.GetEnvironmentVariable("ELASTICSEARCH5_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
-                // normalise between running directly against localhost and against elasticsearch containers
+                // Normalise the dynamically-mapped Testcontainers endpoint.
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: elasticsearch");
-                settings.AddSimpleScrubber("out.host: elasticsearch5", "out.host: elasticsearch");
-                settings.AddSimpleScrubber("out.host: elasticsearch7_arm64", "out.host: elasticsearch");
+                settings.AddSimpleScrubber($"out.host: {_elasticsearchFixture.Host}", "out.host: elasticsearch");
+                settings.AddSimpleScrubber($"out.port: {_elasticsearchFixture.Port}", "out.port: 9200");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: elasticsearch");
-                settings.AddSimpleScrubber("peer.service: elasticsearch5", "peer.service: elasticsearch");
-                settings.AddSimpleScrubber("peer.service: elasticsearch7_arm64", "peer.service: elasticsearch");
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
+                settings.AddSimpleScrubber($"peer.service: {_elasticsearchFixture.Host}", "peer.service: elasticsearch");
+                settings.AddSimpleScrubber(_elasticsearchFixture.HostAndPort, "localhost:00000");
 
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseTextForParameters($"Schema{metadataSchemaVersion.ToUpper()}")

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -7,9 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,16 +20,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(Elasticsearch6Collection.Name)]
     [UsesVerify]
     public class Elasticsearch6Tests : TracingIntegrationTest
     {
         private const string ServiceName = "Samples.Elasticsearch";
+        private readonly Elasticsearch6Fixture _elasticsearchFixture;
 
-        public Elasticsearch6Tests(ITestOutputHelper output)
+        public Elasticsearch6Tests(ITestOutputHelper output, Elasticsearch6Fixture elasticsearchFixture)
             : base("Elasticsearch", output)
         {
+            _elasticsearchFixture = elasticsearchFixture;
             SetServiceName(ServiceName);
             SetServiceVersion("1.0.0");
+            ConfigureContainers(elasticsearchFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -169,20 +175,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     _ => "6_0"
                 };
 
-                var host = Environment.GetEnvironmentVariable("ELASTICSEARCH6_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
-                // normalise between running directly against localhost and against elasticsearch containers
+                // Normalise the dynamically-mapped Testcontainers endpoint.
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: elasticsearch");
-                settings.AddSimpleScrubber("out.host: elasticsearch6", "out.host: elasticsearch");
-                settings.AddSimpleScrubber("out.host: elasticsearch7_arm64", "out.host: elasticsearch");
+                settings.AddSimpleScrubber($"out.host: {_elasticsearchFixture.Host}", "out.host: elasticsearch");
+                settings.AddSimpleScrubber($"out.port: {_elasticsearchFixture.Port}", "out.port: 9200");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: elasticsearch");
-                settings.AddSimpleScrubber("peer.service: elasticsearch6", "peer.service: elasticsearch");
-                settings.AddSimpleScrubber("peer.service: elasticsearch7_arm64", "peer.service: elasticsearch");
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
+                settings.AddSimpleScrubber($"peer.service: {_elasticsearchFixture.Host}", "peer.service: elasticsearch");
+                settings.AddSimpleScrubber(_elasticsearchFixture.HostAndPort, "localhost:00000");
 
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseTextForParameters($"packageVersion={snapshotSuffix}.Schema{metadataSchemaVersion.ToUpper()}")

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,16 +19,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(Elasticsearch7Collection.Name)]
     [UsesVerify]
     public class Elasticsearch7Tests : TracingIntegrationTest
     {
         private const string ServiceName = "Samples.Elasticsearch";
+        private readonly Elasticsearch7Fixture _elasticsearchFixture;
 
-        public Elasticsearch7Tests(ITestOutputHelper output)
+        public Elasticsearch7Tests(ITestOutputHelper output, Elasticsearch7Fixture elasticsearchFixture)
             : base("Elasticsearch.V7", output)
         {
+            _elasticsearchFixture = elasticsearchFixture;
             SetServiceName(ServiceName);
             SetServiceVersion("1.0.0");
+            ConfigureContainers(elasticsearchFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -157,20 +163,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  .OrderBy(s => s.Start)
                                  .ToList();
 
-                var host = Environment.GetEnvironmentVariable("ELASTICSEARCH7_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
-                // normalise between running directly against localhost and against elasticsearch containers
+                // Normalise the dynamically-mapped Testcontainers endpoint.
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: elasticsearch");
-                settings.AddSimpleScrubber("out.host: elasticsearch7", "out.host: elasticsearch");
-                settings.AddSimpleScrubber("out.host: elasticsearch7_arm64", "out.host: elasticsearch");
+                settings.AddSimpleScrubber($"out.host: {_elasticsearchFixture.Host}", "out.host: elasticsearch");
+                settings.AddSimpleScrubber($"out.port: {_elasticsearchFixture.Port}", "out.port: 9200");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: elasticsearch");
-                settings.AddSimpleScrubber("peer.service: elasticsearch7", "peer.service: elasticsearch");
-                settings.AddSimpleScrubber("peer.service: elasticsearch7_arm64", "peer.service: elasticsearch");
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
+                settings.AddSimpleScrubber($"peer.service: {_elasticsearchFixture.Host}", "peer.service: elasticsearch");
+                settings.AddSimpleScrubber(_elasticsearchFixture.HostAndPort, "localhost:00000");
 
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .UseTextForParameters($"Schema{metadataSchemaVersion.ToUpper()}")

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
@@ -18,6 +18,30 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
     }
 
     [CollectionDefinition(Name, DisableParallelization = true)]
+    public class MongoDbCollection : ICollectionFixture<MongoDbFixture>
+    {
+        public const string Name = "MongoDb";
+    }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class Elasticsearch5Collection : ICollectionFixture<Elasticsearch5Fixture>
+    {
+        public const string Name = "Elasticsearch5";
+    }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class Elasticsearch6Collection : ICollectionFixture<Elasticsearch6Fixture>
+    {
+        public const string Name = "Elasticsearch6";
+    }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class Elasticsearch7Collection : ICollectionFixture<Elasticsearch7Fixture>
+    {
+        public const string Name = "Elasticsearch7";
+    }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
     public class ServiceStackRedisCollection : ICollectionFixture<ServiceStackRedisFixture>
     {
         public const string Name = "ServiceStackRedis";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -9,8 +9,10 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using VerifyXunit;
@@ -21,6 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(MongoDbCollection.Name)]
     [UsesVerify]
     public class MongoDbTests : TracingIntegrationTest
     {
@@ -28,11 +31,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         private static readonly Regex ObjectIdRegex = new(@"ObjectId\("".*?""\)");
         private static readonly Regex OIdRegex = new("""\{\s*"\$oid" : "[0-9a-f]+" \}""");
         private static readonly Regex Base64Regex = new("""base64"\s*:\s*"[a-zA-Z0-9+\\]+=*",""");
+        private readonly MongoDbFixture _mongoDbFixture;
 
-        public MongoDbTests(ITestOutputHelper output)
+        public MongoDbTests(ITestOutputHelper output, MongoDbFixture mongoDbFixture)
             : base("MongoDB", output)
         {
+            _mongoDbFixture = mongoDbFixture;
             SetServiceVersion("1.0.0");
+            ConfigureContainers(mongoDbFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -81,8 +87,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // normalise between running directly against localhost and against mongo container
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: mongo");
                 settings.AddSimpleScrubber("out.host: mongo_arm64", "out.host: mongo");
+                settings.AddSimpleScrubber($"out.host: {_mongoDbFixture.Host}", "out.host: mongo");
+                settings.AddSimpleScrubber($"out.port: {_mongoDbFixture.Port}", "out.port: 27017");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: mongo");
                 settings.AddSimpleScrubber("peer.service: mongo_arm64", "peer.service: mongo");
+                settings.AddSimpleScrubber($"peer.service: {_mongoDbFixture.Host}", "peer.service: mongo");
                 // In some package versions, aggregate queries have an ID, others don't
                 settings.AddSimpleScrubber("\"$group\" : { \"_id\" : null, \"n\"", "\"$group\" : { \"_id\" : 1, \"n\"");
                 // In 2.19, The explain query includes { "$expr" : true }, whereas in earlier versions it doesn't

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/Elasticsearch5Fixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/Elasticsearch5Fixture.cs
@@ -1,0 +1,20 @@
+// <copyright file="Elasticsearch5Fixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class Elasticsearch5Fixture : ElasticsearchFixture
+{
+    private const string Image = "docker.elastic.co/elasticsearch/elasticsearch:5.6.16@sha256:9ffbb6d9d0f383d70b8249117e5758dcf9c628a5ab3a78fd6a520ef1d0f416a2";
+    private const string Password = "changeme";
+    private const string Username = "elastic";
+
+    public Elasticsearch5Fixture()
+        : base("ELASTICSEARCH5_HOST", SelectImage(Image), Username, Password)
+    {
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/Elasticsearch6Fixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/Elasticsearch6Fixture.cs
@@ -1,0 +1,18 @@
+// <copyright file="Elasticsearch6Fixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class Elasticsearch6Fixture : ElasticsearchFixture
+{
+    private const string Image = "docker.elastic.co/elasticsearch/elasticsearch:6.4.2@sha256:3da16b2f3b1d4e151c44f1a54f4f29d8be64884a64504b24ebcbdb4e14c80aa1";
+
+    public Elasticsearch6Fixture()
+        : base("ELASTICSEARCH6_HOST", SelectImage(Image))
+    {
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/Elasticsearch7Fixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/Elasticsearch7Fixture.cs
@@ -1,0 +1,18 @@
+// <copyright file="Elasticsearch7Fixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class Elasticsearch7Fixture : ElasticsearchFixture
+{
+    private const string X64Image = "docker.elastic.co/elasticsearch/elasticsearch:7.14.1@sha256:2dcd2f31e246a8b13995ba24922da2edc3d88e65532ff301d0b92cb1be358af5";
+
+    public Elasticsearch7Fixture()
+        : base("ELASTICSEARCH7_HOST", SelectImage(X64Image))
+    {
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ElasticsearchFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ElasticsearchFixture.cs
@@ -1,0 +1,91 @@
+// <copyright file="ElasticsearchFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Newtonsoft.Json.Linq;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public abstract class ElasticsearchFixture : ContainerFixture
+{
+    private const int ElasticsearchPort = 9200;
+    private const string Arm64Image = "elasticsearch:7.10.1@sha256:7cd88158f6ac75d43b447fdd98c4eb69483fa7bf1be5616a85fe556262dc864a";
+    private readonly string _environmentVariable;
+    private readonly string _image;
+    private readonly string? _readinessPassword;
+    private readonly string? _readinessUsername;
+
+    protected ElasticsearchFixture(string environmentVariable, string image)
+    {
+        _environmentVariable = environmentVariable;
+        _image = image;
+    }
+
+    protected ElasticsearchFixture(string environmentVariable, string image, string readinessUsername, string readinessPassword)
+        : this(environmentVariable, image)
+    {
+        _readinessUsername = readinessUsername;
+        _readinessPassword = readinessPassword;
+    }
+
+    public string Host => Container.Hostname;
+
+    public ushort Port => Container.GetMappedPublicPort(ElasticsearchPort);
+
+    public string HostAndPort => $"{Host}:{Port}";
+
+    private IContainer Container => GetResource<IContainer>("container");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new(_environmentVariable, HostAndPort);
+    }
+
+    protected static string SelectImage(string image) =>
+        RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? Arm64Image : image;
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        var container = new ContainerBuilder(_image)
+                       .WithPortBinding(ElasticsearchPort, true)
+                       .WithEnvironment("discovery.type", "single-node")
+                       .WithEnvironment("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+                       .WithWaitStrategy(
+                            Wait.ForUnixContainer()
+                                .UntilHttpRequestIsSucceeded(
+                                     ConfigureReadinessRequest,
+                                     strategy => strategy.WithTimeout(TimeSpan.FromMinutes(2))))
+                       .Build();
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+    }
+
+    private static async Task<bool> IsClusterReady(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return JObject.Parse(content).Value<string>("status") is "yellow" or "green";
+    }
+
+    private HttpWaitStrategy ConfigureReadinessRequest(HttpWaitStrategy request)
+    {
+        request.ForPort(ElasticsearchPort)
+               .ForPath("/_cluster/health")
+               .ForResponseMessageMatching(IsClusterReady);
+
+        return _readinessUsername is not null && _readinessPassword is not null
+                   ? request.WithBasicAuthentication(_readinessUsername, _readinessPassword)
+                   : request;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/MongoDbFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/MongoDbFixture.cs
@@ -1,0 +1,47 @@
+// <copyright file="MongoDbFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class MongoDbFixture : ContainerFixture
+{
+    private const int MongoDbPort = 27017;
+    private const string Image = "mongo:5.0.31@sha256:54bcd8da3ea5eec561b68c605046c55c6b304387dc4c2bf5b3a5f5064fbb7495";
+
+    public string Host => Container.Hostname;
+
+    public ushort Port => Container.GetMappedPublicPort(MongoDbPort);
+
+    private IContainer Container => GetResource<IContainer>("container");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("MONGO_HOST", Host);
+        yield return new("MONGO_PORT", Port.ToString());
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        var container = new ContainerBuilder(Image)
+                       .WithPortBinding(MongoDbPort, true)
+                       .WithWaitStrategy(
+                            Wait.ForUnixContainer()
+                                .UntilCommandIsCompleted(
+                                     ["mongo", "--quiet", "--eval", "db.adminCommand({ ping: 1 }).ok"],
+                                     strategy => strategy.WithTimeout(TimeSpan.FromMinutes(2))))
+                       .Build();
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+    }
+}

--- a/tracer/test/test-applications/aspnet/Samples.WebForms/Database/Elasticsearch.aspx.cs
+++ b/tracer/test/test-applications/aspnet/Samples.WebForms/Database/Elasticsearch.aspx.cs
@@ -13,15 +13,17 @@ namespace Samples.WebForms.Database
             RegisterAsyncTask(new PageAsyncTask(CallElasticsearch));
         }
 
-        private static string Host()
+        private static Uri Endpoint()
         {
-            return Environment.GetEnvironmentVariable("ELASTICSEARCH_HOST") ?? "localhost";
+            var endpoint = Environment.GetEnvironmentVariable("ELASTICSEARCH6_HOST");
+            return endpoint is null
+                       ? new Uri("http://" + (Environment.GetEnvironmentVariable("ELASTICSEARCH_HOST") ?? "localhost") + ":9200")
+                       : new Uri("http://" + endpoint);
         }
 
         private async Task CallElasticsearch()
         {
-            var host = new Uri("http://" + Host() + ":9200");
-            var settings = new ConnectionSettings(host).DefaultIndex("elastic-net-example");
+            var settings = new ConnectionSettings(Endpoint()).DefaultIndex("elastic-net-example");
             var elastic = new ElasticClient(settings);
 
             await elastic.ClusterHealthAsync(new ClusterHealthRequest());

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -19,6 +19,11 @@ namespace Samples.MongoDB
             return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
         }
 
+        private static string Port()
+        {
+            return Environment.GetEnvironmentVariable("MONGO_PORT") ?? "27017";
+        }
+
         public static void Main(string[] args)
         {
             Console.WriteLine($"Profiler attached: {SampleHelpers.IsProfilerAttached()}");
@@ -56,7 +61,7 @@ namespace Samples.MongoDB
 
             using (var mainScope = _sampleHelpers.CreateScope("Main()"))
             {
-                var connectionString = $"mongodb://{Host()}:27017";
+                var connectionString = $"mongodb://{Host()}:{Port()}";
                 var client = new MongoClient(connectionString);
                 var database = client.GetDatabase("test-db");
                 var collection = database.GetCollection<BsonDocument>("employees");


### PR DESCRIPTION
## Summary of changes

Migrates the MongoDB and Elasticsearch 5, 6, and 7 integration tests from Docker Compose-managed dependencies to shared Testcontainers fixtures.

## Reason for change

Only run their containers when the related test(s) are running to help reduce CI load.

## Implementation details

- Adds a MongoDB fixture with an explicit readiness check.
- Adds version-specific Elasticsearch fixtures with shared lifecycle and health-check behavior.
- Preserves the ARM64 Elasticsearch image fallback.
- Normalizes dynamically mapped endpoints in snapshots.
- Moves the Web Forms Elasticsearch test into its own fixture-backed test class.
- Removes the migrated MongoDB and Elasticsearch dependencies from Docker Compose startup.

## Test coverage

Relying on CI for test coverage for this, I ran these initially in https://github.com/DataDog/dd-trace-dotnet/pull/8960.

## Other details
<!-- Fixes #{issue} -->

This is PR 8 of 10 in the Testcontainers migration
The original PR containing the complete set of changes is https://github.com/DataDog/dd-trace-dotnet/pull/8960.


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
