### PR TITLE
Run LocalStack integration tests with Testcontainers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,8 +381,6 @@ cmake-build-debug/
 #datadog coverage
 datadog-coverage-*
 
-.localstack/*
-
 # nuke
 .nuke/build.schema.json
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,7 @@ services:
   # ARM64 dependencies
   localstack_arm64:
     image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
-    environment:
-      - SERVICES=sns,sqs,kinesis,dynamodb,events,s3,stepfunctions,lambda
-      - DEBUG=1
-      - DATA_DIR=/tmp/localstack/data
-      - DEFAULT_REGION=us-east-1
-    ports:
-      - "4566:4566"
+    profiles: ["testcontainers"]
 
   elasticsearch7_arm64:
     image: elasticsearch:7.10.1@sha256:7cd88158f6ac75d43b447fdd98c4eb69483fa7bf1be5616a85fe556262dc864a
@@ -51,16 +45,7 @@ services:
 # Dependencies
   localstack:
     image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
-    profiles: ["group2"]
-    environment:
-      - SERVICES=sns,sqs,kinesis,dynamodb,events,s3,stepfunctions,lambda
-      - DEBUG=1
-      - DATA_DIR=/tmp/localstack/data
-      - DEFAULT_REGION=us-east-1
-    ports:
-      - "4566:4566"
-    volumes:
-      - "./.localstack:/tmp"
+    profiles: ["testcontainers"]
 
   rabbitmq:
     image: rabbitmq:3-management@sha256:e582c0bc7766f3342496d8485efb5a1df782b5ce3886ad017e2eaae442311f69
@@ -258,7 +243,6 @@ services:
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
       - IncludeAllTestFrameworks
-      - AWS_SDK_HOST=localstack:4566
       - ORACLE_HOST=oracle
       - TEST_AGENT_HOST=test-agent
       - CONTAINER_HOSTNAME=http://integrationtests
@@ -466,11 +450,10 @@ services:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     profiles: ["group2"]
     depends_on:
-      - localstack
       - test-agent
     environment:
       - TIMEOUT_LENGTH=120
-    command: localstack:4566 test-agent:8126 test-agent:4317 test-agent:4318
+    command: test-agent:8126 test-agent:4317 test-agent:4318
 
   IntegrationTests.ARM64:
     build:
@@ -502,7 +485,6 @@ services:
       - TESTCONTAINERS_RYUK_CONTAINER_IMAGE
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - IncludeAllTestFrameworks
-      - AWS_SDK_HOST=localstack_arm64:4566
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_TRACE_LOG_DIRECTORY=/project/artifacts/build_data/infra_logs
       - DD_LOGGER_DD_SERVICE
@@ -532,17 +514,15 @@ services:
       - RANDOM_SEED
       - TEST_AGENT_HOST=test-agent
     depends_on:
-      - localstack_arm64
       - test-agent
 
   StartDependencies.ARM64:
     image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
     depends_on:
-      - localstack_arm64
       - test-agent
     environment:
       - TIMEOUT_LENGTH=120
-    command: localstack_arm64:4566 test-agent:8126 test-agent:4317 test-agent:4318
+    command: test-agent:8126 test-agent:4317 test-agent:4318
 
   IntegrationTests.ARM64.Debugger:
     build:
@@ -612,27 +592,11 @@ services:
     # api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
     - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,meta.network.client.ip,meta.http.client_ip,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers,meta._dd.appsec.fp.http.endpoint,meta._dd.appsec.fp.http.header,meta._dd.appsec.fp.http.network
 
-  StartDependencies.OSXARM64:
-    image: andrewlock/wait-for-dependencies:latest@sha256:5d87561de8c019c3954298f707c1f6d7087f620a1ce36c3ec38cdfbc1ec4066e
-    depends_on:
-      - localstack_osx_arm64
-    environment:
-      - TIMEOUT_LENGTH=120
-    command: localstack_osx_arm64:4566
-
   # OSX ARM64 dependencies
 
   localstack_osx_arm64:
     image: localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
-    environment:
-      - SERVICES=sns,sqs,kinesis,dynamodb,events,s3,stepfunctions,lambda
-      - DEBUG=1
-      - DATA_DIR=/tmp/localstack/data
-      - DEFAULT_REGION=us-east-1
-    ports:
-      - "4566:4566"
-    volumes:
-      - "./.localstack:/tmp"
+    profiles: ["testcontainers"]
 
   elasticsearch7_osx_arm64:
     image: elasticsearch:7.10.1@sha256:7cd88158f6ac75d43b447fdd98c4eb69483fa7bf1be5616a85fe556262dc864a

--- a/tracer/README.md
+++ b/tracer/README.md
@@ -151,20 +151,13 @@ brew install cmake
 # Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
 ./build.sh PackageTracerHome
 
-# Start IntergrationTests dependencies, but only for a specific test
-docker-compose up rabbitmq_osx_arm64
-
-# Start IntegrationTests dependencies.
-docker-compose up StartDependencies.OSXARM64
-
-# Build and run integration tests. Requires BuildTracerHome to have previously been run
+# Build and run integration tests. Requires BuildTracerHome to have previously been run.
+# Testcontainers-backed Docker dependencies are started automatically.
 ./build.sh BuildAndRunIntegrationTests
 
 # Build and run integration tests filtering on one framework, one set of tests and a sample app.
 ./build.sh BuildAndRunIntegrationTests --framework "net6.0" --filter "Datadog.Trace.ClrProfiler.IntegrationTests.RabbitMQTests" --SampleName "Samples.Rabbit"
 
-# Stop IntegrationTests dependencies.
-docker-compose down
 ```
 
 Troubleshooting tips for build errors:

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -264,13 +264,6 @@ internal static partial class DotNetSettingsExtensions
         return settings;
     }
 
-    public static T SetLocalOsxEnvironmentVariables<T>(this T toolSettings)
-        where T : ToolSettings
-    {
-        return toolSettings
-              .SetProcessEnvironmentVariable("AWS_SDK_HOST", "localhost:4566");
-    }
-
     public static T ConfigureDotNetRunSettings<T>(this T toolSettings, Func<T, T> configure) where T : DotNetRunSettings
     {
         return configure(toolSettings);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsDynamoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsDynamoDbTests.cs
@@ -3,12 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -18,12 +19,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(LocalStackCollection.Name)]
     [UsesVerify]
     public class AwsDynamoDbTests : TracingIntegrationTest
     {
-        public AwsDynamoDbTests(ITestOutputHelper output)
+        private readonly LocalStackFixture _localStackFixture;
+
+        public AwsDynamoDbTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.DynamoDBv2", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -58,22 +64,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 dynamoDbSpans.Should().NotBeEmpty();
                 ValidateIntegrationSpans(dynamoDbSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 settings.UseFileName($"{nameof(AwsDynamoDbTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_dynamodb");
-                settings.AddSimpleScrubber("out.host: localstack", "out.host: aws_dynamodb");
-                settings.AddSimpleScrubber("out.host: localstack_arm64", "out.host: aws_dynamodb");
+                settings.AddSimpleScrubber($"out.host: {_localStackFixture.Host}", "out.host: aws_dynamodb");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_dynamodb");
-                settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_dynamodb");
-                settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_dynamodb");
+                settings.AddSimpleScrubber($"peer.service: {_localStackFixture.Host}", "peer.service: aws_dynamodb");
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
                 // V4 uses the sockets handler by default where possible instead of the httpclienthandler
                 settings.AddSimpleScrubber("http-client-handler-type: System.Net.Http.SocketsHttpHandler", "http-client-handler-type: System.Net.Http.HttpClientHandler");
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
 
                 settings.DisableRequireUniquePrefix();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsEventBridgeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsEventBridgeTests.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -18,12 +20,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(LocalStackCollection.Name)]
     [UsesVerify]
     public class AwsEventBridgeTests : TracingIntegrationTest
     {
-        public AwsEventBridgeTests(ITestOutputHelper output)
+        private readonly LocalStackFixture _localStackFixture;
+
+        public AwsEventBridgeTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.EventBridge", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -63,23 +70,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 eventBridgeSpans.Should().NotBeEmpty();
                 ValidateIntegrationSpans(eventBridgeSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
 
                 settings.UseFileName($"{nameof(AwsEventBridgeTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_eventbridge");
-                settings.AddSimpleScrubber("out.host: localstack", "out.host: aws_eventbridge");
-                settings.AddSimpleScrubber("out.host: localstack_arm64", "out.host: aws_eventbridge");
+                settings.AddSimpleScrubber($"out.host: {_localStackFixture.Host}", "out.host: aws_eventbridge");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_eventbridge");
-                settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_eventbridge");
-                settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_eventbridge");
+                settings.AddSimpleScrubber($"peer.service: {_localStackFixture.Host}", "peer.service: aws_eventbridge");
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
                 // V4 uses the sockets handler by default where possible instead of the httpclienthandler
                 settings.AddSimpleScrubber("http-client-handler-type: System.Net.Http.SocketsHttpHandler", "http-client-handler-type: System.Net.Http.HttpClientHandler");
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
 
                 settings.DisableRequireUniquePrefix();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -18,15 +20,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(LocalStackCollection.Name)]
     [UsesVerify]
     public class AwsKinesisTests : TracingIntegrationTest
     {
         // Keep in sync with Samples.AWS.Kinesis
         private const string PreTestCleanupOperationName = "KINESIS-CLEAN-UP-SHOULD-NOT-BE-IN-SNAPSHOT";
+        private readonly LocalStackFixture _localStackFixture;
 
-        public AwsKinesisTests(ITestOutputHelper output)
+        public AwsKinesisTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.Kinesis", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -65,22 +71,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 kinesisSpans.Should().NotBeEmpty();
                 ValidateIntegrationSpans(kinesisSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 settings.UseFileName($"{nameof(AwsKinesisTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_kinesis");
-                settings.AddSimpleScrubber("out.host: localstack", "out.host: aws_kinesis");
-                settings.AddSimpleScrubber("out.host: localstack_arm64", "out.host: aws_kinesis");
+                settings.AddSimpleScrubber($"out.host: {_localStackFixture.Host}", "out.host: aws_kinesis");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_kinesis");
-                settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_kinesis");
-                settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_kinesis");
+                settings.AddSimpleScrubber($"peer.service: {_localStackFixture.Host}", "peer.service: aws_kinesis");
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
                 // V4 uses the sockets handler by default where possible instead of the httpclienthandler
                 settings.AddSimpleScrubber("http-client-handler-type: System.Net.Http.SocketsHttpHandler", "http-client-handler-type: System.Net.Http.HttpClientHandler");
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
 
                 settings.DisableRequireUniquePrefix();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsS3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsS3Tests.cs
@@ -8,8 +8,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -19,12 +21,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(LocalStackCollection.Name)]
     [UsesVerify]
     public class AwsS3Tests : TracingIntegrationTest
     {
-        public AwsS3Tests(ITestOutputHelper output)
+        private readonly LocalStackFixture _localStackFixture;
+
+        public AwsS3Tests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.S3", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -63,19 +70,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 s3Spans.Should().NotBeEmpty();
                 ValidateIntegrationSpans(s3Spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
 
                 settings.UseFileName($"{nameof(AwsS3Tests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
                 settings.AddRegexScrubber(
                     new Regex(@"(http\.url: .*?my-bucket)(?=,)"),
                     "$1/");
-
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
 
                 settings.DisableRequireUniquePrefix();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -19,12 +20,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(LocalStackCollection.Name)]
     [UsesVerify]
     public class AwsSnsTests : TracingIntegrationTest
     {
-        public AwsSnsTests(ITestOutputHelper output)
+        private readonly LocalStackFixture _localStackFixture;
+
+        public AwsSnsTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.SimpleNotificationService", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -64,25 +70,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 snsSpans.Should().NotBeEmpty();
                 ValidateIntegrationSpans(snsSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 var suffix = GetSnapshotSuffix(packageVersion);
 
                 settings.UseFileName($"{nameof(AwsSnsTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}{suffix}");
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_sns");
-                settings.AddSimpleScrubber("out.host: localstack", "out.host: aws_sns");
-                settings.AddSimpleScrubber("out.host: localstack_arm64", "out.host: aws_sns");
+                settings.AddSimpleScrubber($"out.host: {_localStackFixture.Host}", "out.host: aws_sns");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_sns");
-                settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_sns");
-                settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_sns");
+                settings.AddSimpleScrubber($"peer.service: {_localStackFixture.Host}", "peer.service: aws_sns");
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
                 // V4 uses the sockets handler by default where possible instead of the httpclienthandler
                 settings.AddSimpleScrubber("http-client-handler-type: System.Net.Http.SocketsHttpHandler", "http-client-handler-type: System.Net.Http.HttpClientHandler");
-
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
 
                 settings.DisableRequireUniquePrefix();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -6,10 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -17,15 +18,19 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
-    [Collection(nameof(AwsSqsTestsCollection))]
+    [Collection(LocalStackCollection.Name)]
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
     [UsesVerify]
     public class AwsSqsTests : TracingIntegrationTest
     {
-        public AwsSqsTests(ITestOutputHelper output)
+        private readonly LocalStackFixture _localStackFixture;
+
+        public AwsSqsTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.SQS", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -66,27 +71,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 sqsSpans.Should().NotBeEmpty();
                 ValidateIntegrationSpans(sqsSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 var suffix = GetSnapshotSuffix(packageVersion);
 
                 settings.UseFileName($"{nameof(AwsSqsTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}{suffix}");
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_sqs");
-                settings.AddSimpleScrubber("out.host: localstack", "out.host: aws_sqs");
-                settings.AddSimpleScrubber("out.host: localstack_arm64", "out.host: aws_sqs");
+                settings.AddSimpleScrubber($"out.host: {_localStackFixture.Host}", "out.host: aws_sqs");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_sqs");
-                settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_sqs");
-                settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_sqs");
-                settings.AddSimpleScrubber("aws.queue.url: localstack_arm64", "peer.service: aws_sqs");
-                settings.AddRegexScrubber(new Regex(@"sqs\..+\.localhost.*\.localstack.*\.cloud:4566"), "localhost:00000");
+                settings.AddSimpleScrubber($"peer.service: {_localStackFixture.Host}", "peer.service: aws_sqs");
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
+                settings.AddSimpleScrubber("/queue/us-east-1", string.Empty);
                 // V4 uses the sockets handler by default where possible instead of the httpclienthandler
                 settings.AddSimpleScrubber("http-client-handler-type: System.Net.Http.SocketsHttpHandler", "http-client-handler-type: System.Net.Http.HttpClientHandler");
-
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
 
                 settings.DisableRequireUniquePrefix();
 
@@ -106,13 +102,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                         _ => string.Empty
                     };
             }
-        }
-
-        [CollectionDefinition(nameof(AwsSqsTestsCollection), DisableParallelization = true)]
-        public class AwsSqsTestsCollection
-        {
-            // Just an empty collection that's going to be used to prevent different SQS tests relying on the same "backend" (an SQS queue)
-            // from running at the same time, which would cause unwanted interactions between them and make tests fail.
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsStepFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsStepFunctionsTests.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using FluentAssertions;
 using VerifyXunit;
 using Xunit;
@@ -18,12 +20,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(LocalStackCollection.Name)]
     [UsesVerify]
     public class AwsStepFunctionsTests : TracingIntegrationTest
     {
-        public AwsStepFunctionsTests(ITestOutputHelper output)
+        private readonly LocalStackFixture _localStackFixture;
+
+        public AwsStepFunctionsTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.StepFunctions", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -63,8 +70,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 stepFunctionsSpans.Should().NotBeEmpty();
                 ValidateIntegrationSpans(stepFunctionsSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan: true);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
 
                 // Default version is 3.7.*
@@ -78,17 +83,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 settings.UseFileName($"{nameof(AwsStepFunctionsTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}{snapshotSuffix}");
                 settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_stepfunctions");
-                settings.AddSimpleScrubber("out.host: localstack", "out.host: aws_stepfunctions");
-                settings.AddSimpleScrubber("out.host: localstack_arm64", "out.host: aws_stepfunctions");
+                settings.AddSimpleScrubber($"out.host: {_localStackFixture.Host}", "out.host: aws_stepfunctions");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_stepfunctions");
-                settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_stepfunctions");
-                settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_stepfunctions");
+                settings.AddSimpleScrubber($"peer.service: {_localStackFixture.Host}", "peer.service: aws_stepfunctions");
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
                 // V4 uses the sockets handler by default where possible instead of the httpclienthandler
                 settings.AddSimpleScrubber("http-client-handler-type: System.Net.Http.SocketsHttpHandler", "http-client-handler-type: System.Net.Http.HttpClientHandler");
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
 
                 settings.DisableRequireUniquePrefix();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsKinesisTests.cs
@@ -7,8 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using FluentAssertions;
 using VerifyXunit;
@@ -19,12 +21,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
     [Trait("DockerGroup", "2")]
+    [Collection(LocalStackCollection.Name)]
     [UsesVerify]
     public class DataStreamsMonitoringAwsKinesisTests : TracingIntegrationTest
     {
-        public DataStreamsMonitoringAwsKinesisTests(ITestOutputHelper output)
+        private readonly LocalStackFixture _localStackFixture;
+
+        public DataStreamsMonitoringAwsKinesisTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
             : base("AWS.Kinesis", output)
         {
+            _localStackFixture = localStackFixture;
+            ConfigureContainers(localStackFixture);
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -71,15 +78,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 var dsPoints = await agent.WaitForDataStreamsPointsAsync(statsCount: 2);
 
-                var host = Environment.GetEnvironmentVariable("AWS_SDK_HOST");
-
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 settings.UseFileName($"{nameof(DataStreamsMonitoringAwsKinesisTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
                 settings.AddDataStreamsScrubber();
-                if (!string.IsNullOrWhiteSpace(host))
-                {
-                    settings.AddSimpleScrubber(host, "localhost:00000");
-                }
+                settings.AddSimpleScrubber(_localStackFixture.HostAndPort, "localhost:00000");
 
                 await Verifier.Verify(MockDataStreamsPayload.Normalize(dsPoints), settings)
                           .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSnsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSnsTests.cs
@@ -5,10 +5,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Versioning;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using FluentAssertions;
 using VerifyXunit;
@@ -19,12 +20,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS;
 
 [Trait("RequiresDockerDependency", "true")]
 [Trait("DockerGroup", "2")]
+[Collection(LocalStackCollection.Name)]
 [UsesVerify]
 public class DataStreamsMonitoringAwsSnsTests : TestHelper
 {
-    public DataStreamsMonitoringAwsSnsTests(ITestOutputHelper output)
+    public DataStreamsMonitoringAwsSnsTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
         : base("AWS.SimpleNotificationService", output)
     {
+        ConfigureContainers(localStackFixture);
     }
 
     public static IEnumerable<object[]> GetEnabledConfig()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSqsTests.cs
@@ -4,11 +4,12 @@
 // </copyright>
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using FluentAssertions;
 using VerifyXunit;
@@ -17,15 +18,16 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS;
 
-[Collection(nameof(AwsSqsTests.AwsSqsTestsCollection))]
+[Collection(LocalStackCollection.Name)]
 [Trait("RequiresDockerDependency", "true")]
 [Trait("DockerGroup", "2")]
 [UsesVerify]
 public class DataStreamsMonitoringAwsSqsTests : TestHelper
 {
-    public DataStreamsMonitoringAwsSqsTests(ITestOutputHelper output)
+    public DataStreamsMonitoringAwsSqsTests(ITestOutputHelper output, LocalStackFixture localStackFixture)
         : base("AWS.SQS", output)
     {
+        ConfigureContainers(localStackFixture);
     }
 
     public static IEnumerable<object[]> GetEnabledConfig()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ContainersCollection.cs
@@ -89,6 +89,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
     {
         public const string Name = "CosmosDbVnext";
     }
+
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class LocalStackCollection : ICollectionFixture<LocalStackFixture>
+    {
+        public const string Name = "LocalStack";
+    }
 }
 
 #pragma warning restore SA1649 // File name should match first type name

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/LocalStackFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/LocalStackFixture.cs
@@ -1,0 +1,54 @@
+// <copyright file="LocalStackFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
+
+public class LocalStackFixture : ContainerFixture
+{
+    private const ushort EdgePort = 4566;
+
+    // Keep synchronized with the image version in docker-compose.yml.
+    private const string Image = "localstack/localstack:4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a";
+
+    public string Host => Container.Hostname;
+
+    public ushort Port => Container.GetMappedPublicPort(EdgePort);
+
+    public string HostAndPort => $"{Host}:{Port}";
+
+    private IContainer Container => GetResource<IContainer>("container");
+
+    public override IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables()
+    {
+        yield return new("AWS_SDK_HOST", HostAndPort);
+    }
+
+    protected override async Task InitializeResources(Action<string, object> registerResource)
+    {
+        var container = new ContainerBuilder(Image)
+                       .WithPortBinding(EdgePort, true)
+                       .WithEnvironment("SERVICES", "sns,sqs,kinesis,dynamodb,events,s3,stepfunctions,lambda")
+                       .WithEnvironment("DEBUG", "1")
+                       .WithEnvironment("DEFAULT_REGION", "us-east-1")
+                       .WithEnvironment("SQS_ENDPOINT_STRATEGY", "dynamic")
+                       .WithWaitStrategy(
+                            Wait.ForUnixContainer()
+                                .UntilHttpRequestIsSucceeded(
+                                     request => request.ForPort(EdgePort).ForPath("/_localstack/health"),
+                                     strategy => strategy.WithTimeout(TimeSpan.FromMinutes(2))))
+                       .Build();
+
+        registerResource("container", container);
+        await StartContainerAsync(container).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary of changes

Migrates the AWS and AWS Data Streams Monitoring integration tests from a Docker Compose-managed LocalStack dependency to a shared Testcontainers fixture.

## Reason for change

LocalStack should only run while the AWS test collection needs it instead of consuming resources throughout the full Docker test group.

## Implementation details

- Adds a shared LocalStack fixture configured with the AWS services used by the integration tests.
- Waits for the LocalStack health endpoint before starting tests.
- Passes the dynamically mapped LocalStack endpoint to the AWS samples and normalizes it in snapshots.
- Shares and serializes the fixture across the AWS and Data Streams Monitoring tests.
- Removes LocalStack from Docker Compose startup and updates the local integration-test instructions.

## Test coverage

Relying on CI for test coverage for this, I ran these initially in https://github.com/DataDog/dd-trace-dotnet/pull/8960.

## Other details
<!-- Fixes #{issue} -->

This is PR 10 of 10 in the Testcontainers migration
The original PR containing the complete set of changes is https://github.com/DataDog/dd-trace-dotnet/pull/8960.


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
