### PR TITLE
Expose the `TrailerSize` of an `ISpanBufferSerializer`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/ISpanBufferSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/ISpanBufferSerializer.cs
@@ -13,6 +13,14 @@ namespace Datadog.Trace.Agent
     {
         int HeaderSize { get; }
 
+        /// <summary>
+        /// Gets the number of bytes <see cref="FinishBody"/> may append when the payload is
+        /// finalized. <see cref="SpanBuffer"/> reserves this much room on every write, so that
+        /// finalizing can never need to grow the buffer - it runs while the buffer's lock is held,
+        /// and that critical section must stay allocation-free.
+        /// </summary>
+        int TrailerSize { get; }
+
         int SerializeSpans(ref byte[] bytes, int temporaryBufferOffset, TraceChunkModel traceChunk, int spanBufferOffset, int maxSize);
 
         void WriteHeader(ref byte[] bytes, int offset, int traceCount);

--- a/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
@@ -27,9 +27,11 @@ namespace Datadog.Trace.Agent
 
         public SpanBuffer(int maxBufferSize, ISpanBufferSerializer serializer)
         {
-            if (maxBufferSize < serializer.HeaderSize)
+            var minimumSize = serializer.HeaderSize + serializer.TrailerSize;
+
+            if (maxBufferSize < minimumSize)
             {
-                ThrowHelper.ThrowArgumentException($"Buffer size should be at least {serializer.HeaderSize}", nameof(maxBufferSize));
+                ThrowHelper.ThrowArgumentException($"Buffer size should be at least {minimumSize}", nameof(maxBufferSize));
             }
 
             _maxBufferSize = maxBufferSize;
@@ -104,7 +106,7 @@ namespace Datadog.Trace.Agent
                     return WriteStatus.Overflow;
                 }
 
-                if (!EnsureCapacity(size + _offset))
+                if (!EnsureCapacity(size + _offset + _serializer.TrailerSize))
                 {
                     if (TraceCount == 0)
                     {

--- a/tracer/src/Datadog.Trace/Agent/SpanBufferMessagePackSerializer.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanBufferMessagePackSerializer.cs
@@ -31,6 +31,8 @@ namespace Datadog.Trace.Agent
 
         public int HeaderSize => HeaderSizeConst;
 
+        public int TrailerSize => 0;
+
         public int SerializeSpans(ref byte[] bytes, int temporaryBufferOffset, TraceChunkModel traceChunk, int spanBufferOffset, int maxSize)
         {
             if (_formatter is SpanMessagePackFormatter spanFormatter)

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesJsonSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesJsonSerializer.cs
@@ -38,6 +38,9 @@ internal sealed class OtlpTracesJsonSerializer : ISpanBufferSerializer
 
     public int HeaderSize => 0;
 
+    // FinishBody appends the closing brackets, so every write reserves room for them
+    public int TrailerSize => ClosingTracesBytes.Length;
+
     internal static void WriteSpanEvent(JsonTextWriter writer, Datadog.Trace.SpanEvent evt)
     {
         writer.WriteStartObject();

--- a/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesProtobufSerializer.cs
+++ b/tracer/src/Datadog.Trace/OpenTelemetry/Traces/OtlpTracesProtobufSerializer.cs
@@ -58,6 +58,8 @@ internal sealed class OtlpTracesProtobufSerializer : ISpanBufferSerializer
 
     public int HeaderSize => 0;
 
+    public int TrailerSize => 0;
+
     public void WriteHeader(ref byte[] bytes, int offset, int traceCount)
     {
         // No fixed header; the outer envelope is opened on the first SerializeSpans call.


### PR DESCRIPTION
## Summary of changes

Expose the `TrailerSize` the same way we do `HeaderSize`

## Reason for change

The `SpanBuffer` implementation can use this to ensure that the buffer is sized appropriately. Without it, there's an edge case that requires doubling the size of the buffer _after_ the traces have been written, when we're about to flush

## Implementation details

- Add `ISpanBufferSerializer.TrailerSize`
- Implement everywhere (`0` for messagepack, JSON has constant value)
- Update `SpanBuffer` to take `TrailerSize` into account during resizes

## Test coverage

Meh, covered by the next PR

## Other details

Preparatory work for #9107