### PR TITLE
Fix lock-contention causing trace to be "stranded"

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -412,6 +412,25 @@ namespace Datadog.Trace.Agent
         {
             try
             {
+                // Report drop counts
+                var droppedTracesTooLarge = Interlocked.Exchange(ref _droppedTracesTooLarge, 0);
+                var droppedTracesBufferFull = Interlocked.Exchange(ref _droppedTracesBufferFull, 0);
+                var droppedTracesBufferFullAndLocked = Interlocked.Exchange(ref _droppedTracesBufferFullAndLocked, 0);
+                var droppedTracesBuffersLocked = Interlocked.Exchange(ref _droppedTracesBuffersLocked, 0);
+
+                if (droppedTracesTooLarge > 0 || droppedTracesBufferFull > 0 || droppedTracesBufferFullAndLocked > 0 || droppedTracesBuffersLocked > 0)
+                {
+                    Log.Warning(
+                        "Traces were dropped since the last flush operation: {TooLargeCount} exceeded the trace buffer limit of {MaxBufferSize} bytes, {BuffersFullCount} found both buffers full, {BufferFullAndLockedCount} found one buffer full and the other unavailable while being flushed, and {BuffersLockedCount} found both buffers unavailable while being flushed.",
+                        [
+                            droppedTracesTooLarge,
+                            _frontBuffer.MaxBufferSize,
+                            droppedTracesBufferFull,
+                            droppedTracesBufferFullAndLocked,
+                            droppedTracesBuffersLocked
+                        ]);
+                }
+
                 var activeBuffer = Volatile.Read(ref _activeBuffer);
                 var fallbackBuffer = activeBuffer == _frontBuffer ? _backBuffer : _frontBuffer;
 
@@ -459,25 +478,6 @@ namespace Datadog.Trace.Agent
                         statsd.Increment(TracerMetricNames.Queue.DequeuedTraces, payload.TraceCount);
                         statsd.Increment(TracerMetricNames.Queue.DequeuedSpans, payload.SpanCount);
                     }
-                }
-
-                var droppedTracesTooLarge = Interlocked.Exchange(ref _droppedTracesTooLarge, 0);
-                var droppedTracesBufferFull = Interlocked.Exchange(ref _droppedTracesBufferFull, 0);
-                var droppedTracesBufferFullAndLocked = Interlocked.Exchange(ref _droppedTracesBufferFullAndLocked, 0);
-                var droppedTracesBuffersLocked = Interlocked.Exchange(ref _droppedTracesBuffersLocked, 0);
-
-                if (droppedTracesTooLarge > 0 || droppedTracesBufferFull > 0 || droppedTracesBufferFullAndLocked > 0 || droppedTracesBuffersLocked > 0)
-                {
-                    Log.Warning(
-                        "Traces were dropped since the last flush operation: {TooLargeCount} exceeded the trace buffer limit of {MaxBufferSize} bytes, {BuffersFullCount} found both buffers full, {BufferFullAndLockedCount} found one buffer full and the other unavailable while being flushed, and {BuffersLockedCount} found both buffers unavailable while being flushed.",
-                        new object?[]
-                        {
-                            droppedTracesTooLarge,
-                            _frontBuffer.MaxBufferSize,
-                            droppedTracesBufferFull,
-                            droppedTracesBufferFullAndLocked,
-                            droppedTracesBuffersLocked,
-                        });
                 }
 
                 if (payload.TraceCount > 0)

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -292,6 +292,15 @@ namespace Datadog.Trace.Agent
         }
 
         /// <summary>
+        /// Swaps the active buffer, so that a test can set up a buffer that holds traces but is
+        /// neither active nor full. In production that state is only produced by a
+        /// <see cref="SpanBuffer.WriteStatus.Locked"/> write.
+        /// </summary>
+        [TestingOnly]
+        internal void SwapActiveBufferForTests()
+            => Volatile.Write(ref _activeBuffer, _activeBuffer == _frontBuffer ? _backBuffer : _frontBuffer);
+
+        /// <summary>
         /// Asks the flush loop to flush both buffers, and waits for that flush to complete. Buffers are
         /// only ever flushed by the flush loop, so at most one payload is in flight at a time.
         /// Concurrent requests share a single flush pass.
@@ -359,11 +368,11 @@ namespace Datadog.Trace.Agent
 
                     // Once serialization has stopped, nothing new can be written to the buffers
                     isFinalPass = _serializationTask.IsCompleted;
-                    var flushAllBuffers = flushRequest is not null;
+                    var hasFlushRequest = flushRequest is not null;
 
-                    if (flushAllBuffers || isFinalPass || _backgroundFlushEnabled)
+                    if (hasFlushRequest || isFinalPass || _backgroundFlushEnabled)
                     {
-                        await FlushBuffers(flushAllBuffers: flushAllBuffers || isFinalPass).ConfigureAwait(false);
+                        await FlushBuffers().ConfigureAwait(false);
                     }
 
                     flushRequest?.TrySetResult(true);
@@ -396,24 +405,20 @@ namespace Datadog.Trace.Agent
         }
 
         /// <summary>
-        /// Flush the active buffer, and the fallback buffer if full.
+        /// Flushes both buffers, oldest traces first.
         /// </summary>
-        /// <param name="flushAllBuffers">If set to true, then flush the back buffer even if not full</param>
         /// <returns>Async operation</returns>
-        private async Task FlushBuffers(bool flushAllBuffers = false)
+        private async Task FlushBuffers()
         {
             try
             {
                 var activeBuffer = Volatile.Read(ref _activeBuffer);
                 var fallbackBuffer = activeBuffer == _frontBuffer ? _backBuffer : _frontBuffer;
 
-                // First, flush the back buffer if full
-                if (fallbackBuffer.IsFull || flushAllBuffers)
-                {
-                    await FlushBuffer(fallbackBuffer).ConfigureAwait(false);
-                }
-
-                // Then, flush the main buffer
+                // The fallback buffer holds the older traces. The read above can go stale
+                // if the serialization thread swaps while we are sending, but as that
+                // only changes which is flushed first, it's fine.
+                await FlushBuffer(fallbackBuffer).ConfigureAwait(false);
                 await FlushBuffer(activeBuffer).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -448,6 +448,12 @@ namespace Datadog.Trace.Agent
 
         private async Task FlushBuffer(SpanBuffer buffer)
         {
+            if (buffer.TraceCount == 0)
+            {
+                // Nothing to send
+                return;
+            }
+
             // Make sure the replacement array is big enough before taking the buffer's lock.
             // This deliberately happens outside the critical section so that the serialization thread
             // never waits on an allocation.

--- a/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
@@ -25,6 +25,7 @@ namespace Datadog.Trace.Agent
 
         private byte[] _buffer;
         private int _offset;
+        private int _traceCount;
 
         public SpanBuffer(int maxBufferSize, ISpanBufferSerializer serializer)
         {
@@ -49,7 +50,7 @@ namespace Datadog.Trace.Agent
             Locked = 3
         }
 
-        public int TraceCount { get; private set; }
+        public int TraceCount => Volatile.Read(ref _traceCount);
 
         public int SpanCount { get; private set; }
 
@@ -75,7 +76,7 @@ namespace Datadog.Trace.Agent
         internal ArraySegment<byte> RawData => new(_buffer, 0, _offset);
 
         [TestingOnly]
-        internal bool IsEmpty => !IsFull && TraceCount == 0 && SpanCount == 0 && _offset == _serializer.HeaderSize;
+        internal bool IsEmpty => !IsFull && _traceCount == 0 && SpanCount == 0 && _offset == _serializer.HeaderSize;
 
         public WriteStatus TryWrite(in SpanCollection spans, ref byte[] temporaryBuffer, int? samplingPriority = null)
         {
@@ -101,7 +102,7 @@ namespace Datadog.Trace.Agent
                 // to get the other values we need (sampling priority, origin, trace tags, etc) for now.
                 // the idea is that as we refactor further, we can pass more than just the spans,
                 // and these values can come directly from the trace context.
-                var traceChunk = new TraceChunkModel(in spans, samplingPriority, isFirstChunkInPayload: TraceCount == 0);
+                var traceChunk = new TraceChunkModel(in spans, samplingPriority, isFirstChunkInPayload: _traceCount == 0);
 
                 // We don't know what the serialized size of the payload will be,
                 // so we need to write to a temporary buffer first
@@ -117,7 +118,7 @@ namespace Datadog.Trace.Agent
                 // the payload in Detach doesn't grow the array while the lock is held.
                 if (!EnsureCapacity(size + _offset + _serializer.TrailerSize))
                 {
-                    if (TraceCount == 0)
+                    if (_traceCount == 0)
                     {
                         // The trace cannot fit in an empty buffer
                         return WriteStatus.Overflow;
@@ -130,7 +131,7 @@ namespace Datadog.Trace.Agent
                 Buffer.BlockCopy(temporaryBuffer, 0, _buffer, _offset, size);
 
                 _offset += size;
-                TraceCount++;
+                _traceCount++;
                 SpanCount += traceChunk.SpanCount;
 
                 return WriteStatus.Success;
@@ -161,22 +162,22 @@ namespace Datadog.Trace.Agent
         {
             lock (_syncRoot)
             {
-                if (TraceCount == 0)
+                if (_traceCount == 0)
                 {
                     // Nothing to send, so don't consume the caller's replacement array
                     return default;
                 }
 
                 // Use a fixed-size header
-                _serializer.WriteHeader(ref _buffer, 0, TraceCount);
+                _serializer.WriteHeader(ref _buffer, 0, _traceCount);
                 int addedBytes = _serializer.FinishBody(ref _buffer, _offset, _maxBufferSize);
                 _offset += addedBytes;
 
-                var payload = new Payload(new ArraySegment<byte>(_buffer, 0, count: _offset), TraceCount, SpanCount);
+                var payload = new Payload(new ArraySegment<byte>(_buffer, 0, count: _offset), _traceCount, SpanCount);
 
                 _buffer = replacement;
                 _offset = _serializer.HeaderSize;
-                TraceCount = 0;
+                _traceCount = 0;
                 SpanCount = 0;
                 IsFull = false;
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -375,6 +375,31 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public async Task FlushesAFallbackBufferThatIsNotFull()
+        {
+            // A Locked write swaps away from a buffer that holds traces but was never marked full.
+            // Nothing else will ever empty that buffer, so a flush has to pick it up regardless of
+            // whether it is full.
+            var api = new MockApi();
+            var agent = AgentWriterHelper.CreateWithManualFlush(api);
+
+            WriteTraceAndWait(agent, CreateTraceChunk(1));
+
+            agent.SwapActiveBufferForTests();
+
+            agent.ActiveBuffer.Should().BeSameAs(agent.BackBuffer);
+            agent.FrontBuffer.IsFull.Should().BeFalse();
+            agent.FrontBuffer.TraceCount.Should().Be(1);
+
+            await agent.FlushTracesAsync();
+
+            api.Traces.Should().HaveCount(1);
+            agent.FrontBuffer.IsEmpty.Should().BeTrue();
+
+            await agent.FlushAndCloseAsync();
+        }
+
+        [Fact]
         public async Task DropTraces()
         {
             // Traces should be dropped when both buffers are full

--- a/tracer/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
@@ -149,6 +149,25 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
+        public void TraceCount_TracksWhetherThereIsAnythingToFlush()
+        {
+            // The flush loop reads this without taking the buffer's lock, to decide whether a
+            // buffer is worth sizing a replacement array for.
+            var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanBufferMessagePackSerializer(SpanFormatterResolver.Instance));
+
+            buffer.TraceCount.Should().Be(0);
+
+            buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            buffer.TraceCount.Should().Be(1);
+
+            buffer.TryWrite(CreateTraceChunk(1), ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
+            buffer.TraceCount.Should().Be(2);
+
+            buffer.Detach(new byte[SpanBuffer.InitialBufferSize]).Array.Should().NotBeNull();
+            buffer.TraceCount.Should().Be(0);
+        }
+
+        [Fact]
         public void DetachingFullBuffer_ClearsTheFullFlag()
         {
             var buffer = new SpanBuffer(512, new SpanBufferMessagePackSerializer(SpanFormatterResolver.Instance));


### PR DESCRIPTION
## Summary of changes

- Always try to flush both buffers
- Skip the flush entirely if the buffer is empty
- Don't log drop stats twice

## Reason for change

Spotted some minor bugs while working on #9107. Notably

- If a buffer was _locked_ (not full), then the serialization thread swaps the buffers, and triggers a flush. However, as the buffer is not full, the flush thread would _not_ flush it automatically, so the trace sits in the back buffer unflushed, until we swap buffers again
- We were trying to log the "drop" stats _twice_ per flush, in cases where we flush both buffers. Not strictly a bug, but unnecessary.
- We were locking the buffer and swapping the array, even if there were no traces in it
  - Not strictly a bug, and this had much more potential to cause genuine drops prior to #9107 
  - Still seems like a worthwhile fix to me

## Implementation details

- Always flush both buffers, starting with the back buffer _regardless_ of whether it is full or not. 
- Log the drop stats in `FlushBuffers` instead of the child `FlushBuffer` calls
- Do a soft check on whether the buffer has stats before taking the lock
  - Worse case, we get a `false` because the serialization thread is actively writing into it, but there's naturally a race here anyway, and we'll catch it next time around.

## Test coverage

Added a `[TestingOnly]` testing seam  so that we can explicitly emulate the scenario where the buffer was locked when we tried to write to it. Allowed red-green testing to prove the edge case was there.

## Other details

Stacked on
- https://github.com/DataDog/dd-trace-dotnet/pull/9115
- https://github.com/DataDog/dd-trace-dotnet/pull/9107