### PR TITLE
feat(openfeature): support arbitrary semver parts

### DIFF
--- a/tracer/src/Datadog.Trace/FeatureFlags/SemanticVersion.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/SemanticVersion.cs
@@ -11,38 +11,30 @@ namespace Datadog.Trace.FeatureFlags;
 
 internal readonly struct SemanticVersion : IComparable<SemanticVersion>
 {
-    private readonly string _major;
-    private readonly string _minor;
-    private readonly string _patch;
+    private readonly string[] _core;
     private readonly string[] _prerelease;
 
-    private SemanticVersion(string major, string minor, string patch, string[] prerelease)
+    private SemanticVersion(string[] core, string[] prerelease)
     {
-        _major = major;
-        _minor = minor;
-        _patch = patch;
+        _core = core;
         _prerelease = prerelease;
     }
 
     public int CompareTo(SemanticVersion other)
     {
-        var result = CompareNumericIdentifier(_major, other._major);
-        if (result != 0)
+        var coreLength = Math.Max(_core.Length, other._core.Length);
+        for (var i = 0; i < coreLength; i++)
         {
-            return result;
+            var left = i < _core.Length ? _core[i] : "0";
+            var right = i < other._core.Length ? other._core[i] : "0";
+            var coreComparison = CompareNumericIdentifier(left, right);
+            if (coreComparison != 0)
+            {
+                return coreComparison;
+            }
         }
 
-        result = CompareNumericIdentifier(_minor, other._minor);
-        if (result != 0)
-        {
-            return result;
-        }
-
-        result = CompareNumericIdentifier(_patch, other._patch);
-        if (result != 0)
-        {
-            return result;
-        }
+        var result = 0;
 
         if (_prerelease.Length == 0 || other._prerelease.Length == 0)
         {
@@ -106,12 +98,12 @@ internal readonly struct SemanticVersion : IComparable<SemanticVersion>
         }
 
         var core = value.Split('.');
-        if (core.Length != 3 || !IsValidCoreIdentifier(core[0]) || !IsValidCoreIdentifier(core[1]) || !IsValidCoreIdentifier(core[2]))
+        if (core.Length == 0 || Array.Exists(core, static identifier => !IsValidCoreIdentifier(identifier)))
         {
             return false;
         }
 
-        version = new SemanticVersion(core[0], core[1], core[2], prerelease);
+        version = new SemanticVersion(core, prerelease);
         return true;
     }
 

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/SemanticVersionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/SemanticVersionTests.cs
@@ -1,0 +1,45 @@
+// <copyright file="SemanticVersionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.FeatureFlags;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.FeatureFlags;
+
+public class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("18.0.0.0.0.0", "18.0.0.0.0.1", -1)]
+    [InlineData("18.0.0.0.0.1", "18.0.0.0.0.0", 1)]
+    [InlineData("18.0.0.0.0.0", "18.0.0.0.0", 0)]
+    public void CompareToSupportsSixOrMoreCoreComponents(string left, string right, int expected)
+    {
+        SemanticVersion.TryParse(left, out var leftVersion).Should().BeTrue();
+        SemanticVersion.TryParse(right, out var rightVersion).Should().BeTrue();
+
+        leftVersion.CompareTo(rightVersion).Should().Be(expected);
+    }
+
+    [Fact]
+    public void TryParseSupportsAnArbitraryNumberOfCoreComponents()
+    {
+        const string lowerVersion = "1.2.3.4.5.6.7.8.9.10.11.12";
+        const string higherVersion = "1.2.3.4.5.6.7.8.9.10.11.13";
+
+        SemanticVersion.TryParse(lowerVersion, out var lower).Should().BeTrue();
+        SemanticVersion.TryParse(higherVersion, out var higher).Should().BeTrue();
+
+        lower.CompareTo(higher).Should().Be(-1);
+    }
+
+    [Fact]
+    public void TryParseRejectsLeadingZerosInExtendedCoreComponents()
+    {
+        SemanticVersion.TryParse("1.2.3.4.5.06", out _).Should().BeFalse();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/SOURCE.md
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/SOURCE.md
@@ -3,7 +3,7 @@
 These files are copied from the canonical FFE fixture repository.
 
 Canonical source: https://github.com/DataDog/ffe-system-test-data
-Source commit: a271dc12ce65eb3d937818a5ba5cf30b78799d26
+Source commit: 2c0c8d55f665fe4a847fc0ded3abf59b7e2896fc
 
 Do not edit these fixtures directly in dd-trace-dotnet. Add or update shared FFE behavior in ffe-system-test-data first, then refresh this snapshot.
 

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/SOURCE.md
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/SOURCE.md
@@ -3,7 +3,7 @@
 These files are copied from the canonical FFE fixture repository.
 
 Canonical source: https://github.com/DataDog/ffe-system-test-data
-Source commit: ea8b5cc5ce335109f11f3efbc5fd608f98a3ca54
+Source commit: a271dc12ce65eb3d937818a5ba5cf30b78799d26
 
 Do not edit these fixtures directly in dd-trace-dotnet. Add or update shared FFE behavior in ffe-system-test-data first, then refresh this snapshot.
 

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-regex-flag.json
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-regex-flag.json
@@ -1,6 +1,45 @@
 [
   {
     "attributes": {
+      "comma_regex_case": "xxaaay"
+    },
+    "defaultValue": "none",
+    "flag": "regex-flag",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "comma-quantifier"
+    },
+    "targetingKey": "comma-quantifier",
+    "variationType": "STRING"
+  },
+  {
+    "attributes": {
+      "whitespace_regex_case": "prefix exact suffix"
+    },
+    "defaultValue": "none",
+    "flag": "regex-flag",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "literal-whitespace"
+    },
+    "targetingKey": "literal-whitespace",
+    "variationType": "STRING"
+  },
+  {
+    "attributes": {
+      "whitespace_regex_case": "exact"
+    },
+    "defaultValue": "none",
+    "flag": "regex-flag",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "none"
+    },
+    "targetingKey": "trimmed-whitespace-does-not-match",
+    "variationType": "STRING"
+  },
+  {
+    "attributes": {
       "email": "user.name+tag@capture.example"
     },
     "defaultValue": "none",

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-invalid-comparand-categories.json
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-invalid-comparand-categories.json
@@ -1,0 +1,120 @@
+[
+  {
+    "description": "A non-parseable SemVer comparand (\"not-a-version\") rejects the flag at parse time with a PARSE_ERROR rather than matching or coercing.",
+    "attributes": {
+      "app_version": "1.2.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-invalid-comparand-syntax-test",
+    "result": {
+      "errorCode": "PARSE_ERROR",
+      "reason": "ERROR",
+      "value": "unknown"
+    },
+    "targetingKey": "invalid-syntax",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A SemVer comparand with repeated hyphens inside its prerelease identifiers (\"1.2.3----R-S.12.9.1--.12+meta\") is valid and matches normally.",
+    "attributes": {
+      "app_version": "1.2.3----R-S.12.9.1--.12+meta"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-valid-comparand-hyphenated-prerelease-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "matched"
+    },
+    "targetingKey": "valid-hyphenated-prerelease",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A SemVer comparand with consecutive dots in its prerelease identifiers (\"1.0.0-alpha..1\") rejects the flag at parse time with a PARSE_ERROR.",
+    "attributes": {
+      "app_version": "1.0.0-alpha.1"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-invalid-comparand-consecutive-dots-test",
+    "result": {
+      "errorCode": "PARSE_ERROR",
+      "reason": "ERROR",
+      "value": "unknown"
+    },
+    "targetingKey": "invalid-consecutive-dots",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A Ruby-style dot-suffixed SemVer comparand (\"1.2.3.DEV\") rejects the flag at parse time with a PARSE_ERROR.",
+    "attributes": {
+      "app_version": "1.2.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-invalid-comparand-dot-suffix-test",
+    "result": {
+      "errorCode": "PARSE_ERROR",
+      "reason": "ERROR",
+      "value": "unknown"
+    },
+    "targetingKey": "invalid-dot-suffix",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A v-prefixed SemVer comparand (\"v1.2.3\") rejects the flag at parse time with a PARSE_ERROR.",
+    "attributes": {
+      "app_version": "1.2.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-invalid-comparand-vprefix-test",
+    "result": {
+      "errorCode": "PARSE_ERROR",
+      "reason": "ERROR",
+      "value": "unknown"
+    },
+    "targetingKey": "invalid-vprefix",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A leading-zero core component in the SemVer comparand (\"01.2.3\") rejects the flag at parse time with a PARSE_ERROR.",
+    "attributes": {
+      "app_version": "1.2.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-invalid-comparand-leading-zero-test",
+    "result": {
+      "errorCode": "PARSE_ERROR",
+      "reason": "ERROR",
+      "value": "unknown"
+    },
+    "targetingKey": "invalid-leading-zero",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A non-string (JSON number) SemVer comparand rejects the flag at parse time with a PARSE_ERROR rather than coercing the number to a string.",
+    "attributes": {
+      "app_version": "1.2.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-invalid-comparand-non-string-test",
+    "result": {
+      "errorCode": "PARSE_ERROR",
+      "reason": "ERROR",
+      "value": "unknown"
+    },
+    "targetingKey": "invalid-non-string",
+    "variationType": "STRING"
+  },
+  {
+    "description": "The rejected invalid-comparand flags must not poison the rest of the configuration: a neighboring valid SemVer flag still evaluates normally.",
+    "attributes": {
+      "app_version": "2.3.4"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "stable"
+    },
+    "targetingKey": "after-invalid-categories",
+    "variationType": "STRING"
+  }
+]

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-invalid-comparand-waterfall.json
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-invalid-comparand-waterfall.json
@@ -1,0 +1,17 @@
+[
+  {
+    "description": "An invalid configured SemVer comparand in a non-last allocation must reject the whole flag at parse time, even though a valid default allocation follows it in the waterfall. An implementation that skips the invalid allocation and falls through to the default would return \"fallback\" with a STATIC reason instead of an error.",
+    "attributes": {
+      "app_version": "1.2.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-invalid-comparand-waterfall-test",
+    "result": {
+      "errorCode": "PARSE_ERROR",
+      "reason": "ERROR",
+      "value": "unknown"
+    },
+    "targetingKey": "waterfall",
+    "variationType": "STRING"
+  }
+]

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-precedence-flag.json
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-precedence-flag.json
@@ -1,0 +1,170 @@
+[
+  {
+    "description": "Multi-digit numeric prerelease identifiers compare by numeric value, not lexicographically: 1.0.0-beta.2 must precede 1.0.0-beta.11. An implementation that string-compares identifiers would treat \"2\" as greater than \"11\" and fail to match.",
+    "attributes": {
+      "app_version": "10.0.0-beta.2"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "numeric-prerelease"
+    },
+    "targetingKey": "numeric-prerelease",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Build metadata is ignored for equality: 1.0.0+linux and 1.0.0+darwin have equal precedence, so SEMVER_EQ matches.",
+    "attributes": {
+      "app_version": "20.0.0+linux"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "build-equal-precedence"
+    },
+    "targetingKey": "build-equal-precedence",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Dotted/multi-segment build metadata is ignored for equality: 4.0.0+exp.sha.5114f85 equals 4.0.0.",
+    "attributes": {
+      "app_version": "30.0.0+exp.sha.5114f85"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "build-dotted-eq"
+    },
+    "targetingKey": "build-dotted-eq",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Build metadata is ignored for SEMVER_LTE: 4.0.0+build.42 <= 4.0.0 is true (match).",
+    "attributes": {
+      "app_version": "40.0.0+build.42"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "build-lte"
+    },
+    "targetingKey": "build-lte",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Build metadata is ignored for SEMVER_GTE: 4.0.0+build.42 >= 4.0.0 is true (match).",
+    "attributes": {
+      "app_version": "50.0.0+build.42"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "build-gte"
+    },
+    "targetingKey": "build-gte",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Build metadata is ignored for SEMVER_NEQ: 4.0.0+build.42 != 4.0.0 is false (no match), so the evaluation falls through to the default.",
+    "attributes": {
+      "app_version": "60.0.0+build.42"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "build-neq",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Build metadata is ignored for SEMVER_LT: 4.0.0+build.42 < 4.0.0 is false (no match), so the evaluation falls through to the default.",
+    "attributes": {
+      "app_version": "70.0.0+build.42"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "build-lt",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Build metadata is ignored for SEMVER_GT: 4.0.0+build.42 > 4.0.0 is false (no match), so the evaluation falls through to the default.",
+    "attributes": {
+      "app_version": "80.0.0+build.42"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "build-gt",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Alphanumeric prerelease ordering: 1.0.0-alpha precedes 1.0.0-alpha.1 (fewer identifiers first), so SEMVER_LT matches.",
+    "attributes": {
+      "app_version": "90.0.0-alpha"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "alpha-before-alpha-1"
+    },
+    "targetingKey": "alpha-before-alpha-1",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Alphanumeric prerelease ordering: numeric identifiers have lower precedence than alphanumeric (1.0.0-alpha.1 precedes 1.0.0-alpha.beta), so SEMVER_LT matches.",
+    "attributes": {
+      "app_version": "91.0.0-alpha.1"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "alpha-1-before-alpha-beta"
+    },
+    "targetingKey": "alpha-1-before-alpha-beta",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Alphanumeric prerelease ordering: identifiers are compared lexicographically (1.0.0-alpha.beta precedes 1.0.0-beta), so SEMVER_LT matches.",
+    "attributes": {
+      "app_version": "92.0.0-alpha.beta"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "alpha-beta-before-beta"
+    },
+    "targetingKey": "alpha-beta-before-beta",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Alphanumeric prerelease ordering: a prerelease version precedes the corresponding release (1.0.0-beta precedes 1.0.0), so SEMVER_LT matches.",
+    "attributes": {
+      "app_version": "93.0.0-beta"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-precedence-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "beta-before-release"
+    },
+    "targetingKey": "beta-before-release",
+    "variationType": "STRING"
+  }
+]

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-validation-flag.json
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-validation-flag.json
@@ -14,20 +14,6 @@
     "variationType": "STRING"
   },
   {
-    "description": "Semver requires all three core components.",
-    "attributes": {
-      "app_version": "1.2"
-    },
-    "defaultValue": "unknown",
-    "flag": "semver-comparison-test",
-    "result": {
-      "reason": "DEFAULT",
-      "value": "unknown"
-    },
-    "targetingKey": "short-version",
-    "variationType": "STRING"
-  },
-  {
     "description": "Semver does not accept a v prefix.",
     "attributes": {
       "app_version": "v1.2.3"
@@ -109,6 +95,146 @@
       "value": "unknown"
     },
     "targetingKey": "non-ascii-prerelease",
+    "variationType": "STRING"
+  },
+  {
+    "description": "An empty string is not a valid SemVer version.",
+    "attributes": {
+      "app_version": ""
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "empty-string",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A leading zero in the minor core component is rejected.",
+    "attributes": {
+      "app_version": "1.02.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "minor-leading-zero",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A leading zero in the patch core component is rejected.",
+    "attributes": {
+      "app_version": "1.2.03"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "patch-leading-zero",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A trailing prerelease delimiter with no identifiers is rejected.",
+    "attributes": {
+      "app_version": "1.2.3-"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "empty-prerelease",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A trailing build delimiter with no identifiers is rejected.",
+    "attributes": {
+      "app_version": "1.2.3+"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "empty-build",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Underscores are not permitted in prerelease identifiers.",
+    "attributes": {
+      "app_version": "1.2.3-alpha_1"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "underscore-prerelease",
+    "variationType": "STRING"
+  },
+  {
+    "description": "More than one build metadata delimiter is rejected.",
+    "attributes": {
+      "app_version": "1.2.3-alpha+build+other"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "multiple-build-delimiters",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Leading whitespace is not accepted by the SemVer parser.",
+    "attributes": {
+      "app_version": " 1.2.3"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "leading-whitespace",
+    "variationType": "STRING"
+  },
+  {
+    "description": "Trailing whitespace is not accepted by the SemVer parser.",
+    "attributes": {
+      "app_version": "1.2.3 "
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "trailing-whitespace",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A non-string attribute (JSON number) does not match any SemVer condition and falls through to the default rather than erroring.",
+    "attributes": {
+      "app_version": 1.2
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-comparison-test",
+    "result": {
+      "reason": "DEFAULT",
+      "value": "unknown"
+    },
+    "targetingKey": "non-string-attribute",
     "variationType": "STRING"
   },
   {

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-version-parts.json
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/evaluation-cases/test-case-semver-version-parts.json
@@ -1,0 +1,118 @@
+[
+  {
+    "description": "A one-part version is normalized with missing minor and patch parts: \"18\" compares equal to \"18.0.0\".",
+    "attributes": {
+      "scenario": "one-part-input",
+      "app_version": "18"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-input-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "one-part-input"
+    },
+    "targetingKey": "one-part-input",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A one-part configured comparand is valid and normalized: \"18.0.0\" compares equal to configured \"18\".",
+    "attributes": {
+      "app_version": "18.0.0"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-one-part-comparand-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "one-part-comparand"
+    },
+    "targetingKey": "one-part-comparand",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A two-part version is normalized with a missing patch part: \"18.0\" compares equal to \"18.0.0\".",
+    "attributes": {
+      "scenario": "two-part-input",
+      "app_version": "18.0"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-input-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "two-part-input"
+    },
+    "targetingKey": "two-part-input",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A two-part configured comparand is valid and normalized: \"18.0.0\" compares equal to configured \"18.0\".",
+    "attributes": {
+      "app_version": "18.0.0"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-two-part-comparand-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "two-part-comparand"
+    },
+    "targetingKey": "two-part-comparand",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A four-part version is accepted as an attribute and compares above a canonical three-part lower version.",
+    "attributes": {
+      "scenario": "four-part-input",
+      "app_version": "18.0.0.0"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-input-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "four-part-input"
+    },
+    "targetingKey": "four-part-input",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A four-part configured comparand is accepted and compares below a canonical three-part higher version.",
+    "attributes": {
+      "app_version": "19.0.0"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-four-part-comparand-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "four-part-comparand"
+    },
+    "targetingKey": "four-part-comparand",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A five-part version is accepted as an attribute and compares above a canonical three-part lower version.",
+    "attributes": {
+      "scenario": "five-part-input",
+      "app_version": "18.0.0.0.0"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-input-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "five-part-input"
+    },
+    "targetingKey": "five-part-input",
+    "variationType": "STRING"
+  },
+  {
+    "description": "A five-part configured comparand is accepted and compares below a canonical three-part higher version.",
+    "attributes": {
+      "app_version": "19.0.0"
+    },
+    "defaultValue": "unknown",
+    "flag": "semver-version-parts-five-part-comparand-test",
+    "result": {
+      "reason": "TARGETING_MATCH",
+      "value": "five-part-comparand"
+    },
+    "targetingKey": "five-part-comparand",
+    "variationType": "STRING"
+  }
+]

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/ufc-config.json
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ffe-system-test-data/ufc-config.json
@@ -89,9 +89,59 @@
         "unicode-word-boundary": {
           "key": "unicode-word-boundary",
           "value": "unicode-word-boundary"
+        },
+        "comma-quantifier": {
+          "key": "comma-quantifier",
+          "value": "comma-quantifier"
+        },
+        "literal-whitespace": {
+          "key": "literal-whitespace",
+          "value": "literal-whitespace"
         }
       },
       "allocations": [
+        {
+          "key": "comma-quantifier",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "comma_regex_case",
+                  "operator": "MATCHES",
+                  "value": "a{1,3}"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "comma-quantifier",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "literal-whitespace",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "whitespace_regex_case",
+                  "operator": "MATCHES",
+                  "value": " exact "
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "literal-whitespace",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
         {
           "key": "capturing-groups",
           "rules": [
@@ -881,6 +931,56 @@
           "splits": [
             {
               "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-invalid-comparand-waterfall-test": {
+      "key": "semver-invalid-comparand-waterfall-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag deliberately places an invalid configured SemVer comparand in a non-last allocation of a waterfall, followed by a valid default allocation. SDKs must reject the whole flag during parsing rather than skipping the invalid allocation and falling through to the default.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        },
+        "fallback": {
+          "key": "fallback",
+          "value": "fallback"
+        }
+      },
+      "allocations": [
+        {
+          "key": "invalid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "18446744073709551616.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "default",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "fallback",
               "shards": []
             }
           ],
@@ -4135,6 +4235,891 @@
           "splits": [
             {
               "variationKey": "expected",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-precedence-test": {
+      "key": "semver-precedence-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "Isolates SemVer precedence rules that are easy to get wrong: multi-digit numeric prerelease ordering (beta.2 < beta.11), build-metadata-ignored across every operator (EQ/NEQ/LT/LTE/GT/GTE), and alphanumeric prerelease ordering (alpha < alpha.1 < alpha.beta < beta < release). Each allocation gates on a unique SEMVER_EQ attribute version so test attributes cannot cross-match other allocations; negative build-metadata cases (NEQ/LT/GT) fall through to DEFAULT.",
+      "variations": {
+        "numeric-prerelease": {
+          "key": "numeric-prerelease",
+          "value": "numeric-prerelease"
+        },
+        "build-equal-precedence": {
+          "key": "build-equal-precedence",
+          "value": "build-equal-precedence"
+        },
+        "build-dotted-eq": {
+          "key": "build-dotted-eq",
+          "value": "build-dotted-eq"
+        },
+        "build-lte": {
+          "key": "build-lte",
+          "value": "build-lte"
+        },
+        "build-gte": {
+          "key": "build-gte",
+          "value": "build-gte"
+        },
+        "alpha-before-alpha-1": {
+          "key": "alpha-before-alpha-1",
+          "value": "alpha-before-alpha-1"
+        },
+        "alpha-1-before-alpha-beta": {
+          "key": "alpha-1-before-alpha-beta",
+          "value": "alpha-1-before-alpha-beta"
+        },
+        "alpha-beta-before-beta": {
+          "key": "alpha-beta-before-beta",
+          "value": "alpha-beta-before-beta"
+        },
+        "beta-before-release": {
+          "key": "beta-before-release",
+          "value": "beta-before-release"
+        },
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "numeric-prerelease",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "10.0.0-beta.2"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_LT",
+                  "value": "10.0.0-beta.11"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "numeric-prerelease",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "build-equal-precedence",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "20.0.0+linux"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "20.0.0+darwin"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "build-equal-precedence",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "build-dotted-eq",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "30.0.0+exp.sha.5114f85"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "30.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "build-dotted-eq",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "build-lte",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "40.0.0+build.42"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_LTE",
+                  "value": "40.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "build-lte",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "build-gte",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "50.0.0+build.42"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_GTE",
+                  "value": "50.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "build-gte",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "build-neq",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "60.0.0+build.42"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_NEQ",
+                  "value": "60.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "build-lt",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "70.0.0+build.42"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_LT",
+                  "value": "70.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "build-gt",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "80.0.0+build.42"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_GT",
+                  "value": "80.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "alpha-before-alpha-1",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "90.0.0-alpha"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_LT",
+                  "value": "90.0.0-alpha.1"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "alpha-before-alpha-1",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "alpha-1-before-alpha-beta",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "91.0.0-alpha.1"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_LT",
+                  "value": "91.0.0-alpha.beta"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "alpha-1-before-alpha-beta",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "alpha-beta-before-beta",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "92.0.0-alpha.beta"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_LT",
+                  "value": "92.0.0-beta"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "alpha-beta-before-beta",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "beta-before-release",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "93.0.0-beta"
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_LT",
+                  "value": "93.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "beta-before-release",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-version-parts-input-test": {
+      "key": "semver-version-parts-input-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "Exercises one- through five-part runtime attributes using only canonical three-part configured comparands, so comparand ingestion cannot prevent an input case from running. Scenario gates isolate each runtime comparison.",
+      "variations": {
+        "one-part-input": {
+          "key": "one-part-input",
+          "value": "one-part-input"
+        },
+        "two-part-input": {
+          "key": "two-part-input",
+          "value": "two-part-input"
+        },
+        "four-part-input": {
+          "key": "four-part-input",
+          "value": "four-part-input"
+        },
+        "five-part-input": {
+          "key": "five-part-input",
+          "value": "five-part-input"
+        }
+      },
+      "allocations": [
+        {
+          "key": "one-part-input",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "scenario",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "one-part-input"
+                  ]
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "18.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "one-part-input",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "two-part-input",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "scenario",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "two-part-input"
+                  ]
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "18.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "two-part-input",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "four-part-input",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "scenario",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "four-part-input"
+                  ]
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_GT",
+                  "value": "17.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "four-part-input",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "five-part-input",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "scenario",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "five-part-input"
+                  ]
+                },
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_GT",
+                  "value": "17.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "five-part-input",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-version-parts-one-part-comparand-test": {
+      "key": "semver-version-parts-one-part-comparand-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "Isolates a one-part configured SemVer comparand from every other extended comparand shape.",
+      "variations": {
+        "one-part-comparand": {
+          "key": "one-part-comparand",
+          "value": "one-part-comparand"
+        }
+      },
+      "allocations": [
+        {
+          "key": "one-part-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "18"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "one-part-comparand",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-version-parts-two-part-comparand-test": {
+      "key": "semver-version-parts-two-part-comparand-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "Isolates a two-part configured SemVer comparand from every other extended comparand shape.",
+      "variations": {
+        "two-part-comparand": {
+          "key": "two-part-comparand",
+          "value": "two-part-comparand"
+        }
+      },
+      "allocations": [
+        {
+          "key": "two-part-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "18.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "two-part-comparand",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-version-parts-four-part-comparand-test": {
+      "key": "semver-version-parts-four-part-comparand-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "Isolates a four-part configured SemVer comparand while the runtime attribute remains a canonical three-part version.",
+      "variations": {
+        "four-part-comparand": {
+          "key": "four-part-comparand",
+          "value": "four-part-comparand"
+        }
+      },
+      "allocations": [
+        {
+          "key": "four-part-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_GT",
+                  "value": "18.0.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "four-part-comparand",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-version-parts-five-part-comparand-test": {
+      "key": "semver-version-parts-five-part-comparand-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "Isolates a five-part configured SemVer comparand while the runtime attribute remains a canonical three-part version.",
+      "variations": {
+        "five-part-comparand": {
+          "key": "five-part-comparand",
+          "value": "five-part-comparand"
+        }
+      },
+      "allocations": [
+        {
+          "key": "five-part-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_GT",
+                  "value": "18.0.0.0.0"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "five-part-comparand",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-invalid-comparand-syntax-test": {
+      "key": "semver-invalid-comparand-syntax-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag deliberately uses a non-parseable SemVer comparand. SDKs must remove this flag without rejecting the full configuration.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "invalid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "not-a-version"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-valid-comparand-hyphenated-prerelease-test": {
+      "key": "semver-valid-comparand-hyphenated-prerelease-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag uses a valid SemVer comparand with repeated hyphens inside its prerelease identifiers.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "valid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "1.2.3----R-S.12.9.1--.12+meta"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-invalid-comparand-consecutive-dots-test": {
+      "key": "semver-invalid-comparand-consecutive-dots-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag deliberately uses consecutive dots in its SemVer prerelease comparand. SDKs must remove this flag without rejecting the full configuration.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "invalid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "1.0.0-alpha..1"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-invalid-comparand-dot-suffix-test": {
+      "key": "semver-invalid-comparand-dot-suffix-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag deliberately uses a Ruby-style dot-suffixed SemVer comparand. SDKs must remove this flag without rejecting the full configuration.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "invalid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "1.2.3.DEV"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-invalid-comparand-vprefix-test": {
+      "key": "semver-invalid-comparand-vprefix-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag deliberately uses a v-prefixed SemVer comparand, which is not valid SemVer. SDKs must remove this flag without rejecting the full configuration.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "invalid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "v1.2.3"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-invalid-comparand-leading-zero-test": {
+      "key": "semver-invalid-comparand-leading-zero-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag deliberately uses a leading-zero core component in its SemVer comparand. SDKs must remove this flag without rejecting the full configuration.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "invalid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": "01.2.3"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "semver-invalid-comparand-non-string-test": {
+      "key": "semver-invalid-comparand-non-string-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "comment": "This flag deliberately uses a non-string (JSON number) SemVer comparand. SDKs must reject this as an invalid comparand without rejecting the full configuration.",
+      "variations": {
+        "matched": {
+          "key": "matched",
+          "value": "matched"
+        }
+      },
+      "allocations": [
+        {
+          "key": "invalid-comparand",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "app_version",
+                  "operator": "SEMVER_EQ",
+                  "value": 1.2
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "matched",
               "shards": []
             }
           ],


### PR DESCRIPTION
## Summary
- refresh FFE fixtures from a271dc12ce65eb3d937818a5ba5cf30b78799d26
- allow any number of numeric SemVer core components
- cover six-part and longer core version comparisons

## Testing
- `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj --no-restore --framework net10.0 --filter FullyQualifiedName~SemanticVersionTests --logger "console;verbosity=minimal"`
- `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj --no-restore --framework net10.0 --filter FullyQualifiedName~FeatureFlagsEvaluatorTests.BundledTest --logger "console;verbosity=minimal"`