### PR TITLE
Mark two Profiler tests as Flaky

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/ReferenceChain/ReferenceChainTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/ReferenceChain/ReferenceChainTest.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Net;
 using System.Text.Json;
 using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.IntegrationTests.Xunit;
 using ReferenceChainModel;
 using Xunit;
 using Xunit.Abstractions;
@@ -241,6 +242,7 @@ namespace Datadog.Profiler.IntegrationTests.ReferenceChain
 
         // Run against JSON as well: the two serializers build their type table independently,
         // so a type/index mismatch in one of them would not show up in the other.
+        [Flaky("Identified as flaky in CI; under investigation")]
         [TestAppFact("Samples.Computer01", new[] { "net10.0" })]
         public void CheckReferenceTreeTypesAreInClassHistogramJson(string appName, string framework, string appAssembly)
         {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.IntegrationTests.Xunit;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,6 +22,7 @@ namespace Datadog.Profiler.IntegrationTests.Signature
             _output = output;
         }
 
+        [Flaky("Identified as flaky in CI; under investigation")]
         [TestAppFact("Samples.Computer01", new[] { "net48", "netcoreapp3.1", "net6.0", "net8.0", })] // FIXME: .NET 9 skipping .NET 9 for now
         public void ValidateSignatures(string appName, string framework, string appAssembly)
         {


### PR DESCRIPTION
## Summary of changes

Mark two profiler integration tests as flaky:
- CheckReferenceTreeTypesAreInClassHistogramJson
- ValidateSignatures


## Reason for change

They flaked, green CI goal

## Implementation details

Added [Flaky] hopefully it works.

## Test coverage

this is it

## Other details
<!-- Fixes #{issue} -->

#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
