### PR TITLE
[CI Visibility] Keep CODEOWNERS matches inside repository

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersFileLocator.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersFileLocator.cs
@@ -91,7 +91,7 @@ internal sealed class CodeOwnersFileLocator
     }
 
     private LocatedCodeOwners? TryLoadFromExplicitRoot(string? root)
-        => StringUtil.IsNullOrEmpty(root) ? null : TryLoadFromRepositoryRoot(root!);
+        => StringUtil.IsNullOrEmpty(root) ? null : TryLoadFromRepositoryRoot(root);
 
     private CodeOwners.Dialect DetectDialect(string root)
     {

--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersFileLocator.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersFileLocator.cs
@@ -25,8 +25,17 @@ internal sealed class CodeOwnersFileLocator
     {
         _repository = repository;
         _provider = provider;
-        LocatedFile = FindFromAncestors(sourceRoot, workspacePath) ??
-                      FindFromAncestors(workspacePath, basePath: null);
+        var sourceDirectory = RepositorySourcePathResolver.GetSearchStart(sourceRoot, workspacePath);
+        var workspaceDirectory = RepositorySourcePathResolver.GetSearchStart(workspacePath, basePath: null);
+        var repositoryRoot = FindGitRoot(sourceDirectory) ?? FindGitRoot(workspaceDirectory);
+
+        if (repositoryRoot is not null)
+        {
+            LocatedFile = TryLoadFromRepositoryRoot(repositoryRoot);
+            return;
+        }
+
+        LocatedFile = TryLoadFromExplicitRoot(workspaceDirectory) ?? TryLoadFromExplicitRoot(sourceDirectory);
     }
 
     /// <summary>
@@ -34,9 +43,8 @@ internal sealed class CodeOwnersFileLocator
     /// </summary>
     internal LocatedCodeOwners? LocatedFile { get; }
 
-    private LocatedCodeOwners? FindFromAncestors(string? startPath, string? basePath)
+    private static string? FindGitRoot(string? startDirectory)
     {
-        var startDirectory = RepositorySourcePathResolver.GetSearchStart(startPath, basePath);
         if (StringUtil.IsNullOrEmpty(startDirectory))
         {
             return null;
@@ -55,15 +63,9 @@ internal sealed class CodeOwnersFileLocator
 
         while (directory is not null)
         {
-            var locatedFile = TryLoadFromRepositoryRoot(directory.FullName);
-            if (locatedFile is not null)
-            {
-                return locatedFile;
-            }
-
             if (HasGitMarker(directory.FullName))
             {
-                return null;
+                return directory.FullName;
             }
 
             directory = directory.Parent;
@@ -87,6 +89,9 @@ internal sealed class CodeOwnersFileLocator
                    ? new LocatedCodeOwners(rules, root)
                    : null;
     }
+
+    private LocatedCodeOwners? TryLoadFromExplicitRoot(string? root)
+        => StringUtil.IsNullOrEmpty(root) ? null : TryLoadFromRepositoryRoot(root!);
 
     private CodeOwners.Dialect DetectDialect(string root)
     {

--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersResolver.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersResolver.cs
@@ -48,17 +48,17 @@ internal sealed class CodeOwnersResolver
         var locatedFile = _locatedCodeOwners;
         if (locatedFile is null)
         {
-            var fallbackPath = _pathResolver.MakeRelativeToSourceRoot(sourceFilePath, useOSSeparator);
-            return new SourceOwnership(fallbackPath, [], isRepositoryRelative: false);
+            var sourceRootPath = _pathResolver.MakeRelativeToSourceRoot(sourceFilePath, useOSSeparator);
+            return new SourceOwnership(sourceRootPath, [], isRepositoryRelative: false);
         }
 
-        _pathResolver.TryMakeRepositoryRelative(sourceFilePath, locatedFile.RepositoryRoot, useOSSeparator, out var repositoryPath);
+        if (_pathResolver.TryMakeRepositoryRelative(sourceFilePath, locatedFile.RepositoryRoot, useOSSeparator, out var repositoryPath))
+        {
+            return new SourceOwnership(repositoryPath, locatedFile.Rules.Match(repositoryPath), isRepositoryRelative: true);
+        }
 
-        var isRepositoryRelative = repositoryPath is not null;
-        var resolvedPath = repositoryPath ?? _pathResolver.MakeRelativeToSourceRoot(sourceFilePath, useOSSeparator);
-        var matchingOwners = locatedFile.Rules.Match(resolvedPath);
-
-        return new SourceOwnership(resolvedPath, matchingOwners, isRepositoryRelative);
+        var fallbackPath = _pathResolver.MakeRelativeToSourceRoot(sourceFilePath, useOSSeparator);
+        return new SourceOwnership(fallbackPath, [], isRepositoryRelative: false);
     }
 
     private readonly struct SourcePathCacheKey : IEquatable<SourcePathCacheKey>

--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/RepositorySourcePathResolver.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/RepositorySourcePathResolver.cs
@@ -29,7 +29,7 @@ internal sealed class RepositorySourcePathResolver
         => MakeRelativePath(_sourceRoot, sourceFilePath, useOSSeparator);
 
     /// <summary>
-    /// Resolves the source path below the repository root, including paths recorded from another CI workspace.
+    /// Resolves the source path below the repository root, including relative paths recorded from another CI workspace.
     /// </summary>
     internal bool TryMakeRepositoryRelative(string sourceFilePath, string repositoryRoot, bool useOSSeparator, [NotNullWhen(true)] out string? relativePath)
     {

--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/RepositorySourcePathResolver.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/RepositorySourcePathResolver.cs
@@ -341,6 +341,12 @@ internal sealed class RepositorySourcePathResolver
         RootPathInfo root,
         [NotNullWhen(true)] out string? absolutePath)
     {
+        if (IsPathRootedCrossPlatform(relativePath))
+        {
+            absolutePath = null;
+            return false;
+        }
+
         var resolvedPath = Path.GetFullPath(Path.Combine(root.FullPath, relativePath));
         if (!resolvedPath.StartsWith(root.FullPathWithSeparator, root.PathComparison) &&
             !string.Equals(resolvedPath, root.FullPath, root.PathComparison))

--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/RepositorySourcePathResolver.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/RepositorySourcePathResolver.cs
@@ -29,7 +29,7 @@ internal sealed class RepositorySourcePathResolver
         => MakeRelativePath(_sourceRoot, sourceFilePath, useOSSeparator);
 
     /// <summary>
-    /// Resolves the source path below the repository root, including relative paths recorded from another CI workspace.
+    /// Resolves the source path below the repository root, including paths recorded in another build environment.
     /// </summary>
     internal bool TryMakeRepositoryRelative(string sourceFilePath, string repositoryRoot, bool useOSSeparator, [NotNullWhen(true)] out string? relativePath)
     {
@@ -165,15 +165,15 @@ internal sealed class RepositorySourcePathResolver
     private static bool TryAnchorExistingSuffix(string sourceFilePath, string repositoryRoot, bool useOSSeparator, [NotNullWhen(true)] out string? relativePath)
     {
         relativePath = null;
-        if (Path.IsPathRooted(sourceFilePath) || Uri.TryCreate(sourceFilePath, UriKind.Absolute, out _))
+        if (!TryNormalizeCompilerPath(sourceFilePath, out var normalizedPath))
         {
             return false;
         }
 
-        var normalizedPath = sourceFilePath.IndexOf('\\') >= 0 ? sourceFilePath.Replace('\\', '/') : sourceFilePath;
         var repositoryPathStart = SkipLeadingNavigationSegments(normalizedPath);
         var pathWithoutLeadingNavigation = repositoryPathStart == 0 ? normalizedPath : normalizedPath.Substring(repositoryPathStart);
-        if (Path.IsPathRooted(pathWithoutLeadingNavigation) || Uri.TryCreate(pathWithoutLeadingNavigation, UriKind.Absolute, out _))
+        if (repositoryPathStart > 0 &&
+            (IsPathRootedCrossPlatform(pathWithoutLeadingNavigation) || Uri.TryCreate(pathWithoutLeadingNavigation, UriKind.Absolute, out _)))
         {
             return false;
         }
@@ -219,6 +219,43 @@ internal sealed class RepositorySourcePathResolver
         }
 
         return false;
+    }
+
+    private static bool TryNormalizeCompilerPath(string sourceFilePath, [NotNullWhen(true)] out string? normalizedPath)
+    {
+        normalizedPath = sourceFilePath;
+        if (!IsPathRootedCrossPlatform(sourceFilePath) && Uri.TryCreate(sourceFilePath, UriKind.Absolute, out var uri))
+        {
+            if (!uri.IsFile)
+            {
+                normalizedPath = null;
+                return false;
+            }
+
+            normalizedPath = uri.LocalPath;
+        }
+
+        if (normalizedPath.IndexOf('\\') >= 0)
+        {
+            normalizedPath = normalizedPath.Replace('\\', '/');
+        }
+
+        return true;
+    }
+
+    private static bool IsPathRootedCrossPlatform(string path)
+    {
+        if (Path.IsPathRooted(path) ||
+            path.StartsWith("\\", StringComparison.Ordinal) ||
+            path.StartsWith("//", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return path.Length >= 3 &&
+               CharHelpers.IsAsciiLetter(path[0]) &&
+               path[1] == ':' &&
+               (path[2] == '\\' || path[2] == '/');
     }
 
     private static int SkipLeadingNavigationSegments(string path)

--- a/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersFallbackTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersFallbackTests.cs
@@ -503,11 +503,11 @@ public class CodeOwnersFallbackTests
     [SkippableTheory]
     [InlineData(@"D:\a\_work\1\s\src\SpanBenchmark.cs")]
     [InlineData(@"D:\a\1\s\src\SpanBenchmark.cs")]
+    [InlineData("D:/a/_work/1/s/src/SpanBenchmark.cs")]
     [InlineData("/home/vsts/work/1/s/src/SpanBenchmark.cs")]
     [InlineData("/tmp/work/1/s/src/SpanBenchmark.cs")]
     [InlineData("file:///D:/a/_work/1/s/src/SpanBenchmark.cs")]
-    [InlineData("https://example.com/a/_work/1/s/src/SpanBenchmark.cs")]
-    public void DoesNotAnchorAbsoluteAzurePipelinesPathsWithMatchingRepositorySuffix(string sourcePath)
+    public void AnchorsRelocatedCompilerPathsWithMatchingRepositorySuffix(string sourcePath)
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.RootPath;
@@ -527,7 +527,9 @@ public class CodeOwnersFallbackTests
         var ciValues = CIEnvironmentValues.Create(env);
 
         var ownership = ciValues.ResolveSourceOwnership(sourcePath, useOSSeparator: false);
-        Assert.False(ownership.IsRepositoryRelative);
+        Assert.True(ownership.IsRepositoryRelative);
+        Assert.Equal("src/SpanBenchmark.cs", ownership.RepositoryRelativePath);
+        Assert.Equal(["@owner"], ownership.MatchingOwners);
     }
 
     [SkippableFact]
@@ -549,12 +551,11 @@ public class CodeOwnersFallbackTests
     }
 
     [SkippableTheory]
-    [InlineData("file:///outside/src/SpanBenchmark.cs")]
     [InlineData("https://example.com/src/SpanBenchmark.cs")]
     [InlineData("../../C:/outside/src/SpanBenchmark.cs")]
     [InlineData("../..//outside/src/SpanBenchmark.cs")]
     [InlineData(@"..\..\\server\share\src\SpanBenchmark.cs")]
-    public void DoesNotAnchorAbsoluteOrEmbeddedRootedPathsWithMatchingRepositorySuffix(string sourceFilePath)
+    public void DoesNotAnchorNonFileUrisOrEmbeddedRootedPaths(string sourceFilePath)
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.RootPath;

--- a/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersFallbackTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersFallbackTests.cs
@@ -79,6 +79,26 @@ public class CodeOwnersFallbackTests
     }
 
     [SkippableFact]
+    public void UsesGitRootInsteadOfNestedCodeOwnersFile()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.RootPath;
+        var srcDir = Path.Combine(repoRoot, "src");
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
+        Directory.CreateDirectory(srcDir);
+        var sourceFile = Path.Combine(srcDir, "SpanBenchmark.cs");
+        File.WriteAllText(Path.Combine(repoRoot, "CODEOWNERS"), "* @repository-owner");
+        File.WriteAllText(Path.Combine(srcDir, "CODEOWNERS"), "* @nested-owner");
+        File.WriteAllText(sourceFile, "class SpanBenchmark {}");
+
+        var ciValues = CreateGitHubEnvironmentForWorkspace(srcDir);
+        var ownership = ciValues.ResolveSourceOwnership(sourceFile, useOSSeparator: false);
+
+        Assert.Equal("src/SpanBenchmark.cs", ownership.RepositoryRelativePath);
+        Assert.Equal(["@repository-owner"], ownership.MatchingOwners);
+    }
+
+    [SkippableFact]
     public void DoesNotUseCurrentDirectoryForRelativeSourceFile()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -295,10 +315,12 @@ public class CodeOwnersFallbackTests
 
         Assert.True(ciValues.HasCodeOwners);
         Assert.False(ownership.IsRepositoryRelative);
+        Assert.Empty(ownership.MatchingOwners);
+        Assert.Null(ownership.CodeOwnersTag);
     }
 
     [SkippableFact]
-    public void KeepsSourceRootMatchWhenFallbackCannotResolve()
+    public void DoesNotMatchCodeOwnersWhenFallbackCannotResolve()
     {
         using var repoDirectory = new TemporaryDirectory();
         var repoRoot = repoDirectory.RootPath;
@@ -315,7 +337,8 @@ public class CodeOwnersFallbackTests
 
         Assert.StartsWith("..", ownership.RepositoryRelativePath, StringComparison.Ordinal);
         Assert.False(ownership.IsRepositoryRelative);
-        Assert.Equal(["@global"], ownership.MatchingOwners);
+        Assert.Empty(ownership.MatchingOwners);
+        Assert.Null(ownership.CodeOwnersTag);
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary of changes

- Resolve CODEOWNERS from the Git repository root instead of accepting a nested file first.
- Do not assign CODEOWNERS to source paths that cannot be resolved inside the repository.
- Resolve absolute or relative PDB source paths recorded in a different build environment.
- Preserve the source-file fallback tag when a compiler path cannot be resolved.

## Reason for change

The CODEOWNERS implementation added in #9099 could select a nested CODEOWNERS file before reaching the repository root. It could also evaluate unresolved source text against repository rules, producing incorrect owners.

PDB paths may come from a different machine or operating system than the test runtime. Requiring those original paths to be valid locally drops legitimate CODEOWNERS metadata, such as Windows build paths consumed by Linux tests.

## Implementation details

- Find the nearest Git root before selecting a CODEOWNERS location.
- Fall back to the explicit workspace or source root when Git metadata is unavailable.
- Re-anchor compiler paths by the longest existing suffix under the repository root, including Windows, Unix, and file URI paths.
- Evaluate rules only after the source path has been resolved inside the CODEOWNERS repository root.
- Reject non-file URIs, embedded rooted paths after parent traversal, and suffixes that do not exist in the repository.

## Test coverage

- CodeOwnersFallbackTests: 34 passed.
- Added coverage for nested CODEOWNERS files, unresolved or external paths, and cross-OS PDB paths.
- Includes the Azure layout from the CI regression: D:/a/_work/1/s/....

## Other details

- Companion logger port: https://github.com/tonyredondo/datadog-test-logger/pull/37
- No public API or dependency changes.