### PR TITLE
Bump test logger to latest (to try to fix codeowners)

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -92,6 +92,6 @@
     <ProjectReference Include="..\..\src\Tools\ReferenceChainExplorer\ReferenceChainModel\ReferenceChainModel.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.55" ExcludeAssets="compile" />
+    <PackageReference Include="DatadogTestLogger" Version="0.0.56" ExcludeAssets="compile" />
   </ItemGroup>
 </Project>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -59,8 +59,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestCollector" Version="0.0.55" ExcludeAssets="compile"/>
-    <PackageReference Include="DatadogTestLogger" Version="0.0.55" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestCollector" Version="0.0.56" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.56" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
## Summary of changes

Bump the version of the testlogger

## Reason for change

It includes the latest codeowners code

## Implementation details

Bump the numbers

## Test coverage

This is the test

## Other details

Currently we're not reporting owners correctly