### PR TITLE
Add `new Random()` to the banned API list, to discourage using those APIs

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -52,3 +52,7 @@ M:Datadog.Trace.Vendors.Newtonsoft.Json.Linq.JToken.ToString(Datadog.Trace.Vendo
 # Ban JsonSerializer.Serialize(TextWriter) - use JsonTextWriter with ArrayPool instead
 M:Datadog.Trace.Vendors.Newtonsoft.Json.JsonSerializer.Serialize(System.IO.TextWriter,System.Object);Use JsonTextWriter with ArrayPool = JsonArrayPool.Shared instead
 M:Datadog.Trace.Vendors.Newtonsoft.Json.JsonSerializer.Serialize(System.IO.TextWriter,System.Object,System.Type);Use JsonTextWriter with ArrayPool = JsonArrayPool.Shared instead
+
+# Ban System.Random constructors - use ThreadSafeRandom instead
+M:System.Random.#ctor;Use Datadog.Trace.Util.ThreadSafeRandom.Shared instead - Random instances are not thread-safe, and before .NET 6 instances created in quick succession are seeded from the tick count and produce identical sequences
+M:System.Random.#ctor(System.Int32);Use Datadog.Trace.Util.ThreadSafeRandom.Shared instead - Random instances are not thread-safe. If you genuinely need a deterministic seeded sequence, suppress RS0030 with a comment explaining why

--- a/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
+++ b/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
@@ -14,7 +14,9 @@ internal static class ThreadSafeRandom
 #if NET6_0_OR_GREATER
     public static Random Shared => Random.Shared;
 #else
+#pragma warning disable RS0030 // ThreadSafeRandom is the sanctioned wrapper for Random
     private static readonly Random Global = new();
+#pragma warning restore RS0030
 
     [ThreadStatic]
     private static Random? _local;
@@ -32,7 +34,9 @@ internal static class ThreadSafeRandom
                     seed = Global.Next();
                 }
 
+#pragma warning disable RS0030 // ThreadSafeRandom is the sanctioned wrapper for Random
                 _local = new Random(seed);
+#pragma warning restore RS0030
             }
 
             return _local;


### PR DESCRIPTION
## Summary of changes

Add `Random` to the banned API list

## Reason for change

We have `ThreadSafeRandom` which should generally be preferred

## Implementation details

- Added `Random()` constructors to the banned API lists
- I _didn't_ add `Random.Shared` (.NET 6+ only) seeing as `ThreadSafeRandom.Shared` just delegates to this directly, so if you're writing .NET 6+ code, using `Random.Shared` is fine.

## Test coverage

This is the test

## Other details

Spotted as part of reviewing #9042