### PR TITLE
Bump SLO for throughput tests

### DIFF
--- a/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
@@ -196,7 +196,7 @@ experiments:
 
           - name: normal_operation--trace_stats-win
             thresholds:
-              # n=601, mean=32212590.57, CI=[36.980ms; 38.784ms]
+              # n=601, mean=37.882ms, CI=[36.980ms; 38.784ms]
               - agg_http_req_duration_p95 < 43093333.33 ns
               # n=601, mean=10609.29, CI=[10439.04, 10779.54]
               - throughput > 9490.03 op/s

--- a/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
@@ -196,7 +196,7 @@ experiments:
 
           - name: normal_operation--trace_stats-win
             thresholds:
-              # n=601, mean=32212590.57, CI=[31276382.79, 33148798.36]
-              - agg_http_req_duration_p95 < 36831998.18 ns
+              # n=601, mean=32212590.57, CI=[36.980ms; 38.784ms]
+              - agg_http_req_duration_p95 < 43093333.33 ns
               # n=601, mean=10609.29, CI=[10439.04, 10779.54]
               - throughput > 9490.03 op/s


### PR DESCRIPTION
## Summary of changes

Bumps the SLO for throughput tests

## Reason for change

They're occasionally touching the threshold

## Implementation details

Told the AI to bump them. It did what it did

## Test coverage

Meh, if this passes, it'll do

## Other details

Fixes https://datadoghq.atlassian.net/browse/SRTEE-7