### PR TITLE
[FeatureFlags] Send API key fingerprint with managed UFC requests

### DIFF
--- a/tracer/src/Datadog.Trace/FeatureFlags/Agentless/AgentlessConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Agentless/AgentlessConfigurationSource.cs
@@ -28,6 +28,8 @@ namespace Datadog.Trace.FeatureFlags.Agentless;
 /// </summary>
 internal sealed class AgentlessConfigurationSource : IDisposable
 {
+    internal const string ApiKeyFingerprintHeader = "DD-API-KEY-FINGERPRINT";
+
     private const int MaxAttempts = 3;
     private const double RetryJitter = 0.2;
 
@@ -222,6 +224,19 @@ internal sealed class AgentlessConfigurationSource : IDisposable
     private static ApiWebRequestFactory CreateRequestFactory(AgentlessEndpoint endpoint, FeatureFlagsSettings settings)
 #endif
     {
+        var headers = CreateRequestHeaders(endpoint, settings);
+
+        // The endpoint is only the factory's default: both transports honour the URI passed to
+        // Create, which is what carries the current environment.
+#if NETCOREAPP
+        return new HttpClientRequestFactory(endpoint.Uri, headers, timeout: settings.RequestTimeout);
+#else
+        return new ApiWebRequestFactory(endpoint.Uri, headers, timeout: settings.RequestTimeout);
+#endif
+    }
+
+    internal static KeyValuePair<string, string>[] CreateRequestHeaders(AgentlessEndpoint endpoint, FeatureFlagsSettings settings)
+    {
         var headers = new List<KeyValuePair<string, string>>
         {
             // The endpoint serves gzip, and neither transport decompresses for us.
@@ -239,15 +254,10 @@ internal sealed class AgentlessConfigurationSource : IDisposable
             // A custom endpoint is left to report its own authentication failure rather than
             // having the Datadog credential sent to it.
             headers.Add(new(TelemetryConstants.ApiKeyHeader, settings.ApiKey!));
+            headers.Add(new(ApiKeyFingerprintHeader, ApiKeyFingerprint.Create(settings.ApiKey!)));
         }
 
-        // The endpoint is only the factory's default: both transports honour the URI passed to
-        // Create, which is what carries the current environment.
-#if NETCOREAPP
-        return new HttpClientRequestFactory(endpoint.Uri, headers.ToArray(), timeout: settings.RequestTimeout);
-#else
-        return new ApiWebRequestFactory(endpoint.Uri, headers.ToArray(), timeout: settings.RequestTimeout);
-#endif
+        return headers.ToArray();
     }
 
     private static bool IsRetryable(in PollResult result)

--- a/tracer/src/Datadog.Trace/FeatureFlags/Agentless/ApiKeyFingerprint.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Agentless/ApiKeyFingerprint.cs
@@ -8,7 +8,7 @@
 using System;
 using Datadog.Trace.Util;
 
-namespace Datadog.Trace.FeatureFlags.Evp;
+namespace Datadog.Trace.FeatureFlags.Agentless;
 
 internal static class ApiKeyFingerprint
 {

--- a/tracer/src/Datadog.Trace/FeatureFlags/Evp/ApiKeyFingerprint.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Evp/ApiKeyFingerprint.cs
@@ -1,0 +1,57 @@
+// <copyright file="ApiKeyFingerprint.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.FeatureFlags.Evp;
+
+internal static class ApiKeyFingerprint
+{
+    private const string Alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private const int EncodedLength = 43;
+
+    public static string Create(string apiKey)
+    {
+#if NETCOREAPP
+        Span<byte> digest = stackalloc byte[32];
+        Sha256Helper.ComputeHash(apiKey, digest);
+        return Encode(digest);
+#else
+        return Encode(Sha256Helper.ComputeHash(apiKey));
+#endif
+    }
+
+    private static string Encode(Span<byte> digest)
+    {
+        Span<char> encoded = stackalloc char[EncodedLength];
+        encoded.Fill('0');
+
+        // The digest is an unsigned big-endian integer. Repeated long division avoids the
+        // signed/little-endian differences in BigInteger across the supported target frameworks.
+        for (var outputIndex = EncodedLength - 1; outputIndex >= 0; outputIndex--)
+        {
+            var remainder = 0;
+            var hasValue = false;
+            for (var digestIndex = 0; digestIndex < digest.Length; digestIndex++)
+            {
+                var current = (remainder * 256) + digest[digestIndex];
+                digest[digestIndex] = (byte)(current / 62);
+                remainder = current % 62;
+                hasValue |= digest[digestIndex] != 0;
+            }
+
+            encoded[outputIndex] = Alphabet[remainder];
+            if (!hasValue)
+            {
+                break;
+            }
+        }
+
+        return "rijn_" + encoded.ToString();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/AgentlessConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/AgentlessConfigurationSourceTests.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -14,8 +15,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.FeatureFlags.Agentless;
 using Datadog.Trace.FeatureFlags.Rcm.Model;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers.TransportHelpers;
 using FluentAssertions;
 using Xunit;
@@ -31,6 +35,37 @@ public class AgentlessConfigurationSourceTests
         """;
 
     private const string EndpointUrl = "https://ufc-server.ff-cdn.datadoghq.com/api/v2/feature-flagging/config/rules-based/server";
+
+    [Fact]
+    public void AddsApiKeyAndFingerprintToManagedRequests()
+    {
+        var settings = CreateTracerSettings(apiKey: "system-tests-mock-api-key").FeatureFlags;
+        var headers = AgentlessConfigurationSource.CreateRequestHeaders(CreateEndpoint(), settings);
+
+        headers.Should().ContainSingle(header => header.Key == TelemetryConstants.ApiKeyHeader)
+               .Which.Value.Should().Be("system-tests-mock-api-key");
+        headers.Should().ContainSingle(header => header.Key == "DD-API-KEY-FINGERPRINT")
+               .Which.Value.Should().Be("rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU");
+    }
+
+    [Fact]
+    public void DoesNotSendApiKeyOrFingerprintToCustomEndpoint()
+    {
+        var settings = CreateTracerSettings(apiKey: "system-tests-mock-api-key", baseUrl: "https://flags.example.com/ufc").FeatureFlags;
+        var endpoint = CreateEndpoint(settings.Site, settings.AgentlessBaseUrl);
+        var headers = AgentlessConfigurationSource.CreateRequestHeaders(endpoint, settings);
+
+        headers.Should().NotContain(header => header.Key == TelemetryConstants.ApiKeyHeader);
+        headers.Should().NotContain(header => header.Key == "DD-API-KEY-FINGERPRINT");
+    }
+
+    [Fact]
+    public void DoesNotCreateManagedSourceWithoutApiKey()
+    {
+        var settings = CreateTracerSettings(apiKey: null);
+
+        AgentlessConfigurationSource.Create(settings.FeatureFlags, settings.Manager, _ => true).Should().BeNull();
+    }
 
     [Fact]
     public async Task AppliesConfigurationFromA200()
@@ -259,10 +294,26 @@ public class AgentlessConfigurationSourceTests
             environment,
             NoWait);
 
-    private static AgentlessEndpoint CreateEndpoint()
+    private static AgentlessEndpoint CreateEndpoint(string site = "datadoghq.com", string? baseUrl = null)
     {
-        AgentlessEndpoint.TryCreate("datadoghq.com", baseUrl: null, out var endpoint, out _).Should().BeTrue();
+        AgentlessEndpoint.TryCreate(site, baseUrl, out var endpoint, out _).Should().BeTrue();
         return endpoint ?? throw new InvalidOperationException("TryCreate reported success without producing an endpoint.");
+    }
+
+    private static TracerSettings CreateTracerSettings(string? apiKey, string? baseUrl = null)
+    {
+        var collection = new NameValueCollection();
+        if (apiKey is not null)
+        {
+            collection[ConfigurationKeys.ApiKey] = apiKey;
+        }
+
+        if (baseUrl is not null)
+        {
+            collection[ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSourceAgentlessBaseUrl] = baseUrl;
+        }
+
+        return new TracerSettings(new NameValueConfigurationSource(collection), NullConfigurationTelemetry.Instance);
     }
 
     private static Task NoWait(TimeSpan delay, CancellationToken cancellationToken) => Task.CompletedTask;

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ApiKeyFingerprintTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ApiKeyFingerprintTests.cs
@@ -5,7 +5,7 @@
 
 #nullable enable
 
-using Datadog.Trace.FeatureFlags.Evp;
+using Datadog.Trace.FeatureFlags.Agentless;
 using FluentAssertions;
 using Xunit;
 

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ApiKeyFingerprintTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ApiKeyFingerprintTests.cs
@@ -1,0 +1,26 @@
+// <copyright file="ApiKeyFingerprintTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.FeatureFlags.Evp;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.FeatureFlags;
+
+public class ApiKeyFingerprintTests
+{
+    [Theory]
+    [InlineData("", "rijn_RZwTDmWjELXeEmMEb0eIIegKayGGUPNsuJweEPhlXi5")]
+    [InlineData("padding-171", "rijn_053ybBRXypQt9AC6UIlqH1YCFYSV1rQl8HCDIcBZs3D")]
+    [InlineData("!@#$%^𐍈한€हИ£", "rijn_eFLHeyLxwaiNs2hY16pjkjNjVSHWRgf2rlveKc8YA1K")]
+    [InlineData("secret", "rijn_amLaG4Pd6h6t9VtJna81k744P1DYxGHzIJ6ECO3OOMj")]
+    [InlineData("system-tests-mock-api-key", "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU")]
+    public void Create_MatchesCanonicalVectors(string apiKey, string expected)
+    {
+        ApiKeyFingerprint.Create(apiKey).Should().Be(expected).And.HaveLength(48);
+    }
+}


### PR DESCRIPTION
## Motivation

Managed agentless Feature Flags configuration requests authenticate with `DD-API-KEY` and must send the corresponding canonical API key fingerprint.

## Changes

- Add an internal SHA-256 plus fixed-width base62 API key fingerprint helper under the agentless configuration source.
- Send `DD-API-KEY-FINGERPRINT` beside `DD-API-KEY` for managed `ufc-server.ff-cdn.*` requests.
- Add canonical vectors covering empty, padded, Unicode, simple, and system-test API keys.
- Add focused tests for managed header presence, custom-endpoint header absence, and the missing-API-key guard.

## Decisions

- Send the fingerprint header only with managed UFC configuration authentication.
- Custom endpoints receive neither the Datadog API key nor its fingerprint.
- The implementation avoids `BigInteger` so byte order and signedness remain stable across supported target frameworks.

## Test coverage

- `./tracer/build.sh CompileManagedSrc BuildAndRunManagedUnitTests --framework net6.0 --filter "FullyQualifiedName~Datadog.Trace.Tests.FeatureFlags"` — source compilation succeeded for netcoreapp3.1, net6.0, netstandard2.0, and net461; 505 tests passed, 0 failed, 0 skipped.

## Other details

- Draft PR against `pavlo.khrebto/EX-2703/ffe-manual-api`.
