### PR TITLE
[FeatureFlags] Add agentless EVP fallback transport

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -926,6 +926,7 @@
       <type fullname="System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs" />
       <type fullname="System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute" />
       <type fullname="System.Runtime.InteropServices.ComVisibleAttribute" />
+      <type fullname="System.Runtime.InteropServices.ExternalException" />
       <type fullname="System.Runtime.InteropServices.GCHandle" />
       <type fullname="System.Runtime.InteropServices.GCHandleType" />
       <type fullname="System.Runtime.InteropServices.InAttribute" />

--- a/tracer/src/Datadog.Trace/FeatureFlags/Agentless/AgentlessConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Agentless/AgentlessConfigurationSource.cs
@@ -49,7 +49,7 @@ internal sealed class AgentlessConfigurationSource : IDisposable
     private readonly Func<ServerConfiguration, bool> _applyConfiguration;
     private readonly Func<TimeSpan, CancellationToken, Task> _waitAsync;
     private readonly CancellationTokenSource _shutdown = new();
-    private readonly Random _random = new();
+    private readonly Random _random = ThreadSafeRandom.Shared;
 
     // Only ever touched from the poll loop.
     private readonly HashSet<string> _loggedFailureCategories = new();

--- a/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpTransport.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpTransport.cs
@@ -1,0 +1,413 @@
+// <copyright file="FeatureFlagsEvpTransport.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+#if NETCOREAPP
+using System.Net.Http;
+#endif
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.FeatureFlags.Evp;
+
+/// <summary>
+/// Selects and sends to a Feature Flags EVP route without changing the product payload.
+/// </summary>
+internal sealed class FeatureFlagsEvpTransport : IDisposable
+{
+    internal const string ExposureIntakePath = "api/v2/exposures";
+    internal const string FlagEvaluationIntakePath = "api/v2/flagevaluation";
+    internal const int PayloadSizeLimitBytes = 5 * 1024 * 1024;
+    internal const string EventPlatformProxyV4 = "evp_proxy/v4";
+    internal const string EventPlatformProxyV2 = "evp_proxy/v2";
+    private static readonly TimeSpan InitialDiscoveryWait = TimeSpan.FromSeconds(5);
+
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(FeatureFlagsEvpTransport));
+
+    private readonly FeatureFlagsSource _source;
+    private readonly IApiRequestFactory? _directRequestFactory;
+    private readonly IDiscoveryService _discoveryService;
+    private readonly Action<AgentConfiguration> _discoveryCallback;
+    private readonly IDisposable? _settingsSubscription;
+    private readonly TimeSpan _initialDiscoveryWait;
+    private readonly TaskCompletionSource<bool> _initialDiscovery = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private IApiRequestFactory _localRequestFactory;
+    private string? _localProxyEndpoint;
+    private int _directIsSticky;
+    private int _disposed;
+    private int _discoveryKnown;
+    private int _unavailableWarningLogged;
+
+    public FeatureFlagsEvpTransport(TracerSettings settings, IDiscoveryService discoveryService)
+    {
+        _source = settings.FeatureFlags.Source;
+        _localRequestFactory = CreateLocalRequestFactory(settings.Manager.InitialExporterSettings);
+        _directRequestFactory = _source == FeatureFlagsSource.Agentless
+                                    ? CreateDirectRequestFactory(settings.FeatureFlags)
+                                    : null;
+        _discoveryService = discoveryService;
+        _discoveryCallback = UpdateAgentConfiguration;
+        _initialDiscoveryWait = InitialDiscoveryWait;
+
+        // Remote Configuration never falls back to direct intake. Keep its historical v2 route
+        // available while discovery starts, and replace it with v4 when the Agent advertises it.
+        _localProxyEndpoint = _source == FeatureFlagsSource.RemoteConfig ? EventPlatformProxyV2 : null;
+
+        _settingsSubscription = settings.Manager.SubscribeToChanges(changes =>
+        {
+            if (changes.UpdatedExporter is { } exporter)
+            {
+                Interlocked.Exchange(ref _localRequestFactory!, CreateLocalRequestFactory(exporter));
+            }
+        });
+
+        _discoveryService.SubscribeToChanges(_discoveryCallback);
+    }
+
+    [TestingOnly]
+    internal FeatureFlagsEvpTransport(
+        FeatureFlagsSource source,
+        IApiRequestFactory localRequestFactory,
+        IApiRequestFactory? directRequestFactory,
+        IDiscoveryService discoveryService,
+        string? initialLocalProxyEndpoint = null,
+        bool initialDiscoveryKnown = true,
+        TimeSpan? initialDiscoveryWait = null)
+    {
+        _source = source;
+        _localRequestFactory = localRequestFactory;
+        _directRequestFactory = source == FeatureFlagsSource.Agentless ? directRequestFactory : null;
+        _discoveryService = discoveryService;
+        _discoveryCallback = UpdateAgentConfiguration;
+        _initialDiscoveryWait = initialDiscoveryWait ?? InitialDiscoveryWait;
+        _localProxyEndpoint = initialLocalProxyEndpoint ?? (source == FeatureFlagsSource.RemoteConfig ? EventPlatformProxyV2 : null);
+        if (initialDiscoveryKnown)
+        {
+            Volatile.Write(ref _discoveryKnown, 1);
+            _initialDiscovery.TrySetResult(true);
+        }
+
+        _discoveryService.SubscribeToChanges(_discoveryCallback);
+    }
+
+    private enum NetworkFailure
+    {
+        None,
+        DefinitivePreSend,
+        Ambiguous,
+    }
+
+    internal static KeyValuePair<string, string>[] GetDirectHeaders(string apiKey) =>
+    [
+        new(TelemetryConstants.ApiKeyHeader, apiKey),
+        new(TelemetryConstants.ClientLibraryLanguageHeader, TracerConstants.Language),
+        new(TelemetryConstants.ClientLibraryVersionHeader, TracerConstants.ThreePartVersion),
+    ];
+
+    internal static IApiRequestFactory? CreateDirectRequestFactory(FeatureFlagsSettings settings)
+    {
+        if (string.IsNullOrWhiteSpace(settings.ApiKey) || !TryNormalizeSite(settings.Site, out var site))
+        {
+            return null;
+        }
+
+        var expectedHost = $"event-platform-intake.{site}";
+        if (!Uri.TryCreate($"https://{expectedHost}", UriKind.Absolute, out var endpoint)
+         || endpoint.Scheme != Uri.UriSchemeHttps
+         || !string.Equals(endpoint.IdnHost, expectedHost, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var headers = GetDirectHeaders(settings.ApiKey!);
+#if NETCOREAPP
+        // With no custom handler/proxy, HttpClientHandler honours the standard HTTPS_PROXY and
+        // NO_PROXY environment variables for the current runtime.
+        return new HttpClientRequestFactory(endpoint, headers, timeout: TimeSpan.FromSeconds(5));
+#else
+        // HttpWebRequest uses the platform default proxy, including its bypass list.
+        return new ApiWebRequestFactory(endpoint, headers, timeout: TimeSpan.FromSeconds(5));
+#endif
+    }
+
+    private static bool TryNormalizeSite(string? value, out string site)
+    {
+        site = string.Empty;
+        if (value is null || value.Length is 0 or > 230)
+        {
+            return false;
+        }
+
+        var labelLength = 0;
+        var previousWasHyphen = false;
+        foreach (var c in value)
+        {
+            if (c == '.')
+            {
+                if (labelLength == 0 || previousWasHyphen)
+                {
+                    return false;
+                }
+
+                labelLength = 0;
+                previousWasHyphen = false;
+                continue;
+            }
+
+            if (c is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9')
+            {
+                labelLength++;
+                previousWasHyphen = false;
+            }
+            else if (c == '-' && labelLength > 0)
+            {
+                labelLength++;
+                previousWasHyphen = true;
+            }
+            else
+            {
+                return false;
+            }
+
+            if (labelLength > 63)
+            {
+                return false;
+            }
+        }
+
+        if (labelLength == 0 || previousWasHyphen)
+        {
+            return false;
+        }
+
+        site = value.ToLowerInvariant();
+        return true;
+    }
+
+    private static IApiRequestFactory CreateLocalRequestFactory(ExporterSettings exporterSettings)
+        => AgentTransportStrategy.Get(
+            exporterSettings,
+            productName: "Feature Flags EVP",
+            tcpTimeout: TimeSpan.FromSeconds(5),
+            httpHeaderHelper: EventPlatformHeaderHelper.Instance);
+
+    private static NetworkFailure ClassifyNetworkFailure(Exception exception)
+    {
+        var isNetworkFailure = false;
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            switch (current)
+            {
+                case SocketException socketException:
+                    return socketException.SocketErrorCode is SocketError.HostNotFound
+                                                               or SocketError.TryAgain
+                                                               or SocketError.ConnectionRefused
+                                                               or SocketError.NetworkUnreachable
+                                                               or SocketError.HostUnreachable
+                                                               or SocketError.AddressNotAvailable
+                        || socketException.ErrorCode == 2 // ENOENT for a missing Unix domain socket
+                               ? NetworkFailure.DefinitivePreSend
+                               : NetworkFailure.Ambiguous;
+                case WebException webException:
+                    switch (webException.Status)
+                    {
+                        case WebExceptionStatus.ConnectFailure:
+                        case WebExceptionStatus.NameResolutionFailure:
+                        case WebExceptionStatus.ProxyNameResolutionFailure:
+                            return NetworkFailure.DefinitivePreSend;
+                        case WebExceptionStatus.ConnectionClosed:
+                        case WebExceptionStatus.KeepAliveFailure:
+                        case WebExceptionStatus.PipelineFailure:
+                        case WebExceptionStatus.ReceiveFailure:
+                        case WebExceptionStatus.RequestCanceled:
+                        case WebExceptionStatus.SendFailure:
+                        case WebExceptionStatus.Timeout:
+                            return NetworkFailure.Ambiguous;
+                    }
+
+                    isNetworkFailure = true;
+                    break;
+#if NETCOREAPP
+                case HttpRequestException:
+#endif
+                case IOException:
+                case TimeoutException:
+                    isNetworkFailure = true;
+                    break;
+            }
+        }
+
+        return isNetworkFailure ? NetworkFailure.Ambiguous : NetworkFailure.None;
+    }
+
+    public void Dispose()
+    {
+        Volatile.Write(ref _disposed, 1);
+        _initialDiscovery.TrySetResult(false);
+        _settingsSubscription?.Dispose();
+        _discoveryService.RemoveSubscription(_discoveryCallback);
+    }
+
+    internal Task SendAsync<T>(T payload, string intakePath, JsonSerializerSettings serializerSettings)
+        => SendAsync(intakePath, request => request.PostAsJsonAsync(payload, MultipartCompression.GZip, serializerSettings));
+
+    internal Task SendCompressedAsync(ArraySegment<byte> payload, string intakePath)
+        => SendAsync(intakePath, request => request.PostAsync(payload, MimeTypes.Json, "gzip"));
+
+    private async Task SendAsync(string intakePath, Func<IApiRequest, Task<IApiResponse>> sendAsync)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
+        if (Volatile.Read(ref _directIsSticky) != 0)
+        {
+            await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        // Remote Configuration starts with the historical v2 route, so it must not wait for /info.
+        var localProxyEndpoint = Volatile.Read(ref _localProxyEndpoint);
+        if (localProxyEndpoint is not null)
+        {
+            await SendLocalAsync(intakePath, localProxyEndpoint, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        if (Volatile.Read(ref _discoveryKnown) == 0)
+        {
+            var completed = await Task.WhenAny(_initialDiscovery.Task, Task.Delay(_initialDiscoveryWait)).ConfigureAwait(false);
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
+            if (completed != _initialDiscovery.Task)
+            {
+                // Re-check after the timer wins so a concurrently published /info response can
+                // still select the local route before direct intake becomes sticky.
+                localProxyEndpoint = Volatile.Read(ref _localProxyEndpoint);
+                if (localProxyEndpoint is not null)
+                {
+                    await SendLocalAsync(intakePath, localProxyEndpoint, sendAsync).ConfigureAwait(false);
+                    return;
+                }
+
+                if (Volatile.Read(ref _discoveryKnown) == 0)
+                {
+                    Volatile.Write(ref _discoveryKnown, 1);
+                    _initialDiscovery.TrySetResult(false);
+                }
+            }
+        }
+
+        localProxyEndpoint = Volatile.Read(ref _localProxyEndpoint);
+        if (localProxyEndpoint is not null)
+        {
+            await SendLocalAsync(intakePath, localProxyEndpoint, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        if (_source == FeatureFlagsSource.Agentless && _directRequestFactory is not null)
+        {
+            Interlocked.Exchange(ref _directIsSticky, 1);
+            await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _unavailableWarningLogged, 1) == 0)
+        {
+            Log.Warning("Feature Flags event delivery is disabled because no compatible local EVP route or direct intake credentials are available");
+        }
+    }
+
+    private void UpdateAgentConfiguration(AgentConfiguration configuration)
+    {
+        var endpoint = configuration.EventPlatformProxyEndpoint switch
+        {
+            EventPlatformProxyV4 => EventPlatformProxyV4,
+            EventPlatformProxyV2 => EventPlatformProxyV2,
+            _ => null,
+        };
+
+        Volatile.Write(ref _localProxyEndpoint, endpoint);
+        Volatile.Write(ref _discoveryKnown, 1);
+        _initialDiscovery.TrySetResult(true);
+    }
+
+    private async Task SendLocalAsync(string intakePath, string localProxyEndpoint, Func<IApiRequest, Task<IApiResponse>> sendAsync)
+    {
+        var localFactory = Volatile.Read(ref _localRequestFactory);
+        var endpoint = localFactory.GetEndpoint($"{localProxyEndpoint}/{intakePath}");
+
+        try
+        {
+            var request = localFactory.Create(endpoint);
+            using var response = await sendAsync(request).ConfigureAwait(false);
+            if (response.StatusCode is 403 or 404 or 405 && _directRequestFactory is not null)
+            {
+                Interlocked.Exchange(ref _directIsSticky, 1);
+                await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ClassifyNetworkFailure(ex) is NetworkFailure.DefinitivePreSend && _directRequestFactory is not null)
+        {
+            Interlocked.Exchange(ref _directIsSticky, 1);
+            await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ClassifyNetworkFailure(ex) is NetworkFailure.Ambiguous)
+        {
+            // The local relay may have received this payload. Switch only future payloads so the
+            // current one can never be duplicated across the local and direct routes.
+            if (_directRequestFactory is not null)
+            {
+                Interlocked.Exchange(ref _directIsSticky, 1);
+            }
+
+            Log.ErrorSkipTelemetry(ex, "Feature Flags local EVP request failed ambiguously; the current event batch will not be replayed");
+        }
+    }
+
+    private async Task SendDirectAsync(string intakePath, Func<IApiRequest, Task<IApiResponse>> sendAsync)
+    {
+        var directFactory = _directRequestFactory;
+        if (directFactory is null)
+        {
+            return;
+        }
+
+        var endpoint = directFactory.GetEndpoint(intakePath);
+        try
+        {
+            var request = directFactory.Create(endpoint);
+            using var response = await sendAsync(request).ConfigureAwait(false);
+            if (response.StatusCode is < 200 or >= 300)
+            {
+                Log.Warning<int>("Feature Flags direct EVP request failed with HTTP status code {StatusCode}", response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Direct intake is terminal: never loop a failed direct request back through the Agent.
+            Log.ErrorSkipTelemetry(ex, "Feature Flags direct EVP request failed");
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
@@ -7,15 +7,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace.Agent;
-using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags.Evp;
 using Datadog.Trace.FeatureFlags.Exposure.Model;
-using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -28,7 +25,6 @@ internal sealed class ExposureApi : IDisposable
     internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ExposureApi));
 
     private const int DefaultCapacity = 1 << 16; // 65536 elements
-    public const string ExposurePath = "evp_proxy/v2/api/v2/exposures";
     [TestingAndPrivateOnly]
     internal static readonly JsonSerializerSettings SerializerSettings = new()
     {
@@ -44,39 +40,22 @@ internal sealed class ExposureApi : IDisposable
     private readonly Queue<ExposureEvent> _exposures = new Queue<ExposureEvent>();
 
     private readonly ExposureCache _exposureCache = new ExposureCache(DefaultCapacity);
-    private IApiRequestFactory _apiRequestFactory;
+    private readonly FeatureFlagsEvpTransport _transport;
     private Dictionary<string, string> _context;
     private int _started;
 
-    internal ExposureApi(TracerSettings tracerSettings)
+    internal ExposureApi(TracerSettings tracerSettings, IDiscoveryService discoveryService)
     {
-        UpdateApi(tracerSettings.Manager.InitialExporterSettings);
+        _transport = new FeatureFlagsEvpTransport(tracerSettings, discoveryService);
         UpdateContext(tracerSettings.Manager.InitialMutableSettings);
 
         tracerSettings.Manager.SubscribeToChanges(changes =>
         {
-            if (changes.UpdatedExporter is { } exporter)
-            {
-                UpdateApi(exporter);
-            }
-
             if (changes.UpdatedMutable is { } mutable)
             {
                 UpdateContext(mutable);
             }
         });
-
-        [MemberNotNull(nameof(_apiRequestFactory))]
-        void UpdateApi(ExporterSettings exporterSettings)
-        {
-            Log.Debug("ExposureApi::UpdateApi-> Applying settings");
-            var apiRequestFactory = AgentTransportStrategy.Get(
-                exporterSettings,
-                productName: "FeatureFlags exposure",
-                tcpTimeout: TimeSpan.FromSeconds(5),
-                httpHeaderHelper: EventPlatformHeaderHelper.Instance);
-            Interlocked.Exchange(ref _apiRequestFactory!, apiRequestFactory);
-        }
 
         [MemberNotNull(nameof(_context))]
         void UpdateContext(MutableSettings settings)
@@ -95,6 +74,7 @@ internal sealed class ExposureApi : IDisposable
     public void Dispose()
     {
         _processExit.TrySetResult(true);
+        _transport.Dispose();
     }
 
     public void TryToStartSendLoopIfNotStarted()
@@ -114,13 +94,10 @@ internal sealed class ExposureApi : IDisposable
         {
             try
             {
-                var apiRequestFactory = _apiRequestFactory;
-                var uri = apiRequestFactory.GetEndpoint(ExposurePath);
                 var payload = TryGetPayload();
                 if (payload is not null)
                 {
-                    var request = apiRequestFactory.Create(uri);
-                    using var response = await request.PostAsJsonAsync(payload, MultipartCompression.GZip, SerializerSettings).ConfigureAwait(false);
+                    await _transport.SendAsync(payload, FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsModule.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsModule.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.FeatureFlags.Agentless;
 using Datadog.Trace.FeatureFlags.Exposure;
@@ -51,13 +52,13 @@ namespace Datadog.Trace.FeatureFlags
         private bool _disposed;
         private bool _deliveryStarted;
 
-        internal FeatureFlagsModule(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager)
+        internal FeatureFlagsModule(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager, IDiscoveryService? discoveryService = null)
         {
             _settings = settings.FeatureFlags;
             _settingsManager = settings.Manager;
             _isRemoteConfigurationAvailable = settings.IsRemoteConfigurationAvailable;
             _spanEnrichmentEnabled = settings.IsSpanEnrichmentEnabled;
-            _exposureApiFactory = () => new ExposureApi(settings);
+            _exposureApiFactory = () => new ExposureApi(settings, discoveryService ?? NullDiscoveryService.Instance);
             _rcmSubscriptionManager = rcmSubscriptionManager;
 
             Log.Debug<FeatureFlagsSource>("FeatureFlagsModule ENABLED with source {Source}", _settings.Source);
@@ -70,14 +71,14 @@ namespace Datadog.Trace.FeatureFlags
 
         internal FeatureFlagsSettings Settings => _settings;
 
-        public static FeatureFlagsModule? Create(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager)
+        public static FeatureFlagsModule? Create(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager, IDiscoveryService? discoveryService = null)
         {
             if (!settings.FeatureFlags.Enabled)
             {
                 return null;
             }
 
-            var module = new FeatureFlagsModule(settings, rcmSubscriptionManager);
+            var module = new FeatureFlagsModule(settings, rcmSubscriptionManager, discoveryService);
 
             // Subscribing here rather than in the constructor: SubscribeToChanges can invoke the
             // callback, which must not reach a module that is still being constructed.

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -189,7 +189,7 @@ namespace Datadog.Trace
                 }
             }
 
-            featureFlags = FeatureFlagsModule.Create(settings, RcmSubscriptionManager.Instance);
+            featureFlags = FeatureFlagsModule.Create(settings, RcmSubscriptionManager.Instance, discoveryService);
 
             return CreateTracerManagerFrom(
                 settings,

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvpTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvpTransportTests.cs
@@ -1,0 +1,406 @@
+// <copyright file="FeatureFlagsEvpTransportTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags;
+using Datadog.Trace.FeatureFlags.Evp;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using Datadog.Trace.Tests.Agent;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.FeatureFlags;
+
+public class FeatureFlagsEvpTransportTests
+{
+    private static readonly JsonSerializerSettings SerializerSettings = new();
+
+    public static IEnumerable<object[]> AmbiguousFailures()
+    {
+        yield return [new IOException("broken pipe")];
+        yield return [new TimeoutException("timeout")];
+        yield return [new SocketException((int)SocketError.ConnectionReset)];
+        yield return [new WebException("send failed", WebExceptionStatus.SendFailure)];
+    }
+
+    public static IEnumerable<object[]> DefinitivePreSendSocketFailures()
+    {
+        yield return [SocketError.HostNotFound];
+        yield return [SocketError.TryAgain];
+        yield return [SocketError.ConnectionRefused];
+        yield return [SocketError.NetworkUnreachable];
+        yield return [SocketError.HostUnreachable];
+        yield return [SocketError.AddressNotAvailable];
+    }
+
+    [Theory]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV4, FeatureFlagsEvpTransport.ExposureIntakePath)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV4, FeatureFlagsEvpTransport.FlagEvaluationIntakePath)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV2, FeatureFlagsEvpTransport.ExposureIntakePath)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV2, FeatureFlagsEvpTransport.FlagEvaluationIntakePath)]
+    public async Task Discovery_SelectsAdvertisedLocalRoute(string proxyEndpoint, string intakePath)
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery);
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: proxyEndpoint);
+
+        await transport.SendAsync(new object(), intakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle()
+             .Which.Endpoint.AbsolutePath.Should().Be($"/{proxyEndpoint}/{intakePath}");
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AgentlessWithoutCompatibleLocalRoute_UsesDirectAndStaysDirect()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery);
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: "v0.4/traces");
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        // A late discovery result must not move a writer after it selected direct for a batch.
+        discovery.TriggerChange(eventPlatformProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().BeEmpty();
+        direct.RequestsSent.Should().HaveCount(2);
+        direct.RequestsSent.Select(r => r.Endpoint.AbsolutePath).Should().Equal(
+            $"/{FeatureFlagsEvpTransport.ExposureIntakePath}",
+            $"/{FeatureFlagsEvpTransport.FlagEvaluationIntakePath}");
+    }
+
+    [Fact]
+    public async Task SendRacingFirstDiscovery_WaitsAndUsesAdvertisedLocalRoute()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery, initialDiscoveryKnown: false);
+
+        var send = transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        discovery.TriggerChange(eventPlatformProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+        await send;
+
+        local.RequestsSent.Should().ContainSingle()
+             .Which.Endpoint.AbsolutePath.Should().Be($"/{FeatureFlagsEvpTransport.EventPlatformProxyV4}/{FeatureFlagsEvpTransport.ExposureIntakePath}");
+        direct.RequestsSent.Should().BeEmpty("direct intake is selected only after /info establishes that no compatible local route exists");
+    }
+
+    [Fact]
+    public async Task InitialDiscoveryTimeout_UsesDirectForCurrentAndLaterBatches()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(
+            local,
+            direct,
+            initialDiscoveryKnown: false,
+            initialDiscoveryWait: TimeSpan.FromMilliseconds(10));
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().BeEmpty();
+        direct.RequestsSent.Should().HaveCount(2, "the discovery timeout selects direct intake for the current and subsequent batches");
+    }
+
+    [Theory]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV4, false)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV2, false)]
+    [InlineData(null, true)]
+    public async Task CompressedFlagEvaluationPayloadUsesSelectedRoute(string? proxyEndpoint, bool usesDirect)
+    {
+        var local = CreateFactory("http://agent:8126/", uri => new RecordingCompressedApiRequest(uri));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/", uri => new RecordingCompressedApiRequest(uri));
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery);
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: proxyEndpoint ?? "v0.4/traces");
+        var payload = new byte[] { 1, 2, 3 };
+
+        await transport.SendCompressedAsync(new ArraySegment<byte>(payload), FeatureFlagsEvpTransport.FlagEvaluationIntakePath);
+
+        var selectedFactory = usesDirect ? direct : local;
+        var request = selectedFactory.RequestsSent.Should().ContainSingle().Which.Should().BeOfType<RecordingCompressedApiRequest>().Subject;
+        request.Endpoint.AbsolutePath.Should().Be(
+            usesDirect
+                ? $"/{FeatureFlagsEvpTransport.FlagEvaluationIntakePath}"
+                : $"/{proxyEndpoint}/{FeatureFlagsEvpTransport.FlagEvaluationIntakePath}");
+        request.Payload.Should().Equal(payload);
+        request.ContentType.Should().Be(MimeTypes.Json);
+        request.ContentEncoding.Should().Be("gzip");
+        (usesDirect ? local : direct).RequestsSent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoteConfigurationNeverUsesDirectIntake()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = new FeatureFlagsEvpTransport(FeatureFlagsSource.RemoteConfig, local, direct, discovery);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle()
+             .Which.Endpoint.AbsolutePath.Should().Be($"/{FeatureFlagsEvpTransport.EventPlatformProxyV2}/{FeatureFlagsEvpTransport.ExposureIntakePath}");
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(403)]
+    [InlineData(404)]
+    [InlineData(405)]
+    public async Task DefinitiveLocalHttpFailure_ReplaysCurrentBatchDirectAndStaysDirect(int statusCode)
+    {
+        var local = CreateFactory("http://agent:8126/", _ => new TestApiRequest(new Uri("http://agent"), statusCode));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().HaveCount(2, "the failed current batch and the next batch both use direct intake");
+    }
+
+    [Theory]
+    [InlineData(429)]
+    [InlineData(500)]
+    [InlineData(503)]
+    public async Task OverloadOrServerFailure_DoesNotFallbackOrChangeFutureRoute(int statusCode)
+    {
+        var local = CreateFactory(
+            "http://agent:8126/",
+            _ => new TestApiRequest(new Uri("http://agent"), statusCode),
+            uri => new TestApiRequest(uri));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().HaveCount(2);
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DefinitiveConnectFailure_ReplaysCurrentBatchDirectAndStaysDirect()
+    {
+        var failure = new WebException("refused", WebExceptionStatus.ConnectFailure);
+        var local = CreateFactory("http://agent:8126/", uri => new ThrowingApiRequest(uri, failure));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [MemberData(nameof(DefinitivePreSendSocketFailures))]
+    public async Task DefinitivePreSendSocketFailure_ReplaysCurrentBatchDirectAndStaysDirect(SocketError socketError)
+    {
+        var local = CreateFactory("http://agent:8126/", uri => new ThrowingApiRequest(uri, new SocketException((int)socketError)));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [MemberData(nameof(AmbiguousFailures))]
+    public async Task AmbiguousLocalFailure_DoesNotReplayCurrentBatchButChangesFutureRoute(Exception failure)
+    {
+        var local = CreateFactory("http://agent:8126/", uri => new ThrowingApiRequest(uri, failure));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        direct.RequestsSent.Should().BeEmpty("an ambiguously failed payload may already have reached the local relay");
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().ContainSingle("only the later payload is safe to send direct");
+    }
+
+    [Fact]
+    public async Task DirectFailure_DoesNotLoopBackToLocalRoute()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory(
+            "https://event-platform-intake.datadoghq.com/",
+            uri => new ThrowingApiRequest(uri, new IOException("direct reset")));
+        using var transport = CreateTransport(local, direct);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        direct.RequestsSent.Should().ContainSingle();
+        local.RequestsSent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DirectCredentialsAreIsolatedFromLocalHeaders()
+    {
+        var headers = FeatureFlagsEvpTransport.GetDirectHeaders("test-api-key").ToDictionary(x => x.Key, x => x.Value);
+
+        headers.Should().Contain("DD-API-KEY", "test-api-key");
+        EventPlatformHeaderHelper.Instance.DefaultHeaders
+                                 .Should().NotContain(pair => pair.Key == "DD-API-KEY");
+    }
+
+    [Fact]
+    public void DirectFactoryUsesHttpsIntakeAndTheRuntimeDefaultProxy()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "agentless"),
+            (ConfigurationKeys.ApiKey, "test-api-key"),
+            (ConfigurationKeys.Site, "datadoghq.eu"));
+
+        var factory = FeatureFlagsEvpTransport.CreateDirectRequestFactory(settings.FeatureFlags);
+
+        factory.Should().NotBeNull();
+        factory!.GetEndpoint(FeatureFlagsEvpTransport.ExposureIntakePath)
+                .Should().Be(new Uri("https://event-platform-intake.datadoghq.eu/api/v2/exposures"));
+        factory.GetEndpoint(FeatureFlagsEvpTransport.FlagEvaluationIntakePath)
+               .Should().Be(new Uri("https://event-platform-intake.datadoghq.eu/api/v2/flagevaluation"));
+        factory.GetType().Name.Should().BeOneOf("HttpClientRequestFactory", "ApiWebRequestFactory");
+    }
+
+    [Theory]
+    [InlineData("datadoghq.com@attacker.example")]
+    [InlineData("https://attacker.example")]
+    [InlineData("datadoghq.com/path")]
+    [InlineData("datadoghq.com?redirect=attacker.example")]
+    [InlineData("datadoghq.com#attacker.example")]
+    [InlineData("datadoghq.com:443")]
+    [InlineData(" datadoghq.com")]
+    [InlineData("datadoghq.com ")]
+    [InlineData("data doghq.com")]
+    [InlineData("-datadoghq.com")]
+    [InlineData("datadoghq.com-")]
+    [InlineData("datadoghq..com")]
+    public void DirectFactoryRejectsSiteThatIsNotAHostnameComponent(string site)
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "agentless"),
+            (ConfigurationKeys.ApiKey, "test-api-key"),
+            (ConfigurationKeys.Site, site));
+
+        FeatureFlagsEvpTransport.CreateDirectRequestFactory(settings.FeatureFlags).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DisposeUnsubscribesFromDiscovery()
+    {
+        var discovery = new DiscoveryServiceMock();
+        var transport = CreateTransport(CreateFactory("http://agent:8126/"), CreateFactory("https://direct/"), discovery);
+
+        discovery.Callbacks.Should().ContainSingle();
+        transport.Dispose();
+
+        discovery.Callbacks.Should().BeEmpty();
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+    }
+
+    [Fact]
+    public async Task DisposeUnblocksInitialDiscoveryWaitWithoutSending()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var transport = CreateTransport(
+            local,
+            direct,
+            initialDiscoveryKnown: false,
+            initialDiscoveryWait: TimeSpan.FromMinutes(1));
+
+        var send = transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        transport.Dispose();
+
+        var completed = await Task.WhenAny(send, Task.Delay(TimeSpan.FromSeconds(1)));
+        completed.Should().BeSameAs(send);
+        await send;
+        local.RequestsSent.Should().BeEmpty();
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    private static FeatureFlagsEvpTransport CreateTransport(
+        TestRequestFactory local,
+        TestRequestFactory direct,
+        DiscoveryServiceMock? discovery = null,
+        string? initialLocalProxyEndpoint = null,
+        bool initialDiscoveryKnown = true,
+        TimeSpan? initialDiscoveryWait = null)
+        => new(
+            FeatureFlagsSource.Agentless,
+            local,
+            direct,
+            discovery ?? new DiscoveryServiceMock(),
+            initialLocalProxyEndpoint,
+            initialDiscoveryKnown,
+            initialDiscoveryWait);
+
+    private static TestRequestFactory CreateFactory(string baseEndpoint, params Func<Uri, TestApiRequest>[] requests)
+        => new(new Uri(baseEndpoint), requests);
+
+    private static TracerSettings CreateSettings(params (string Key, string Value)[] values)
+    {
+        var source = new NameValueCollection();
+        foreach (var (key, value) in values)
+        {
+            source[key] = value;
+        }
+
+        return new TracerSettings(new NameValueConfigurationSource(source));
+    }
+
+    private sealed class ThrowingApiRequest(Uri endpoint, Exception exception) : TestApiRequest(endpoint)
+    {
+        public override Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
+            => Task.FromException<IApiResponse>(exception);
+    }
+
+    private sealed class RecordingCompressedApiRequest(Uri endpoint) : TestApiRequest(endpoint)
+    {
+        public byte[] Payload { get; private set; } = [];
+
+        public string ContentEncoding { get; private set; } = string.Empty;
+
+        public override Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
+        {
+            Payload = bytes.ToArray();
+            ContentEncoding = contentEncoding;
+            return base.PostAsync(bytes, contentType, contentEncoding);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsModuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsModuleTests.cs
@@ -305,6 +305,7 @@ public class FeatureFlagsModuleTests
         var collection = new NameValueCollection
         {
             { ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "remote_config" },
+            { ConfigurationKeys.Rcm.RemoteConfigurationEnabled, "true" },
 #pragma warning disable 618 // superseded, but still honoured for existing adopters
             { ConfigurationKeys.FeatureFlags.FlaggingProviderEnabled, "true" },
 #pragma warning restore 618


### PR DESCRIPTION
## Motivation

Feature-flag events need a direct EVP route when the Agent does not advertise an EVP proxy endpoint.

Linear: [FFL-1486](https://linear.app/datadoghq/issue/FFL-1486)

```mermaid
flowchart LR
  SDK[".NET agentless Feature Flags"] --> Signals["Feature-flag events"]
  Signals --> Receiver["Local Agent or sidecar"]
  Receiver -->|"Compatible EVP route"| Intake["Event Platform intake"]
  Receiver -.->|"No advertised EVP route"| Gap["No delivery path"]
```

## Changes

```mermaid
flowchart LR
  Startup["Feature Flags transport startup"] --> Wait["Bounded initial /info wait"]
  Wait -->|"v4 advertised"| V4["/evp_proxy/v4"]
  Wait -->|"v2 only"| V2["/evp_proxy/v2"]
  Wait -->|"Timeout or no compatible route"| Direct["Direct intake + DD-API-KEY"]
  V4 --> Intake["Event Platform intake"]
  V2 --> Intake
  Direct --> Intake
```

- Wait up to five seconds for the initial Agent `/info` response.
- Prefer the advertised EVP v4 route, then v2, and select direct intake when neither route is available.
- Keep the selected transport for the lifetime of the feature-flags transport.
- Validate `DD_SITE` before constructing the direct intake hostname or adding `DD-API-KEY`.
- Add transport coverage for discovery, timeout, disposal, route selection, direct headers, and rejected site values.

## Decisions

- A bounded initial discovery wait avoids changing route selection after events begin flushing.
- Direct intake is allowed only for the exact validated `event-platform-intake.<site>` host.
- Existing Agent EVP v4 and v2 routes remain preferred whenever advertised.

## Validation

The .NET flag-evaluation system tests are defined and enabled in [DataDog/system-tests#7603](https://github.com/DataDog/system-tests/pull/7603).

- `./tracer/build.sh Restore CompileManagedSrc`: passed across the managed target frameworks with the banned API analyzer enabled.
- `FEATURE_FLAGGING_AND_EXPERIMENTATION`: 1 flag-evaluation egress test completed successfully.
- `FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT`: 1 flag-evaluation egress test completed successfully.
- `FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS`: 1 flag-evaluation egress test completed successfully.

The system tests verified the aggregate payload on `/api/v2/flagevaluation`, selected-route behavior, direct-intake host, response status and API-key header where applicable, and zero events on the unused route.
