### PR TITLE
[Profiler] Fix bug in FrameStore

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/GenericTypes.cs
+++ b/profiler/src/Demos/Samples.Computer01/GenericTypes.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -135,6 +136,9 @@ namespace Samples.Computer01
                 // container.LongGenericParameterList<byte, bool, bool, bool, bool, bool, bool, bool>(i, out _);
                 container.LongGenericParameterList<byte, bool, bool, bool, string, bool, bool, bool>(i, out _);
             }
+
+            // Check the profiler can handle long generic parameter names
+            new GenericTypeWithLongParameterNames<string, object>().ThrowFromLongParameterNames(null, null);
         }
 
         private void RunValueAndReferenceTypes(IEnumerable<int> numbers)
@@ -186,6 +190,25 @@ namespace Samples.Computer01
         public bool LongGenericParameterList<MT1, MT2, MT3, MT4, MT5, MT6, MT7, MT8>(K key, out V val)
         {
             return TryGet(key, out val);
+        }
+    }
+
+    public class GenericTypeWithLongParameterNames<
+        TParam1ThatIsDeliberatelyLongerThanTheBufferTheProfilerUsesWhenItReadsGenericParameterNamesFromTheAssemblyMetadata,
+        TParam2ThatIsDeliberatelyLongerThanTheBufferTheProfilerUsesWhenItReadsGenericParameterNamesFromTheAssemblyMetadata>
+    {
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        public void ThrowFromLongParameterNames(
+            TParam1ThatIsDeliberatelyLongerThanTheBufferTheProfilerUsesWhenItReadsGenericParameterNamesFromTheAssemblyMetadata first,
+            TParam2ThatIsDeliberatelyLongerThanTheBufferTheProfilerUsesWhenItReadsGenericParameterNamesFromTheAssemblyMetadata second)
+        {
+            try
+            {
+                throw new InvalidOperationException("long generic parameter names");
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -759,7 +759,7 @@ std::vector<std::string> GetGenericTypeParameters(IMetaDataImport2* pMetadata, m
         {
             ULONG index;
             DWORD flags;
-            hr = pMetadata->GetGenericParamProps(genericParams[currentParam], &index, &flags, nullptr, nullptr, paramName, paramNameLen, &paramNameLen);
+            hr = pMetadata->GetGenericParamProps(genericParams[currentParam], &index, &flags, nullptr, nullptr, paramName, ARRAY_LEN(paramName) - 1, &paramNameLen);
             if (SUCCEEDED(hr))
             {
                 // need to convert from UTF16 to UTF8

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -759,7 +759,7 @@ std::vector<std::string> GetGenericTypeParameters(IMetaDataImport2* pMetadata, m
         {
             ULONG index;
             DWORD flags;
-            hr = pMetadata->GetGenericParamProps(genericParams[currentParam], &index, &flags, nullptr, nullptr, paramName, ARRAY_LEN(paramName) - 1, &paramNameLen);
+            hr = pMetadata->GetGenericParamProps(genericParams[currentParam], &index, &flags, nullptr, nullptr, paramName, ARRAY_LEN(paramName), &paramNameLen);
             if (SUCCEEDED(hr))
             {
                 // need to convert from UTF16 to UTF8

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
@@ -97,13 +97,13 @@ namespace Datadog.Profiler.IntegrationTests.Signature
             StackTrace stack;
             if (os == PlatformID.Unix && framework != "net8.0")
             {
-                // BUG on Linux: invalid TKey instead of TVal
+                // BUG on Linux: invalid TKey instead of TValue
                 stack = new StackTrace(
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TKey> |fn:ThrowFromGeneric |fg:<T0> |sg:(T0 element, TKey key1, TKey value, TKey key2)"),
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TKey> |fn:ThrowGenericFromGeneric |fg:<T0> |sg:(T0 element)"),
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TKey> |fn:ThrowOneGeneric |fg: |sg:(TKey value)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowFromGeneric |fg:<T0> |sg:(T0 element, TKey key1, TValue value, TKey key2)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowGenericFromGeneric |fg:<T0> |sg:(T0 element)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowOneGeneric |fg: |sg:(TValue value)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromMethod |fg:<System.Boolean> |sg:(System.Boolean value)"),
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromType |fg: |sg:(TKey value)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromType |fg: |sg:(TValue value)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:MethodsSignature |cg: |fn:ThrowGenericMethod2 |fg:<T0, System.Int32, T2, T3> |sg:(T0 key1, System.Int32 value1, System.Int32 value2, T2 key2, T3 key3, System.Collections.Generic.List<System.Int32> listOfTValue)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:MethodsSignature |cg: |fn:ThrowGenericMethod1 |fg:<T0> |sg:(T0 element)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:MethodsSignature |cg: |fn:ThrowGenericMethod1 |fg:<GlobalStruct> |sg:(GlobalStruct element)"),
@@ -124,11 +124,11 @@ namespace Datadog.Profiler.IntegrationTests.Signature
             else
             {
                 stack = new StackTrace(
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowFromGeneric |fg:<T0> |sg:(T0 element, TKey key1, TVal value, TKey key2)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowFromGeneric |fg:<T0> |sg:(T0 element, TKey key1, TValue value, TKey key2)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowGenericFromGeneric |fg:<T0> |sg:(T0 element)"),
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowOneGeneric |fg: |sg:(TVal value)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowOneGeneric |fg: |sg:(TValue value)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromMethod |fg:<System.Boolean> |sg:(System.Boolean value)"),
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromType |fg: |sg:(TVal value)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromType |fg: |sg:(TValue value)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:MethodsSignature |cg: |fn:ThrowGenericMethod2 |fg:<T0, System.Int32, T2, T3> |sg:(T0 key1, System.Int32 value1, System.Int32 value2, T2 key2, T3 key3, System.Collections.Generic.List<System.Int32> listOfTValue)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:MethodsSignature |cg: |fn:ThrowGenericMethod1 |fg:<T0> |sg:(T0 element)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:MethodsSignature |cg: |fn:ThrowGenericMethod1 |fg:<GlobalStruct> |sg:(GlobalStruct element)"),

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
@@ -124,9 +124,9 @@ namespace Datadog.Profiler.IntegrationTests.Signature
             else
             {
                 stack = new StackTrace(
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TVal> |fn:ThrowFromGeneric |fg:<T0> |sg:(T0 element, TKey key1, TVal value, TKey key2)"),
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TVal> |fn:ThrowGenericFromGeneric |fg:<T0> |sg:(T0 element)"),
-                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TVal> |fn:ThrowOneGeneric |fg: |sg:(TVal value)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowFromGeneric |fg:<T0> |sg:(T0 element, TKey key1, TVal value, TKey key2)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowGenericFromGeneric |fg:<T0> |sg:(T0 element)"),
+                    new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TValue> |fn:ThrowOneGeneric |fg: |sg:(TVal value)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromMethod |fg:<System.Boolean> |sg:(System.Boolean value)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClassForValueTypeTest |cg:<System.Int32, System.Boolean> |fn:ThrowOneGenericFromType |fg: |sg:(TVal value)"),
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:MethodsSignature |cg: |fn:ThrowGenericMethod2 |fg:<T0, System.Int32, T2, T3> |sg:(T0 key1, System.Int32 value1, System.Int32 value2, T2 key2, T3 key3, System.Collections.Generic.List<System.Int32> listOfTValue)"),


### PR DESCRIPTION
## Summary of changes

Fix a bug in `FrameStore`


## Reason for change

`GetGenericTypeParameters` reuses one length variable as both capacity and output across loop iterations, overrunning a 64-WCHAR buffer.

## Implementation details

Use `ARRAY_LEN(...)`

## Test coverage

Adding a new integration.
## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
