### PR TITLE
Add many timeouts and retries to build stages in Azure DevOps

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -31,6 +31,10 @@ parameters:
     type: number
     default: 0
 
+  - name: timeoutInMinutesForRunCommand
+    type: number
+    default: 0
+
 steps:
 - template: ensure-docker-ready.yml
 
@@ -135,6 +139,7 @@ steps:
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }}:$sdkVersion \
         dotnet /build/bin/Debug/_build.dll ${{ parameters.command }}
   displayName: Run '${{ parameters.command }}' in Docker
+  timeoutInMinutes: ${{ parameters.timeoutInMinutesForRunCommand }}
   retryCountOnTaskFailure: ${{ parameters.retryCountForRunCommand }}
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -586,7 +586,6 @@ stages:
         baseImage: $(managedBaseImage)
         command: "ExtractDebugInfoLinux ValidateNativeProfilerGlibcCompatibility"
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 10
 
     - publish: $(monitoringHome)
       displayName: Uploading linux profiler home artifact
@@ -1468,7 +1467,7 @@ stages:
       jobs: [managed]
 
   - job: managed
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90 # BuildManagedUnitTests can retry up to 4x15 min, so make sure there's headroom for RunManagedUnitTests too
     strategy:
       matrix:
         $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_linux_x64_matrix'] ]
@@ -1525,7 +1524,7 @@ stages:
         jobs: [test]
 
     - job: test
-      timeoutInMinutes: 60 #default value
+      timeoutInMinutes: 90 # BuildManagedUnitTests can retry up to 4x15 min, so make sure there's headroom for RunManagedUnitTests too
 
       strategy:
         matrix:
@@ -3123,8 +3122,7 @@ stages:
         useNativeSdkVersion: true
         command: "BuildProfilerAsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
-        retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 30
+        timeoutInMinutesForRunCommand: 30 # No retry: this target also runs the sanitizer unit tests, and retrying could mask a real intermittent finding
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3206,8 +3204,7 @@ stages:
         baseImage: debian
         command: "BuildProfilerAsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
-        retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 30
+        timeoutInMinutesForRunCommand: 30 # No retry: this target also runs the sanitizer unit tests, and retrying could mask a real intermittent finding
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3264,8 +3261,7 @@ stages:
         baseImage: debian
         command: "BuildProfilerUbsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
-        retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 30
+        timeoutInMinutesForRunCommand: 30 # No retry: this target also runs the sanitizer unit tests, and retrying could mask a real intermittent finding
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3325,8 +3321,7 @@ stages:
         useNativeSdkVersion: true
         command: "BuildProfilerUbsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
-        retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 30
+        timeoutInMinutesForRunCommand: 30 # No retry: this target also runs the sanitizer unit tests, and retrying could mask a real intermittent finding
 
     - template: steps/run-in-docker.yml
       parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -523,7 +523,7 @@ stages:
         useNativeSdkVersion: true
         command: "Clean BuildNativeLoader BuildNativeWrapper ExtractDebugInfoLinux ValidateNativeLoaderSnapshotTestsLinux"
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 20
+        timeoutInMinutesForRunCommand: 10
 
     - publish: $(monitoringHome)/linux-musl-x64
       displayName: Uploading linux universal artifacts
@@ -869,7 +869,7 @@ stages:
         useNativeSdkVersion: true
         command: "Clean BuildNativeLoader BuildNativeWrapper ExtractDebugInfoLinux ValidateNativeLoaderSnapshotTestsLinux"
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 20
+        timeoutInMinutesForRunCommand: 10
 
     - publish: $(monitoringHome)/linux-musl-arm64
       displayName: Uploading linux universal arm64 artifacts
@@ -1003,7 +1003,7 @@ stages:
       artifact: build-macos-native_tracer
 
   - job: native_loader_and_managed
-    timeoutInMinutes: 100
+    timeoutInMinutes: 80
     dependsOn: [ ]
     pool:
       vmImage: macos-14
@@ -1017,7 +1017,7 @@ stages:
     # The CreateTrimmingFile tasks expects the managed loader but we build that in the other stage
     - script: ./tracer/build.sh BuildManagedTracerHome BuildNativeLoader --skip CreateTrimmingFile
       displayName: Build managed tracer + native loader
-      timeoutInMinutes: 40
+      timeoutInMinutes: 30
       retryCountOnTaskFailure: 1
 
     - publish: $(monitoringHome)
@@ -1082,7 +1082,7 @@ stages:
 
       - script: tracer\build.cmd PackageTracerHome PublishFleetInstaller DownloadWinSsiTelemetryForwarder
         displayName: Build MSI, Tracer home, FleetInstaller, and TelemetryForwarder
-        timeoutInMinutes: 20
+        timeoutInMinutes: 10
         retryCountOnTaskFailure: 1
 
       - publish: $(artifacts)/windows-tracer-home.zip
@@ -1377,7 +1377,7 @@ stages:
 
       - script: tracer\build.cmd BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build unit tests
-        timeoutInMinutes: 35
+        timeoutInMinutes: 15
         retryCountOnTaskFailure: 3
         env:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1595,7 +1595,7 @@ stages:
 
         - script: tracer\build.cmd CreateRequiredDirectories CompileSamples
           displayName: Build sample projects
-          timeoutInMinutes: 50
+          timeoutInMinutes: 20
           retryCountOnTaskFailure: 1
           env:
             SampleName: $(IntegrationTestSampleName)
@@ -1645,7 +1645,7 @@ stages:
 
         - script: tracer\build.cmd CreateRequiredDirectories CompileSamples -Framework $(framework) -TestAllPackageVersions
           displayName: Build sample projects
-          timeoutInMinutes: 50
+          timeoutInMinutes: 20
           retryCountOnTaskFailure: 1
           env:
             SampleName: $(IntegrationTestSampleName)
@@ -1674,7 +1674,7 @@ stages:
         jobs: [macos]
 
     - job: macos
-      timeoutInMinutes: 60 #default value
+      timeoutInMinutes: 90
       pool:
         vmImage: macos-14
       steps:
@@ -1686,7 +1686,7 @@ stages:
 
         - script: ./tracer/build.sh CreateRequiredDirectories CompileSamples
           displayName: Build sample projects
-          timeoutInMinutes: 50
+          timeoutInMinutes: 40
           retryCountOnTaskFailure: 1
           env:
             SampleName: $(IntegrationTestSampleName)
@@ -3101,7 +3101,7 @@ stages:
       allowSkipped: true
 
   - job: Linux
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
 
     pool:
       name: $(linuxX64Pool)
@@ -3124,7 +3124,7 @@ stages:
         command: "BuildProfilerAsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 30
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3134,7 +3134,7 @@ stages:
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 10
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3189,7 +3189,7 @@ stages:
       jobs: [Linux]
 
   - job: Linux
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
 
     pool:
       name: $(linuxArm64Pool)
@@ -3207,7 +3207,7 @@ stages:
         command: "BuildProfilerAsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 30
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3216,7 +3216,7 @@ stages:
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 10
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3247,7 +3247,7 @@ stages:
       jobs: [Linux]
 
   - job: Linux
-    timeoutInMinutes: 60
+    timeoutInMinutes: 90
 
     pool:
       name: $(linuxArm64Pool)
@@ -3265,7 +3265,7 @@ stages:
         command: "BuildProfilerUbsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 30
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3274,7 +3274,7 @@ stages:
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 10
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3305,7 +3305,7 @@ stages:
       jobs: [Linux]
 
   - job: Linux
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
 
     pool:
       name: $(linuxX64Pool)
@@ -3326,7 +3326,7 @@ stages:
         command: "BuildProfilerUbsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 30
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3336,7 +3336,7 @@ stages:
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 1
-        timeoutInMinutesForRunCommand: 40
+        timeoutInMinutesForRunCommand: 10
 
     - template: steps/run-in-docker.yml
       parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -273,7 +273,7 @@ stages:
       jobs: [build]
 
   - job: build
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90 # Build can take up to 30 minutes, so make sure we have headroom on failure+retry
     pool:
       name: $(windowsX64Pool)
     steps:
@@ -284,6 +284,7 @@ stages:
 
     - script: tracer\build.cmd BuildTracerHome BuildNativeLoader
       displayName: Build tracer home
+      timeoutInMinutes: 30
       retryCountOnTaskFailure: 1
 
     - script: tracer\build.cmd CompileTracerNativeTests RunTracerNativeTests CompileNativeLoaderNativeTests RunNativeLoaderNativeTests
@@ -329,6 +330,7 @@ stages:
 
     - script: tracer\build.cmd BuildProfilerHome
       displayName: Build profiler home
+      timeoutInMinutes: 20
       retryCountOnTaskFailure: 1
 
     - script: tracer\build.cmd CompileProfilerNativeTests RunProfilerNativeTests
@@ -390,6 +392,7 @@ stages:
         baseImage: $(managedBaseImage)
         command: "Clean CompileManagedLoader"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 10
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -407,6 +410,7 @@ stages:
         baseImage: $(managedBaseImage)
         command: "BuildManagedTracerHome ExtractDebugInfoLinux ValidateNativeTracerGlibcCompatibility"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 20
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
@@ -453,6 +457,7 @@ stages:
             baseImage: debian
             command: "Clean CompileManagedLoader"
             retryCountForRunCommand: 1
+            timeoutInMinutesForRunCommand: 10
 
         - template: steps/run-in-docker.yml
           parameters:
@@ -470,6 +475,7 @@ stages:
             baseImage: debian
             command: "BuildManagedTracerHomeR2R ExtractDebugInfoLinux"
             retryCountForRunCommand: 1
+            timeoutInMinutesForRunCommand: 20
 
         - publish: $(monitoringHome)
           displayName: Uploading linux tracer home artifact
@@ -517,6 +523,7 @@ stages:
         useNativeSdkVersion: true
         command: "Clean BuildNativeLoader BuildNativeWrapper ExtractDebugInfoLinux ValidateNativeLoaderSnapshotTestsLinux"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 20
 
     - publish: $(monitoringHome)/linux-musl-x64
       displayName: Uploading linux universal artifacts
@@ -579,6 +586,7 @@ stages:
         baseImage: $(managedBaseImage)
         command: "ExtractDebugInfoLinux ValidateNativeProfilerGlibcCompatibility"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 10
 
     - publish: $(monitoringHome)
       displayName: Uploading linux profiler home artifact
@@ -721,6 +729,7 @@ stages:
         baseImage: $(baseImage)
         command: "Clean CompileManagedLoader BuildNativeTracerHome BuildManagedTracerHome ExtractDebugInfoLinux ValidateNativeTracerGlibcCompatibility"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 20
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
@@ -764,6 +773,7 @@ stages:
         baseImage: debian
         command: "Clean CompileManagedLoader BuildNativeTracerHome BuildManagedTracerHomeR2R ExtractDebugInfoLinux"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 20
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
@@ -814,6 +824,7 @@ stages:
         baseImage: $(baseImage)
         command: "Clean BuildProfilerHome ExtractDebugInfoLinux ValidateNativeProfilerGlibcCompatibility"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 15
 
     - publish: $(System.DefaultWorkingDirectory)/artifacts/profiler-build
       displayName: Uploading linux profiler output build folder
@@ -858,6 +869,7 @@ stages:
         useNativeSdkVersion: true
         command: "Clean BuildNativeLoader BuildNativeWrapper ExtractDebugInfoLinux ValidateNativeLoaderSnapshotTestsLinux"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 20
 
     - publish: $(monitoringHome)/linux-musl-arm64
       displayName: Uploading linux universal arm64 artifacts
@@ -970,7 +982,7 @@ stages:
       jobs: [native_tracer, native_loader_and_managed, upload_artifacts]
 
   - job: native_tracer
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
     dependsOn: [ ]
     pool:
       vmImage: macos-14
@@ -983,6 +995,7 @@ stages:
 
     - script: ./tracer/build.sh CreateRequiredDirectories CompileManagedLoader BuildNativeTracerHome
       displayName: Build native-tracer
+      timeoutInMinutes: 35
       retryCountOnTaskFailure: 1
 
     - publish: $(monitoringHome)
@@ -990,7 +1003,7 @@ stages:
       artifact: build-macos-native_tracer
 
   - job: native_loader_and_managed
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 100
     dependsOn: [ ]
     pool:
       vmImage: macos-14
@@ -1004,6 +1017,7 @@ stages:
     # The CreateTrimmingFile tasks expects the managed loader but we build that in the other stage
     - script: ./tracer/build.sh BuildManagedTracerHome BuildNativeLoader --skip CreateTrimmingFile
       displayName: Build managed tracer + native loader
+      timeoutInMinutes: 40
       retryCountOnTaskFailure: 1
 
     - publish: $(monitoringHome)
@@ -1068,6 +1082,7 @@ stages:
 
       - script: tracer\build.cmd PackageTracerHome PublishFleetInstaller DownloadWinSsiTelemetryForwarder
         displayName: Build MSI, Tracer home, FleetInstaller, and TelemetryForwarder
+        timeoutInMinutes: 20
         retryCountOnTaskFailure: 1
 
       - publish: $(artifacts)/windows-tracer-home.zip
@@ -1115,6 +1130,8 @@ stages:
 
     - script: tracer\build.cmd BuildDdDotnet -framework=$(targetFramework)
       displayName: Build dd-dotnet
+      timeoutInMinutes: 10
+      retryCountOnTaskFailure: 1
 
     - publish: $(artifacts)/dd-dotnet/win-x64/dd-dotnet.exe
       displayName: Uploading dd-dotnet win-x64
@@ -1161,6 +1178,7 @@ stages:
         baseImage: $(baseImage)
         command: "Clean BuildDdDotnet --framework net8.0"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 10
 
     - publish: $(artifacts)/dd-dotnet/$(artifactSuffix)/dd-dotnet
       displayName: Uploading dd-dotnet $(artifactSuffix)
@@ -1208,6 +1226,7 @@ stages:
         baseImage: $(baseImage)
         command: "Clean BuildDdDotnet --framework $(targetFramework)"
         retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 10
 
     - publish: $(artifacts)/dd-dotnet/$(artifactSuffix)/dd-dotnet
       displayName: Uploading dd-dotnet $(artifactSuffix)
@@ -1258,6 +1277,7 @@ stages:
           baseImage: $(managedBaseImage)
           command: "Clean CompileManagedLoader -buildConfiguration Debug"
           retryCountForRunCommand: 1
+          timeoutInMinutesForRunCommand: 10
 
       - template: steps/run-in-docker.yml
         parameters:
@@ -1267,6 +1287,7 @@ stages:
           useNativeSdkVersion: $(useNativeSdkVersion)
           command: "BuildNativeTracerHome -buildConfiguration Debug"
           retryCountForRunCommand: 1
+          timeoutInMinutesForRunCommand: 15
 
       - template: steps/run-in-docker.yml
         parameters:
@@ -1274,6 +1295,7 @@ stages:
           baseImage: $(managedBaseImage)
           command: "BuildManagedTracerHome ExtractDebugInfoLinux -buildConfiguration Debug"
           retryCountForRunCommand: 1
+          timeoutInMinutesForRunCommand: 20
 
   - job: windows
     timeoutInMinutes: 60 #default value
@@ -1288,6 +1310,7 @@ stages:
 
       - script: tracer\build.cmd Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug
         displayName: Build tracer home in debug
+        timeoutInMinutes: 30
         retryCountOnTaskFailure: 1
 
   - job: linux_arm64
@@ -1309,6 +1332,7 @@ stages:
           baseImage: debian
           command: "Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug"
           retryCountForRunCommand: 1
+          timeoutInMinutesForRunCommand: 30
 
   - job: macos
     timeoutInMinutes: 60 #default value
@@ -1324,6 +1348,7 @@ stages:
 
       - script: ./tracer/build.sh Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug
         displayName: Build tracer home
+        timeoutInMinutes: 30
         retryCountOnTaskFailure: 1
 
 - stage: unit_tests_windows
@@ -1340,7 +1365,7 @@ stages:
         jobs: [managed]
 
     - job: managed
-      timeoutInMinutes: 60 #default value
+      timeoutInMinutes: 90
       strategy:
         matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.unit_tests_windows_matrix'] ]
       steps:
@@ -1352,6 +1377,7 @@ stages:
 
       - script: tracer\build.cmd BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build unit tests
+        timeoutInMinutes: 35
         retryCountOnTaskFailure: 3
         env:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1408,6 +1434,7 @@ stages:
 
       - script: ./tracer/build.sh BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build unit tests
+        timeoutInMinutes: 35
         retryCountOnTaskFailure: 3
         env:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1465,6 +1492,7 @@ stages:
         command: "BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 15
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -1522,6 +1550,7 @@ stages:
             command: "BuildManagedUnitTests --framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
+            timeoutInMinutesForRunCommand: 15
 
         - template: steps/run-in-docker.yml
           parameters:
@@ -1566,6 +1595,7 @@ stages:
 
         - script: tracer\build.cmd CreateRequiredDirectories CompileSamples
           displayName: Build sample projects
+          timeoutInMinutes: 50
           retryCountOnTaskFailure: 1
           env:
             SampleName: $(IntegrationTestSampleName)
@@ -1615,6 +1645,7 @@ stages:
 
         - script: tracer\build.cmd CreateRequiredDirectories CompileSamples -Framework $(framework) -TestAllPackageVersions
           displayName: Build sample projects
+          timeoutInMinutes: 50
           retryCountOnTaskFailure: 1
           env:
             SampleName: $(IntegrationTestSampleName)
@@ -1655,6 +1686,7 @@ stages:
 
         - script: ./tracer/build.sh CreateRequiredDirectories CompileSamples
           displayName: Build sample projects
+          timeoutInMinutes: 50
           retryCountOnTaskFailure: 1
           env:
             SampleName: $(IntegrationTestSampleName)
@@ -1720,6 +1752,7 @@ stages:
 
     - script: tracer\build.cmd CompileTrimmingSamples BuildIntegrationTests BuildWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Build integration tests
+      timeoutInMinutes: 10
       retryCountOnTaskFailure: 3
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1807,6 +1840,7 @@ stages:
 
     - script: tracer\build.cmd BuildDebuggerIntegrationTests -Framework $(framework) --TargetPlatform $(targetPlatform) --DebugType $(debugType) --Optimize $(optimize) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Build integration tests
+      timeoutInMinutes: 10
       retryCountOnTaskFailure: 3
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1871,6 +1905,7 @@ stages:
 
     - script: tracer\build.cmd BuildAspNetIntegrationTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Build Integration Tests
+      timeoutInMinutes: 10
       retryCountOnTaskFailure: 3
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2156,6 +2191,7 @@ stages:
 
     - script: tracer\build.cmd BuildAspNetIntegrationTests -Framework $(framework)
       displayName: BuildAspNetIntegrationTests
+      timeoutInMinutes: 10
       retryCountOnTaskFailure: 3
 
     - template: steps/ensure-docker-ready.yml
@@ -2232,6 +2268,7 @@ stages:
 
     - script: tracer\build.cmd BuildIntegrationTests  -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: BuildIntegrationTests
+      timeoutInMinutes: 10
       retryCountOnTaskFailure: 3
 
     - script: tracer\build.cmd RunIntegrationTests -filter FleetInstaller=True -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
@@ -2305,6 +2342,7 @@ stages:
         command: "BuildIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
         apikey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 15
 
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
@@ -2408,6 +2446,7 @@ stages:
         command: "BuildIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 15
 
     - script: |
         docker-compose -p $(DockerComposeProjectName)-g$(dockerGroup) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
@@ -2529,6 +2568,7 @@ stages:
         command: "BuildIntegrationTests --framework $(publishTargetFramework) --SampleName Samples.Aws.Lambda"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 15
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -2537,6 +2577,7 @@ stages:
         command: "BuildIntegrationTests --framework $(publishTargetFramework) --SampleName Samples.Amazon.Lambda.RuntimeSupport"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 15
 
     - script: |
         # Include the serverless dockerfile
@@ -2707,6 +2748,7 @@ stages:
         command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64 --debugtype portable --optimize $(optimize)"
         apikey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 15
 
     - script: |
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
@@ -2880,6 +2922,7 @@ stages:
         command: "BuildProfilerSamples"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 10
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -2992,6 +3035,7 @@ stages:
         command: "BuildProfilerSamples"
         apiKey: $(DD_LOGGER_DD_API_KEY)
         retryCountForRunCommand: 3
+        timeoutInMinutesForRunCommand: 10
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3079,6 +3123,8 @@ stages:
         useNativeSdkVersion: true
         command: "BuildProfilerAsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3087,6 +3133,8 @@ stages:
         baseImage: debian
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3158,6 +3206,8 @@ stages:
         baseImage: debian
         command: "BuildProfilerAsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3165,6 +3215,8 @@ stages:
         baseImage: debian
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3212,6 +3264,8 @@ stages:
         baseImage: debian
         command: "BuildProfilerUbsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3219,6 +3273,8 @@ stages:
         baseImage: debian
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3269,6 +3325,8 @@ stages:
         useNativeSdkVersion: true
         command: "BuildProfilerUbsanTest -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3277,6 +3335,8 @@ stages:
         baseImage: debian
         command: "BuildProfilerSampleForSanitiserTests -Framework net7.0"
         apiKey: $(DD_LOGGER_DD_API_KEY)
+        retryCountForRunCommand: 1
+        timeoutInMinutesForRunCommand: 40
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3383,6 +3443,7 @@ stages:
             command: "BuildIntegrationTests CompileTrimmingSamples --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
+            timeoutInMinutesForRunCommand: 15
 
         - script: |
             docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
@@ -3453,6 +3514,7 @@ stages:
             command: "BuildIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true --Filter \"$(IntegrationTestFilter)\" --SampleName \"$(IntegrationTestSampleName)\""
             apiKey: $(DD_LOGGER_DD_API_KEY)
             retryCountForRunCommand: 3
+            timeoutInMinutesForRunCommand: 15
 
         - script: |
             docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) IntegrationTests.ARM64
@@ -3562,6 +3624,8 @@ stages:
             baseImage: $(baseImage)
             command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64 --debugtype portable --optimize $(optimize)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
+            retryCountForRunCommand: 1
+            timeoutInMinutesForRunCommand: 15
 
         - script: |
             docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
@@ -3937,6 +4001,8 @@ stages:
 
     - script: tracer\build.cmd CreateBundleHome BuildBundleNuget BuildAzureFunctionsNuget BuildRunnerTool PackRunnerToolNuget BuildStandaloneTool BuildBenchmarkNuget
       displayName: Build tools and pack NuGet packages (Bundle, AzureFunctions, Benchmark)
+      timeoutInMinutes: 20
+      retryCountOnTaskFailure: 1
       env:
         MSBUILDDISABLENODEREUSE: "1"
 


### PR DESCRIPTION
## Summary of changes

Add explicit timeouts + retries for stages that didn't have them

## Reason for change

We [recently had a build](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_build/results?buildId=207980) where the unit tests stage failed because the _build_ part timed out. The build was absolutely fine, there was just _Something_ that caused the nuke call to hang, which eventually hit the stage timeout, and caused everything to failure. With these extra timeouts, the build steps should hit their "local" timeouts, and get retried, allowing the stage to ultimately pass.

This only adds new retries to "build" stages, not to "test" stages. 

In some cases, also extended the stage timeout to accommodate the new retries - it's better for a job to take a long time than for it to fail completely.

## Implementation details

Asked the API to grab the stats for each job in each stage, focus on the "build" jobs, and suggest new timeouts. The timeouts are intentionally conservative (a slow, no-retry complete is almost always preferable to a retry that forces re-doing work).

## Test coverage

This is the test, but also, we'll see how it goes

## Other details

#incident-57303

<details><summary>The stats the AI produced. Obvs, take with a pinch of salt </summary>
<p>


| Stage                              | Step / command                                                                                                                                | Samples |  Mean |   P95 |     Max | Applied timeout | Applied retry    |
| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------: | ----: | ----: | ------: | --------------: | ---------------- |
| build_windows_tracer               | Build tracer home                                                                                                                             |      25 | 13.50 | 14.32 |   14.61 |              30 | 1                |
| build_windows_profiler             | Build profiler home                                                                                                                           |      25 |  8.33 |  9.15 |    9.38 |              20 | 1                |
| build_linux_tracer                 | Clean CompileManagedLoader (docker)                                                                                                           |      50 |  0.48 |  0.55 |    0.60 |              10 | 1                |
| build_linux_tracer                 | BuildManagedTracerHome ExtractDebugInfoLinux ValidateNativeTracerGlibcCompatibility (docker)                                                  |      50 |  5.16 |  5.51 |    5.52 |              20 | 1                |
| build_linux_tracer_r2r             | Clean CompileManagedLoader (docker)                                                                                                           |      25 |  0.49 |  0.77 |    0.82 |              10 | 1                |
| build_linux_tracer_r2r             | BuildManagedTracerHomeR2R ExtractDebugInfoLinux (docker)                                                                                      |      25 |  5.68 |  6.15 |    6.17 |              20 | 1                |
| build_linux_universal              | Clean BuildNativeLoader BuildNativeWrapper ExtractDebugInfoLinux ValidateNativeLoaderSnapshotTestsLinux (docker)                              |      25 |  2.29 |  2.54 |    2.64 |          **10** | 1                |
| build_arm64_tracer                 | Clean CompileManagedLoader BuildNativeTracerHome BuildManagedTracerHome ExtractDebugInfoLinux ValidateNativeTracerGlibcCompatibility (docker) |      50 |  8.62 |  9.59 |    9.80 |              20 | 1                |
| build_arm64_tracer_r2r             | same, R2R variant (docker)                                                                                                                    |      25 |  9.39 |  9.97 |   10.41 |              20 | 1                |
| build_arm64_profiler               | Clean BuildProfilerHome ExtractDebugInfoLinux ValidateNativeProfilerGlibcCompatibility (docker)                                               |      50 |  5.49 |  6.21 |    6.93 |              15 | 1                |
| build_arm64_universal              | Clean BuildNativeLoader BuildNativeWrapper ... (docker)                                                                                       |      25 |  1.47 |  1.69 |    1.70 |          **10** | 1                |
| build_macos                        | Build native-tracer                                                                                                                           |      25 | 10.16 | 14.48 |   16.39 |              35 | 1                |
| build_macos                        | Build managed tracer + native loader                                                                                                          |      25 | 12.72 | 19.46 |   20.76 |          **30** | 1                |
| package_windows                    | Build MSI, Tracer home, FleetInstaller, and TelemetryForwarder                                                                                |      25 |  1.38 |  1.62 |    1.66 |          **10** | 1                |
| build_dd_dotnet_windows            | Build dd-dotnet                                                                                                                               |      25 |  1.30 |  1.54 |    1.70 |              10 | 1                |
| build_dd_dotnet_linux              | Clean BuildDdDotnet --framework net8.0 (docker)                                                                                               |      50 |  1.26 |  1.37 |    1.59 |              10 | 1                |
| build_dd_dotnet_linux_arm64        | Clean BuildDdDotnet --framework TFM (docker)                                                                                                  |      50 |  0.95 |  1.06 |    1.08 |              10 | 1                |
| debug_builds                       | Clean CompileManagedLoader -buildConfiguration Debug (docker)                                                                                 |      50 |  0.48 |  0.60 |    0.62 |              10 | 1                |
| debug_builds                       | BuildNativeTracerHome -buildConfiguration Debug (docker)                                                                                      |      50 |  3.75 |  4.13 |    4.51 |              15 | 1                |
| debug_builds                       | BuildManagedTracerHome ExtractDebugInfoLinux -buildConfiguration Debug (docker)                                                               |      50 |  5.18 |  5.60 |    6.21 |              20 | 1                |
| debug_builds                       | Build tracer home in debug                                                                                                                    |      25 |  6.27 |  7.00 |    7.05 |              30 | 1                |
| debug_builds                       | Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug (docker)                                  |      25 |  4.97 |  5.57 |    5.77 |              30 | 1                |
| debug_builds                       | Build tracer home                                                                                                                             |      25 |  8.87 | 13.42 |   15.97 |              30 | 1                |
| unit_tests_windows                 | Build unit tests                                                                                                                              |     225 |  6.59 |  7.02 |    7.29 |          **15** | 3 (pre-existing) |
| unit_tests_macos                   | Build unit tests                                                                                                                              |     200 |  9.42 | 14.13 |   17.77 |              35 | 3 (pre-existing) |
| unit_tests_linux                   | BuildManagedUnitTests --framework TFM --code-coverage-enabled BOOL (docker)                                                                   |     400 |  5.92 |  6.26 | 57.72 ⚠ |              15 | 3 (pre-existing) |
| unit_tests_arm64                   | same (docker)                                                                                                                                 |     300 |  5.49 |  6.16 |    6.69 |              15 | 3 (pre-existing) |
| build_samples                      | Build sample projects                                                                                                                         |     275 |  5.19 |  7.52 |    8.11 |          **15** | 1                |
| build_samples_macos                | Build sample projects                                                                                                                         |      25 | 10.43 | 18.17 |   20.43 |          **40** | 1                |
| integration_tests_windows          | Build integration tests                                                                                                                       |     900 |  2.64 |  3.36 |    4.32 |              10 | 3 (pre-existing) |
| integration_tests_windows_debugger | Build integration tests                                                                                                                       |    1600 |  1.53 |  1.92 |    2.91 |              10 | 3 (pre-existing) |
| integration_tests_windows_iis      | Build Integration Tests                                                                                                                       |     100 |  2.36 |  2.94 |    3.44 |              10 | 3 (pre-existing) |
| msi_integration_tests_windows      | BuildAspNetIntegrationTests                                                                                                                   |      50 |  2.04 |  2.66 |    3.14 |              10 | 3 (pre-existing) |
| msi_integration_tests_windows      | BuildIntegrationTests                                                                                                                         |      25 |  1.65 |  2.02 |    2.05 |              10 | 3 (pre-existing) |
| integration_tests_linux            | BuildIntegrationTests CompileTrimmingSamples ... (docker)                                                                                     |    1600 |  2.74 |  3.10 |    5.52 |              15 | 3 (pre-existing) |
| integration_tests_linux            | BuildIntegrationTests --framework TFM --SampleName Lambda (docker)                                                                            |     250 |  1.40 |  2.07 |    2.43 |              15 | 3 (pre-existing) |
| integration_tests_arm64            | BuildIntegrationTests CompileTrimmingSamples ... (docker)                                                                                     |     300 |  2.34 |  2.60 |    3.63 |              15 | 3 (pre-existing) |
| integration_tests_arm64            | BuildIntegrationTests --framework TFM --IncludeTestsRequiringDocker BOOL --SampleName (docker)                                                |     300 |  1.61 |  1.73 |    2.07 |              15 | 3 (pre-existing) |
| integration_tests_linux_debugger   | BuildDebuggerIntegrationTests ... (docker)                                                                                                    |     800 |  1.80 |  2.14 |    2.70 |              15 | 3 (pre-existing) |
| integration_tests_arm64_debugger   | BuildDebuggerIntegrationTests ... (docker)                                                                                                    |     600 |  1.50 |  1.67 |    2.07 |              15 | 1 (was missing)  |
| profiler_integration_tests_linux   | BuildProfilerSamples (docker)                                                                                                                 |      50 |  1.24 |  1.54 |    1.80 |              10 | 3 (pre-existing) |
| profiler_integration_tests_arm64   | BuildProfilerSamples (docker)                                                                                                                 |      50 |  0.87 |  0.95 |    0.97 |              10 | 3 (pre-existing) |
| asan_profiler_tests                | BuildProfilerAsanTest -Framework net7.0 (docker)                                                                                              |      25 | 18.00 | 19.05 |   19.11 |          **30** | 1 (was missing)  |
| asan_profiler_tests                | BuildProfilerSampleForSanitiserTests (docker)                                                                                                 |      25 |  0.52 |  0.61 |    0.65 |          **10** | 1 (was missing)  |
| asan_arm64_profiler_tests          | BuildProfilerAsanTest (docker)                                                                                                                |      25 | 10.21 | 11.02 |   11.38 |          **30** | 1 (was missing)  |
| asan_arm64_profiler_tests          | BuildProfilerSampleForSanitiserTests (docker)                                                                                                 |      25 |  0.25 |  0.31 |    0.34 |          **10** | 1 (was missing)  |
| ubsan_profiler_tests               | BuildProfilerUbsanTest (docker)                                                                                                               |      25 | 18.10 | 19.20 |   19.49 |          **30** | 1 (was missing)  |
| ubsan_profiler_tests               | BuildProfilerSampleForSanitiserTests (docker)                                                                                                 |      25 |  0.51 |  0.62 |    0.65 |          **10** | 1 (was missing)  |
| ubsan_arm64_profiler_tests         | BuildProfilerUbsanTest (docker)                                                                                                               |      25 | 10.39 | 11.27 |   11.81 |          **30** | 1 (was missing)  |
| ubsan_arm64_profiler_tests         | BuildProfilerSampleForSanitiserTests (docker)                                                                                                 |      25 |  0.25 |  0.31 |    0.32 |          **10** | 1 (was missing)  |
| dotnet_tool                        | Build tools and pack NuGet packages (Bundle, AzureFunctions, Benchmark)                                                                       |      25 |  8.64 |  9.26 |    9.92 |              20 | 1 (was missing)  |




</p>
</details> 

