### PR TITLE
Move CI uploads to new subscription

### DIFF
--- a/.azure-pipelines/steps/upload-artifacts-to-azure-storage.yml
+++ b/.azure-pipelines/steps/upload-artifacts-to-azure-storage.yml
@@ -46,6 +46,7 @@ steps:
     AZURE_STORAGE_CONTAINER: $(${{ parameters.containerVariable }})
 
 - bash: |
+    set -e
     az storage blob upload --container-name "$AZURE_STORAGE_CONTAINER" --file "index.txt" --name "index.txt" --overwrite true
     az storage blob upload --container-name "$AZURE_STORAGE_CONTAINER" --file "sha.txt" --name "sha.txt" --overwrite true
     az storage blob upload --container-name "$AZURE_STORAGE_CONTAINER" --file "version.txt" --name "version.txt" --overwrite true

--- a/.azure-pipelines/steps/upload-artifacts-to-azure-storage.yml
+++ b/.azure-pipelines/steps/upload-artifacts-to-azure-storage.yml
@@ -1,0 +1,63 @@
+# .azure-pipelines/steps/upload-artifacts-to-azure-storage.yml
+#
+# Uploads the release assets staged in $(Build.ArtifactStagingDirectory) to a blob
+# container, keyed by commit SHA, and (on master only) refreshes the container-root
+# index blobs (index.txt / sha.txt / version.txt). Instantiated once per target
+# storage account so we can dual-write while migrating between Azure subscriptions.
+#
+# The caller must already have written index.txt / sha.txt / version.txt into the
+# working directory - they are shared between instantiations, so they are written
+# once by the caller rather than here.
+#
+# Both steps pass --overwrite true and retry on failure, so re-running a build for
+# the same commit is safe and transient upload failures self-heal.
+parameters:
+  - name: 'name' # display only, e.g. 'apmdotnetci'
+    type: string
+  - name: 'accountVariable' # e.g. 'AZURE_STORAGE_ACCOUNT_NAME'
+    type: string
+  - name: 'containerVariable'
+    type: string
+  - name: 'sasTokenVariable'
+    type: string
+
+steps:
+- bash: |
+    az storage blob upload-batch \
+      --destination "$AZURE_STORAGE_CONTAINER" \
+      --destination-path "$(Build.SourceVersion)" \
+      --source "$(Build.ArtifactStagingDirectory)" \
+      --overwrite true
+  displayName: Upload blobs to Azure (${{ parameters.name }})
+  retryCountOnTaskFailure: 3
+  condition: >
+    and(
+      succeeded(),
+      ne(variables['${{ parameters.accountVariable }}'], ''),
+      ne(variables['push_artifacts_to_azure_storage'], 'false'),
+      or(
+        eq(variables['push_artifacts_to_azure_storage'], 'true'),
+        eq(variables.isMainOrReleaseBranch, true)
+      )
+    )
+  env:
+    AZURE_STORAGE_ACCOUNT: $(${{ parameters.accountVariable }})
+    AZURE_STORAGE_SAS_TOKEN: $(${{ parameters.sasTokenVariable }})
+    AZURE_STORAGE_CONTAINER: $(${{ parameters.containerVariable }})
+
+- bash: |
+    az storage blob upload --container-name "$AZURE_STORAGE_CONTAINER" --file "index.txt" --name "index.txt" --overwrite true
+    az storage blob upload --container-name "$AZURE_STORAGE_CONTAINER" --file "sha.txt" --name "sha.txt" --overwrite true
+    az storage blob upload --container-name "$AZURE_STORAGE_CONTAINER" --file "version.txt" --name "version.txt" --overwrite true
+  displayName: Upload indexes to Azure (${{ parameters.name }})
+  retryCountOnTaskFailure: 3
+  condition: >
+    and(
+      succeeded(),
+      ne(variables['${{ parameters.accountVariable }}'], ''),
+      eq(variables.isMainBranch, true)
+    )
+  env:
+    AZURE_STORAGE_ACCOUNT: $(${{ parameters.accountVariable }})
+    AZURE_STORAGE_SAS_TOKEN: $(${{ parameters.sasTokenVariable }})
+    AZURE_STORAGE_CONTAINER: $(${{ parameters.containerVariable }})

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4490,42 +4490,26 @@ stages:
           displayName: Write description of assets
 
         - bash: |
-            az storage blob upload-batch \
-              --destination "$(AZURE_STORAGE_CONTAINER_NAME)" \
-              --destination-path "$(Build.SourceVersion)" \
-              --source "$(Build.ArtifactStagingDirectory)"
-          displayName: Upload blobs to Azure
-          condition: >
-            and(
-              succeeded(),
-              ne(variables['push_artifacts_to_azure_storage'], 'false'),
-              or(
-                eq(variables['push_artifacts_to_azure_storage'], 'true'),
-                eq(variables.isMainOrReleaseBranch, true)
-              )
-            )
-          env:
-            AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
-            AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
+            ls "$(Build.ArtifactStagingDirectory)" > index.txt
+            echo "$(Build.SourceVersion)" > sha.txt
+            echo "$(tracer_version)" > version.txt
+          displayName: Write index.txt, sha.txt, and version.txt
 
-        - bash: ls "$(Build.ArtifactStagingDirectory)" > index.txt
-          displayName: Write file list to index.txt
+        # Upload to legacy storage
+        - template: steps/upload-artifacts-to-azure-storage.yml
+          parameters:
+            name: apmdotnetci
+            accountVariable: AZURE_STORAGE_ACCOUNT_NAME
+            containerVariable: AZURE_STORAGE_CONTAINER_NAME
+            sasTokenVariable: AZURE_STORAGE_SHARED_ACCESS_TOKEN
 
-        - bash: echo "$(Build.SourceVersion)" > sha.txt
-          displayName: Write commit hash to sha.txt
-
-        - bash: echo "$(tracer_version)" > version.txt
-          displayName: Write tracer version number to version.txt
-
-        - bash: |
-            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "index.txt" --name "index.txt" --overwrite true
-            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "sha.txt" --name "sha.txt" --overwrite true
-            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "version.txt" --name "version.txt" --overwrite true
-          displayName: Upload indexes to Azure
-          condition: and(succeeded(), eq(variables.isMainBranch, true))
-          env:
-            AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
-            AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
+        # Upload to new storage
+        - template: steps/upload-artifacts-to-azure-storage.yml
+          parameters:
+            name: apmdotnetbuildstorage
+            accountVariable: AZURE_BUILD_STORAGE_ACCOUNT_NAME
+            containerVariable: AZURE_BUILD_STORAGE_CONTAINER_NAME
+            sasTokenVariable: AZURE_BUILD_STORAGE_SHARED_ACCESS_TOKEN
 
 # Only run these on merges to master and PRs with the docker_image_artifacts label
 - stage: upload_container_images

--- a/.gitlab/download-serverless-artifacts.sh
+++ b/.gitlab/download-serverless-artifacts.sh
@@ -14,7 +14,7 @@ if [ -n "$CI_COMMIT_TAG" ] && [ -n "$CI_COMMIT_SHA" ]; then
   echo "Downloading artifacts from Azure"
   curl --location --fail \
     --output $target_dir/serverless-artifacts.zip \
-    "https://apmdotnetci.blob.core.windows.net/apm-dotnet-ci-artifacts-master/${CI_COMMIT_SHA}/serverless-artifacts.zip"
+    "https://apmdotnetbuildstorage.blob.core.windows.net/apm-dotnet-ci-artifacts-master/${CI_COMMIT_SHA}/serverless-artifacts.zip"
 
   # Extract top level artifact
   unzip $target_dir/serverless-artifacts.zip -d $target_dir/

--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -32,7 +32,7 @@ partial class Build
         {
             // Download the forwarder from Azure for now.
             // We will likely change this in the future, but it'll do for now.
-            const string url = "https://apmdotnetci.blob.core.windows.net/apm-datadog-win-ssi-telemetry-forwarder/c83ee9ad2f93c7314779051662e2e00086a213e0/telemetry_forwarder.exe";
+            const string url = "https://apmdotnetbuildstorage.blob.core.windows.net/build-dependencies/apm-datadog-win-ssi-telemetry-forwarder/c83ee9ad2f93c7314779051662e2e00086a213e0/telemetry_forwarder.exe";
             const string expectedHash = "0B192C1901C670FC9A55464AFDF39774AB7CD0D667ECFB37BC22C27184B49C37D4658383E021F792A2F0C7024E1091F35C3CAD046EC68871FAEEE3C98A40163A";
 
             var tempFile = await DownloadFile(url);


### PR DESCRIPTION
## Summary of changes

Upload/download build artifacts to new Azure subscription

## Reason for change

We are moving uploads to a new location for technical reasons. We'll need to update all downstream consumers to pull from the new location. We already have some build dependencies stored here, so we're just expanding that for now (until we move to gitlab)

## Implementation details

- Dual-upload to the old and new location, until we can update all the consumers to pull from the new place. 
- Extracted common code to reusable action for now
  - We can inline this again once we have all the consumers of the old location migrated

## Test coverage

Did a run [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=208065&view=results) that forces the dual upload location, verified it exists

## Other details

AFAICT, this covers everything using the "old" subscription in this repo. Next step is to update consumers to pull from the new location instead 