### PR TITLE
[CI Visibility] Stabilize CODEOWNERS concurrency test

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersSpecTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersSpecTests.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci.CodeOwnership;
 using FluentAssertions;
@@ -936,9 +937,23 @@ public class CodeOwnersSpecTests
         stopwatch.Elapsed.Should().BeLessThan(TestTimeout, "glob matching has bounded, non-backtracking cost");
         Match(codeOwners, matchingPath).Should().Equal(["@slow"], "a difficult non-match must not disable the rule globally");
 
-        var concurrentMatches = Enumerable.Range(0, 64)
-                                          .Select(_ => Task.Run(() => Match(codeOwners, nonMatchingPath)))
+        const int concurrentWorkerCount = 4;
+        using var startSignal = new ManualResetEventSlim();
+        // Dedicated threads keep this check independent of the shared ThreadPool used by the test runner.
+        var concurrentMatches = Enumerable.Range(0, concurrentWorkerCount)
+                                          .Select(
+                                               _ => Task.Factory.StartNew(
+                                                   () =>
+                                                   {
+                                                       startSignal.Wait();
+                                                       return Match(codeOwners, nonMatchingPath);
+                                                   },
+                                                   CancellationToken.None,
+                                                   TaskCreationOptions.LongRunning,
+                                                   TaskScheduler.Default))
                                           .ToArray();
+        startSignal.Set();
+
         Task.WaitAll(concurrentMatches, TestTimeout).Should().BeTrue("concurrent matching must not deadlock");
         foreach (var concurrentMatch in concurrentMatches)
         {

--- a/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersSpecTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersSpecTests.cs
@@ -938,21 +938,20 @@ public class CodeOwnersSpecTests
         Match(codeOwners, matchingPath).Should().Equal(["@slow"], "a difficult non-match must not disable the rule globally");
 
         const int concurrentWorkerCount = 4;
-        using var startSignal = new ManualResetEventSlim();
-        // Dedicated threads keep this check independent of the shared ThreadPool used by the test runner.
+        using var startBarrier = new Barrier(concurrentWorkerCount);
+        // The barrier releases all dedicated threads together without relying on the shared ThreadPool.
         var concurrentMatches = Enumerable.Range(0, concurrentWorkerCount)
                                           .Select(
                                                _ => Task.Factory.StartNew(
                                                    () =>
                                                    {
-                                                       startSignal.Wait();
+                                                       startBarrier.SignalAndWait(TestTimeout).Should().BeTrue("all workers must be ready before matching starts");
                                                        return Match(codeOwners, nonMatchingPath);
                                                    },
                                                    CancellationToken.None,
                                                    TaskCreationOptions.LongRunning,
                                                    TaskScheduler.Default))
                                           .ToArray();
-        startSignal.Set();
 
         Task.WaitAll(concurrentMatches, TestTimeout).Should().BeTrue("concurrent matching must not deadlock");
         foreach (var concurrentMatch in concurrentMatches)


### PR DESCRIPTION
## Summary of changes

- Run the CODEOWNERS concurrency check on four dedicated threads.
- Start all workers together while keeping the existing timeout and ownership assertions.

## Reason for change

The test used `Task.Run` and then blocked its xUnit worker with `Task.WaitAll`. On a busy CI agent, the shared ThreadPool could not schedule all 64 tasks before the timeout, so the test reported a CODEOWNERS deadlock even though matching had completed normally. This failed in [Azure build 208058](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=208058).

## Implementation details

`TaskCreationOptions.LongRunning` gives each of the four workers a dedicated thread, and a start signal makes the matching calls concurrent. The test no longer depends on ThreadPool capacity shared with the rest of the test suite.

## Test coverage

- `CodeOwnersSpecTests`: 92 passed.
- The affected test passed 10 consecutive runs (approximately 27-30 ms each).

## Other details

Test-only change; no production behavior or public API changes.

#incident-57303