### PR TITLE
Add handling of timeouts to `ApiWebRequest`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
@@ -193,6 +194,7 @@ namespace Datadog.Trace.Agent.Transports
 
         private async Task<IApiResponse> SendAsync<TState>(string method, string? contentType, string? contentEncoding, TState state, Func<Stream, TState, Task>? writeBody, CancellationTokenSource cts)
         {
+            CancellationTokenRegistration registration = default;
             try
             {
                 ResetRequest(method, contentType, contentEncoding);
@@ -208,7 +210,7 @@ namespace Datadog.Trace.Agent.Transports
                 // This diverges slightly from HttpClient, where the timeout covers the _whole_ read
                 // currently, however, this _may_ change if we switch to using HttpCompletionMode.
                 // ResponseHeadersRead to avoid the full buffering into memory as we do today.
-                cts.Token.Register(static s => { try { ((HttpWebRequest)s!).Abort(); } catch { } }, _request);
+                registration = cts.Token.Register(static s => { try { ((HttpWebRequest)s!).Abort(); } catch { } }, _request);
 
                 if (writeBody is not null)
                 {
@@ -219,22 +221,46 @@ namespace Datadog.Trace.Agent.Transports
                 }
 
                 var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
+
+                // Make sure we don't have a concurrent Abort() before returning - calling Dispose() here waits
+                // for in-flight cancellation, and it's safe to call Dispose() more than once.
+                registration.Dispose();
+                if (cts.IsCancellationRequested)
+                {
+                    httpWebResponse.Dispose();
+                    ThrowCancelledException(_request, cts.Token, null);
+                }
+
                 return new ApiWebResponse(httpWebResponse);
             }
             catch (WebException exception)
                 when (exception.Status == WebExceptionStatus.ProtocolError && exception.Response != null)
             {
+                // Same race as above, and we don't want Abort() to happen after we return response to caller
+                registration.Dispose();
+                if (cts.IsCancellationRequested)
+                {
+                    exception.Response.Dispose();
+                    ThrowCancelledException(_request, cts.Token, exception);
+                }
+
                 // If the exception is caused by an error status code, ignore it and let the caller handle the result
                 return new ApiWebResponse((HttpWebResponse)exception.Response);
             }
-            catch (Exception ex) when (cts.IsCancellationRequested)
+            catch (Exception ex) when (cts.IsCancellationRequested && ex is not OperationCanceledException)
             {
-                throw new OperationCanceledException($"The request to {_request.RequestUri} timed out after {_request.Timeout}ms.", ex, cts.Token);
+                ThrowCancelledException(_request, cts.Token, ex);
+                return default; // never hit, compiler is stupid
             }
             finally
             {
+                registration.Dispose();
                 cts.Dispose();
             }
+
+            [DoesNotReturn]
+            static void ThrowCancelledException(HttpWebRequest request, CancellationToken token, Exception? innerException)
+                => throw new OperationCanceledException($"The request to {request.RequestUri} timed out after {request.Timeout}ms.", innerException, token);
         }
 
         private readonly struct JsonState<T>(T payload, JsonSerializerSettings settings, MultipartCompression compression)

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -244,11 +244,11 @@ namespace Datadog.Trace.Agent.Transports
                 var getResponseResult = await Task.WhenAny(getResponseTask, deadlineExpired.Task).ConfigureAwait(false);
                 if (getResponseResult == deadlineExpired.Task)
                 {
-                    // The deadline fired before the body producer finished. Don't wait for it any longer - observe
-                    // its eventual fault here so it can't surface as an unobserved task exception later.
-                    _ = getResponseTask.ContinueWith(
-                        static t => _ = t.Exception,
-                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                    // The deadline fired before GetResponseAsync() finished. Don't wait for it any longer:
+                    // if it eventually faults, observe the exception so it can't surface as an unobserved
+                    // task exception; if it eventually succeeds _despite_ Abort(), dispose the orphaned
+                    // response instead of leaking the underlying connection.
+                    _ = getResponseTask.ContinueWith(static t => ObserveOrphanedResponse(t), TaskContinuationOptions.ExecuteSynchronously);
                     ThrowCancelledException(_request, cts.Token, null);
                     httpWebResponse = default; // Not reachable, but easiest way to keep the compiler happy
                 }
@@ -296,6 +296,18 @@ namespace Datadog.Trace.Agent.Transports
             [DoesNotReturn]
             static void ThrowCancelledException(HttpWebRequest request, CancellationToken token, Exception? innerException)
                 => throw new OperationCanceledException($"The request to {request.RequestUri} timed out after {request.Timeout}ms.", innerException, token);
+
+            static void ObserveOrphanedResponse(Task<WebResponse> task)
+            {
+                if (task.IsFaulted)
+                {
+                    _ = task.Exception;
+                }
+                else if (task.Status == TaskStatus.RanToCompletion)
+                {
+                    task.Result.Dispose();
+                }
+            }
         }
 
         private readonly struct JsonState<T>(T payload, JsonSerializerSettings settings, MultipartCompression compression)

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Util;
@@ -210,17 +211,51 @@ namespace Datadog.Trace.Agent.Transports
                 // This diverges slightly from HttpClient, where the timeout covers the _whole_ read
                 // currently, however, this _may_ change if we switch to using HttpCompletionMode.
                 // ResponseHeadersRead to avoid the full buffering into memory as we do today.
+                var deadlineExpired = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                using var tcsRegistration = cts.Token.Register(x => ((TaskCompletionSource<object?>)x!).TrySetResult(true), deadlineExpired, useSynchronizationContext: false);
                 registration = cts.Token.Register(static s => { try { ((HttpWebRequest)s!).Abort(); } catch { } }, _request);
 
                 if (writeBody is not null)
                 {
                     using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
                     {
-                        await writeBody(requestStream, state).ConfigureAwait(false);
+                        var writeBodyTask = writeBody(requestStream, state);
+                        var result = await Task.WhenAny(writeBodyTask, deadlineExpired.Task).ConfigureAwait(false);
+                        if (result == deadlineExpired.Task)
+                        {
+                            // The deadline fired before the body producer finished. Don't wait for it any longer - observe
+                            // its eventual fault here so it can't surface as an unobserved task exception later.
+                            _ = writeBodyTask.ContinueWith(
+                                static t => _ = t.Exception,
+                                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                            ThrowCancelledException(_request, cts.Token, null);
+                        }
+                        else
+                        {
+                            // This has  finished, but not necessarily succesfully, so await it
+                            await writeBodyTask.ConfigureAwait(false);
+                        }
                     }
                 }
 
-                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
+                // Call GetResponseAsync(), but make sure we handle cancellation in the mean time
+                HttpWebResponse httpWebResponse;
+                var getResponseTask = _request.GetResponseAsync();
+                var getResponseResult = await Task.WhenAny(getResponseTask, deadlineExpired.Task).ConfigureAwait(false);
+                if (getResponseResult == deadlineExpired.Task)
+                {
+                    // The deadline fired before the body producer finished. Don't wait for it any longer - observe
+                    // its eventual fault here so it can't surface as an unobserved task exception later.
+                    _ = getResponseTask.ContinueWith(
+                        static t => _ = t.Exception,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+                    ThrowCancelledException(_request, cts.Token, null);
+                    httpWebResponse = default; // Not reachable, but easiest way to keep the compiler happy
+                }
+                else
+                {
+                    httpWebResponse = (HttpWebResponse)await getResponseTask.ConfigureAwait(false);
+                }
 
                 // Make sure we don't have a concurrent Abort() before returning - calling Dispose() here waits
                 // for in-flight cancellation, and it's safe to call Dispose() more than once.

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Agent.Transports
         }
 
         public Task<IApiResponse> GetAsync()
-            => SendAsync(method: "GET", contentType: null, contentEncoding: null, state: this, writeBody: null);
+            => SendAsync(method: "GET", contentType: null, contentEncoding: null, state: this, writeBody: null, new CancellationTokenSource(_request.Timeout));
 
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
             => PostAsync(bytes, contentType, null);
@@ -184,11 +184,31 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        private async Task<IApiResponse> SendAsync<TState>(string method, string? contentType, string? contentEncoding, TState state, Func<Stream, TState, Task>? writeBody)
+        private Task<IApiResponse> SendAsync<TState>(string method, string? contentType, string? contentEncoding, TState state, Func<Stream, TState, Task> writeBody)
+            => SendAsync(method, contentType, contentEncoding, state, writeBody, new CancellationTokenSource(_request.Timeout));
+
+        [TestingOnly]
+        internal Task<IApiResponse> SendAsync(string method, string? contentType, string? contentEncoding, Func<Stream, Task>? writeBody, CancellationTokenSource cts)
+            => SendAsync(method, contentType, contentEncoding, state: writeBody, writeBody is null ? null : static (stream, writeFunc) => writeFunc!(stream), cts);
+
+        private async Task<IApiResponse> SendAsync<TState>(string method, string? contentType, string? contentEncoding, TState state, Func<Stream, TState, Task>? writeBody, CancellationTokenSource cts)
         {
             try
             {
                 ResetRequest(method, contentType, contentEncoding);
+
+                // The callback runs on a CancellationTokenSource timer thread (or
+                // synchronously if the token is already cancelled), so it must swallow
+                // exceptions -- nothing observes them there.
+
+                // Note that this deadline is currently _only_ scoped to the "send": connect,
+                // writing the request body, and waiting for response headers - ending when
+                // SendAsync returns. Reading the response body afterwards is not covered.
+                //
+                // This diverges slightly from HttpClient, where the timeout covers the _whole_ read
+                // currently, however, this _may_ change if we switch to using HttpCompletionMode.
+                // ResponseHeadersRead to avoid the full buffering into memory as we do today.
+                cts.Token.Register(static s => { try { ((HttpWebRequest)s!).Abort(); } catch { } }, _request);
 
                 if (writeBody is not null)
                 {
@@ -206,6 +226,14 @@ namespace Datadog.Trace.Agent.Transports
             {
                 // If the exception is caused by an error status code, ignore it and let the caller handle the result
                 return new ApiWebResponse((HttpWebResponse)exception.Response);
+            }
+            catch (Exception ex) when (cts.IsCancellationRequested)
+            {
+                throw new OperationCanceledException($"The request to {_request.RequestUri} timed out after {_request.Timeout}ms.", ex, cts.Token);
+            }
+            finally
+            {
+                cts.Dispose();
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
@@ -130,6 +130,23 @@ public class ApiRequestTests
         }
     }
 
+    [Fact]
+    public async Task ApiWebRequest_ProtocolError_WithoutTimeout_StillReturnsResponse()
+    {
+        using var agent = MockTracerAgent.Create(_output);
+        agent.ShouldDeserializeTraces = false;
+        agent.CustomResponses[MockTracerResponseType.Traces] = new MockTracerResponse("{\"errors\":[\"bad request\"]}", 400);
+
+        var url = new Uri($"http://localhost:{agent.Port}/");
+        var factory = new ApiWebRequestFactory(url, AgentHttpHeaderNames.DefaultHeaders, TimeSpan.FromSeconds(30));
+        var request = factory.Create(url);
+        var bytes = Encoding.UTF8.GetBytes("{}");
+
+        var response = await request.PostAsync(new ArraySegment<byte>(bytes), "application/json");
+
+        response.StatusCode.Should().Be(400);
+    }
+
 #if NETCOREAPP3_1_OR_GREATER
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
@@ -7,7 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.StreamFactories;
@@ -43,12 +47,87 @@ public class ApiRequestTests
 
     [Theory]
     [CombinatorialData]
-    public async Task ApiWebRequest(bool useGzip)
+    public async Task ApiWebRequest(bool useGzip, bool withTimeout)
     {
         using var agent = MockTracerAgent.Create(_output);
         var url = new Uri($"http://localhost:{agent.Port}/");
-        var factory = new ApiWebRequestFactory(url, AgentHttpHeaderNames.DefaultHeaders);
+
+        var timeout = withTimeout ? TimeSpan.FromSeconds(90) : (TimeSpan?)null;
+        var factory = new ApiWebRequestFactory(url, AgentHttpHeaderNames.DefaultHeaders, timeout);
         await RunTest(agent, () => factory.Create(url), useGzip);
+    }
+
+    // These tests exercise the deadline-enforcement added to ApiWebRequest to work around
+    // HttpWebRequest.Timeout having no effect on the async GetRequestStreamAsync/
+    // GetResponseAsync APIs.
+
+    [Fact]
+    public async Task ApiWebRequest_PostAsync_AbortedMidFlight_ThrowsOperationCanceledException()
+    {
+        using var listener = new BlackHoleTcpListener();
+        using var cts = new CancellationTokenSource();
+        var request = CreateWebRequest(listener.Port);
+        var bytes = Encoding.UTF8.GetBytes("{}");
+
+        try
+        {
+            var pending = request.SendAsync("POST", "application/json", null, stream => stream.WriteAsync(bytes, 0, bytes.Length), cts);
+
+            await listener.Accepted;
+            cts.Cancel();
+
+            Func<Task> act = () => pending;
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            listener.Release();
+        }
+    }
+
+    [Fact]
+    public async Task ApiWebRequest_GetAsync_AbortedMidFlight_ThrowsOperationCanceledException()
+    {
+        using var listener = new BlackHoleTcpListener();
+        using var cts = new CancellationTokenSource();
+        var request = CreateWebRequest(listener.Port);
+
+        try
+        {
+            var pending = request.SendAsync("GET", null, null, null, cts);
+
+            await listener.Accepted;
+            cts.Cancel();
+
+            Func<Task> act = () => pending;
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            listener.Release();
+        }
+    }
+
+    [Fact]
+    public async Task ApiWebRequest_AlreadyCancelledDeadline_ThrowsOperationCanceledException()
+    {
+        using var listener = new BlackHoleTcpListener();
+        using var cts = new CancellationTokenSource();
+        var request = CreateWebRequest(listener.Port);
+
+        try
+        {
+            // Cancel before the send even starts, so the abort lands during
+            // GetRequestStreamAsync/connect, not during GetResponseAsync.
+            cts.Cancel();
+
+            Func<Task> act = () => request.SendAsync("GET", null, null, null, cts);
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            listener.Release();
+        }
     }
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -73,6 +152,28 @@ public class ApiRequestTests
             new DatadogHttpClient(TraceAgentHttpHeaderHelper.Instance),
             Localhost);
         await RunTest(agent, () => factory.Create(Localhost), useGzip);
+    }
+
+    [Fact]
+    public async Task HttpClientRequest_TimesOut_PropagatesTaskCanceledException()
+    {
+        var handler = new StubHttpMessageHandler(_ => throw new TaskCanceledException("Simulated HttpClient.Timeout"));
+        var factory = new HttpClientRequestFactory(Localhost, AgentHttpHeaderNames.DefaultHeaders, handler);
+        var request = factory.Create(Localhost);
+
+        Func<Task> act = request.GetAsync;
+        await act.Should().ThrowAsync<TaskCanceledException>();
+    }
+
+    [Fact]
+    public async Task HttpClientRequest_OtherFailure_PropagatesUnchanged()
+    {
+        var handler = new StubHttpMessageHandler(_ => throw new HttpRequestException("Simulated connection failure"));
+        var factory = new HttpClientRequestFactory(Localhost, AgentHttpHeaderNames.DefaultHeaders, handler);
+        var request = factory.Create(Localhost);
+
+        Func<Task> act = request.GetAsync;
+        await act.Should().ThrowAsync<HttpRequestException>();
     }
 #endif
 
@@ -105,6 +206,8 @@ public class ApiRequestTests
             Localhost);
         await RunTest(agent, () => factory.Create(Localhost), useGzip);
     }
+
+    private static ApiWebRequest CreateWebRequest(int port) => new((HttpWebRequest)WebRequest.Create($"http://127.0.0.1:{port}/"));
 
     private async Task RunTest(MockTracerAgent agent, Func<IApiRequest> createRequest, bool useGzip)
     {
@@ -187,4 +290,77 @@ public class ApiRequestTests
                         Interval = 60,
                     },
                 }));
+
+#if NETCOREAPP3_1_OR_GREATER
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_responder(request));
+    }
+#endif
+
+    private sealed class BlackHoleTcpListener : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly TaskCompletionSource<bool> _accepted = new();
+        private readonly TaskCompletionSource<bool> _release = new();
+
+        public BlackHoleTcpListener()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+            var thread = new Thread(Run) { IsBackground = true };
+            thread.Start();
+        }
+
+        public int Port { get; }
+
+        public Task Accepted => _accepted.Task;
+
+        public void Release() => _release.TrySetResult(true);
+
+        public void Dispose()
+        {
+            Release();
+
+            try
+            {
+                _listener.Stop();
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+
+        private void Run()
+        {
+            TcpClient client = null;
+            try
+            {
+                client = _listener.AcceptTcpClient();
+                _accepted.TrySetResult(true);
+
+                // Hold the connection open -- never finish the response -- until the test is done with it.
+                _release.Task.Wait();
+            }
+            catch (Exception ex)
+            {
+                _accepted.TrySetException(ex);
+            }
+            finally
+            {
+                client?.Close();
+            }
+        }
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
@@ -415,6 +415,7 @@ public class ApiRequestTests
         private readonly TcpListener _listener;
         private readonly TaskCompletionSource<bool> _accepted = new();
         private readonly TaskCompletionSource<bool> _release = new();
+        private volatile bool _stopping;
 
         public BlackHoleTcpListener()
         {
@@ -434,6 +435,12 @@ public class ApiRequestTests
 
         public void Dispose()
         {
+            // Tell Run() to give up instead of calling the blocking AcceptTcpClient() if nothing has
+            // connected yet. On some runtimes (e.g. netcoreapp3.1 on Linux), Stop()/Dispose() spin-waits
+            // for an in-flight accept to release the socket handle, and a newly-arriving connection
+            // doesn't reliably wake it -- deadlocking test cleanup. Avoiding the blocking call entirely
+            // once we're stopping sidesteps that instead of depending on the runtime to interrupt it.
+            _stopping = true;
             Release();
 
             try
@@ -451,6 +458,16 @@ public class ApiRequestTests
             TcpClient client = null;
             try
             {
+                while (!_stopping && !_listener.Pending())
+                {
+                    Thread.Sleep(10);
+                }
+
+                if (_stopping)
+                {
+                    return;
+                }
+
                 client = _listener.AcceptTcpClient();
                 _accepted.TrySetResult(true);
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/Transports/ApiRequestTests.cs
@@ -147,6 +147,93 @@ public class ApiRequestTests
         response.StatusCode.Should().Be(400);
     }
 
+    [Fact]
+    public async Task ApiWebRequest_PostAsync_ProducerStalledOnUnrelatedIO_ThrowsOperationCanceledException()
+    {
+        // The deadline must bound the request-body producer even when it's blocked on something
+        // other than the request stream (e.g. reading a local file), where Abort() alone has no
+        // effect. Use a body producer that never completes on its own -- if the deadline doesn't
+        // bound it, this test hangs instead of failing.
+        //
+        // This producer never writes to the request stream, so we can't synchronize on
+        // listener.Accepted: GetRequestStreamAsync() hands back a buffering stream (neither
+        // ContentLength nor SendChunked is set), and HttpWebRequest defers the actual connect/send
+        // until that stream sees data or is closed. Since nothing is ever written, no connection is
+        // ever attempted - waiting on the listener would hang forever. Instead, synchronize on the
+        // producer having actually been invoked.
+        using var listener = new BlackHoleTcpListener();
+        using var cts = new CancellationTokenSource();
+        var request = CreateWebRequest(listener.Port);
+        var neverCompletes = new TaskCompletionSource<bool>();
+        var started = new TaskCompletionSource<bool>();
+
+        try
+        {
+            var pending = request.SendAsync(
+                "POST",
+                "application/json",
+                null,
+                _ =>
+                {
+                    started.TrySetResult(true);
+                    return neverCompletes.Task;
+                },
+                cts);
+
+            await started.Task;
+            cts.Cancel();
+
+            Func<Task> act = () => pending;
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            neverCompletes.TrySetResult(true);
+            listener.Release();
+        }
+    }
+
+    [Fact]
+    public async Task ApiWebRequest_PostAsync_AbortedWhileBlockedWritingRequestStream_ThrowsOperationCanceledException()
+    {
+        // Make sure that request is aborted when the producer is blocked writing to the request stream
+        // BlackHoleTcpListener never reads from the socket, so a large enough write blocks once the OS send buffer fills.
+        using var listener = new BlackHoleTcpListener();
+        using var cts = new CancellationTokenSource();
+        var request = CreateWebRequest(listener.Port);
+        var bytes = new byte[10 * 1024 * 1024];
+
+        try
+        {
+            var pending = request.SendAsync(
+                "POST",
+                "application/json",
+                null,
+                async stream =>
+                {
+                    // Write in chunks so the write genuinely blocks on the full send buffer instead
+                    // of buffering the whole payload in one WriteAsync call.
+                    const int chunkSize = 64 * 1024;
+                    for (var offset = 0; offset < bytes.Length; offset += chunkSize)
+                    {
+                        var count = Math.Min(chunkSize, bytes.Length - offset);
+                        await stream.WriteAsync(bytes, offset, count);
+                    }
+                },
+                cts);
+
+            await listener.Accepted;
+            cts.Cancel();
+
+            Func<Task> act = () => pending;
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+        finally
+        {
+            listener.Release();
+        }
+    }
+
 #if NETCOREAPP3_1_OR_GREATER
 
     [Theory]


### PR DESCRIPTION
## Summary of changes

Fixes timeout handling for `ApiWebRequest`

## Reason for change

Basically, timeouts never worked in our `ApiWebRequest`, because the APIs we call (`GetRequestStreamAsync`/`GetResponseAsync`) simply don't pay attention to it. That means we effectively had no timeout on any http calls for .NET Framework.

## Implementation details

_Actually_ handle a timeout in `ApiWebRequest`. Technically this still isn't _quite_ the same as our `HttpClient` implementations, because for `HttpClient` we're using a mode that buffers everything in memory immediately, and applies the timeout including that. That's more effort to do with `ApiWebRequest`, as you need to explicitly pass the cancellation token through to the _response_ etc, which all becomes kinda different to `HttpClient`. Ultimately, what this adds is better than what we have _today_

**Note**: My assumption is that we will _not_ want to buffer everything in memory soon, seeing as we're always explicitly copying the body or stream decoding it. Today, we are doing more copying than we should. I expect we'll look at using `HttpCompletionOption.ResponseHeadersRead` instead soon, in which case, we will need to unify our handling of timeouts in any case. A follow up process.

## Test coverage

Added unit tests for the timeouts (which hopefully are _not_ flaky), given I'm cheating by passing in a deterministic cancellation token instead of trying to "wait for it to fail". There's a bunch of edge cases around exactly _when_ the timeout is cancelled which we handle. There's the occasional additional edge case that we can't test without a lot more work, so left that to manual testing instead

## Other details


Stacked on:
- https://github.com/DataDog/dd-trace-dotnet/pull/9145

Discovered as part of:
- https://github.com/DataDog/dd-trace-dotnet/pull/9042
