### PR TITLE
Refactor `ApiWebRequest`

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -34,7 +34,6 @@ src/Datadog.Trace/TracerManagerFactory.cs
 src/Datadog.Trace/Agent/Api.cs
 src/Datadog.Trace/Agent/ApiOtlp.cs
 src/Datadog.Trace/Agent/IApi.cs
-src/Datadog.Trace/Agent/IApiRequest.cs
 src/Datadog.Trace/Agent/IApiRequestFactory.cs
 src/Datadog.Trace/Agent/IApiResponseTelemetryExtensions.cs
 src/Datadog.Trace/Agent/IKeepRateCalculator.cs
@@ -212,7 +211,6 @@ src/Datadog.Trace/Agent/TraceSamplers/ErrorSampler.cs
 src/Datadog.Trace/Agent/TraceSamplers/ITraceChunkSampler.cs
 src/Datadog.Trace/Agent/TraceSamplers/PrioritySampler.cs
 src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
-src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
 src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
 src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
 src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -238,7 +238,7 @@ namespace Datadog.Trace.Agent
                 }
                 catch (Exception ex)
                 {
-                    var tag = ex is TimeoutException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
+                    var tag = ex is TimeoutException or OperationCanceledException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
                     TelemetryFactory.Metrics.RecordCountStatsApiErrors(tag);
                     throw;
                 }
@@ -321,7 +321,7 @@ namespace Datadog.Trace.Agent
                 {
                     // count only network/infrastructure errors, not valid responses with error status codes
                     // (which are handled below)
-                    var tag = ex is TimeoutException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
+                    var tag = ex is TimeoutException or OperationCanceledException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
                     TelemetryFactory.Metrics.RecordCountTraceApiErrors(tag);
                     healthStats?.Increment(TracerMetricNames.Api.Errors);
                     throw;

--- a/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -19,13 +21,13 @@ namespace Datadog.Trace.Agent
 
         Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType);
 
-        Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding);
+        Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string? contentEncoding);
 
         Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression);
 
         Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings);
 
-        Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary);
+        Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string? contentEncoding, string multipartBoundary);
 
         Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None);
     }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -8,8 +8,10 @@ using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Serilog.Events;
@@ -33,31 +35,23 @@ namespace Datadog.Trace.Agent.Transports
         }
 
         public Task<IApiResponse> GetAsync()
-        {
-            ResetRequest(method: "GET", contentType: null, contentEncoding: null);
-
-            return FinishAndGetResponse();
-        }
+            => SendAsync(method: "GET", contentType: null, contentEncoding: null, state: this, writeBody: null);
 
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
             => PostAsync(bytes, contentType, null);
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
-        {
-            ResetRequest(method: "POST", contentType, contentEncoding);
-
-            using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
-            {
-                await requestStream.WriteAsync(bytes.Array, bytes.Offset, bytes.Count).ConfigureAwait(false);
-            }
-
-            return await FinishAndGetResponse().ConfigureAwait(false);
-        }
+        public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
+            => SendAsync(
+                method: "POST",
+                contentType,
+                contentEncoding,
+                state: bytes,
+                writeBody: static (requestStream, body) => requestStream.WriteAsync(body.Array!, body.Offset, body.Count));
 
         public Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression)
             => PostAsJsonAsync(payload, compression, SerializationHelpers.DefaultJsonSettings);
 
-        public async Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
+        public Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
         {
             var contentEncoding = compression == MultipartCompression.GZip ? "gzip" : null;
             if (Log.IsEnabled(LogEventLevel.Debug))
@@ -65,27 +59,21 @@ namespace Datadog.Trace.Agent.Transports
                 Log.Debug("Sending {Type} data as JSON with compression '{Compression}'", typeof(T).FullName, contentEncoding ?? "none");
             }
 
-            ResetRequest(method: "POST", contentType: MimeTypes.Json, contentEncoding: contentEncoding);
-
-            using (var reqStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
-            {
-                await SerializationHelpers.WriteAsJson(reqStream, payload, settings, compression).ConfigureAwait(false);
-            }
-
-            return await FinishAndGetResponse().ConfigureAwait(false);
+            return SendAsync(
+                method: "POST",
+                contentType: MimeTypes.Json,
+                contentEncoding,
+                state: new JsonState<T>(payload, settings, compression),
+                writeBody: static (reqStream, state) => SerializationHelpers.WriteAsJson(reqStream, state.Payload, state.Settings, state.Compression));
         }
 
-        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
-        {
-            ResetRequest(method: "POST", ContentTypeHelper.GetContentType(contentType, multipartBoundary), contentEncoding);
-
-            using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
-            {
-                await writeToRequestStream(requestStream).ConfigureAwait(false);
-            }
-
-            return await FinishAndGetResponse().ConfigureAwait(false);
-        }
+        public Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+            => SendAsync(
+                method: "POST",
+                ContentTypeHelper.GetContentType(contentType, multipartBoundary),
+                contentEncoding,
+                state: writeToRequestStream,
+                writeBody: static (stream, wb) => wb(stream));
 
         /// <summary>
         /// Send a Post request using multipart form data.
@@ -94,7 +82,7 @@ namespace Datadog.Trace.Agent.Transports
         /// <param name="items">Multipart form data items</param>
         /// <param name="multipartCompression">Multipart compression</param>
         /// <returns>Task with the response</returns>
-        public async Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None)
+        public Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None)
         {
             if (items is null)
             {
@@ -103,77 +91,81 @@ namespace Datadog.Trace.Agent.Transports
 
             Log.Debug<int>("Sending multipart form request with {Count} items.", items.Length);
 
-            ResetRequest(method: "POST", contentType: "multipart/form-data; boundary=" + Boundary, contentEncoding: multipartCompression == MultipartCompression.GZip ? "gzip" : null);
-            using (var reqStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
+            return SendAsync(
+                method: "POST",
+                contentType: "multipart/form-data; boundary=" + Boundary,
+                contentEncoding: multipartCompression == MultipartCompression.GZip ? "gzip" : null,
+                state: new MultipartState(items, multipartCompression),
+                writeBody: static (requestStream, state) => WriteMultipartAsync(state.Items, requestStream, state.Compression));
+        }
+
+        private static async Task WriteMultipartAsync(MultipartFormItem[] items, Stream reqStream, MultipartCompression multipartCompression)
+        {
+            if (multipartCompression == MultipartCompression.GZip)
             {
-                if (multipartCompression == MultipartCompression.GZip)
-                {
-                    Log.Debug("Using MultipartCompression.GZip");
-                    using var gzip = new GZipStream(reqStream, CompressionMode.Compress, leaveOpen: true);
-                    await WriteToStreamAsync(items, gzip).ConfigureAwait(false);
-                    await gzip.FlushAsync().ConfigureAwait(false);
-                    Log.Debug("Compressing multipart payload...");
-                }
-                else
-                {
-                    await WriteToStreamAsync(items, reqStream).ConfigureAwait(false);
-                }
+                Log.Debug("Using MultipartCompression.GZip");
+                using var gzip = new GZipStream(reqStream, CompressionMode.Compress, leaveOpen: true);
+                await WriteToStreamAsync(items, gzip).ConfigureAwait(false);
+                await gzip.FlushAsync().ConfigureAwait(false);
+                Log.Debug("Compressing multipart payload...");
             }
-
-            return await FinishAndGetResponse().ConfigureAwait(false);
-
-            async Task WriteToStreamAsync(MultipartFormItem[] multipartItems, Stream requestStream)
+            else
             {
-                // Write form request using the boundary
-                var boundaryBytes = MultipartBytes.BoundarySeparator;
-                var trailerBytes = MultipartBytes.BoundaryTrailer;
+                await WriteToStreamAsync(items, reqStream).ConfigureAwait(false);
+            }
+        }
 
-                // Write each MultipartFormItem
-                var itemsWritten = 0;
-                foreach (var item in multipartItems)
+        private static async Task WriteToStreamAsync(MultipartFormItem[] multipartItems, Stream requestStream)
+        {
+            // Write form request using the boundary
+            var boundaryBytes = MultipartBytes.BoundarySeparator;
+            var trailerBytes = MultipartBytes.BoundaryTrailer;
+
+            // Write each MultipartFormItem
+            var itemsWritten = 0;
+            foreach (var item in multipartItems)
+            {
+                if (!item.IsValid(Log))
                 {
-                    if (!item.IsValid(Log))
-                    {
-                        continue;
-                    }
-
-                    var headerBytes = Encoding.ASCII.GetBytes(
-                        item.FileName is not null
-                            ? $"Content-Type: {item.ContentType}\r\nContent-Disposition: form-data; name=\"{item.Name}\"; filename=\"{item.FileName}\"\r\n\r\n"
-                            : $"Content-Type: {item.ContentType}\r\nContent-Disposition: form-data; name=\"{item.Name}\"\r\n\r\n");
-
-                    if (itemsWritten == 0)
-                    {
-                        // If we are writing the first item, we skip the initial `\r\n` in the array
-                        await requestStream.WriteAsync(boundaryBytes, 2, boundaryBytes.Length - 2).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await requestStream.WriteAsync(boundaryBytes, 0, boundaryBytes.Length).ConfigureAwait(false);
-                    }
-
-                    await requestStream.WriteAsync(headerBytes, 0, headerBytes.Length).ConfigureAwait(false);
-                    if (item.ContentInBytes is { } arraySegment)
-                    {
-                        Log.Debug("Adding to Multipart Byte Array | Name: {Name} | FileName: {FileName} | ContentType: {ContentType}", item.Name, item.FileName, item.ContentType);
-                        await requestStream.WriteAsync(arraySegment.Array, arraySegment.Offset, arraySegment.Count).ConfigureAwait(false);
-                    }
-                    else if (item.ContentInStream is { } stream)
-                    {
-                        Log.Debug("Adding to Multipart Stream | Name: {Name} | FileName: {FileName} | ContentType: {ContentType}", item.Name, item.FileName, item.ContentType);
-                        await stream.CopyToAsync(requestStream).ConfigureAwait(false);
-                    }
-
-                    itemsWritten++;
+                    continue;
                 }
+
+                var headerBytes = Encoding.ASCII.GetBytes(
+                    item.FileName is not null
+                        ? $"Content-Type: {item.ContentType}\r\nContent-Disposition: form-data; name=\"{item.Name}\"; filename=\"{item.FileName}\"\r\n\r\n"
+                        : $"Content-Type: {item.ContentType}\r\nContent-Disposition: form-data; name=\"{item.Name}\"\r\n\r\n");
 
                 if (itemsWritten == 0)
                 {
+                    // If we are writing the first item, we skip the initial `\r\n` in the array
                     await requestStream.WriteAsync(boundaryBytes, 2, boundaryBytes.Length - 2).ConfigureAwait(false);
                 }
+                else
+                {
+                    await requestStream.WriteAsync(boundaryBytes, 0, boundaryBytes.Length).ConfigureAwait(false);
+                }
 
-                await requestStream.WriteAsync(trailerBytes, 0, trailerBytes.Length).ConfigureAwait(false);
+                await requestStream.WriteAsync(headerBytes, 0, headerBytes.Length).ConfigureAwait(false);
+                if (item.ContentInBytes is { } arraySegment)
+                {
+                    Log.Debug("Adding to Multipart Byte Array | Name: {Name} | FileName: {FileName} | ContentType: {ContentType}", item.Name, item.FileName, item.ContentType);
+                    await requestStream.WriteAsync(arraySegment.Array!, arraySegment.Offset, arraySegment.Count).ConfigureAwait(false);
+                }
+                else if (item.ContentInStream is { } stream)
+                {
+                    Log.Debug("Adding to Multipart Stream | Name: {Name} | FileName: {FileName} | ContentType: {ContentType}", item.Name, item.FileName, item.ContentType);
+                    await stream.CopyToAsync(requestStream).ConfigureAwait(false);
+                }
+
+                itemsWritten++;
             }
+
+            if (itemsWritten == 0)
+            {
+                await requestStream.WriteAsync(boundaryBytes, 2, boundaryBytes.Length - 2).ConfigureAwait(false);
+            }
+
+            await requestStream.WriteAsync(trailerBytes, 0, trailerBytes.Length).ConfigureAwait(false);
         }
 
         private void ResetRequest(string method, string contentType, string contentEncoding)
@@ -190,10 +182,20 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        private async Task<IApiResponse> FinishAndGetResponse()
+        private async Task<IApiResponse> SendAsync<TState>(string method, string contentType, string contentEncoding, TState state, Func<Stream, TState, Task> writeBody)
         {
             try
             {
+                ResetRequest(method, contentType, contentEncoding);
+
+                if (writeBody is not null)
+                {
+                    using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
+                    {
+                        await writeBody(requestStream, state).ConfigureAwait(false);
+                    }
+                }
+
                 var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
                 return new ApiWebResponse(httpWebResponse);
             }
@@ -203,6 +205,19 @@ namespace Datadog.Trace.Agent.Transports
                 // If the exception is caused by an error status code, ignore it and let the caller handle the result
                 return new ApiWebResponse((HttpWebResponse)exception.Response);
             }
+        }
+
+        private readonly struct JsonState<T>(T payload, JsonSerializerSettings settings, MultipartCompression compression)
+        {
+            public readonly T Payload = payload;
+            public readonly JsonSerializerSettings Settings = settings;
+            public readonly MultipartCompression Compression = compression;
+        }
+
+        private readonly struct MultipartState(MultipartFormItem[] items, MultipartCompression compression)
+        {
+            public readonly MultipartFormItem[] Items = items;
+            public readonly MultipartCompression Compression = compression;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -19,14 +19,8 @@ namespace Datadog.Trace.Agent.Transports
 {
     internal sealed class ApiWebRequest : IApiRequest
     {
-        private const string BoundarySeparator = $"{CrLf}--{Boundary}{CrLf}";
-        private const string BoundaryTrailer = $"{CrLf}--{Boundary}--{CrLf}";
-
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ApiWebRequest>();
         private readonly HttpWebRequest _request;
-
-        private byte[] _boundarySeparatorInBytes;
-        private byte[] _boundaryTrailerInBytes;
 
         public ApiWebRequest(HttpWebRequest request)
         {
@@ -131,8 +125,8 @@ namespace Datadog.Trace.Agent.Transports
             async Task WriteToStreamAsync(MultipartFormItem[] multipartItems, Stream requestStream)
             {
                 // Write form request using the boundary
-                var boundaryBytes = _boundarySeparatorInBytes ??= Encoding.ASCII.GetBytes(BoundarySeparator);
-                var trailerBytes = _boundaryTrailerInBytes ??= Encoding.ASCII.GetBytes(BoundaryTrailer);
+                var boundaryBytes = MultipartBytes.BoundarySeparator;
+                var trailerBytes = MultipartBytes.BoundaryTrailer;
 
                 // Write each MultipartFormItem
                 var itemsWritten = 0;

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.IO.Compression;
@@ -40,7 +42,7 @@ namespace Datadog.Trace.Agent.Transports
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
             => PostAsync(bytes, contentType, null);
 
-        public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
+        public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string? contentEncoding)
             => SendAsync(
                 method: "POST",
                 contentType,
@@ -67,7 +69,7 @@ namespace Datadog.Trace.Agent.Transports
                 writeBody: static (reqStream, state) => SerializationHelpers.WriteAsJson(reqStream, state.Payload, state.Settings, state.Compression));
         }
 
-        public Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+        public Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string? contentEncoding, string multipartBoundary)
             => SendAsync(
                 method: "POST",
                 ContentTypeHelper.GetContentType(contentType, multipartBoundary),
@@ -168,7 +170,7 @@ namespace Datadog.Trace.Agent.Transports
             await requestStream.WriteAsync(trailerBytes, 0, trailerBytes.Length).ConfigureAwait(false);
         }
 
-        private void ResetRequest(string method, string contentType, string contentEncoding)
+        private void ResetRequest(string method, string? contentType, string? contentEncoding)
         {
             _request.Method = method;
             _request.ContentType = string.IsNullOrEmpty(contentType) ? null : contentType;
@@ -182,7 +184,7 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        private async Task<IApiResponse> SendAsync<TState>(string method, string contentType, string contentEncoding, TState state, Func<Stream, TState, Task> writeBody)
+        private async Task<IApiResponse> SendAsync<TState>(string method, string? contentType, string? contentEncoding, TState state, Func<Stream, TState, Task>? writeBody)
         {
             try
             {

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -111,9 +111,9 @@ internal sealed class CIWriterHttpSender : ICIVisibilityProtocolWriterSender
                 {
                     request.AddHeader(EvpSubdomainHeader, payload.EventPlatformSubdomain);
                 }
-                else
+                else if (TestOptimization.Instance.Settings.ApiKey is { } apiKey)
                 {
-                    request.AddHeader(ApiKeyHeader, TestOptimization.Instance.Settings.ApiKey);
+                    request.AddHeader(ApiKeyHeader, apiKey);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.cs
@@ -414,9 +414,9 @@ internal sealed partial class TestOptimizationClient : ITestOptimizationClient
         {
             request.AddHeader(EvpSubdomainHeader, "api");
         }
-        else
+        else if (_testOptimization.Settings.ApiKey is { } apiKey)
         {
-            request.AddHeader(ApiKeyHeader, _testOptimization.Settings.ApiKey);
+            request.AddHeader(ApiKeyHeader, apiKey);
         }
     }
 

--- a/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
@@ -11,5 +11,20 @@ namespace Datadog.Trace.HttpOverStreams
         public const string CrLf = "\r\n";
 
         public const string Boundary = "faa0a896-8bc8-48f3-b46d-016f2b15a884";
+
+        public static class MultipartBytes
+        {
+            // $"{CrLf}--{Boundary}{CrLf}"
+            public static byte[] BoundarySeparator { get; } =
+            [
+                13, 10, 45, 45, 102, 97, 97, 48, 97, 56, 57, 54, 45, 56, 98, 99, 56, 45, 52, 56, 102, 51, 45, 98, 52, 54, 100, 45, 48, 49, 54, 102, 50, 98, 49, 53, 97, 56, 56, 52, 13, 10,
+            ];
+
+            // $"{CrLf}--{Boundary}--{CrLf}"
+            public static byte[] BoundaryTrailer { get; } =
+            [
+                13, 10, 45, 45, 102, 97, 97, 48, 97, 56, 57, 54, 45, 56, 98, 99, 56, 45, 52, 56, 102, 51, 45, 98, 52, 54, 100, 45, 48, 49, 54, 102, 50, 98, 49, 53, 97, 56, 56, 52, 45, 45, 13, 10
+            ];
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                 }
                 catch (Exception ex)
                 {
-                    var tag = ex is TimeoutException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
+                    var tag = ex is TimeoutException or OperationCanceledException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
                     TelemetryFactory.Metrics.RecordCountDirectLogApiErrors(tag);
 
                     exception = ex;

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
@@ -82,14 +82,14 @@ namespace Datadog.Trace.Telemetry.Transports
             catch (Exception ex) when (IsFatalException(ex))
             {
                 Log.Information(ex, "Error sending telemetry data, unable to communicate with '{Endpoint}'. CompressionEnabled {Compression}", GetEndpointInfo(), _telemetryGzipCompressionEnabled);
-                var tag = ex is TimeoutException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
+                var tag = ex is TimeoutException or OperationCanceledException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
                 TelemetryFactory.Metrics.RecordCountTelemetryApiErrors(endpointMetricTag, tag);
                 return TelemetryPushResult.FatalError;
             }
             catch (Exception ex)
             {
                 Log.Information(ex, "Error sending telemetry data to '{Endpoint}'. CompressionEnabled {Compression}", GetEndpointInfo(), _telemetryGzipCompressionEnabled);
-                var tag = ex is TimeoutException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
+                var tag = ex is TimeoutException or OperationCanceledException ? MetricTags.ApiError.Timeout : MetricTags.ApiError.NetworkError;
                 TelemetryFactory.Metrics.RecordCountTelemetryApiErrors(endpointMetricTag, tag);
                 return TelemetryPushResult.TransientFailure;
             }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploadApiTests.cs
@@ -363,7 +363,7 @@ public class SymbolUploadApiTests
             return Task.FromResult<IApiResponse>(new TestApiResponse(_statusCode, "{}", MimeTypes.Json));
         }
 
-        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string? contentEncoding, string multipartBoundary)
         {
             using var stream = new MemoryStream();
             await writeToRequestStream(stream).ConfigureAwait(false);


### PR DESCRIPTION
## Summary of changes

Refactoring of `ApiWebRequest` logic in preparation for follow up PR

## Reason for change

I needed to do some work to add timeouts in #9144, and that required doing some cleanup first. Extracted here for simplicity of reviews

## Implementation details

Commits can most easily be reviewed individually:

- Avoid creating the multipart upload arrays every time we send a request, instead cache them.
  - Moved to a separate time to avoid creating them in cases where we never do a multipart upload
- We need to listen for `OperationCancelledException` as well to know if a failure was a timeout (for telemetry purposes)
- Reduce duplication in `ApiWebRequest` by pushing through a central `SendAsync()`
- Add `#nullable enable`
- Fix ci vis violations

## Test coverage

Just  a refactor, so basically covered by existing tests

## Other details

Required by https://github.com/DataDog/dd-trace-dotnet/pull/9144