### PR TITLE
Improve `GcMemoryLoadCalculator` by using `GC.GetConfigurationVariables()` where possible

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/PlatformKeys.DotNet.cs
+++ b/tracer/src/Datadog.Trace/Configuration/PlatformKeys.DotNet.cs
@@ -47,4 +47,42 @@ internal static partial class PlatformKeys
     /// Legacy alias for <see cref="DotNetGCHighMemPercent"/>, also parsed as hexadecimal.
     /// </summary>
     public const string ComPlusGCHighMemPercent = "COMPlus_GCHighMemPercent";
+
+    /// <summary>
+    /// Names of the GC hard-limit configuration knobs (env vars and runtimeconfig/<see cref="System.AppContext"/>
+    /// keys). We only ever check for the <b>presence</b> of these - never parse their values, which would require
+    /// reproducing the runtime's hex/octal env-var parsing and percent/absolute/SOH+LOH+POH resolution logic.
+    /// See GcMemoryLoadCalculator.cs, and also <c>GCConfig::GetHeapHardLimit</c> and friends in src/coreclr/gc/gcconfig.h.
+    /// </summary>
+    public const string DotNetGCHeapHardLimit = "DOTNET_GCHeapHardLimit";
+    public const string ComPlusGCHeapHardLimit = "COMPlus_GCHeapHardLimit";
+    public const string AppContextGCHeapHardLimit = "System.GC.HeapHardLimit";
+
+    public const string DotNetGCHeapHardLimitPercent = "DOTNET_GCHeapHardLimitPercent";
+    public const string ComPlusGCHeapHardLimitPercent = "COMPlus_GCHeapHardLimitPercent";
+    public const string AppContextGCHeapHardLimitPercent = "System.GC.HeapHardLimitPercent";
+
+    public const string DotNetGCHeapHardLimitSOH = "DOTNET_GCHeapHardLimitSOH";
+    public const string ComPlusGCHeapHardLimitSOH = "COMPlus_GCHeapHardLimitSOH";
+    public const string AppContextGCHeapHardLimitSOH = "System.GC.HeapHardLimitSOH";
+
+    public const string DotNetGCHeapHardLimitLOH = "DOTNET_GCHeapHardLimitLOH";
+    public const string ComPlusGCHeapHardLimitLOH = "COMPlus_GCHeapHardLimitLOH";
+    public const string AppContextGCHeapHardLimitLOH = "System.GC.HeapHardLimitLOH";
+
+    public const string DotNetGCHeapHardLimitPOH = "DOTNET_GCHeapHardLimitPOH";
+    public const string ComPlusGCHeapHardLimitPOH = "COMPlus_GCHeapHardLimitPOH";
+    public const string AppContextGCHeapHardLimitPOH = "System.GC.HeapHardLimitPOH";
+
+    public const string DotNetGCHeapHardLimitSOHPercent = "DOTNET_GCHeapHardLimitSOHPercent";
+    public const string ComPlusGCHeapHardLimitSOHPercent = "COMPlus_GCHeapHardLimitSOHPercent";
+    public const string AppContextGCHeapHardLimitSOHPercent = "System.GC.HeapHardLimitSOHPercent";
+
+    public const string DotNetGCHeapHardLimitLOHPercent = "DOTNET_GCHeapHardLimitLOHPercent";
+    public const string ComPlusGCHeapHardLimitLOHPercent = "COMPlus_GCHeapHardLimitLOHPercent";
+    public const string AppContextGCHeapHardLimitLOHPercent = "System.GC.HeapHardLimitLOHPercent";
+
+    public const string DotNetGCHeapHardLimitPOHPercent = "DOTNET_GCHeapHardLimitPOHPercent";
+    public const string ComPlusGCHeapHardLimitPOHPercent = "COMPlus_GCHeapHardLimitPOHPercent";
+    public const string AppContextGCHeapHardLimitPOHPercent = "System.GC.HeapHardLimitPOHPercent";
 }

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/GcMemoryLoadCalculator.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/GcMemoryLoadCalculator.cs
@@ -7,6 +7,8 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
@@ -32,7 +34,7 @@ internal static class GcMemoryLoadCalculator
 
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(GcMemoryLoadCalculator));
 
-    private static readonly Lazy<bool> HasConfiguredHighMemoryLoadPercent = new(ReadHasConfiguredHighMemoryLoadPercent);
+    private static readonly Lazy<GcMemoryConfiguration> Configuration = new(ReadConfiguration);
 
     private static bool _unableToResolveLogged;
 
@@ -45,81 +47,180 @@ internal static class GcMemoryLoadCalculator
             info.MemoryLoadBytes,
             info.HighMemoryLoadThresholdBytes,
             info.TotalAvailableMemoryBytes,
-            HasConfiguredHighMemoryLoadPercent.Value);
+            Configuration.Value);
     }
 
     [TestingAndPrivateOnly]
-    internal static double? TryCalculate(long memoryLoadBytes, long highMemoryLoadThresholdBytes, long totalAvailableMemoryBytes, bool hasConfiguredHighMemoryLoadPercent)
+    internal static double? TryCalculate(long memoryLoadBytes, long highMemoryLoadThresholdBytes, long totalAvailableMemoryBytes, GcMemoryConfiguration configuration)
     {
-        if (highMemoryLoadThresholdBytes <= 0 || totalAvailableMemoryBytes <= 0)
+        if (highMemoryLoadThresholdBytes <= 0)
         {
             // HighMemoryLoadThresholdBytes is 0 before the first GC has run, so we can't calculate anything
             return null;
         }
 
-        // We need to recreate this flow from the GC: https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/init.cpp#L1488C59-L1519
-        if (hasConfiguredHighMemoryLoadPercent)
+        var highMemoryLoadThresholdPercent = configuration.HighMemoryLoadThresholdPercent;
+
+        if (highMemoryLoadThresholdPercent is null
+            && !configuration.HasConfiguredHighMemoryLoadPercent
+            && highMemoryLoadThresholdBytes <= EightyGiBBytesAt90Percent)
         {
-            // If there's a high memory threshold, then bail out, as we can't reliably calculate without parsing all the values
-            // identically to the GC, which is fragile
-            return UseFallback(memoryLoadBytes, totalAvailableMemoryBytes);
+            // Unconfigured, and the runtime's default formula (init.cpp: compute_memory_settings()) only resolves
+            // above 90 once physical memory reaches 80GiB, so below that threshold it must be exactly 90.
+            highMemoryLoadThresholdPercent = 90;
         }
 
-        // Check if the threshold is within the runtime's "easy" default formula".
-        // Since the resolved percentage is always >= 90, the _implied_ total
-        // here is always >= total_physical_mem, so "implied < 80GiB" implies "total_physical_mem < 80GiB".
-        if (highMemoryLoadThresholdBytes > EightyGiBBytesAt90Percent)
+        if (highMemoryLoadThresholdPercent is { } percent)
         {
-            // If we know we're > 80GB, then we can't accurately calculate the high memory load threshold percent without
-            // getting the processors, which is a pain
-            // If that processor count couldn't be reliably determined, we don't guess, we bail out.
-            if (!Volatile.Read(ref _unableToResolveLogged))
+            // Route A: MemoryLoadBytes and HighMemoryLoadThresholdBytes are both scaled by total_physical_mem, so
+            // it cancels out of this division, making the result exact regardless of whether a GC hard limit is in play.
+            var memoryLoad = Math.Round(memoryLoadBytes * (double)percent / highMemoryLoadThresholdBytes);
+            return Clamp(memoryLoad);
+        }
+
+        if (!configuration.HasHeapHardLimit && totalAvailableMemoryBytes > 0)
+        {
+            // Route B: no GC hard limit is explicitly configured, so TotalAvailableMemoryBytes ==
+            // total_physical_mem (unless we're running in containers - that triggers a 75% scaling issue)
+            // but as that's pre-existing, we're glossing over it...
+            return Clamp(memoryLoadBytes * 100.0 / totalAvailableMemoryBytes);
+        }
+
+        // Neither route is sound: the threshold percentage is unknown (unconfigured and >= 80GiB physical memory)
+        // or a GC hard limit might be set, so TotalAvailableMemoryBytes can't be trusted either. Publishing a
+        // value here would mean guessing, so we don't - we bail out instead.
+        if (totalAvailableMemoryBytes > 0 && !Volatile.Read(ref _unableToResolveLogged))
+        {
+            Volatile.Write(ref _unableToResolveLogged, true);
+            if (configuration.HasHeapHardLimit)
             {
-                Volatile.Write(ref _unableToResolveLogged, true);
-                Log.Warning("Unable to resolve GC memory load percentage: total machine processor count is unknown (HighMemoryLoadThresholdBytes={HighMemoryLoadThresholdBytes})", highMemoryLoadThresholdBytes);
+                Log.Warning(
+                    "Unable to resolve GC memory load percentage: the high memory load threshold percentage is unknown and a GC heap hard limit may be set (HighMemoryLoadThresholdBytes={HighMemoryLoadThresholdBytes}, TotalAvailableMemoryBytes={TotalAvailableMemoryBytes})",
+                    highMemoryLoadThresholdBytes,
+                    totalAvailableMemoryBytes);
+            }
+            else
+            {
+                Log.Warning(
+                    "Unable to resolve GC memory load percentage: the high memory load threshold percentage is unknown (HighMemoryLoadThresholdBytes={HighMemoryLoadThresholdBytes}, TotalAvailableMemoryBytes={TotalAvailableMemoryBytes})",
+                    highMemoryLoadThresholdBytes,
+                    totalAvailableMemoryBytes);
+            }
+        }
+
+        return null;
+
+        static double Clamp(double memoryLoad) => Math.Min(100d, Math.Max(0d, memoryLoad));
+    }
+
+    [TestingAndPrivateOnly]
+    internal static GcMemoryConfiguration ReadConfiguration()
+    {
+        var configurationVariables = TryReadConfigurationVariables();
+
+        // On .NET 7, GCHighMemPercent in the dictionary is broken - it reports 0 even when explicitly
+        // configured, so we can only trust it on .NET 8+. GCHeapHardLimit _is_ correct on .NET 7.
+        return Parse(
+            configurationVariables,
+            canTrustHighMemoryLoadPercent: FrameworkDescription.Instance.RuntimeVersion.Major >= 8);
+    }
+
+    /// <summary>
+    /// Parse the values returned by <see cref="TryReadConfigurationVariables"/>
+    /// </summary>
+    /// <param name="configurationVariables">The variables to parse (or null if they couldn't be found)</param>
+    /// <param name="hasConfiguredHighMemoryLoadPercentFallback">The value to use as the fallback for hasConfiguredHighMemoryLoadPercent (testing only)</param>
+    /// <param name="hasHeapHardLimitKnobFallback">The value to use as the fallback for hasHeapHardLimit (testing only)</param>
+    /// <param name="canTrustHighMemoryLoadPercent">Whether the <c>GCHighMemPercent</c> entry can be trusted (<c>false</c> on .NET 7, where it always reports 0)</param>
+    [TestingAndPrivateOnly]
+    internal static GcMemoryConfiguration Parse(
+        IReadOnlyDictionary<string, object>? configurationVariables,
+        bool? hasConfiguredHighMemoryLoadPercentFallback = null,
+        bool? hasHeapHardLimitKnobFallback = null,
+        bool canTrustHighMemoryLoadPercent = true)
+    {
+        // Don't use GCHighMemPercent unless it can be trusted.
+        long rawPercent = 0;
+        var hasPercent = canTrustHighMemoryLoadPercent
+                       && TryGetInt64(configurationVariables, "GCHighMemPercent", out rawPercent);
+        var hasLimit = TryGetInt64(configurationVariables, "GCHeapHardLimit", out var rawLimit);
+
+        if (hasPercent && hasLimit)
+        {
+            // In .NET 10, rawPercent contains the "real" value. Never 0.
+            // In .NET 8/9 it has a value _only_ if specifically configured, otherwise it's 0 (so 0 == not configured).
+            // We need to clamp it though, as values could exceed 99, and can overflow - we handle this the same way the GC does in gc.cpp
+            //
+            // In all cases, rawLimit != 0 if there is a heap hard limit at all (explicit configured or a container-derived default)
+            var unsignedPercent = unchecked((ulong)rawPercent);
+            int? percent = rawPercent != 0
+                               ? unsignedPercent > 99 ? 99 : (int)unsignedPercent
+                               : null;
+            return new GcMemoryConfiguration(
+                highMemoryLoadThresholdPercent: percent,
+                hasConfiguredHighMemoryLoadPercent: rawPercent != 0,
+                hasHeapHardLimit: rawLimit != 0);
+        }
+
+        // Only .NET 7 trusts half a dictionary: there GCHeapHardLimit is reliable while GCHighMemPercent isn't,
+        // and the resolved limit beats a presence check that can't see an implicit container limit. Note that an
+        // explicit limit set to exactly total physical memory now bails rather than answering - the safe direction.
+        // On .NET 8+ we only reach here if the dictionary itself was unusable, so keep the historical behaviour.
+        var hasHeapHardLimit = !canTrustHighMemoryLoadPercent && hasLimit
+                                    ? rawLimit != 0 // .NET 7 path
+                                    : hasHeapHardLimitKnobFallback ?? ReadHasConfiguredHeapHardLimit(); // Everything else
+
+        return new GcMemoryConfiguration(
+            highMemoryLoadThresholdPercent: null,
+            hasConfiguredHighMemoryLoadPercent: hasConfiguredHighMemoryLoadPercentFallback ?? ReadHasConfiguredHighMemoryLoadPercent(),
+            hasHeapHardLimit: hasHeapHardLimit);
+
+        static bool TryGetInt64(IReadOnlyDictionary<string, object>? variables, string name, out long value)
+        {
+            // Integer GC config knobs are always boxed as System.Int64:
+            // https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+            // Anything else means an unexpected runtime change, not a value we should trust.
+            if (variables is not null && variables.TryGetValue(name, out var raw) && raw is long knob)
+            {
+                value = knob;
+                return true;
             }
 
-            return UseFallback(memoryLoadBytes, totalAvailableMemoryBytes);
+            value = 0;
+            return false;
+        }
+    }
+
+    [TestingAndPrivateOnly]
+    internal static IReadOnlyDictionary<string, object>? TryReadConfigurationVariables()
+    {
+        // GC.GetConfigurationVariables() was added in .NET 7 (dotnet/runtime#70514) and genuinely doesn't
+        // exist on .NET 6, so short-circuit rather than paying for a reflection lookup that can only fail.
+        // Note that the values we read are buggy in various different ways on < .NET 10, which is handled in Parse().
+        if (FrameworkDescription.Instance.RuntimeVersion.Major < 7)
+        {
+            return null;
         }
 
-        // heap_hard_limit (TotalAvailableMemoryBytes) can never exceed total_physical_mem. If the implied total
-        // from our resolved threshold is smaller than TotalAvailableMemoryBytes, then we got something wrong in our
-        // calculations, so bail out rather than publish a skewed value.
-        // This should never be violated in practice, it's a safety check for our calculations
-        const double highMemoryLoadThresholdPercentage = 90.0;
-        const double highMemoryLoadThresholdRatio = highMemoryLoadThresholdPercentage / 100.0;
-
-        var impliedTotalPhysicalMemoryBytes = highMemoryLoadThresholdBytes / highMemoryLoadThresholdRatio;
-
-        // include some tolerance
-        if (impliedTotalPhysicalMemoryBytes < totalAvailableMemoryBytes * 0.99)
+        try
         {
-            if (!Volatile.Read(ref _unableToResolveLogged))
+            // We use reflection instead of ducktyping as doesn't make sense to pay the one-off cost of Reflection.Emit
+            // when we are only going to invoke it once
+            var methodInfo = typeof(GC).GetMethod("GetConfigurationVariables", BindingFlags.Public | BindingFlags.Static);
+            if (methodInfo is null)
             {
-                Volatile.Write(ref _unableToResolveLogged, true);
-                Log.Error(
-                    "Unable to resolve GC memory load percentage, calculated total available bytes {ImpliedTotalAvailableMemoryBytes} is less than provided GC value {TotalAvailableMemoryBytes} (MemoryLoadBytes={MemoryLoadBytes}, HighMemoryLoadThresholdBytes={HighMemoryLoadThresholdBytes})",
-                    [
-                        impliedTotalPhysicalMemoryBytes,
-                        totalAvailableMemoryBytes,
-                        memoryLoadBytes,
-                        highMemoryLoadThresholdBytes
-                    ]);
+                Log.Debug("GC.GetConfigurationVariables() is not available on this runtime; GC hard-limit and high-memory-load-percent detection will fall back to presence-only checks.");
+                return null;
             }
 
-            // Something is wrong with our calculation, shouldn't happen
-            return UseFallback(memoryLoadBytes, totalAvailableMemoryBytes);
+            var getConfigurationVariables = methodInfo.CreateDelegate<Func<IReadOnlyDictionary<string, object>>>();
+            return getConfigurationVariables();
         }
-
-        var memoryLoad = Math.Round(memoryLoadBytes * highMemoryLoadThresholdPercentage / highMemoryLoadThresholdBytes);
-        return Math.Min(100d, Math.Max(0d, memoryLoad));
-
-        // Fallback used when we can't reliably invert the threshold back to a total: fall back to the simple
-        // pre-refactor calculation of load relative to TotalAvailableMemoryBytes. This is exactly correct unless a
-        // GC hard limit is in play (TotalAvailableMemoryBytes then reflects heap_hard_limit rather than
-        // total_physical_mem, which can inflate the result) - but that's still a better bet than the alternative.
-        static double UseFallback(long memoryLoadBytes, long totalAvailableMemoryBytes)
-            => Math.Min(100d, Math.Max(0d, memoryLoadBytes * 100.0 / totalAvailableMemoryBytes));
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error calling GC.GetConfigurationVariables()");
+            return null;
+        }
     }
 
     [TestingAndPrivateOnly]
@@ -127,6 +228,8 @@ internal static class GcMemoryLoadCalculator
     {
         // Check if either of the configs defined here are set, so we can bail out
         // https://github.com/dotnet/runtime/blob/2cc068d0008c898c67578f2868bd5b17a64c6366/src/coreclr/gc/gcconfig.h#L100
+        // This is also our only option on .NET 7: GCHighMemPercent in GC.GetConfigurationVariables() always
+        // reports 0 there, even when explicitly configured (dotnet/runtime#84198), so we group .NET 7 with .NET 6.
         try
         {
             var envValue = EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHighMemPercent)
@@ -158,6 +261,92 @@ internal static class GcMemoryLoadCalculator
         }
 
         return false;
+    }
+
+    [TestingAndPrivateOnly]
+    internal static bool ReadHasConfiguredHeapHardLimit()
+    {
+        // Presence-only: we never parse these values (hex/octal env vars, percent vs. absolute, SOH+LOH+POH
+        // summation), we only care whether *something* in the GCHeapHardLimit family is configured.
+        try
+        {
+            if (EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimit) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimit) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimitPercent) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimitPercent) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimitSOH) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimitSOH) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimitLOH) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimitLOH) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimitPOH) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimitPOH) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimitSOHPercent) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimitSOHPercent) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimitLOHPercent) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimitLOHPercent) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.DotNetGCHeapHardLimitPOHPercent) is not null
+             || EnvironmentHelpers.GetEnvironmentVariable(PlatformKeys.ComPlusGCHeapHardLimitPOHPercent) is not null)
+            {
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error reading configured GC heap hard limit");
+        }
+
+        try
+        {
+            // Presence-only fallback signal for pre-.NET 7, or when GC.GetConfigurationVariables() in unusable.
+            // See gcconfig.h in src/coreclr/gc.
+            return AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimit) is string
+                || AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimitPercent) is string
+                || AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimitSOH) is string
+                || AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimitLOH) is string
+                || AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimitPOH) is string
+                || AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimitSOHPercent) is string
+                || AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimitLOHPercent) is string
+                || AppContext.GetData(PlatformKeys.AppContextGCHeapHardLimitPOHPercent) is string;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Error reading GC heap hard limit knobs from AppContext");
+            // If there's an exception, fail "safe"
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// The GC memory configuration, either resolved authoritatively via <c>GC.GetConfigurationVariables()</c> (.NET
+    /// 8+, plus the heap hard limit only on .NET 7) or inferred from configuration-knob presence checks.
+    /// </summary>
+    internal readonly struct GcMemoryConfiguration(int? highMemoryLoadThresholdPercent, bool hasConfiguredHighMemoryLoadPercent, bool hasHeapHardLimit)
+    {
+        /// <summary>
+        /// Gets the GC's true "high memory load" threshold percentage (already clamped to 0-99), or <c>null</c> if
+        /// it can't be determined reliably.
+        /// </summary>
+        public int? HighMemoryLoadThresholdPercent { get; } = highMemoryLoadThresholdPercent;
+
+        /// <summary>
+        /// Gets a value indicating whether a <c>GCHighMemPercent</c>-style override is configured. This can be true
+        /// even when <see cref="HighMemoryLoadThresholdPercent"/> is null (.NET 6/7, where we can detect that
+        /// *something* is configured via env vars/AppContext, but not resolve the actual value).
+        /// </summary>
+        public bool HasConfiguredHighMemoryLoadPercent { get; } = hasConfiguredHighMemoryLoadPercent;
+
+        /// <summary>
+        /// Gets a value indicating whether a GC heap hard limit is in play. Authoritative - including a
+        /// container's implicit default - only when <c>GC.GetConfigurationVariables()</c> succeeded (.NET 7+, the
+        /// common case). Otherwise (primarily .NET 6) this falls back to a best-effort presence
+        /// check over <em>explicit</em> configuration knobs only: it cannot see a hard limit the runtime derives
+        /// implicitly from a container/cgroup memory limit, since the runtime exposes no knob for that case.
+        /// A false negative here lets <see cref="TryCalculate"/> take Route B and scale by <c>TotalAvailableMemoryBytes</c>
+        /// as if it were <c>total_physical_mem</c>, when it may actually be a smaller, implicit <c>heap_hard_limit</c>
+        /// (the runtime defaults it to 75% of the cgroup limit), leading to silently inflating/over-reporting
+        /// the load percentage, rather than returning <c>null</c>.
+        /// </summary>
+        public bool HasHeapHardLimit { get; } = hasHeapHardLimit;
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/GcMemoryLoadCalculatorTests.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.TestHelpers;
@@ -17,7 +18,25 @@ using Xunit;
 namespace Datadog.Trace.Tests.RuntimeMetrics;
 
 [Collection(nameof(EnvironmentVariablesTestCollection))]
-[EnvironmentRestorer(PlatformKeys.DotNetGCHighMemPercent, PlatformKeys.ComPlusGCHighMemPercent)]
+[EnvironmentRestorer(
+    PlatformKeys.DotNetGCHighMemPercent,
+    PlatformKeys.ComPlusGCHighMemPercent,
+    PlatformKeys.DotNetGCHeapHardLimit,
+    PlatformKeys.ComPlusGCHeapHardLimit,
+    PlatformKeys.DotNetGCHeapHardLimitPercent,
+    PlatformKeys.ComPlusGCHeapHardLimitPercent,
+    PlatformKeys.DotNetGCHeapHardLimitSOH,
+    PlatformKeys.ComPlusGCHeapHardLimitSOH,
+    PlatformKeys.DotNetGCHeapHardLimitLOH,
+    PlatformKeys.ComPlusGCHeapHardLimitLOH,
+    PlatformKeys.DotNetGCHeapHardLimitPOH,
+    PlatformKeys.ComPlusGCHeapHardLimitPOH,
+    PlatformKeys.DotNetGCHeapHardLimitSOHPercent,
+    PlatformKeys.ComPlusGCHeapHardLimitSOHPercent,
+    PlatformKeys.DotNetGCHeapHardLimitLOHPercent,
+    PlatformKeys.ComPlusGCHeapHardLimitLOHPercent,
+    PlatformKeys.DotNetGCHeapHardLimitPOHPercent,
+    PlatformKeys.ComPlusGCHeapHardLimitPOHPercent)]
 public class GcMemoryLoadCalculatorTests
 {
     private const long Total8GiB = 8L * 1024 * 1024 * 1024;
@@ -30,7 +49,7 @@ public class GcMemoryLoadCalculatorTests
         var totalAvailableMemoryBytes = Total8GiB;
         var memoryLoadBytes = AsBytes(Total8GiB, 42);
 
-        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, Config());
 
         result.Should().Be(42);
     }
@@ -45,37 +64,67 @@ public class GcMemoryLoadCalculatorTests
     [InlineData(100)]
     public void TryCalculate_DefaultContainerHardLimit_RecoversTrueLoad(int loadPercent)
     {
-        // e.g. a memory-limited container with no explicit GC hard limit, where the runtime defaults to 75%
+        // e.g. a memory-limited container with no explicit GC hard limit, where the runtime defaults to 75%.
+        // Route A (the inferred-default-90 case) ignores TotalAvailableMemoryBytes / HasHeapHardLimit entirely,
+        // so it recovers the true load exactly even though a hard limit is genuinely in play here.
         var highMemoryLoadThresholdBytes = AsBytes(Total8GiB, 90);
         var totalAvailableMemoryBytes = AsBytes(Total8GiB, 75);
         var memoryLoadBytes = AsBytes(Total8GiB, loadPercent);
 
-        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, Config(hasHeapHardLimit: true));
 
         result.Should().Be(loadPercent);
     }
 
     [Theory]
-    // An explicit threshold-percent override (DOTNET_GCHighMemPercent / System.GC.HighMemoryPercent) can't be
-    // reliably inverted without parsing those values identically to the runtime, which is fragile.
+    [InlineData(90)]
+    [InlineData(97)]
+    [InlineData(99)]
+    public void TryCalculate_KnownThresholdPercent_RecoversTrueLoad(int percent)
+    {
+        // Represents a resolved GCHighMemPercent from GC.GetConfigurationVariables() (.NET 8+, or .NET 10's
+        // always-effective value even above 80GiB) - Route A is exact and completely ignores TotalAvailableMemoryBytes / HasHeapHardLimit.
+        var highMemoryLoadThresholdBytes = AsBytes(Total96GiB, percent);
+        var memoryLoadBytes = AsBytes(Total96GiB, 60);
+        var configuration = Config(percent: percent, hasConfiguredPercent: true, hasHeapHardLimit: true);
+
+        // TotalAvailableMemoryBytes is deliberately nonsensical (1 byte) to prove Route A never looks at it.
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes: 1, configuration);
+
+        result.Should().Be(60);
+    }
+
+    [Fact]
+    public void TryCalculate_ThresholdBelowEightyGiBAndUnconfigured_RecoversTrueLoad_RegressionTest()
+    {
+        // Regression test for the #9095 bug. TotalAvailableMemoryBytes (2000) is deliberately inconsistent with
+        // a heap hard limit larger than physical memory (a decimal DOTNET_GCHeapHardLimit parsed as hexadecimal by the runtime).
+        // Route A doesn't use TotalAvailableMemoryBytes at all, so it's unaffected: threshold=1000 implies total_physical_mem =
+        // 1000/0.9 ~= 1111, so 500/1111 = 45%.
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 1000, totalAvailableMemoryBytes: 2000, Config(hasHeapHardLimit: true));
+
+        result.Should().Be(45);
+    }
+
+    [Theory]
+    // An explicit threshold-percent override (DOTNET_GCHighMemPercent / System.GC.HighMemoryPercent) is
+    // configured, but its resolved value is unknown (pre-.NET 8, or GetConfigurationVariables() unavailable) -
+    // Route A is unavailable, so this falls back to Route B (load relative to TotalAvailableMemoryBytes).
     [InlineData(42, 70, 75, true, 56)]
-    // >= 80GiB, no hard limit: fallback
+    // >= 80GiB and unconfigured: the runtime's default formula could resolve anywhere in [90, 97], so Route A
+    // is unavailable - falls back to Route B.
     [InlineData(42_000_000_000, 97_000_000_000, 100_000_000_000, false, 42)]
-    // TotalAvailableMemoryBytes (heap_hard_limit) can never exceed total_physical_mem, so a tiny threshold next to
-    // a huge totalAvailableMemoryBytes can never be consistent with that invariant.
-    [InlineData(500, 1000, 2000, false, 25)]
-    // Like the primary calculation, the fallback clamps to [0, 100] - it must not publish a value above 100 just
-    // because the actual load already exceeds TotalAvailableMemoryBytes...
+    // Route B clamps to [0, 100] - it must not publish a value above 100 just because the actual load already
+    // exceeds TotalAvailableMemoryBytes...
     [InlineData(90, 70, 75, true, 100)]
     // ...nor below 0 for a negative load.
     [InlineData(-1000, 70, 75, true, 0)]
-    public void TryCalculate_WhenItCannotInvertTheThreshold_FallsBackToLoadRelativeToTotalAvailableMemory(
+    public void TryCalculate_WhenThresholdPercentIsUnknown_FallsBackToRouteB(
         long memoryLoadBytes, long highMemoryLoadThresholdBytes, long totalAvailableMemoryBytes, bool hasConfiguredHighMemoryLoadPercent, double expected)
     {
-        // We can't reliably recover the *true* load percentage relative to the threshold in these cases - so
-        // instead of bailing out, this falls back to the simple pre-refactor calculation of load relative to
-        // TotalAvailableMemoryBytes.
-        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent);
+        var configuration = Config(hasConfiguredPercent: hasConfiguredHighMemoryLoadPercent);
+
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, configuration);
 
         result.Should().Be(expected);
     }
@@ -84,15 +133,52 @@ public class GcMemoryLoadCalculatorTests
     public void TryCalculate_HighMemoryLoadThresholdBytesIsZero_ReturnsNull()
     {
         // HighMemoryLoadThresholdBytes is 0 before the first GC has run
-        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 0, totalAvailableMemoryBytes: Total8GiB, hasConfiguredHighMemoryLoadPercent: false);
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 0, totalAvailableMemoryBytes: Total8GiB, Config());
 
         result.Should().BeNull();
     }
 
     [Fact]
-    public void TryCalculate_TotalAvailableMemoryBytesIsZero_ReturnsNull()
+    public void TryCalculate_TotalAvailableMemoryBytesIsZero_RouteAStillResolves()
     {
-        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 1000, totalAvailableMemoryBytes: 0, hasConfiguredHighMemoryLoadPercent: false);
+        // Route A (the inferred-default-90 case) never reads TotalAvailableMemoryBytes, so a nonsensical 0
+        // there doesn't stop it from resolving the true load.
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 1000, totalAvailableMemoryBytes: 0, Config());
+
+        result.Should().Be(45);
+    }
+
+    [Fact]
+    public void TryCalculate_ThresholdPercentUnknownAndTotalAvailableMemoryBytesIsZero_ReturnsNull()
+    {
+        // Route A is unavailable (percent unknown) and Route B requires a positive TotalAvailableMemoryBytes.
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 1000, totalAvailableMemoryBytes: 0, Config(hasConfiguredPercent: true));
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryCalculate_ThresholdPercentUnknownAndHardLimitInPlay_ReturnsNull()
+    {
+        // Neither route is sound: the percent is unknown (an override is configured but unresolved) and a GC
+        // heap hard limit may be in play, so TotalAvailableMemoryBytes can't be trusted as a stand-in for
+        // total_physical_mem either. We publish nothing rather than guess.
+        var configuration = Config(hasConfiguredPercent: true, hasHeapHardLimit: true);
+
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 500, highMemoryLoadThresholdBytes: 1000, totalAvailableMemoryBytes: 2000, configuration);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryCalculate_AboveEightyGiBUnconfiguredWithHardLimit_ReturnsNull()
+    {
+        // >= 80GiB, unconfigured (percent unknown), and a hard limit is in play. Only reachable on .NET 8/9 -
+        // .NET 10 always resolves a non-zero effective percent, so the percent is never unknown there once
+        // GetConfigurationVariables() is authoritative.
+        var configuration = Config(hasHeapHardLimit: true);
+
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: 42_000_000_000, highMemoryLoadThresholdBytes: 97_000_000_000, totalAvailableMemoryBytes: 100_000_000_000, configuration);
 
         result.Should().BeNull();
     }
@@ -106,7 +192,7 @@ public class GcMemoryLoadCalculatorTests
         var totalAvailableMemoryBytes = Total8GiB;
         var memoryLoadBytes = AsBytes(Total8GiB, 150);
 
-        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, Config());
 
         result.Should().Be(100);
     }
@@ -117,7 +203,7 @@ public class GcMemoryLoadCalculatorTests
         var highMemoryLoadThresholdBytes = AsBytes(Total8GiB, 90);
         var totalAvailableMemoryBytes = Total8GiB;
 
-        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: -1000, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, hasConfiguredHighMemoryLoadPercent: false);
+        var result = GcMemoryLoadCalculator.TryCalculate(memoryLoadBytes: -1000, highMemoryLoadThresholdBytes, totalAvailableMemoryBytes, Config());
 
         result.Should().Be(0);
     }
@@ -129,13 +215,207 @@ public class GcMemoryLoadCalculatorTests
 
         var result = GcMemoryLoadCalculator.TryGetMemoryLoadPercentage(info);
 
-        // Legitimately null if no GC has run yet, a configured override is in play, or the host is >= 80GiB -
-        // but whenever it does resolve, it must be a valid percentage.
+        // Legitimately null in various cases, but whenever it does resolve, it must be a valid percentage.
         if (result is { } value)
         {
             value.Should().BeInRange(0, 100);
         }
     }
+
+    [Fact]
+    public void Parse_BothKeysPresentNonZeroPercent_ResolvesThresholdFromConfig()
+    {
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 92L, ["GCHeapHardLimit"] = 0L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: false, hasHeapHardLimitKnobFallback: false);
+
+        result.HighMemoryLoadThresholdPercent.Should().Be(92);
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeTrue();
+        result.HasHeapHardLimit.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_RawPercentAbove99_ClampsTo99()
+    {
+        // The GC itself clamps GCHighMemPercent to 99 (gc.cpp: min(99u, ...)); in .NET 10+, we reproduce that clamp
+        // caller-side since GetConfigurationVariables() returns the raw configured value, pre-clamp.
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 150L, ["GCHeapHardLimit"] = 0L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: false, hasHeapHardLimitKnobFallback: false);
+
+        result.HighMemoryLoadThresholdPercent.Should().Be(99);
+    }
+
+    [Fact]
+    public void Parse_RawPercentNegative_TreatsAsUnsignedOverflowAndClampsTo99()
+    {
+        // CoreCLR parses DOTNET_GCHighMemPercent as an unsigned 64-bit hex value (gcenv.ee.cpp: u16_strtoui64(..., 16))
+        // then stores it as static_cast<int64_t>, so an oversized hex value (e.g. 0xFFFFFFFFFFFFFFFF) surfaces here
+        // as negative - GC then caps the effective threshold at 99 (rather than clamping to 0)
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = -1L, ["GCHeapHardLimit"] = 0L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: false, hasHeapHardLimitKnobFallback: false);
+
+        result.HighMemoryLoadThresholdPercent.Should().Be(99);
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_PercentZeroButHardLimitSet_ResolvesHardLimitOnly()
+    {
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 0L, ["GCHeapHardLimit"] = 1_073_741_824L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: false, hasHeapHardLimitKnobFallback: false);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeFalse();
+        result.HasHeapHardLimit.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_BothZero_ResolvesUnconfiguredIgnoringFallbacks()
+    {
+        // When GetConfigurationVariables() is available, it's authoritative - the fallback flags (which only
+        // exist for pre-.NET 8) must be ignored entirely, not merged in.
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 0L, ["GCHeapHardLimit"] = 0L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: true, hasHeapHardLimitKnobFallback: true);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeFalse();
+        result.HasHeapHardLimit.Should().BeFalse();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void Parse_NullDictionary_FallsBackToProvidedFlags(bool hasConfiguredPercent, bool hasHardLimitKnob)
+    {
+        var result = GcMemoryLoadCalculator.Parse(null, hasConfiguredPercent, hasHardLimitKnob);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().Be(hasConfiguredPercent);
+        result.HasHeapHardLimit.Should().Be(hasHardLimitKnob);
+    }
+
+    [Fact]
+    public void Parse_EmptyDictionary_FallsBackToProvidedFlags()
+    {
+        var result = GcMemoryLoadCalculator.Parse(new Dictionary<string, object>(), hasConfiguredHighMemoryLoadPercentFallback: true, hasHeapHardLimitKnobFallback: false);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeTrue();
+        result.HasHeapHardLimit.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_MissingHeapHardLimitKey_FallsBackToProvidedFlags()
+    {
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 90L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: false, hasHeapHardLimitKnobFallback: true);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeFalse();
+        result.HasHeapHardLimit.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_WrongBoxedType_FallsBackToProvidedFlags()
+    {
+        // Defensive: integer GC config knobs are always boxed as long. Seeing an int here would mean an
+        // unexpected runtime change, not a value we should trust.
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 90, ["GCHeapHardLimit"] = 0 };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: true, hasHeapHardLimitKnobFallback: true);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeTrue();
+        result.HasHeapHardLimit.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_WhenPercentUntrusted_UsesAuthoritativeHardLimitOverKnobFallback()
+    {
+        // For .NET 7 GCHighMemPercent buggily reports 0 (dotnet/runtime#84198) so the
+        // presence-only fallback would normally win, but the resolved container-derived GCHeapHardLimit is
+        // reliable and overrides it - the knob-presence check can't see an implicit limit at all.
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 0L, ["GCHeapHardLimit"] = 1_610_612_736L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: true, hasHeapHardLimitKnobFallback: false, canTrustHighMemoryLoadPercent: false);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().BeTrue();
+        result.HasHeapHardLimit.Should().BeTrue();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void Parse_WhenPercentUntrusted_NeverResolvesPercent(bool hasConfiguredPercentFallback)
+    {
+        // Even a plausible non-zero value must be discarded when it can't be trusted, and the resolved 0
+        // limit beats a "true" knob fallback.
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 92L, ["GCHeapHardLimit"] = 0L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredPercentFallback, hasHeapHardLimitKnobFallback: true, canTrustHighMemoryLoadPercent: false);
+
+        result.HighMemoryLoadThresholdPercent.Should().BeNull();
+        result.HasConfiguredHighMemoryLoadPercent.Should().Be(hasConfiguredPercentFallback);
+        result.HasHeapHardLimit.Should().BeFalse();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void Parse_WhenPercentUntrustedAndLimitKeyUnusable_FallsBackEntirely(bool hasHardLimitKnob)
+    {
+        // Defensive: integer GC config knobs are always boxed as long. Seeing an int here would mean an
+        // unexpected runtime change, not a value we should trust - fall back to the knob presence check.
+        var vars = new Dictionary<string, object> { ["GCHighMemPercent"] = 0L, ["GCHeapHardLimit"] = 0 };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: false, hasHeapHardLimitKnobFallback: hasHardLimitKnob, canTrustHighMemoryLoadPercent: false);
+
+        result.HasHeapHardLimit.Should().Be(hasHardLimitKnob);
+    }
+
+    [Fact]
+    public void Parse_WhenPercentTrustedAndPercentKeyMissing_IgnoresAuthoritativeHardLimit()
+    {
+        // Regression lock for the strict .NET 8+ behaviour: we never trust half a dictionary there, even
+        // though the limit alone would be usable - .NET 8+ must remain bit-identical to before this change.
+        var vars = new Dictionary<string, object> { ["GCHeapHardLimit"] = 1_073_741_824L };
+
+        var result = GcMemoryLoadCalculator.Parse(vars, hasConfiguredHighMemoryLoadPercentFallback: false, hasHeapHardLimitKnobFallback: false);
+
+        result.HasHeapHardLimit.Should().BeFalse();
+    }
+
+#if NET7_0_OR_GREATER
+    [Fact]
+    public void TryReadConfigurationVariables_Net7OrGreater_MatchesDirectCall()
+    {
+        var expected = GC.GetConfigurationVariables();
+
+        // Today, GC always boxes values as longs, if that changes, our Parse code would fail, so make it explicit
+        expected.Should().NotBeNull();
+        expected["GCHighMemPercent"].Should().BeOfType<long>();
+        expected["GCHeapHardLimit"].Should().BeOfType<long>();
+
+        // Make sure we match
+        var result = GcMemoryLoadCalculator.TryReadConfigurationVariables();
+        result.Should().NotBeNull();
+        result!["GCHighMemPercent"].Should().Be(expected["GCHighMemPercent"]);
+        result!["GCHeapHardLimit"].Should().Be(expected["GCHeapHardLimit"]);
+    }
+#else
+    [SkippableFact]
+    public void TryReadConfigurationVariables_Net6_ReturnsNull()
+    {
+        // The net6.0 leg can roll forward onto a newer runtime, where the API exists and the gate now lets
+        // it through - only assert the .NET 6 behaviour when we're genuinely on .NET 6.
+        Skip.If(FrameworkDescription.Instance.RuntimeVersion.Major >= 7);
+
+        GcMemoryLoadCalculator.TryReadConfigurationVariables().Should().BeNull();
+    }
+#endif
 
     // AppContext.SetData is public at runtime on every supported TFM, but the net6.0 (and earlier) reference
     // assemblies used to compile this project don't declare it - only GetData, which the product code under test
@@ -215,6 +495,70 @@ public class GcMemoryLoadCalculatorTests
             ClearAppContextData();
         }
     }
+
+    [Fact]
+    public void ReadHasHeapHardLimitKnob_NoConfig_ReturnsFalse()
+    {
+        ClearHeapHardLimitAppContextData();
+
+        var result = GcMemoryLoadCalculator.ReadHasConfiguredHeapHardLimit();
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimit)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimit)]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimitPercent)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimitPercent)]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimitSOH)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimitSOH)]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimitLOH)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimitLOH)]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimitPOH)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimitPOH)]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimitSOHPercent)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimitSOHPercent)]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimitLOHPercent)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimitLOHPercent)]
+    [InlineData(PlatformKeys.DotNetGCHeapHardLimitPOHPercent)]
+    [InlineData(PlatformKeys.ComPlusGCHeapHardLimitPOHPercent)]
+    public void ReadHasHeapHardLimitKnob_EnvVarSet_ReturnsTrue(string envVar)
+    {
+        ClearHeapHardLimitAppContextData();
+        Environment.SetEnvironmentVariable(envVar, "1073741824");
+
+        var result = GcMemoryLoadCalculator.ReadHasConfiguredHeapHardLimit();
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("System.GC.HeapHardLimit")]
+    [InlineData("System.GC.HeapHardLimitPercent")]
+    [InlineData("System.GC.HeapHardLimitSOH")]
+    [InlineData("System.GC.HeapHardLimitLOH")]
+    [InlineData("System.GC.HeapHardLimitPOH")]
+    [InlineData("System.GC.HeapHardLimitSOHPercent")]
+    [InlineData("System.GC.HeapHardLimitLOHPercent")]
+    [InlineData("System.GC.HeapHardLimitPOHPercent")]
+    public void ReadHasHeapHardLimitKnob_RuntimeConfigKnobSetAsString_ReturnsTrue(string appContextKey)
+    {
+        ClearHeapHardLimitAppContextData();
+
+        try
+        {
+            AppContext.SetData(appContextKey, "1073741824");
+
+            var result = GcMemoryLoadCalculator.ReadHasConfiguredHeapHardLimit();
+
+            result.Should().BeTrue();
+        }
+        finally
+        {
+            ClearHeapHardLimitAppContextData();
+        }
+    }
 #endif
 
     // Mirrors how the GC encodes a percentage into bytes (compute_memory_settings, src/coreclr/gc/init.cpp as of
@@ -223,11 +567,26 @@ public class GcMemoryLoadCalculatorTests
     // asserts we decode the original percentage back.
     private static long AsBytes(long total, double percent) => (long)((percent / 100.0) * total);
 
+    private static GcMemoryLoadCalculator.GcMemoryConfiguration Config(int? percent = null, bool hasConfiguredPercent = false, bool hasHeapHardLimit = false)
+        => new(percent, hasConfiguredPercent, hasHeapHardLimit);
+
     // AppContext.SetData is public at runtime on every supported TFM, but the net6.0 (and earlier) reference
     // assemblies used to compile this project don't declare it. Below net7.0, nothing in this test binary can
     // set the value in the first place, so clearing it is a no-op.
 #if NET7_0_OR_GREATER
     private static void ClearAppContextData() => AppContext.SetData("System.GC.HighMemoryPercent", null);
+
+    private static void ClearHeapHardLimitAppContextData()
+    {
+        AppContext.SetData("System.GC.HeapHardLimit", null);
+        AppContext.SetData("System.GC.HeapHardLimitPercent", null);
+        AppContext.SetData("System.GC.HeapHardLimitSOH", null);
+        AppContext.SetData("System.GC.HeapHardLimitLOH", null);
+        AppContext.SetData("System.GC.HeapHardLimitPOH", null);
+        AppContext.SetData("System.GC.HeapHardLimitSOHPercent", null);
+        AppContext.SetData("System.GC.HeapHardLimitLOHPercent", null);
+        AppContext.SetData("System.GC.HeapHardLimitPOHPercent", null);
+    }
 #endif
 }
 #endif


### PR DESCRIPTION
## Summary of changes

Fix nonsense `memory_load` runtime metrics when GC hard limits have been set via configuration

## Reason for change

After rolling out a fix for the runtime metrics `memory_load` calculation in #9095, we saw cases in production where our "sense check" for the calculated value was failing. 

This only happened for a few customers, and the best guess of what happened, is that the customers set a _decimal_ value for one of the GC configs, instead of the hex values it should be (e.g. `DOTNET_GCHeapHardLimit=1073741824` i.e. "`1 GB`" is actually read as `0x1073741824` i.e. `~70.6 GB`. The GC doesn't "fix" this value, which means the `TotalAvailableMemoryBytes` value we use is actually completely wrong. We can reproduce all this locally.

The crux of the calculation is:
- `MemoryLoadBytes` `HighMemoryLoadThresholdBytes` are both scaled by `total_physical_mem`
- `TotalAvailableMemoryBytes` is the same as `heap_hard_limit` when this is set. 
- So there are two independent routes to an exact answer for the total available memory:
  - **Route A**: if we know the **true** threshold percentage `T; 
    - `load = MemoryLoadBytes × T / HighMemoryLoadThresholdBytes`
    - _Correct regardless of any hard limit_
  - **Route B**: if we know there is _definitely_ no hard limit;
    - `TotalAvailableMemoryBytes == total_physical_mem`, so   
    - `load = MemoryLoadBytes × 100 / TotalAvailableMemoryBytes`
    - _Correct regardless of `T`_.
  - **Neither**: we can't find out, return `null`

Currently, we are trying to calculate `T` to handle route `A`, but we made assumptions about `B` that don't hold, and produce nonsense in some cases. The only way around that is to directly read the process available memory, which we're trying to avoid currently due to differences in platform subtleties.


Essentially, our previous "sense check" was never really valid, so we have to just be more careful about what we assume. Luckily, while investigating, I learned about [the `GC.GetConfigurationVariables()` method](https://learn.microsoft.com/en-us/dotnet/api/system.gc.getconfigurationvariables?view=net-7.0), which natively exposes some of the values we are trying to calculate. Unfortunately, it doesn't expose the total memory value we really want, and it is also buggy for the other values we can use in < .NET 10. And it doesn't exist in .NET 6 😅 Nevertheless, we can use it to improve our calculations...

## Implementation details

We can grab the `HighMemoryLoadThresholdBytes` value (AKA `T`) directly using `GC.GetConfigurationVariables()` in some cases:

| Runtime  | `GCHighMemPercent` from config vars    | Resolution                         |
| -------- | -------------------------------------- | ---------------------------------- |
| .NET 10+ | correct resolved value, always 90-99   | `T = value` — always exact         |
| .NET 8/9 | _raw_ configured value, `0` when unset | `T = min(99, value)` when non-zero |
| .NET 6/7 | unavailable / always 0                 | can't use this                     |

When `T` is unknown but we know the knob is unconfigured (i.e. in .NET 8 + 9), then we can do the 80GB check, and know our value is correct. For > 80GB or .NET 6/7 we have to take a fallback.

Our _current_ fallback blindly uses `TotalAvailableMemoryBytes`, but we only know that value is correct if there's no _manually_ configured GC hard limit. If there is _no_ explicit configuration, then it means the value of `TotalAvailableMemoryBytes` is not _corrupted_ by manual config, which means it's _either_ the total available memory _or_ it's the 75% of total available memory used in containers.

i.e. in that very last case, .NET 6/7, with no manual config, on big machines we still give the wrong value in containers (we clamp to 100% now, but it's still scaled wrong). But that's essentially an existing gap.

In summary

- ✔️ correct
- ⚠️ bail out (no value)
- ❌ returns wrong value



| Runtime  | <80GiB, no config | ≥80GiB, no config, no hard limit | ≥80GiB, no config, explicit hard limit | ≥80GiB, no config, container limit | configured %, no hard limit | configured %, explicit hard limit | configured %, container limit |
| -------- | ----------------- | -------------------------------- | -------------------------------------- | ---------------------------------- | --------------------------- | --------------------------------- | ----------------------------- |
| .NET 10  | ✔️ A              | ✔️ A                             | ✔️ A                                   | ✔️ A                               | ✔️ A                        | ✔️ A                              | ✔️ A                          |
| .NET 8/9 | ✔️ A              | ✔️ B                             | ⚠️ –                                   | ⚠️ –                               | ✔️ A                        | ✔️ A                              | ✔️ A                          |
| .NET 7 | ✔️ A              | ✔️ B                             | ⚠️️ –                                  | ⚠️ –                                | ✔️ B                        | ⚠️ –                              | ⚠️ –                           |
| .NET 6 | ✔️ A              | ✔️ B                             | ⚠️️ –                                  | ❌ B                                | ✔️ B                        | ⚠️ –                              | ❌ B                           |


## Test coverage

Added various unit tests to cover all the new stuff, and ran a bunch of local manual tests to confirm the behaviours above

## Other details

