### PR TITLE
[CI Visibility] Resolve CODEOWNERS from matching local checkout

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/CIEnvironmentValues.cs
@@ -335,7 +335,8 @@ internal abstract class CIEnvironmentValues
         CommitterDate = null;
         Message = null;
         SourceRoot = null;
-        Setup(StringUtil.IsNullOrEmpty(_gitSearchFolder) ? GitInfo.GetCurrent() : GitInfo.GetFrom(_gitSearchFolder));
+        var gitInfo = StringUtil.IsNullOrEmpty(_gitSearchFolder) ? GitInfo.GetCurrent() : GitInfo.GetFrom(_gitSearchFolder);
+        Setup(gitInfo);
 
         // **********
         // Remove sensitive info from repository url
@@ -359,7 +360,16 @@ internal abstract class CIEnvironmentValues
             Repository = Repository.Replace(uriRepository.UserInfo, string.Empty);
         }
 
-        _codeOwnersResolver = new CodeOwnersResolver(SourceRoot, WorkspacePath, Repository, Provider);
+        // The local checkout is safe to use for CODEOWNERS only when it contains the CI revision.
+        var localGitMatchesCi = !StringUtil.IsNullOrEmpty(Commit) &&
+                                string.Equals(gitInfo.Commit, Commit, StringComparison.OrdinalIgnoreCase);
+        _codeOwnersResolver = new CodeOwnersResolver(
+            SourceRoot,
+            WorkspacePath,
+            Repository,
+            Provider,
+            localGitMatchesCi ? gitInfo.SourceRoot : null,
+            localGitMatchesCi ? gitInfo.Repository : null);
     }
 
     protected abstract void Setup(IGitInfo gitInfo);

--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersFileLocator.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersFileLocator.cs
@@ -21,13 +21,19 @@ internal sealed class CodeOwnersFileLocator
     private readonly string? _provider;
     private readonly string? _repository;
 
-    internal CodeOwnersFileLocator(string? sourceRoot, string? workspacePath, string? repository, string? provider)
+    internal CodeOwnersFileLocator(
+        string? sourceRoot,
+        string? workspacePath,
+        string? repository,
+        string? provider,
+        string? localRepositoryRoot,
+        string? localRepository)
     {
-        _repository = repository;
+        _repository = StringUtil.IsNullOrWhiteSpace(localRepository) ? repository : localRepository;
         _provider = provider;
         var sourceDirectory = RepositorySourcePathResolver.GetSearchStart(sourceRoot, workspacePath);
         var workspaceDirectory = RepositorySourcePathResolver.GetSearchStart(workspacePath, basePath: null);
-        var repositoryRoot = FindGitRoot(sourceDirectory) ?? FindGitRoot(workspaceDirectory);
+        var repositoryRoot = FindGitRoot(sourceDirectory) ?? FindGitRoot(workspaceDirectory) ?? FindGitRoot(localRepositoryRoot);
 
         if (repositoryRoot is not null)
         {

--- a/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersResolver.cs
+++ b/tracer/src/Datadog.Trace/Ci/CodeOwnership/CodeOwnersResolver.cs
@@ -21,9 +21,15 @@ internal sealed class CodeOwnersResolver
     private readonly SmallCacheOrNoCache<SourcePathCacheKey, SourceOwnership> _sourcePathCache;
     private readonly Func<SourcePathCacheKey, SourceOwnership> _resolveCacheMiss;
 
-    internal CodeOwnersResolver(string? sourceRoot, string? workspacePath, string? repository, string? provider)
+    internal CodeOwnersResolver(
+        string? sourceRoot,
+        string? workspacePath,
+        string? repository,
+        string? provider,
+        string? localRepositoryRoot,
+        string? localRepository)
     {
-        _locatedCodeOwners = new CodeOwnersFileLocator(sourceRoot, workspacePath, repository, provider).LocatedFile;
+        _locatedCodeOwners = new CodeOwnersFileLocator(sourceRoot, workspacePath, repository, provider, localRepositoryRoot, localRepository).LocatedFile;
         _pathResolver = new RepositorySourcePathResolver(sourceRoot);
         // The cache disables itself after the limit instead of retaining an unbounded number of source paths.
         _sourcePathCache = new SmallCacheOrNoCache<SourcePathCacheKey, SourceOwnership>(SourcePathCacheLimit, "CODEOWNERS source paths");

--- a/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersFallbackTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/CodeOwnersFallbackTests.cs
@@ -366,6 +366,48 @@ public class CodeOwnersFallbackTests
     }
 
     [SkippableFact]
+    public void UsesMatchingLocalGitCheckoutForMirroredCiWorkspace()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.RootPath;
+        var sourceDirectory = Path.Combine(repoRoot, "tracer", "test", "benchmarks", "Benchmarks.Trace", "Asm");
+        const string codeOwnersFile = """
+            tracer/ @DataDog/tracing-dotnet
+            /tracer/test/benchmarks/Benchmarks.Trace/Asm/ @DataDog/asm-dotnet
+
+            """;
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".github"));
+        Directory.CreateDirectory(sourceDirectory);
+        File.WriteAllText(Path.Combine(repoRoot, ".github", "CODEOWNERS"), codeOwnersFile);
+        File.WriteAllText(Path.Combine(sourceDirectory, "AppSecBodyBenchmark.cs"), "// benchmark");
+
+        var ciValues = new MirroredGitLabEnvironmentValues(repoRoot, CommitSha, CommitSha);
+        var ownership = ciValues.ResolveSourceOwnership(
+            @"D:\build\dd-trace-dotnet\tracer\test\benchmarks\Benchmarks.Trace\Asm\AppSecBodyBenchmark.cs",
+            useOSSeparator: false);
+
+        Assert.True(ciValues.HasCodeOwners);
+        Assert.True(ownership.IsRepositoryRelative);
+        Assert.Equal("tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs", ownership.RepositoryRelativePath);
+        Assert.Equal(["@DataDog/asm-dotnet"], ownership.MatchingOwners);
+    }
+
+    [SkippableFact]
+    public void DoesNotUseLocalGitCheckoutWhenCommitDoesNotMatchCi()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.RootPath;
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".github"));
+        File.WriteAllText(Path.Combine(repoRoot, ".github", "CODEOWNERS"), OwnerOnly);
+
+        var ciValues = new MirroredGitLabEnvironmentValues(repoRoot, CommitSha, "different-commit");
+
+        Assert.False(ciValues.HasCodeOwners);
+    }
+
+    [SkippableFact]
     public void DoesNotSearchOutsideWorkspaceForRelativeSourceFile()
     {
         using var repoDirectory = new TemporaryDirectory();
@@ -647,6 +689,36 @@ public class CodeOwnersFallbackTests
             SourceRoot = _sourceRoot;
             WorkspacePath = _sourceRoot;
             Provider = _provider;
+        }
+    }
+
+    private sealed class MirroredGitLabEnvironmentValues : CIEnvironmentValues
+    {
+        private readonly string _localRepositoryRoot;
+        private readonly string _localCommit;
+        private readonly string _ciCommit;
+
+        public MirroredGitLabEnvironmentValues(string localRepositoryRoot, string localCommit, string ciCommit)
+        {
+            _localRepositoryRoot = localRepositoryRoot;
+            _localCommit = localCommit;
+            _ciCommit = ciCommit;
+            ReloadEnvironmentData();
+        }
+
+        protected override void Setup(IGitInfo gitInfo)
+        {
+            var localGitInfo = (GitInfo)gitInfo;
+            localGitInfo.SourceRoot = _localRepositoryRoot;
+            localGitInfo.Repository = "https://github.com/DataDog/dd-trace-dotnet.git";
+            localGitInfo.Commit = _localCommit;
+
+            var unavailableCiRoot = Path.Combine(_localRepositoryRoot, "remote-ci-workspace");
+            SourceRoot = unavailableCiRoot;
+            WorkspacePath = unavailableCiRoot;
+            Repository = "https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-dotnet.git";
+            Commit = _ciCommit;
+            Provider = "gitlab";
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Use the current local Git checkout as a CODEOWNERS fallback when the CI workspace paths are not available in the test process.
- Trust that fallback only when the local Git commit exactly matches the commit reported by CI.

## Reason for change

Distributed CI jobs can build and run tests on different machines and filesystems. Our benchmark job reports a Linux CI workspace and a GitLab mirror URL, while BenchmarkDotNet executes in a Windows checkout cloned from GitHub. The resolver therefore cannot reach the reported workspace and selects the GitLab CODEOWNERS layout instead of the .github/CODEOWNERS file present in the worker checkout. The benchmark source paths are valid, but their test events receive no owners.

## Implementation details

- Keep the GitInfo instance that is already collected during CI environment initialization.
- Compare its commit with the CI commit once when the test session starts.
- When they match, pass the local repository root and URL to CODEOWNERS discovery.
- Search the local Git root only after the CI source and workspace roots fail.
- Use the local repository URL to select the matching CODEOWNERS dialect and location.

This adds no extra Git command and no per-test allocation or filesystem scan. CODEOWNERS is still located and loaded once per test session.

## Test coverage

- Added a regression test for a GitLab mirror with an unavailable CI workspace, a GitHub worker checkout, and a relocated Windows PDB source path.
- Added a guard test proving that a local checkout at a different commit is not trusted.
- All 179 CODEOWNERS tests pass on .NET 6 and .NET 8.

## Other details

No public API or dependency changes.