### PR TITLE
Support stable OTel deployment environment attribute

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Activity
             // Fixup "env" tag
             if (traceContext is not null
              && traceContext.Environment is null
-             && span.GetTag("deployment.environment") is { Length: > 0 } otelServiceEnv)
+             && (span.GetTag("deployment.environment.name") ?? span.GetTag("deployment.environment")) is { Length: > 0 } otelServiceEnv)
             {
                 traceContext.Environment = otelServiceEnv;
             }

--- a/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/MutableSettings.cs
@@ -1107,8 +1107,10 @@ internal sealed class MutableSettings : IEquatable<MutableSettings>
         if (original.ConfigurationResult is { IsValid: true, Result: { } values })
         {
             // Update well-known service information resources
-            if (values.TryGetValue("deployment.environment", out var envValue))
+            if (values.TryGetValue("deployment.environment.name", out var envValue) ||
+                values.TryGetValue("deployment.environment", out envValue))
             {
+                values.Remove("deployment.environment.name");
                 values.Remove("deployment.environment");
                 values[Tags.Env] = envValue;
             }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MutableSettingsTests.cs
@@ -652,20 +652,44 @@ namespace Datadog.Trace.Tests.Configuration
             mutable.GitCommitSha.Should().Be("42");
         }
 
-        [Fact]
-        public void OTELTagsSetsServiceInformation()
+        [Theory]
+        [InlineData("deployment.environment.name=stable_env", "stable_env")]
+        [InlineData("deployment.environment=legacy_env", "legacy_env")]
+        [InlineData("deployment.environment.name=stable_env,deployment.environment=legacy_env", "stable_env")]
+        [InlineData("deployment.environment=legacy_env,deployment.environment.name=stable_env", "stable_env")]
+        public void OTELTagsSetServiceInformation(string environmentAttributes, string expectedEnvironment)
         {
             var source = new NameValueConfigurationSource(new()
             {
-                { "OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=datadog_env,service.name=datadog_service,service.version=datadog_version" },
+                { ConfigurationKeys.OpenTelemetry.ResourceAttributes, $"{environmentAttributes},service.name=datadog_service,service.version=datadog_version,custom.attribute=custom_value" },
+            });
+
+            var tracerSettings = new TracerSettings(source);
+            var mutable = GetMutableSettings(source, tracerSettings);
+
+            mutable.Environment.Should().Be(expectedEnvironment);
+            mutable.ServiceVersion.Should().Be("datadog_version");
+            mutable.ServiceName.Should().Be("datadog_service");
+            mutable.GlobalTags.Should().NotContainKey("deployment.environment.name");
+            mutable.GlobalTags.Should().NotContainKey("deployment.environment");
+            mutable.GlobalTags.Should().Contain("custom.attribute", "custom_value");
+        }
+
+        [Fact]
+        public void DDEnvTakesPrecedenceOverOTELTags()
+        {
+            var source = new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.Environment, "datadog_env" },
+                { ConfigurationKeys.OpenTelemetry.ResourceAttributes, "deployment.environment=legacy_env,deployment.environment.name=stable_env" },
             });
 
             var tracerSettings = new TracerSettings(source);
             var mutable = GetMutableSettings(source, tracerSettings);
 
             mutable.Environment.Should().Be("datadog_env");
-            mutable.ServiceVersion.Should().Be("datadog_version");
-            mutable.ServiceName.Should().Be("datadog_service");
+            mutable.GlobalTags.Should().NotContainKey("deployment.environment.name");
+            mutable.GlobalTags.Should().NotContainKey("deployment.environment");
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Tagging/ActivityTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/ActivityTagsTests.cs
@@ -132,4 +132,46 @@ public class ActivityTagsTests
             }
         }
     }
+
+    [Theory]
+    [InlineData("deployment.environment.name", "stable_env")]
+    [InlineData("deployment.environment", "legacy_env")]
+    public async Task Environment_ShouldBe_FixedUpFromActivityTag(string tagKey, string tagValue)
+    {
+        var activityMock = new Mock<IActivity5>();
+        activityMock.Setup(x => x.Kind).Returns(ActivityKind.Producer);
+
+        var tagObjects = new Dictionary<string, object> { { tagKey, tagValue } };
+        activityMock.Setup(x => x.TagObjects).Returns(tagObjects);
+
+        // UpdateSpanFromActivity implicitly accesses Tracer.Instance if there's no associated Tracer in the span
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        using var span = tracer.StartSpan("operation", new OpenTelemetryTags());
+
+        OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span);
+
+        span.Context.TraceContext!.Environment.Should().Be(tagValue);
+    }
+
+    [Fact]
+    public async Task Environment_StableTagName_ShouldTakePrecedenceOverLegacyTagName()
+    {
+        var activityMock = new Mock<IActivity5>();
+        activityMock.Setup(x => x.Kind).Returns(ActivityKind.Producer);
+
+        var tagObjects = new Dictionary<string, object>
+        {
+            { "deployment.environment", "legacy_env" },
+            { "deployment.environment.name", "stable_env" }
+        };
+        activityMock.Setup(x => x.TagObjects).Returns(tagObjects);
+
+        // UpdateSpanFromActivity implicitly accesses Tracer.Instance if there's no associated Tracer in the span
+        await using var tracer = TracerHelper.CreateWithFakeAgent();
+        using var span = tracer.StartSpan("operation", new OpenTelemetryTags());
+
+        OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span);
+
+        span.Context.TraceContext!.Environment.Should().Be("stable_env");
+    }
 }


### PR DESCRIPTION
## Summary of changes

Map `deployment.environment.name` to the Datadog environment. Keep `deployment.environment` as a fallback, and keep `DD_ENV` as the highest-precedence source.

## Reason for change

OpenTelemetry stabilized the deployment environment semantic convention under `deployment.environment.name`.

Related PRs:

- DataDog/system-tests#7613
- DataDog/dd-trace-go#5285
- DataDog/dd-trace-dotnet#9150
- DataDog/dd-trace-rb#6261
- DataDog/dd-trace-php#4148
- DataDog/dd-trace-js#10050
- DataDog/dd-trace-rs#300
- DataDog/dd-trace-java#12324
- DataDog/dd-trace-py#19901

## Implementation details

The resource attribute mapper tracks the stable and legacy values separately, then chooses the stable value regardless of input order. It removes both source aliases after promotion and leaves unrelated attributes alone.

## Test coverage

Five focused mapping cases and 182 adjacent configuration tests passed locally. Formatting checks also passed.

## Other details

None.
