### PR TITLE
[CI Visibility] Bump Datadog test packages to 0.0.59

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -92,6 +92,6 @@
     <ProjectReference Include="..\..\src\Tools\ReferenceChainExplorer\ReferenceChainModel\ReferenceChainModel.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.56" ExcludeAssets="compile" />
+    <PackageReference Include="DatadogTestLogger" Version="0.0.59" ExcludeAssets="compile" />
   </ItemGroup>
 </Project>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -59,8 +59,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestCollector" Version="0.0.56" ExcludeAssets="compile"/>
-    <PackageReference Include="DatadogTestLogger" Version="0.0.56" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestCollector" Version="0.0.59" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.59" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
## Summary of changes

- Bump `DatadogTestLogger` from `0.0.56` to `0.0.59`.
- Bump `DatadogTestCollector` from `0.0.56` to `0.0.59`.

## Reason for change

Consume the latest test logger release, including the CODEOWNERS local-checkout fixes from [datadog-test-logger#40](https://github.com/tonyredondo/datadog-test-logger/pull/40).

## Implementation details

- Update the shared tracer test package references.
- Update the profiler integration test logger reference.

## Test coverage

- Restored `Datadog.Trace.Tests` successfully and verified both packages resolve to `0.0.59`.
- Restored `Datadog.Profiler.IntegrationTests` successfully and verified `DatadogTestLogger` resolves to `0.0.59`.

## Other details

Dependency-only change.