### PR TITLE
Try to call dotnet CLI after install

### DIFF
--- a/.azure-pipelines/steps/install-dotnet.yml
+++ b/.azure-pipelines/steps/install-dotnet.yml
@@ -70,3 +70,6 @@ steps:
     packageType: sdk
     version: $(dotnetCoreSdkLatestVersion)
   retryCountOnTaskFailure: 5
+
+- script: dotnet --info
+  displayName: validate .NET SDK $(dotnetCoreSdkLatestVersion) installation

--- a/.azure-pipelines/steps/install-latest-dotnet-sdk.yml
+++ b/.azure-pipelines/steps/install-latest-dotnet-sdk.yml
@@ -12,6 +12,9 @@ steps:
     includePreviewVersions: true
   retryCountOnTaskFailure: 5
 
+- script: dotnet --info
+  displayName: validate .NET SDK $(dotnetCoreSdkLatestVersion) installation
+
 - ${{ if eq(parameters.includeX86, true) }}:
     - template: install-dotnet-sdk-manually.yml
       parameters:


### PR DESCRIPTION
## Summary of changes

Adds a `dotnet --info` call after getting the latest .NET SDK. This should allow to detect corrupted installs/downloads to prevent transient flake breaking builds.

## Reason for change

CI Flaked here https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=208254&view=logs&j=a0f3966e-357c-5798-a5d6-9d9363e088f0&t=acaef5a3-badf-52cb-a1a0-927b26fdcc86 and it appeared that the file we downloaded got corrupted somehow but was marked as a "valid" at the end. This attempts to use it.

tar: Damaged tar archive
tar: Retrying...
.... many times
Successfully installed .NET Core sdk version 10.0.100.

Which didn't actually work.

## Implementation details

Add `dotnet --info`

## Test coverage

I don't know

## Other details
<!-- Fixes #{issue} -->


#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
