### PR TITLE
Increase profiler integration test timeout

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2805,7 +2805,7 @@ stages:
       jobs: [Win]
 
   - job: Win
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
     strategy:
       matrix:
         x86:
@@ -2873,7 +2873,7 @@ stages:
       jobs: [Test]
 
   - job: Test
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
     strategy:
       matrix:
         x64:
@@ -2991,7 +2991,7 @@ stages:
       jobs: [Test]
 
   - job: Test
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
     strategy:
       matrix:
         arm64:


### PR DESCRIPTION
## Summary of changes

Increases profiler integration test timeout

## Reason for change

They timed out (but they all passed 🎉) but because they timed out they failed 😢.

## Implementation details

60 -> 90

## Test coverage

nope

## Other details
<!-- Fixes #{issue} -->

#incident-57303

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
