### PR TITLE
[CI Visibility] Fix TIA missing line coverage response field

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/SkippableTest.cs
+++ b/tracer/src/Datadog.Trace/Ci/SkippableTest.cs
@@ -28,7 +28,7 @@ internal readonly struct SkippableTest
     /// <summary>
     /// Indicates whether the backend explicitly reported missing line coverage for this skippable test.
     /// </summary>
-    [JsonProperty("_missing_line_code_coverage")]
+    [JsonProperty("_is_missing_line_code_coverage")]
     public readonly bool? MissingLineCodeCoverage;
 
     /// <summary>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -338,7 +338,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                       "suite": "{{TestSuiteName}}",
                                       "name": "SimpleParameterizedTest",
                                       "parameters": "{{skippedRowParameters.Replace("\"", "\\\"")}}",
-                                      "_missing_line_code_coverage": false
+                                      "_is_missing_line_code_coverage": false
                                     }
                                   }
                                 ],

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -849,7 +849,7 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
                             "attributes": {
                               "suite": "{{TestSuiteName}}",
                               "name": "SimplePassTest",
-                              "_missing_line_code_coverage": false
+                              "_is_missing_line_code_coverage": false
                             }
                           }
                         ],
@@ -1384,7 +1384,7 @@ public abstract class XUnitEvpTests : TestingFrameworkEvpTest
             {
                 ["suite"] = TestSuiteName,
                 ["name"] = name,
-                ["_missing_line_code_coverage"] = missingLineCodeCoverage,
+                ["_is_missing_line_code_coverage"] = missingLineCodeCoverage,
                 ["configurations"] = configurations
             }
         };

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationClientTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationClientTests.cs
@@ -77,7 +77,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                   "attributes": {
                     "suite": "Samples.XUnitTests.TestSuite",
                     "name": "SimplePassTest",
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],
@@ -147,7 +147,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                   "attributes": {
                     "suite": "Samples.XUnitTests.TestSuite",
                     "name": "SimplePassTest",
-                    "_missing_line_code_coverage": true
+                    "_is_missing_line_code_coverage": true
                   }
                 }
               ],
@@ -183,7 +183,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                         "queue": "nightly"
                       }
                     },
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],
@@ -220,7 +220,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                         "test.bundle": "Samples.XUnitTests"
                       }
                     },
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],
@@ -255,7 +255,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                         "test.bundle": "Samples.XUnitTests"
                       }
                     },
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],
@@ -290,7 +290,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                         "test.bundle": "Other.Tests"
                       }
                     },
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],
@@ -325,7 +325,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                         "test.module": "Samples.XUnitTests"
                       }
                     },
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],
@@ -360,7 +360,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                         "test.module": "Samples.XUnitTests"
                       }
                     },
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],
@@ -393,7 +393,7 @@ public class TestOptimizationClientTests : SettingsTestsBase
                     "configurations": {
                       "test.bundle": "Other.Tests"
                     },
-                    "_missing_line_code_coverage": false
+                    "_is_missing_line_code_coverage": false
                   }
                 }
               ],


### PR DESCRIPTION
## Summary of changes

Updates TIA skippable-test response parsing and fixtures to use `_is_missing_line_code_coverage`.

## Reason for change

Aligns the .NET tracer with the backend response contract.

## Implementation details

Updates the JSON property name used by the skippable-test model and its test payloads.

## Test coverage

The focused `TestOptimizationClientTests` suite passes on .NET 10.

## Other details

None.
