### PR TITLE
Don't run high-concurrency tests in parallel with other tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -651,58 +651,6 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public async Task ConcurrentFlushTracesAsync_NeverRunsMoreThanOneFlushAtATime()
-        {
-            // Buffers are only ever locked and flushed by the flush loop, so no matter how many callers
-            // are flushing concurrently, a buffer is never sent while another send is in flight.
-            var api = new Mock<IApi>();
-            var concurrentSends = 0;
-            var maxConcurrentSends = 0;
-            var maxLock = new object();
-
-            api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
-                .Returns(async () =>
-                {
-                    var current = Interlocked.Increment(ref concurrentSends);
-
-                    lock (maxLock)
-                    {
-                        maxConcurrentSends = Math.Max(maxConcurrentSends, current);
-                    }
-
-                    // Give any other flush a chance to overlap with this one, but not too big,
-                    // otherwise could cause flake
-                    await Task.Delay(5);
-
-                    Interlocked.Decrement(ref concurrentSends);
-                    return true;
-                });
-
-            // Buffers big enough for a single trace, so that they fill up and the active buffer keeps
-            // switching while flushes are in flight. Background flushes are enabled too, so those must
-            // not overlap with the requested ones either.
-            var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1, batchInterval: 0);
-
-            var flushes = new List<Task>();
-
-            for (var i = 0; i < 10; i++)
-            {
-                agent.WriteTrace(CreateTraceChunk(1));
-                flushes.Add(agent.FlushTracesAsync());
-            }
-
-            await Task.WhenAll(flushes).WaitAsync(TimeSpan.FromMilliseconds(30000));
-
-            lock (maxLock)
-            {
-                maxConcurrentSends.Should().Be(1);
-            }
-
-            await agent.FlushAndCloseAsync();
-        }
-
-        [Fact]
         public async Task FlushTracesAsync_SendsTracesWrittenOnTheSameThread()
         {
             // A trace written before FlushTracesAsync() is called must have left the pending queue and be
@@ -853,6 +801,62 @@ namespace Datadog.Trace.Tests.Agent
             };
 
             return TracerSettings.Create(new() { { ConfigurationKeys.SpanSamplingRules, JsonConvert.SerializeObject(rules) } });
+        }
+
+        [Collection(nameof(HighConcurrencyTestCollection))]
+        public class ConcurrencyTests
+        {
+            [Fact]
+            public async Task ConcurrentFlushTracesAsync_NeverRunsMoreThanOneFlushAtATime()
+            {
+                // Buffers are only ever locked and flushed by the flush loop, so no matter how many callers
+                // are flushing concurrently, a buffer is never sent while another send is in flight.
+                var api = new Mock<IApi>();
+                var concurrentSends = 0;
+                var maxConcurrentSends = 0;
+                var maxLock = new object();
+
+                api.Setup(i => i.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<bool>()))
+                    .Returns(async () =>
+                    {
+                        var current = Interlocked.Increment(ref concurrentSends);
+
+                        lock (maxLock)
+                        {
+                            maxConcurrentSends = Math.Max(maxConcurrentSends, current);
+                        }
+
+                        // Give any other flush a chance to overlap with this one, but not too big,
+                        // otherwise could cause flake
+                        await Task.Delay(5);
+
+                        Interlocked.Decrement(ref concurrentSends);
+                        return true;
+                    });
+
+                // Buffers big enough for a single trace, so that they fill up and the active buffer keeps
+                // switching while flushes are in flight. Background flushes are enabled too, so those must
+                // not overlap with the requested ones either.
+                var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
+                var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: TestStatsdManager.NoOp, maxBufferSize: (sizeOfTrace * 2) + SpanBufferMessagePackSerializer.HeaderSizeConst - 1, batchInterval: 0);
+
+                var flushes = new List<Task>();
+
+                for (var i = 0; i < 10; i++)
+                {
+                    agent.WriteTrace(CreateTraceChunk(1));
+                    flushes.Add(agent.FlushTracesAsync());
+                }
+
+                await Task.WhenAll(flushes).WaitAsync(TimeSpan.FromMilliseconds(60_000));
+
+                lock (maxLock)
+                {
+                    maxConcurrentSends.Should().Be(1);
+                }
+
+                await agent.FlushAndCloseAsync();
+            }
         }
 
         internal class StubStatsAggregator(bool shouldKeepTrace, Func<SpanCollection, SpanCollection> processTrace) : IStatsAggregator

--- a/tracer/test/Datadog.Trace.Tests/Ci/Ipc/CircularChannelTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/Ipc/CircularChannelTests.cs
@@ -65,63 +65,67 @@ public class CircularChannelTests
         writer.TryWrite(in valueSegment).Should().BeFalse();
     }
 
-    [Theory]
-    [MemberData(nameof(GetWriteData), DisableDiscoveryEnumeration = true)]
-    public void CircularChannelReadAndWriteTest(byte[] value)
+    [Collection(nameof(HighConcurrencyTestCollection))]
+    public class ConcurrencyTests
     {
-        var name = nameof(CircularChannelReadAndWriteTest) + "-" + Guid.NewGuid().ToString("n");
-        using var channel = new CircularChannel(name, new CircularChannelSettings { BufferSize = BufferSize, PollingInterval = 100 });
-        using var writer = channel.GetWriter();
-        using var reader = channel.GetReader();
-
-        var valueSegment = new ArraySegment<byte>(value);
-
-        // Message size
-        var messageSize = writer.GetMessageSize(in valueSegment);
-
-        // Calculate how many messages we can write
-        var messagesCount = AvailableBufferSize / messageSize;
-
-        // we duplicate the number of messages to test the circular buffer
-        messagesCount *= 2;
-
-        ExceptionDispatchInfo? exceptionDispatchInfo = null;
-        var countdownEvent = new CountdownEvent(messagesCount);
-        reader.SetCallback(bytes =>
+        [Theory]
+        [MemberData(nameof(GetWriteData), MemberType = typeof(CircularChannelTests), DisableDiscoveryEnumeration = true)]
+        public void CircularChannelReadAndWriteTest(byte[] value)
         {
-            try
-            {
-                using var scope = new AssertionScope();
-                var cValue = new byte[bytes.Count];
-                Array.Copy(bytes.Array!, bytes.Offset, cValue, 0, bytes.Count);
-                cValue.Should().HaveCount(value.Length);
-                cValue.Should().Equal(value);
-                countdownEvent.Signal();
-            }
-            catch (Exception ex)
-            {
-                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
-            }
-        });
+            var name = nameof(CircularChannelReadAndWriteTest) + "-" + Guid.NewGuid().ToString("n");
+            using var channel = new CircularChannel(name, new CircularChannelSettings { BufferSize = BufferSize, PollingInterval = 100 });
+            using var writer = channel.GetWriter();
+            using var reader = channel.GetReader();
 
-        for (var i = 0; i < messagesCount; i++)
-        {
-            var retries = 0;
-            while (!writer.TryWrite(in valueSegment))
+            var valueSegment = new ArraySegment<byte>(value);
+
+            // Message size
+            var messageSize = writer.GetMessageSize(in valueSegment);
+
+            // Calculate how many messages we can write
+            var messagesCount = AvailableBufferSize / messageSize;
+
+            // we duplicate the number of messages to test the circular buffer
+            messagesCount *= 2;
+
+            ExceptionDispatchInfo? exceptionDispatchInfo = null;
+            var countdownEvent = new CountdownEvent(messagesCount);
+            reader.SetCallback(bytes =>
             {
-                // Wait for the receiver to process the messages before trying again
-                Thread.Sleep(500);
-                if (retries++ == 20)
+                try
                 {
-                    throw new Exception("Error writing messages to the channel. After 20 retries, the channel is still full.");
+                    using var scope = new AssertionScope();
+                    var cValue = new byte[bytes.Count];
+                    Array.Copy(bytes.Array!, bytes.Offset, cValue, 0, bytes.Count);
+                    cValue.Should().HaveCount(value.Length);
+                    cValue.Should().Equal(value);
+                    countdownEvent.Signal();
+                }
+                catch (Exception ex)
+                {
+                    exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
+                }
+            });
+
+            for (var i = 0; i < messagesCount; i++)
+            {
+                var retries = 0;
+                while (!writer.TryWrite(in valueSegment))
+                {
+                    // Wait for the receiver to process the messages before trying again
+                    Thread.Sleep(500);
+                    if (retries++ == 20)
+                    {
+                        throw new Exception("Error writing messages to the channel. After 20 retries, the channel is still full.");
+                    }
                 }
             }
-        }
 
-        if (!countdownEvent.Wait(10_000))
-        {
-            exceptionDispatchInfo?.Throw();
-            throw new Exception("Timeout waiting for messages");
+            if (!countdownEvent.Wait(10_000))
+            {
+                exceptionDispatchInfo?.Throw();
+                throw new Exception("Timeout waiting for messages");
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/DogStatsd/StatsdManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsd/StatsdManagerTests.cs
@@ -671,54 +671,6 @@ public class StatsdManagerTests
     }
 
     [Fact]
-    public async Task ConcurrentLeaseDisposalDuringClientRecreation_ThreadSafe()
-    {
-        var holders = new ConcurrentQueue<StatsdManager.StatsdClientHolder>();
-        var manager = new StatsdManager(new TracerSettings(), (_, _) =>
-        {
-            var client = new StatsdManager.StatsdClientHolder(new MockStatsdClient());
-            holders.Enqueue(client);
-            return client;
-        });
-
-        manager.SetRequired(StatsdConsumer.RuntimeMetricsWriter, true);
-
-        // Create a bunch of leases
-        var leases = Enumerable.Range(0, 10)
-            .Select(_ => manager.TryGetClientLease())
-            .ToList();
-
-        var random = new Random();
-
-        var mutex = new CountdownEvent(leases.Count + 1);
-        var tasks = leases.Select(lease => Task.Run(() =>
-        {
-            mutex.Signal(); // decrement
-            mutex.Wait(); // wait for count to hit zero
-            Thread.Sleep(random.Next(1, 10));
-            lease.Dispose();
-        })).ToList();
-
-        // Wait and then do everything at once
-        mutex.Signal();
-        mutex.Wait();
-
-        // Trigger recreation while leases are being disposed
-        manager.SetRequired(StatsdConsumer.RuntimeMetricsWriter, false);
-        manager.SetRequired(StatsdConsumer.RuntimeMetricsWriter, true);
-
-        await Task.WhenAll(tasks);
-
-        // We only recreated once
-        holders.Should().HaveCount(2);
-        holders.TryDequeue(out var client1).Should().BeTrue();
-        client1.IsDisposed.Should().BeTrue("old client should be disposed");
-        holders.TryDequeue(out var client2).Should().BeTrue();
-        client2.IsDisposed.Should().BeFalse("latest client should not be disposed");
-        await manager.DisposeAsync();
-    }
-
-    [Fact]
     public async Task MultipleTransitionsBetweenRequiredAndNotRequired()
     {
         var holders = new List<StatsdManager.StatsdClientHolder>();
@@ -811,6 +763,58 @@ public class StatsdManagerTests
         holder.IsDisposed.Should().BeTrue();
         statsdClient.DisposeCount.Should().BeLessThanOrEqualTo(1); // we dispose in the background, so may not have happened yet
         await manager.DisposeAsync();
+    }
+
+    [Collection(nameof(HighConcurrencyTestCollection))]
+    public class ConcurrencyTests
+    {
+        [Fact]
+        public async Task ConcurrentLeaseDisposalDuringClientRecreation_ThreadSafe()
+        {
+            var holders = new ConcurrentQueue<StatsdManager.StatsdClientHolder>();
+            var manager = new StatsdManager(new TracerSettings(), (_, _) =>
+            {
+                var client = new StatsdManager.StatsdClientHolder(new MockStatsdClient());
+                holders.Enqueue(client);
+                return client;
+            });
+
+            manager.SetRequired(StatsdConsumer.RuntimeMetricsWriter, true);
+
+            // Create a bunch of leases
+            var leases = Enumerable.Range(0, 10)
+                .Select(_ => manager.TryGetClientLease())
+                .ToList();
+
+            var random = new Random();
+
+            var mutex = new CountdownEvent(leases.Count + 1);
+            var tasks = leases.Select(lease => Task.Run(() =>
+            {
+                mutex.Signal(); // decrement
+                mutex.Wait(); // wait for count to hit zero
+                Thread.Sleep(random.Next(1, 10));
+                lease.Dispose();
+            })).ToList();
+
+            // Wait and then do everything at once
+            mutex.Signal();
+            mutex.Wait();
+
+            // Trigger recreation while leases are being disposed
+            manager.SetRequired(StatsdConsumer.RuntimeMetricsWriter, false);
+            manager.SetRequired(StatsdConsumer.RuntimeMetricsWriter, true);
+
+            await Task.WhenAll(tasks);
+
+            // We only recreated once
+            holders.Should().HaveCount(2);
+            holders.TryDequeue(out var client1).Should().BeTrue();
+            client1.IsDisposed.Should().BeTrue("old client should be disposed");
+            holders.TryDequeue(out var client2).Should().BeTrue();
+            client2.IsDisposed.Should().BeFalse("latest client should not be disposed");
+            await manager.DisposeAsync();
+        }
     }
 
     private class MockStatsdClient : IDogStatsd

--- a/tracer/test/Datadog.Trace.Tests/HighConcurrencyTestCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/HighConcurrencyTestCollection.cs
@@ -1,0 +1,19 @@
+// <copyright file="HighConcurrencyTestCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    /// <summary>
+    /// Tests that deliberately either run many operations concurrently to assert on precise interleaving
+    /// (e.g. maximum-overlap counts) or are sensitive to timing issues. These tests are prone to false failures
+    /// from resource starvation when they run in parallel with other tests.
+    /// </summary>
+    [CollectionDefinition(nameof(HighConcurrencyTestCollection), DisableParallelization = true)]
+    public class HighConcurrencyTestCollection
+    {
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -55,62 +55,6 @@ namespace Datadog.Trace.Tests.Sampling
             Assert.Equal(expected: DefaultLimitPerSecond, actual: allowedCount);
         }
 
-        [Fact]
-        public void Limits_Approximately_To_Defaults()
-        {
-            Run_Limit_Test(intervalLimit: null, numberPerBurst: 100, numberOfBursts: 18, millisecondsBetweenBursts: 247);
-        }
-
-        [Fact]
-        public void Limits_To_Custom_Amount_Per_Second()
-        {
-            Run_Limit_Test(intervalLimit: 500, numberPerBurst: 200, numberOfBursts: 18, millisecondsBetweenBursts: 247);
-        }
-
-        private static void Run_Limit_Test(int? intervalLimit, int numberPerBurst, int numberOfBursts, int millisecondsBetweenBursts)
-        {
-            var actualIntervalLimit = intervalLimit ?? DefaultLimitPerSecond;
-
-            var test = new RateLimitLoadTest()
-            {
-                NumberPerBurst = numberPerBurst,
-                TimeBetweenBursts = TimeSpan.FromMilliseconds(millisecondsBetweenBursts),
-                NumberOfBursts = numberOfBursts
-            };
-
-            var result = RunTest(intervalLimit, test);
-
-            var theoreticalTime = numberOfBursts * millisecondsBetweenBursts;
-            var expectedLimit = theoreticalTime * actualIntervalLimit / 1_000;
-
-            var acceptableUpperVariance = (actualIntervalLimit * 1.0);
-            var acceptableLowerVariance = (actualIntervalLimit * 1.15); // Allow for increased tolerance on lower limit since the rolling window does not get dequeued as quickly as it can queued
-            var upperLimit = expectedLimit + acceptableUpperVariance;
-            var lowerLimit = expectedLimit - acceptableLowerVariance;
-
-            Assert.True(
-                result.TotalAllowed >= lowerLimit && result.TotalAllowed <= upperLimit,
-                $"Expected between {lowerLimit} and {upperLimit}, received {result.TotalAllowed} out of {result.TotalAttempted} within {theoreticalTime} milliseconds.");
-
-            // Rate should match for the last two intervals, which is a total of two seconds
-            var numberOfBurstsWithinTwoIntervals = 2_000 / millisecondsBetweenBursts;
-            var totalExpectedSent = numberOfBurstsWithinTwoIntervals * numberPerBurst;
-            var totalExpectedAllowed = 2 * actualIntervalLimit;
-            var expectedRate = totalExpectedAllowed / (float)totalExpectedSent;
-
-            var lowestRate = expectedRate - 0.40f;
-            if (lowestRate < 0)
-            {
-                lowestRate = expectedRate / 2;
-            }
-
-            var highestRate = expectedRate + 0.40f;
-
-            Assert.True(
-                result.ReportedRate >= lowestRate && result.ReportedRate <= highestRate,
-                $"Expected rate between {lowestRate} and {highestRate}, received {result.ReportedRate}.");
-        }
-
         private static async Task<int> AskTheRateLimiterABunchOfTimes(RateLimiter rateLimiter, int howManyTimes)
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
@@ -132,94 +76,154 @@ namespace Datadog.Trace.Tests.Sampling
             return allowedCount;
         }
 
-        private static RateLimitResult RunTest(int? intervalLimit, RateLimitLoadTest test)
+        [Collection(nameof(HighConcurrencyTestCollection))]
+        public class ConcurrencyTests
         {
-            var parallelism = test.NumberPerBurst;
-
-            if (parallelism > Environment.ProcessorCount)
+            [Fact]
+            public void Limits_Approximately_To_Defaults()
             {
-                parallelism = Environment.ProcessorCount;
+                Run_Limit_Test(intervalLimit: null, numberPerBurst: 100, numberOfBursts: 18, millisecondsBetweenBursts: 247);
             }
 
-            var clock = new SimpleClock();
-
-            var limiter = new TracerRateLimiter(maxTracesPerInterval: intervalLimit, intervalMilliseconds: null);
-            var barrier = new Barrier(parallelism + 1, _ => clock.UtcNow += test.TimeBetweenBursts);
-            var numberPerThread = test.NumberPerBurst / parallelism;
-            var workers = new Task[parallelism];
-            int totalAttempted = 0;
-            int totalAllowed = 0;
-
-            for (int i = 0; i < workers.Length; i++)
+            [Fact]
+            public void Limits_To_Custom_Amount_Per_Second()
             {
-                workers[i] = Task.Factory.StartNew(
-                    () =>
-                    {
-                        using var lease = Clock.SetForCurrentThread(clock);
+                Run_Limit_Test(intervalLimit: 500, numberPerBurst: 200, numberOfBursts: 18, millisecondsBetweenBursts: 247);
+            }
 
-                        for (var i = 0; i < test.NumberOfBursts; i++)
+            private static void Run_Limit_Test(int? intervalLimit, int numberPerBurst, int numberOfBursts, int millisecondsBetweenBursts)
+            {
+                var actualIntervalLimit = intervalLimit ?? DefaultLimitPerSecond;
+
+                var test = new RateLimitLoadTest()
+                {
+                    NumberPerBurst = numberPerBurst,
+                    TimeBetweenBursts = TimeSpan.FromMilliseconds(millisecondsBetweenBursts),
+                    NumberOfBursts = numberOfBursts
+                };
+
+                var result = RunTest(intervalLimit, test);
+
+                var theoreticalTime = numberOfBursts * millisecondsBetweenBursts;
+                var expectedLimit = theoreticalTime * actualIntervalLimit / 1_000;
+
+                var acceptableUpperVariance = (actualIntervalLimit * 1.0);
+                var acceptableLowerVariance = (actualIntervalLimit * 1.15); // Allow for increased tolerance on lower limit since the rolling window does not get dequeued as quickly as it can queued
+                var upperLimit = expectedLimit + acceptableUpperVariance;
+                var lowerLimit = expectedLimit - acceptableLowerVariance;
+
+                Assert.True(
+                    result.TotalAllowed >= lowerLimit && result.TotalAllowed <= upperLimit,
+                    $"Expected between {lowerLimit} and {upperLimit}, received {result.TotalAllowed} out of {result.TotalAttempted} within {theoreticalTime} milliseconds.");
+
+                // Rate should match for the last two intervals, which is a total of two seconds
+                var numberOfBurstsWithinTwoIntervals = 2_000 / millisecondsBetweenBursts;
+                var totalExpectedSent = numberOfBurstsWithinTwoIntervals * numberPerBurst;
+                var totalExpectedAllowed = 2 * actualIntervalLimit;
+                var expectedRate = totalExpectedAllowed / (float)totalExpectedSent;
+
+                var lowestRate = expectedRate - 0.40f;
+                if (lowestRate < 0)
+                {
+                    lowestRate = expectedRate / 2;
+                }
+
+                var highestRate = expectedRate + 0.40f;
+
+                Assert.True(
+                    result.ReportedRate >= lowestRate && result.ReportedRate <= highestRate,
+                    $"Expected rate between {lowestRate} and {highestRate}, received {result.ReportedRate}.");
+            }
+
+            private static RateLimitResult RunTest(int? intervalLimit, RateLimitLoadTest test)
+            {
+                var parallelism = test.NumberPerBurst;
+
+                if (parallelism > Environment.ProcessorCount)
+                {
+                    parallelism = Environment.ProcessorCount;
+                }
+
+                var clock = new SimpleClock();
+
+                var limiter = new TracerRateLimiter(maxTracesPerInterval: intervalLimit, intervalMilliseconds: null);
+                var barrier = new Barrier(parallelism + 1, _ => clock.UtcNow += test.TimeBetweenBursts);
+                var numberPerThread = test.NumberPerBurst / parallelism;
+                var workers = new Task[parallelism];
+                int totalAttempted = 0;
+                int totalAllowed = 0;
+
+                for (int i = 0; i < workers.Length; i++)
+                {
+                    workers[i] = Task.Factory.StartNew(
+                        () =>
                         {
-                            // Wait for every worker to be ready for next burst
-                            barrier.SignalAndWait();
+                            using var lease = Clock.SetForCurrentThread(clock);
 
-                            for (int j = 0; j < numberPerThread; j++)
+                            for (var i = 0; i < test.NumberOfBursts; i++)
                             {
-                                // trace id and span id are not used in rate-limiting
-                                var spanContext = new SpanContext(traceId: 1, spanId: 1, serviceName: "Weeeee");
+                                // Wait for every worker to be ready for next burst
+                                barrier.SignalAndWait();
 
-                                // pass a specific start time since there is no TraceContext
-                                var span = new Span(spanContext, DateTimeOffset.UtcNow);
-
-                                Interlocked.Increment(ref totalAttempted);
-
-                                if (limiter.Allowed(span))
+                                for (int j = 0; j < numberPerThread; j++)
                                 {
-                                    Interlocked.Increment(ref totalAllowed);
+                                    // trace id and span id are not used in rate-limiting
+                                    var spanContext = new SpanContext(traceId: 1, spanId: 1, serviceName: "Weeeee");
+
+                                    // pass a specific start time since there is no TraceContext
+                                    var span = new Span(spanContext, DateTimeOffset.UtcNow);
+
+                                    Interlocked.Increment(ref totalAttempted);
+
+                                    if (limiter.Allowed(span))
+                                    {
+                                        Interlocked.Increment(ref totalAllowed);
+                                    }
                                 }
                             }
-                        }
-                    },
-                    TaskCreationOptions.LongRunning);
+                        },
+                        TaskCreationOptions.LongRunning);
+                }
+
+                // Wait for all workers to be ready
+                barrier.SignalAndWait();
+
+                // We do not need to synchronize with workers anymore
+                barrier.RemoveParticipant();
+
+                // Wait for workers to finish
+                Task.WaitAll(workers);
+
+                var result = new RateLimitResult
+                {
+                    RateLimiter = limiter,
+                    ReportedRate = limiter.GetEffectiveRate(),
+                    TotalAttempted = totalAttempted,
+                    TotalAllowed = totalAllowed
+                };
+
+                return result;
             }
 
-            // Wait for all workers to be ready
-            barrier.SignalAndWait();
-
-            // We do not need to synchronize with workers anymore
-            barrier.RemoveParticipant();
-
-            // Wait for workers to finish
-            Task.WaitAll(workers);
-
-            var result = new RateLimitResult
+            private class RateLimitLoadTest
             {
-                RateLimiter = limiter,
-                ReportedRate = limiter.GetEffectiveRate(),
-                TotalAttempted = totalAttempted,
-                TotalAllowed = totalAllowed
-            };
+                public int NumberPerBurst { get; set; }
 
-            return result;
-        }
+                public TimeSpan TimeBetweenBursts { get; set; }
 
-        private class RateLimitLoadTest
-        {
-            public int NumberPerBurst { get; set; }
+                public int NumberOfBursts { get; set; }
+            }
 
-            public TimeSpan TimeBetweenBursts { get; set; }
+            private class RateLimitResult
+            {
+                public RateLimiter RateLimiter { get; set; }
 
-            public int NumberOfBursts { get; set; }
-        }
+                public float ReportedRate { get; set; }
 
-        private class RateLimitResult
-        {
-            public RateLimiter RateLimiter { get; set; }
+                public int TotalAttempted { get; set; }
 
-            public float ReportedRate { get; set; }
-
-            public int TotalAttempted { get; set; }
-
-            public int TotalAllowed { get; set; }
+                public int TotalAllowed { get; set; }
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -43,53 +43,6 @@ namespace Datadog.Trace.Tests.Tagging
         public async Task DisposeAsync() => await _tracer.DisposeAsync();
 
         [Fact]
-        [Flaky("This concurrency test can time out on saturated CI agents")]
-        public async Task SetTagAndSetTags_WhenCalledConcurrently_ShouldKeepSingleEntryPerKey()
-        {
-            var tags = new TagsList();
-
-            const int workerCount = 4;
-            const int iterationsPerWorker = 1_000;
-            var timeout = TimeSpan.FromSeconds(20);
-            var expectedKeys = new[] { "k1", "k2", "k3", "k4" };
-
-            using var startSignal = new ManualResetEventSlim(false);
-            var workers = Enumerable.Range(0, workerCount)
-                                    .Select(
-                                         workerId => Task.Run(
-                                             () =>
-                                             {
-                                                 startSignal.Wait();
-
-                                                 for (var i = 0; i < iterationsPerWorker; i++)
-                                                 {
-                                                     tags.SetTags(
-                                                         new("k1", workerId.ToString()),
-                                                         new("k2", i.ToString()),
-                                                         new("k3", "stable"));
-                                                     tags.SetTag("k4", workerId.ToString());
-                                                 }
-                                             }))
-                                    .ToArray();
-
-            startSignal.Set();
-
-            var allWorkers = Task.WhenAll(workers);
-            var completedTask = await Task.WhenAny(allWorkers, Task.Delay(timeout));
-            if (completedTask != allWorkers)
-            {
-                throw new TimeoutException($"Concurrent tag updates exceeded {timeout}. Worker statuses: {string.Join(", ", workers.Select(w => w.Status))}");
-            }
-
-            await allWorkers;
-
-            var snapshot = GetTagsSnapshot(tags);
-
-            snapshot.Select(x => x.Key).Should().BeEquivalentTo(expectedKeys);
-            snapshot.Select(x => x.Key).Should().OnlyHaveUniqueItems();
-        }
-
-        [Fact]
         public void SetTags_WithOnlyNullValues_DoesNotInitializeBackingTagsList()
         {
             var tags = new TagsList();
@@ -680,6 +633,57 @@ namespace Datadog.Trace.Tests.Tagging
             public void Process(TagItem<int> item)
             {
                 _items.Add(new(item.Key, item.Value.ToString(CultureInfo.InvariantCulture)));
+            }
+        }
+
+        [Collection(nameof(HighConcurrencyTestCollection))]
+        public class ConcurrencyTests
+        {
+            [Fact]
+            [Flaky("This concurrency test can time out on saturated CI agents")]
+            public async Task SetTagAndSetTags_WhenCalledConcurrently_ShouldKeepSingleEntryPerKey()
+            {
+                var tags = new TagsList();
+
+                const int workerCount = 4;
+                const int iterationsPerWorker = 1_000;
+                var timeout = TimeSpan.FromSeconds(20);
+                var expectedKeys = new[] { "k1", "k2", "k3", "k4" };
+
+                using var startSignal = new ManualResetEventSlim(false);
+                var workers = Enumerable.Range(0, workerCount)
+                                        .Select(
+                                             workerId => Task.Run(
+                                                 () =>
+                                                 {
+                                                     startSignal.Wait();
+
+                                                     for (var i = 0; i < iterationsPerWorker; i++)
+                                                     {
+                                                         tags.SetTags(
+                                                             new("k1", workerId.ToString()),
+                                                             new("k2", i.ToString()),
+                                                             new("k3", "stable"));
+                                                         tags.SetTag("k4", workerId.ToString());
+                                                     }
+                                                 }))
+                                        .ToArray();
+
+                startSignal.Set();
+
+                var allWorkers = Task.WhenAll(workers);
+                var completedTask = await Task.WhenAny(allWorkers, Task.Delay(timeout));
+                if (completedTask != allWorkers)
+                {
+                    throw new TimeoutException($"Concurrent tag updates exceeded {timeout}. Worker statuses: {string.Join(", ", workers.Select(w => w.Status))}");
+                }
+
+                await allWorkers;
+
+                var snapshot = GetTagsSnapshot(tags);
+
+                snapshot.Select(x => x.Key).Should().BeEquivalentTo(expectedKeys);
+                snapshot.Select(x => x.Key).Should().OnlyHaveUniqueItems();
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

Move tests that can flake due to heavy resource usage to their own non-parallelized test class

## Reason for change

We saw some flake, and it looks like it was because we were running tests that do high concurrency tests but also have hard deadlines. For example `AgentWriterTests.ConcurrentFlushTracesAsync_NeverRunsMoreThanOneFlushAtATime` timed out after 30s, but was running at the same time as two tests that were maxing out the CPU and another test doing concurrency test (which took 45s), so it looks very much like a starvation issue.

## Implementation details

To mitigate the problem, don't run these "sensitive" or "high concurrency" tests in parallel with other tests, to reduce the chance of flake.

## Test coverage

This is the test.

## Other details

I didn't change the tests, I just moved them into nested classes

#incident-57303