### PR TITLE
Add `[Trait("Area", "CiVisibility")]` to CI Vis tests, and run in dedicated jobs only when required

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -209,10 +209,14 @@ Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/PDBs/MethodSymbolResolver.cs        @DataDog/ci-app-libraries-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/  @DataDog/ci-app-libraries-dotnet
+/tracer/src/Datadog.Trace.BenchmarkDotNet/                          @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace.Coverage.collector/                       @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace.MSBuild/                                  @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/test/test-applications/integrations/Samples.XUnit*/  @DataDog/ci-app-libraries-dotnet
 /tracer/test/test-applications/integrations/Samples.NUnit*/  @DataDog/ci-app-libraries-dotnet
 /tracer/test/test-applications/integrations/Samples.MSTest*/  @DataDog/ci-app-libraries-dotnet
 /tracer/test/test-applications/integrations/Samples.Selenium/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.CIVisibilityIpc/  @DataDog/ci-app-libraries-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs  @DataDog/ci-app-libraries-dotnet
 /tracer/test/snapshots/MsTestV2* @DataDog/ci-app-libraries-dotnet
 /tracer/test/snapshots/NUnit* @DataDog/ci-app-libraries-dotnet
@@ -220,8 +224,11 @@ Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
 /tracer/test/snapshots/Selenium* @DataDog/ci-app-libraries-dotnet
 /tracer/src/Datadog.Trace.Tools.Runner/Ci* @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.Tools.Runner/CI* @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.Tools.Runner/Coverage* @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs      @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/ConfigureCiCommandTests.cs @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 
 # Common Files
 Datadog.Trace.Trimming.xml                @DataDog/apm-dotnet

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1950,12 +1950,20 @@ partial class Build
             return filter;
         }
 
+        // CI Visibility tests live in the same test assemblies as the Tracer area (so they carry
+        // both Area=Tracer at the assembly level and Area=CIVisibility at the class level), but
+        // they run in their own job. Exclude them explicitly from the Tracer area to avoid running
+        // them twice.
+        var areaFilter = Area == TracerArea
+                             ? $"(Area={Area})&(Area!={CiVisibilityArea})"
+                             : $"(Area={Area})";
+
         if (string.IsNullOrWhiteSpace(filter))
         {
-            return $"(Area={Area})";
+            return areaFilter;
         }
 
-        return filter + $"&(Area={Area})";
+        return filter + $"&{areaFilter}";
     }
 
     Target CompileAzureFunctionsSamplesWindows => _ => _

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -18,10 +18,12 @@ partial class Build : NukeBuild
 {
     private const string TracerArea = "Tracer";
     private const string AsmArea = "ASM";
+    private const string CiVisibilityArea = "CIVisibility";
     private const string TracingDotnet = "@DataDog/tracing-dotnet";
     private const string ASMDotnet = "@DataDog/asm-dotnet";
     private const string DebuggerDotnet = "@DataDog/debugger-dotnet";
     private const string ProfilerDotnet = "@DataDog/profiling-dotnet";
+    private const string CiAppLibrariesDotnet = "@DataDog/ci-app-libraries-dotnet";
 
     class ChangedTeamValue
     {
@@ -36,6 +38,7 @@ partial class Build : NukeBuild
         new ChangedTeamValue { VariableName = "isTracerChanged", TeamName = TracingDotnet},
         new ChangedTeamValue { VariableName = "isDebuggerChanged", TeamName = DebuggerDotnet},
         new ChangedTeamValue { VariableName = "isProfilerChanged", TeamName = ProfilerDotnet},
+        new ChangedTeamValue { VariableName = "isCiVisibilityChanged", TeamName = CiAppLibrariesDotnet},
     };
 
     Target GenerateVariables
@@ -131,10 +134,11 @@ partial class Build : NukeBuild
                         var changedFiles = GetGitChangedFiles(baseBranch);
                         // Choose changedFiles that meet any of the filters => Choose changedFiles that DON'T meet any of the exclusion filters
 
-                        if (changedTeamValue.TeamName == ASMDotnet && CommonTracerChanges(changedFiles, codeOwners))
+                        if ((changedTeamValue.TeamName == ASMDotnet || changedTeamValue.TeamName == CiAppLibrariesDotnet)
+                         && CommonTracerChanges(changedFiles, codeOwners))
                         {
                             isChanged = true;
-                            Logger.Information($"ASM tests will be launched based on common changes.");
+                            Logger.Information($"{changedTeamValue.VariableName} tests will be launched based on common changes.");
                         }
                         else
                         {
@@ -189,12 +193,17 @@ partial class Build : NukeBuild
                 }
             }
 
-            // We only call this method for the tracer and ASM areas
+            // We only call this method for the tracer, ASM, and CI Visibility areas
             bool ShouldBeIncluded(string area)
             {
                 if (area == AsmArea)
                 {
                     return _changedTeamValue.First(x => x.TeamName == ASMDotnet).IsChanged;
+                }
+
+                if (area == CiVisibilityArea)
+                {
+                    return _changedTeamValue.First(x => x.TeamName == CiAppLibrariesDotnet).IsChanged;
                 }
 
                 return true;
@@ -213,7 +222,7 @@ partial class Build : NukeBuild
             {
                 var targetFrameworks = GetTestingFrameworks(PlatformFamily.Windows);
                 var targetPlatforms = new[] { "x86", "x64" };
-                var areas = new[] { TracerArea, AsmArea };
+                var areas = new[] { TracerArea, AsmArea, CiVisibilityArea };
                 var matrix = new Dictionary<string, object>();
 
                 foreach (var framework in targetFrameworks)
@@ -374,7 +383,7 @@ partial class Build : NukeBuild
                         }
                         else
                         {
-                            var areas = new[] { TracerArea, AsmArea };
+                            var areas = new[] { TracerArea, AsmArea, CiVisibilityArea };
                             foreach (var area in areas)
                             {
                                 if (ShouldBeIncluded(area))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/ApmAgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/ApmAgentWriterTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
+    [Trait("Area", "CIVisibility")]
     public class ApmAgentWriterTests : IAsyncLifetime
     {
         private readonly ApmAgentWriter _ciAgentWriter;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessEventBufferTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessEventBufferTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
+    [Trait("Area", "CIVisibility")]
     public class CIAgentlessEventBufferTests
     {
         [Theory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
@@ -34,6 +34,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
+    [Trait("Area", "CIVisibility")]
     public class CiVisibilityProtocolWriterTests
     {
         [Fact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
@@ -22,6 +22,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     [CollectionDefinition(nameof(CIEnvironmentVariableTests), DisableParallelization = true)]
     [Collection(nameof(CIEnvironmentVariableTests))]
+    [Trait("Area", "CIVisibility")]
     public class CIEnvironmentVariableTests
     {
         private IDictionary _originalEnvVars;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CIVisibility")]
     public class CIVisibilityTests
     {
         private static readonly ITestOptimizationTracerManagement TracerManagement = new TestOptimizationTracerManagement(TestOptimizationSettings.FromDefaultSources());

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Coverage/FileBitmapTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Coverage/FileBitmapTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Coverage;
 
+[Trait("Area", "CIVisibility")]
 public class FileBitmapTests
 {
     [Fact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GitParserTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CIVisibility")]
     public class GitParserTests
     {
         public static IEnumerable<object[]> GetData()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GlobalCoverageMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/GlobalCoverageMemoryTests.cs
@@ -34,6 +34,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 public sealed class GlobalCoverageMemoryTests : TestingFrameworkEvpTest
 {
     private const long MaximumProcessMemoryGrowth = 512L * 1024 * 1024;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Ipc/IpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Ipc/IpcTests.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Ipc;
 
+[Trait("Area", "CIVisibility")]
 public class IpcTests : TestingFrameworkEvpTest
 {
     public IpcTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CIVisibility")]
     [UsesVerify]
     public class MsTestV2EvpTests : TestingFrameworkEvpTest
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class MsTestV2RetriesTests : TestingFrameworkRetriesTests
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
     public class MsTestV2Tests2(ITestOutputHelper output) : MsTestV2TestsBase("MSTestTests2", output, pre224TestCount: 19, post224TestCount: 21);
 
+    [Trait("Area", "CIVisibility")]
     [Collection("MsTestV2Tests")]
     [UsesVerify]
     public abstract class MsTestV2TestsBase : TestingFrameworkTest

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CIVisibility")]
     [UsesVerify]
     public class NUnitEvpTests : TestingFrameworkEvpTest
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class NUnitRetriesTests : TestingFrameworkRetriesTests
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CIVisibility")]
     [UsesVerify]
     public class NUnitTests : TestingFrameworkTest
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitEvpTests.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class PipesXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output)
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/PipesXUnitTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class PipesXUnitTests(ITestOutputHelper output) : XUnitTests(output)
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/SeleniumTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/SeleniumTests.cs
@@ -27,6 +27,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [UsesVerify]
 public class SeleniumTests : TestingFrameworkEvpTest
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitEvpTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class TcpXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output)
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TcpXUnitTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class TcpXUnitTests(ITestOutputHelper output) : XUnitTests(output)
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkEvpTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkEvpTest.cs
@@ -27,6 +27,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 public abstract class TestingFrameworkEvpTest : TestHelper
 {
     private readonly GacFixture _gacFixture;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkImpactedTests.cs
@@ -23,6 +23,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [UsesVerify]
 public abstract class TestingFrameworkImpactedTests : TestingFrameworkTest
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkRetriesTests.cs
@@ -18,6 +18,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 public abstract class TestingFrameworkRetriesTests : TestingFrameworkEvpTest
 {
     public TestingFrameworkRetriesTests(string sampleAppName, ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkTest.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 public abstract class TestingFrameworkTest : TestHelper
 {
     private readonly GacFixture _gacFixture;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TransportTestsCollection.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TransportTestsCollection.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [CollectionDefinition(nameof(TransportTestsCollection), DisableParallelization = true)]
 public class TransportTestsCollection
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitEvpTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class UdsXUnitEvpTests(ITestOutputHelper output) : XUnitEvpTests(output)
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/UdsXUnitTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class UdsXUnitTests(ITestOutputHelper output) : XUnitTests(output)
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -31,6 +31,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [UsesVerify]
 public abstract class XUnitEvpTests : TestingFrameworkEvpTest
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTestsV3.cs
@@ -25,6 +25,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
 #if NET8_0_OR_GREATER
+[Trait("Area", "CIVisibility")]
 [UsesVerify]
 public class XUnitEvpTestsV3 : TestingFrameworkEvpTest
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitImpactedTests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CIVisibility")]
     [UsesVerify]
     public class XUnitImpactedTests : TestingFrameworkImpactedTests
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class XUnitRetriesTests : TestingFrameworkRetriesTests
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTestsV3.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI;
 
+[Trait("Area", "CIVisibility")]
 [Collection(nameof(TransportTestsCollection))]
 public class XUnitRetriesTestsV3 : TestingFrameworkRetriesTests
 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
+    [Trait("Area", "CIVisibility")]
     [UsesVerify]
     public abstract class XUnitTests : TestingFrameworkTest
     {

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
@@ -27,6 +27,7 @@ using Xunit;
 namespace Datadog.Trace.Tools.Runner.IntegrationTests
 {
     [Collection(nameof(ConsoleTestsCollection))]
+    [Trait("Area", "CIVisibility")]
     [EnvironmentVariablesCleaner(
         Configuration.ConfigurationKeys.DebugEnabled,
         Configuration.ConfigurationKeys.CIVisibility.ExternalCodeCoveragePath,

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/ConfigureCiCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/ConfigureCiCommandTests.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.Tools.Runner.IntegrationTests
 {
     [Collection(nameof(ConsoleTestsCollection))]
+    [Trait("Area", "CIVisibility")]
     public class ConfigureCiCommandTests(ITestOutputHelper output)
     {
         private static readonly string[] RunScopedBackfillEnvironmentVariables =


### PR DESCRIPTION
## Summary of changes

Splits out CiVisibility tests to only run when CI Visibility files have changed.

## Reason for change

The CI Vis tests take a long time, and are getting longer with new major versions of xunit etc. Splitting them out as we do for ASM should reduce PR build times (and incidentally reduce chances of flake etc too).

## Implementation details

This is an alternative approach to https://github.com/DataDog/dd-trace-dotnet/pull/9113, in which we keep using the `Area` approach. My thinking there was that we _might_ want to split this out later, + it also gives an easy mechanism for skipping _unit_ tests etc later as well if we want to, without introducing additional filter concepts.

## Test coverage

This is the test.

## Other details

Splitting the Windows integration tests doesn't really gain anything because hardly any ci vis tests run on windows, but I think it still makes sense for parity.

I'm also thinking we _should_ split the arm64 integration tests now, as they're getting that much longer. I'll do a separate PR for that