### PR TITLE
Fix RunNativeLoaderTestsWindows artifact name

### DIFF
--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -81,7 +81,7 @@ partial class Build
             foreach (var architecture in ArchitecturesForPlatformForTracer)
             {
                 var workingDirectory = GetNativeOutputDirectory(NativeLoaderTestsProject.Name) / BuildConfiguration / architecture.ToString();
-                var testsResultFile = BuildDataDirectory / "tests" / $"{FileNames.NativeLoaderTests}.Results.{BuildConfiguration}.{TargetPlatform}.xml";
+                var testsResultFile = BuildDataDirectory / "tests" / $"{FileNames.NativeLoaderTests}.Results.{BuildConfiguration}.{architecture}.xml";
                 var exePath = workingDirectory / $"{FileNames.NativeLoaderTests}.exe";
                 var testExe = ToolResolver.GetLocalTool(exePath);
                 testExe($"--gtest_output=xml:{testsResultFile}", workingDirectory: workingDirectory);


### PR DESCRIPTION
## Summary of changes

Use the architecture currently being tested when naming Windows native-loader test result files.

## Reason for change

`RunNativeLoaderTestsWindows` can execute both x86 and x64 binaries in the same build. Using the shared `TargetPlatform` value gave both runs the same XML output path, allowing the later run to overwrite the earlier architecture's results.

## Implementation details

Replace `TargetPlatform` with the loop's `architecture` value in the GoogleTest result filename.

## Test coverage

Built `tracer/build/_build/_build.csproj` in Release configuration successfully with no warnings or errors.

## Other details

None.