### PR TITLE
Add non-allocating `ToLowerInvariant()` / `ToUpperInvariant()` for .NET Framework

### DIFF
--- a/tracer/src/Datadog.Trace/Util/StringUtil.cs
+++ b/tracer/src/Datadog.Trace/Util/StringUtil.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace - Putting this in system so we can do simple drop-in replacement
@@ -38,4 +39,42 @@ internal static class StringUtil
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsNullOrWhiteSpace([NotNullWhen(false)] string? value)
         => string.IsNullOrWhiteSpace(value);
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Non-allocating alternative to <paramref name="value"/>.ToUpperInvariant(). May return the same
+    /// instance (instead of allocating) when no character in <paramref name="value"/> actually needs to change.
+    /// </summary>
+    public static string ToUpperInvariant(string value)
+    {
+        foreach (var digit in value)
+        {
+            if (digit > '\x7F' || (uint)(digit - 'a') <= 'z' - 'a')
+            {
+                // Note: we don't call string.ToUpperInvariant() here to avoid potential accidental recursion
+                return CultureInfo.InvariantCulture.TextInfo.ToUpper(value);
+            }
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Non-allocating alternative to <paramref name="value"/>.ToLowerInvariant(). May return the same
+    /// instance (instead of allocating) when no character in <paramref name="value"/> actually needs to change.
+    /// </summary>
+    public static string ToLowerInvariant(string value)
+    {
+        foreach (var digit in value)
+        {
+            if (digit > '\x7F' || (uint)(digit - 'A') <= 'Z' - 'A')
+            {
+                // Note: we don't call string.ToLowerInvariant() here to avoid potential accidental recursion
+                return CultureInfo.InvariantCulture.TextInfo.ToLower(value);
+            }
+        }
+
+        return value;
+    }
+#endif
 }

--- a/tracer/src/Datadog.Trace/Util/StringUtil.cs
+++ b/tracer/src/Datadog.Trace/Util/StringUtil.cs
@@ -49,7 +49,7 @@ internal static class StringUtil
     {
         foreach (var digit in value)
         {
-            if (digit > '\x7F' || (uint)(digit - 'a') <= 'z' - 'a')
+            if (digit > '\x7F' || char.IsBetween(digit, 'a', 'z'))
             {
                 // Note: we don't call string.ToUpperInvariant() here to avoid potential accidental recursion
                 return CultureInfo.InvariantCulture.TextInfo.ToUpper(value);
@@ -67,7 +67,7 @@ internal static class StringUtil
     {
         foreach (var digit in value)
         {
-            if (digit > '\x7F' || (uint)(digit - 'A') <= 'Z' - 'A')
+            if (digit > '\x7F' || char.IsBetween(digit, 'A', 'Z'))
             {
                 // Note: we don't call string.ToLowerInvariant() here to avoid potential accidental recursion
                 return CultureInfo.InvariantCulture.TextInfo.ToLower(value);

--- a/tracer/test/Datadog.Trace.Tests/Util/StringUtilTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/StringUtilTests.cs
@@ -69,4 +69,110 @@ public class StringUtilTests
             var test = input.Length;
         }
     }
+
+#if NETFRAMEWORK
+    [Theory]
+    [MemberData(nameof(Data.SemanticEquivalenceInputs), MemberType = typeof(Data))]
+    public void ToUpperInvariant_IsSemanticallyEquivalentToBcl(string value)
+    {
+        StringUtil.ToUpperInvariant(value).Should().Be(value.ToUpperInvariant());
+    }
+
+    [Theory]
+    [MemberData(nameof(Data.SemanticEquivalenceInputs), MemberType = typeof(Data))]
+    public void ToLowerInvariant_IsSemanticallyEquivalentToBcl(string value)
+    {
+        StringUtil.ToLowerInvariant(value).Should().Be(value.ToLowerInvariant());
+    }
+
+    [Theory]
+    [MemberData(nameof(Data.AsciiNoOpInputs), MemberType = typeof(Data))]
+    public void ToUpperInvariant_AlreadyUppercaseAscii_ReturnsSameInstance(string value)
+    {
+        // Build an entirely fresh instance to make sure
+        var input = new string(value.ToUpperInvariant().ToCharArray());
+
+        var result = StringUtil.ToUpperInvariant(input);
+
+        result.Should().BeSameAs(input);
+    }
+
+    [Theory]
+    [MemberData(nameof(Data.AsciiNoOpInputs), MemberType = typeof(Data))]
+    public void ToLowerInvariant_AlreadyLowercaseAscii_ReturnsSameInstance(string value)
+    {
+        var input = new string(value.ToLowerInvariant().ToCharArray());
+
+        var result = StringUtil.ToLowerInvariant(input);
+
+        result.Should().BeSameAs(input);
+    }
+
+    [Fact]
+    public void ToUpperInvariant_ContainingAsciiLowercase_ReturnsNewInstance()
+    {
+        var input = new string("already Upper".ToCharArray());
+
+        var result = StringUtil.ToUpperInvariant(input);
+
+        result.Should().NotBeSameAs(input);
+        result.Should().Be(input.ToUpperInvariant());
+    }
+
+    [Fact]
+    public void ToLowerInvariant_ContainingAsciiUppercase_ReturnsNewInstance()
+    {
+        var input = new string("already Lower".ToCharArray());
+
+        var result = StringUtil.ToLowerInvariant(input);
+
+        result.Should().NotBeSameAs(input);
+        result.Should().Be(input.ToLowerInvariant());
+    }
+
+    public static class Data
+    {
+        public static readonly object[][] SemanticEquivalenceInputs =
+        {
+            [string.Empty],
+            ["a"],
+            ["A"],
+            ["already upper".ToUpperInvariant()],
+            ["already lower".ToLowerInvariant()],
+            ["MixedCase123!@#"],
+            ["İstanbul"], // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE -> lowercases across the ASCII boundary
+            ["K"], // U+212A KELVIN SIGN -> lowercases to 'k'
+            ["ſ"], // U+017F LATIN SMALL LETTER LONG S -> uppercases to 'S'
+            ["École"],
+            ["ÉCOLE"],
+            ["grüße"],
+            ["GRÜSSE"],
+            ["😀"], // surrogate pair (U+1F600), aligned at index 0
+            ["a😀"], // surrogate pair unaligned to the 2-char stride
+            ["ab😀"], // surrogate pair aligned again after an even prefix
+            ["\uD83D"], // lone high surrogate
+            ["\uDE00"], // lone low surrogate
+            ["\u0000"], // NUL - lowest code point
+            ["\u007F"], // DEL - last ASCII code point
+            ["\u0080"], // first non-ASCII code point (C1 control range)
+            ["az"],
+            [new string('x', 200)], // long all-ASCII no-op input
+            [new string('X', 200)],
+            ["/API/v2/Orders/{id}/Items"],
+            ["get"],
+            ["GET"],
+        };
+
+        public static readonly object[][] AsciiNoOpInputs =
+        {
+            [string.Empty],
+            ["a"],
+            ["z"],
+            ["0123456789"],
+            ["already upper text with spaces and !@#$%^&*()"],
+            [new string('x', 199)], // odd length
+            [new string('x', 200)], // even length
+        };
+    }
+#endif
 }


### PR DESCRIPTION
## Summary of changes

Adds a cheap "should we do any conversion" check for .NET Framework

## Reason for change

.NET Framework allocates on calls to `ToLowerInvariant()` and `ToUpperInvariant()` even if the `string` doesn't need to change (.NET Core etc don't allocate in these cases).

## Implementation details

- Created a helper in `StringUtil` (because it holds "replacement" versions of our method calls)
- Does a scan for anything that indicates we might need to case-convert, and just calls the same underlying `ToLower` methods that the BCL does if necessary.
- Fails "safe", anything non-ascii and we bail out
- Didn't do anything fancy - basically all of the strings we try to convert are small (<200 chars), and at those sizes, foreach beats other optimizations (which are available in .NET FX)
- No _usage_ yet, that's in the stacked PR

## Test coverage

Unit tests ensure we return the same thing


Benchmarking shows that this is worthwhile I think, given we are faster and no allocation on the noop path, and approximately equal to the baseline where changes _Are_ required



| Method                        |        Mean |     Error |    StdDev |      Median |   Gen0 | Allocated |
| ----------------------------- | ----------: | --------: | --------: | ----------: | -----: | --------: |
| BCL_UpperNoOp_Short           |  30.3868 ns | 0.9382 ns | 2.6307 ns |  30.3068 ns | 0.0051 |      32 B |
| StringUtil_UpperNoOp_Short    |   3.0599 ns | 0.2265 ns | 0.6388 ns |   2.7809 ns |      - |         - |
| BCL_LowerNoOp_Even            |  48.1674 ns | 0.9939 ns | 1.2206 ns |  47.8483 ns | 0.0127 |      80 B |
| StringUtil_LowerNoOp_Even     |  11.7767 ns | 0.2673 ns | 0.2370 ns |  11.8849 ns |      - |         - |
| BCL_LowerNoOp_Odd             |  52.5739 ns | 1.7445 ns | 4.8339 ns |  51.9809 ns | 0.0126 |      80 B |
| StringUtil_LowerNoOp_Odd      |  12.1018 ns | 0.2768 ns | 0.3399 ns |  12.0449 ns |      - |         - |
| BCL_LowerNoOp_Long            | 227.2840 ns | 4.3785 ns | 5.2123 ns | 227.4469 ns | 0.0687 |     433 B |
| StringUtil_LowerNoOp_Long     | 102.2266 ns | 2.0332 ns | 2.2599 ns | 101.6906 ns |      - |         - |
| BCL_UpperChanges_Short        |  27.9617 ns | 0.5801 ns | 0.5958 ns |  27.9097 ns | 0.0051 |      32 B |
| StringUtil_UpperChanges_Short |  29.4467 ns | 0.5964 ns | 0.8927 ns |  29.4103 ns | 0.0051 |      32 B |
| BCL_LowerChanges_Long         |  48.2923 ns | 0.9799 ns | 1.4666 ns |  48.0425 ns | 0.0127 |      80 B |
| StringUtil_LowerChanges_Long  |  47.8436 ns | 0.9508 ns | 0.9339 ns |  47.7409 ns | 0.0127 |      80 B |
| BCL_Lower_NonAscii            |  31.8346 ns | 0.6609 ns | 0.6182 ns |  31.8471 ns | 0.0063 |      40 B |
| StringUtil_Lower_NonAscii     |  34.5830 ns | 0.6951 ns | 1.8554 ns |  33.9048 ns | 0.0063 |      40 B |



<details><summary>Benchmark Code</summary>

```csharp
#nullable enable

using BenchmarkDotNet.Attributes;

namespace Benchmarks.Trace;

// Scratch benchmark (this folder is gitignored) backing the decision in
// docs-adjacent PR "[Perf] Intercept ToUpperInvariant/ToLowerInvariant on .NET Framework":
// on net472, the BCL's ToUpperInvariant()/ToLowerInvariant() always allocate, even when no
// character changes case. StringUtil.ToUpperInvariant()/ToLowerInvariant() (net461-only) scan
// first and return the original instance when nothing would change. This benchmark quantifies
// that win, and guards that the *_Changes arms (where a new string genuinely must be allocated)
// don't regress.
//
// All inputs go through Build() (new string(...ToCharArray())) so literal interning can't produce
// a false pass on the reference-identity/zero-allocation arms.
[MemoryDiagnoser]
[BenchmarkCategory(Constants.TracerCategory, Constants.RunOnPrs, Constants.RunOnMaster)]
public class StringCaseBenchmark
{
    // No-op inputs: already in the target case, so StringUtil should return the same instance
    // (0 B) while the BCL always allocates a byte-for-byte-identical copy on net472.
    private static readonly string UpperNoOpShort = Build("GET");                    // len 3 (odd)
    private static readonly string LowerNoOpEven = Build(new string('a', 24));       // len 24 (even)
    private static readonly string LowerNoOpOdd = Build(new string('a', 25));        // len 25 (odd)
    private static readonly string LowerNoOpLong = Build(new string('a', 200));      // len 200

    // *_Changes inputs: a real conversion is required, so this is pure scan overhead for
    // StringUtil - the arms that must not regress relative to the BCL baseline.
    private static readonly string UpperChanges = Build("get");
    private static readonly string LowerChanges = Build("/API/v2/Orders/{id}/Items");

    // Non-ASCII no-op: StringUtil must bail out to TextInfo on the first non-ASCII char rather
    // than mis-classify this as a no-op (e.g. Kelvin sign / Turkish İ case-map into ASCII).
    private static readonly string NonAsciiNoOp = Build("grüße");

    // Controls, to prove the harness itself isn't eliding the work being measured.
    private static readonly string ControlSource = Build(new string('x', 25));

    private static string Build(string value) => new(value.ToCharArray());

    [Benchmark(Baseline = true)]
    public string Bcl_UpperNoOp_Short() => UpperNoOpShort.ToUpperInvariant();

    [Benchmark]
    public string Bcl_LowerNoOp_Even() => LowerNoOpEven.ToLowerInvariant();

    [Benchmark]
    public string Bcl_LowerNoOp_Odd() => LowerNoOpOdd.ToLowerInvariant();

    [Benchmark]
    public string Bcl_LowerNoOp_Long() => LowerNoOpLong.ToLowerInvariant();

    [Benchmark]
    public string Bcl_UpperChanges() => UpperChanges.ToUpperInvariant();

    [Benchmark]
    public string Bcl_LowerChanges() => LowerChanges.ToLowerInvariant();

    [Benchmark]
    public string Bcl_NonAsciiNoOp() => NonAsciiNoOp.ToLowerInvariant();

#if NETFRAMEWORK
    [Benchmark]
    public string StringUtil_UpperNoOp_Short() => System.StringUtil.ToUpperInvariant(UpperNoOpShort);

    [Benchmark]
    public string StringUtil_LowerNoOp_Even() => System.StringUtil.ToLowerInvariant(LowerNoOpEven);

    [Benchmark]
    public string StringUtil_LowerNoOp_Odd() => System.StringUtil.ToLowerInvariant(LowerNoOpOdd);

    [Benchmark]
    public string StringUtil_LowerNoOp_Long() => System.StringUtil.ToLowerInvariant(LowerNoOpLong);

    [Benchmark]
    public string StringUtil_UpperChanges() => System.StringUtil.ToUpperInvariant(UpperChanges);

    [Benchmark]
    public string StringUtil_LowerChanges() => System.StringUtil.ToLowerInvariant(LowerChanges);

    [Benchmark]
    public string StringUtil_NonAsciiNoOp() => System.StringUtil.ToLowerInvariant(NonAsciiNoOp);
#endif
}

```

</details> 


## Other details

Kudos to @bouwkast for identifying this when working on #8903
