### PR TITLE
[CI] Bump LLM validation platform to v0.1.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'ddoghq/llm-validation-platform'
-    ref: 0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf   # v0.1.1 (immutable SHA; a tag could be retargeted)
+    ref: d59e4af6d6666092f65740b9a4d1bf3651a64321   # v0.1.2 (immutable SHA; a tag could be retargeted)
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
   # GitLab does not expand top-level `variables:` inside `include:` keywords,
@@ -45,7 +45,7 @@ variables:
 "llm validation":
   variables:
     LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
-    LLMVAL_PLATFORM_REF: "0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf"   # v0.1.1 (must match include ref above)
+    LLMVAL_PLATFORM_REF: "d59e4af6d6666092f65740b9a4d1bf3651a64321"   # v0.1.2 (must match include ref above)
 
 build-windows-ci-image:
   stage: build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ The full managed tracer (`Datadog.Trace.dll`) contains all auto-instrumentation 
 - Use modern C# syntax, but avoid features requiring types unavailable in older runtimes (e.g., no `ValueTuple` syntax for .NET Framework 4.6.1)
   - For instance, prefer `is not null` to `!= null`
 - Prefer modern collection expressions (`[]`)
-- Use `StringUtil.IsNullOrEmpty()` instead of `string.IsNullOrEmpty()` for compatibility across all supported runtimes
+- Use `StringUtil.IsNullOrEmpty()` instead of `string.IsNullOrEmpty()` for compatibility across all supported runtimes.
 - StyleCop: see `tracer/stylecop.json`; address warnings before pushing.
 - Never manually edit generated files (`.g.` in the file extension). Read the file header for regeneration instructions instead.
 


### PR DESCRIPTION
## Summary of changes

Bump the pinned LLM Validation Platform ref from **v0.1.1** (`0f48ca3`) to **v0.1.2** (`d59e4af`) in `.gitlab-ci.yml` — both the `include:` ref and the `"llm validation"` job's `LLMVAL_PLATFORM_REF`, kept identical per the platform's supply-chain pinning guidance. Plus a one-character punctuation fix in `AGENTS.md`.

## Reason for change

Keep the prompt-regression gate on the latest released, immutably-pinned platform version. v0.1.2 brings:
- Fail loudly on an unresolvable base ref instead of silently comparing against an empty baseline (across the CLI and both shell layers).
- Advisory expected-criteria coverage in the report (gate verdict unchanged).
- Fixes: always send the gateway `Authorization` header; confine candidate-file resolution to the repo root; validate `--repo` before the candidate-absent degenerate-skip.

## Implementation details

## Test coverage

## Other details

Full changelog: https://github.com/ddoghq/llm-validation-platform/compare/v0.1.1...v0.1.2

<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
