### PR TITLE
[Native Profiler] Request ReJIT shutdown before draining the work queue

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -367,12 +367,25 @@ void RejitHandler::Shutdown()
 {
     DBG("RejitHandler::Shutdown");
 
+    // Request shutdown before draining the queue. WaitForTermination() below joins the worker
+    // thread, so it processes every item already queued first. Setting m_shutdown afterwards
+    // meant those items still did full RequestReJIT work against the CLR, and because
+    // CorProfiler::Shutdown holds module_ids across this call, a deep queue stalled every thread
+    // that needs to JIT a method or load a module. Setting it first lets the queued items
+    // short-circuit (they still resolve their promises, so no waiter hangs).
+    //
+    // The write lock is released before WaitForTermination(): the worker calls
+    // IsShutdownRequested(), which takes a read lock on the same lock.
+    {
+        WriteLock w_lock(m_shutdown_lock);
+        m_shutdown.store(true);
+    }
+
     // Wait for exiting the thread
     m_work_offloader->Enqueue(RejitWorkItem::CreateTerminatingWorkItem());
     m_work_offloader->WaitForTermination();
 
     WriteLock w_lock(m_shutdown_lock);
-    m_shutdown.store(true);
 
     for (size_t x = 0; x < m_rejittersCount; x++)
     {


### PR DESCRIPTION
## Summary of changes

Reported in [APMS-20456](https://datadoghq.atlassian.net/browse/APMS-20456) (internal): a process-wide hang in an IIS worker process running the .NET tracer. Investigating that report surfaced a general pattern in the native profiler, described under *Reason for change*, which has several instances. This change fixes one of them — not the pattern as a whole, and not the instance considered most likely in the reported incident, which is noted under *Other details*.

The ReJIT work offloader is a single worker thread with a shared FIFO queue. `RejitHandler::Shutdown()` waits for that queue to drain completely, and it is called while holding a lock that every JIT and module-load callback also needs. When the queue is deep, that wait — and therefore the lock hold — is long enough to stall the whole process. The queued work is not needed once shutdown has started, and there are already guards to skip it; the flag those guards read was simply set after the wait instead of before it.

`RejitHandler::Shutdown()` now sets the `m_shutdown` flag *before* it drains the queue, instead of after. One statement moved; no other behaviour change.

## Reason for change

`CorProfiler::module_ids` is a single `std::mutex` (via `Synchronized<std::vector<ModuleID>>`) acquired by every one of these paths:

- `JITCompilationStarted`
- `JITCachedFunctionSearchStarted`
- `ModuleLoadFinished`
- `ModuleUnloadStarted`
- `AppDomainShutdownFinished`
- the `InstrumentProbes` P/Invoke path

Several callers also wait on the ReJIT work offloader — a single worker thread — while holding that lock. Because the offloader queue is FIFO and shared across products (Exception Replay, which is enabled by default where supported and re-instruments on each newly-seen exception case; Dynamic Instrumentation probes; CallTarget registration), a burst of enqueued work makes any such wait proportional to the whole backlog. For its duration, every thread in the process that needs to JIT a method or load a module blocks on `module_ids`. In an IIS worker process with many concurrent request threads that presents as a process-wide hang: most threads parked on one lock, no CPU usage.

`RejitHandler::Shutdown()` is the unbounded case. It enqueues a terminating work item and calls `WaitForTermination()`, which joins the worker thread and so does not return until every already-queued item has been processed. `m_shutdown` was only set *after* that join, so those queued items still observed `IsShutdownRequested() == false` and each went on to do full `RequestReJIT` work against the CLR, which requires a runtime-wide safepoint. `CorProfiler::Shutdown()` calls this while holding `module_ids`, so the lock was held for the entire drain.

This case was identified by inspection rather than observed in a dump: it requires shutdown to coincide with a deep queue. The bounded waits under *Other details* require no shutdown and are more readily reachable.

## Implementation details

Setting the flag before the drain lets the already-queued items short-circuit instead of calling into the CLR:

- `RejitPreprocessor::PreprocessRejitRequests` returns `0` once shutdown has been requested, before it calls `GetModuleInfo()`, so draining items no longer touch module metadata.
- `RejitHandler::RequestRejit` early-returns.
- The work-item lambdas in `EnqueueForRejit`, `EnqueueRequestRejit` and `EnqueueRequestRejitForLoadedModules` resolve their promise unconditionally after the call, so nothing waiting on those futures can hang as a result of the short-circuit.

The queue drains promptly and `module_ids` is held only briefly.

Two things are deliberately unchanged:

- **`CorProfiler::Shutdown()` still holds `module_ids` across the call.** That hold is load-bearing: `ModuleUnloadStarted` takes the same lock specifically to block "until the module metadata is no longer being used". Releasing it around the drain would allow a module to unload while the worker is still reading its metadata, so this targets the drain duration rather than the lock scope.
- **The write lock is released before `WaitForTermination()`**, because the worker thread calls `IsShutdownRequested()`, which takes a read lock on the same `std::shared_mutex`.

Discarding pending rejit work once shutdown has started is consistent with the existing `IsShutdownRequested()` guards throughout these files.

## Test coverage

No tests added. There is no existing native unit-test coverage for `RejitHandler` (`tracer/test/Datadog.Tracer.Native.Tests/` contains no rejit tests); this path is exercised implicitly by integration tests that tear the profiler down.

Not built locally, so CI is the first build check on it.

What has been verified is the ordering logic, against a standalone model using the same `std::shared_mutex` / `unique_lock` / `shared_lock` types: with a 50-item backlog the drain drops from ~2.2s to ~44ms, 49 of 50 queued items short-circuit, and all 50 promises still resolve, so no waiter is left blocked. That covers the concurrency reasoning, not the build.

## Other details

Two related observations, both left out of this change.

**Other unbounded waits.** Five further callers take `module_ids` and then call `future.get()` with no timeout, so a backlogged offloader stalls them — and everything else contending for the lock — indefinitely:

- `InternalAddInstrumentation` (cor_profiler.cpp:1875)
- `RegisterCallTargetDefinitions` (:2001)
- `EnableCallTargetDefinitions` (:2037)
- `DisableCallTargetDefinitions` (:2072)
- `InitializeTraceMethods` (:2205)

None of these are shutdown-specific, so unlike the case fixed here they are reachable during normal operation — `EnableCallTargetDefinitions`, for instance, runs when a product is switched on via Remote Configuration.

`ModuleLoadFinished` (:547) and `TryRejitModule` (:1196) already use a bounded `future.wait_for(200ms)` for this reason, which suggests the bounded form is the intended pattern.

The rejit counts look low-risk to change: `RegisterCallTargetDefinitions` only logs its count and returns `enabledTargets` instead, `DisableCallTargetDefinitions`' caller discards the result, and `EnableCallTargetDefinitions`' result feeds a telemetry gauge. The reason for leaving them out of this change is timing rather than return values — bounding these waits lets the call return before the instrumentation has actually been applied, which is the tradeoff `ModuleLoadFinished` already accepts but may matter to callers that enable a product and expect it to be live immediately.

**Serialized bounded waits.** Even where the wait is bounded, `module_ids` is exclusive, so concurrent callers cannot overlap. If the offloader is backlogged enough that each `ModuleLoadFinished` hits its full 200ms timeout, the lock is handed from one waiting thread to the next at roughly 200ms per acquisition, so the aggregate stall grows with the number of pending module loads even though no individual wait is unbounded. An application that generates types at runtime — dynamic proxies, for example — can drive a large number of these concurrently. That path is unaffected by this change and may warrant separate consideration.


[APMS-20456]: https://datadoghq.atlassian.net/browse/APMS-20456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ