### PR TITLE
Fix release creation

### DIFF
--- a/.github/workflows/_create_draft_release.yml
+++ b/.github/workflows/_create_draft_release.yml
@@ -16,6 +16,16 @@ on:
         description: 'Is this a hotfix release? If true, skips vNext milestone renaming'
         required: true
         type: boolean
+    # These must be declared (and explicitly passed by the caller below) even though their
+    # actual values come from the job's `environment: publish-debug-symbols-env` secrets, not
+    # from the caller's own secrets. Without a declared+passed secret of the same name, the
+    # `secrets.X` context inside this reusable workflow resolves empty regardless of the
+    # environment secret's value - see https://github.com/actions/runner/issues/1490.
+    secrets:
+      AZURE_DEVOPS_TOKEN:
+        required: true
+      NUGET_TRUSTED_PUBLISHING_USERNAME:
+        required: true
 
 jobs:
   create_draft_release:
@@ -75,7 +85,7 @@ jobs:
            echo "The NUGET_TRUSTED_PUBLISHING_USERNAME contains the username that should have the trusted policy configured on nuget.org." >&2
            echo "If this user is no longer part of the datadog organisation on nuget.org: create a new trusted policy using your nuget user " >&2
            echo "  1. Create a new trusted policy using your nuget user. Follow the example in https://github.com/DataDog/dd-trace-dotnet/pull/8209" >&2
-           echo "  2. Replace the NUGET_TRUSTED_PUBLISHING_USERNAME GitHub secret with your nuget.org username (not email) at https://github.com/DataDog/dd-trace-dotnet/settings/secrets/actions " >&2
+           echo "  2. Replace the NUGET_TRUSTED_PUBLISHING_USERNAME secret on the publish-debug-symbols-env environment with your nuget.org username (not email) at https://github.com/DataDog/dd-trace-dotnet/settings/environments " >&2
            echo "  3. Try running this release again" >&2
             exit 1
           fi

--- a/.github/workflows/create_hotfix_draft_release.yml
+++ b/.github/workflows/create_hotfix_draft_release.yml
@@ -33,6 +33,13 @@ jobs:
         permissions:
           contents: read # actions/checkout uses the workflow token to clone
           id-token: write # required for dd-octo-sts OIDC and NuGet trusted publishing
+        # Must be declared here (even though the real values come from the reusable
+        # workflow's `environment: publish-debug-symbols-env` secrets) - the environment
+        # secret only overrides a name already known to the called workflow's secrets
+        # context; it doesn't get exposed on its own. See _create_draft_release.yml.
+        secrets:
+            AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+            NUGET_TRUSTED_PUBLISHING_USERNAME: ${{ secrets.NUGET_TRUSTED_PUBLISHING_USERNAME }}
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}

--- a/.github/workflows/create_normal_draft_release.yml
+++ b/.github/workflows/create_normal_draft_release.yml
@@ -33,6 +33,13 @@ jobs:
         permissions:
           contents: read # actions/checkout uses the workflow token to clone
           id-token: write # required for dd-octo-sts OIDC and NuGet trusted publishing
+        # Must be declared here (even though the real values come from the reusable
+        # workflow's `environment: publish-debug-symbols-env` secrets) - the environment
+        # secret only overrides a name already known to the called workflow's secrets
+        # context; it doesn't get exposed on its own. See _create_draft_release.yml.
+        secrets:
+            AZURE_DEVOPS_TOKEN: ${{ secrets.AZURE_DEVOPS_TOKEN }}
+            NUGET_TRUSTED_PUBLISHING_USERNAME: ${{ secrets.NUGET_TRUSTED_PUBLISHING_USERNAME }}
         with:
             forced_commit_id: ${{ inputs.forced_commit_id }}
             ignore_gitlab_failures: ${{ inputs.ignore_gitlab_failures }}


### PR DESCRIPTION
## Summary of changes

Fixes creating releases

## Reason for change

#8865 broke the release, [because the way secrets work is apparently crazy](https://github.com/actions/runner/issues/1490).

## Implementation details

You apparently have to declare _and pass in_ secrets to a reusable workflow, even though the caller _can not access those secrets_. [Apparently](https://github.com/AllanOricil/workflow-template-bug/tree/master). Sure.

## Test coverage

Can't test this without merging it, so YOLO

## Other details

Blocker for the release