### PR TITLE
[tracer] Fix potential crash at shutdown

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -552,6 +552,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
         return S_OK;
     }
 
+    rejit_handler->NotifyModuleLoaded(module_id);
+
     auto hr = TryRejitModule(module_id, modules.Ref());
 
     // Push integration definitions from past modules that were unable to be added
@@ -600,6 +602,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
             {
                 Logger::Warn("Timeout while waiting for the rejit requests to be processed. Rejit will continue asynchronously, but some initial calls may not be instrumented");
             }
+        }
+
+        // The enqueued request holds its own token now, so drop the ones taken when the modules
+        // were queued above.
+        for (size_t i = 0; i < rejitModuleIds.size(); i++)
+        {
+            rejit_handler->ReleaseInFlightRequest();
         }
     }
 
@@ -1163,6 +1172,9 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
 
                 if (methodReferences.size() > 0)
                 {
+                    // The module can unload while it waits here, so keep its unload recorded until
+                    // we dequeue it.
+                    rejit_handler->AcquireInFlightRequest();
                     rejit_module_method_pairs.push_back(std::make_pair(module_id, methodReferences));
                 }
             }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -821,6 +821,15 @@ bool Dataflow::HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef)
 {
     return false;
 }
+void Dataflow::NotifyModuleLoaded(ModuleID moduleId)
+{
+}
+void Dataflow::AcquireInFlightRequest()
+{
+}
+void Dataflow::ReleaseInFlightRequest()
+{
+}
 void Dataflow::RemoveModule(ModuleID moduleId)
 {
 }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
@@ -116,6 +116,9 @@ namespace iast
         void Shutdown() override;
         RejitHandlerModule* GetOrAddModule(ModuleID moduleId) override;
         bool HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef) override;
+        void NotifyModuleLoaded(ModuleID moduleId) override;
+        void AcquireInFlightRequest() override;
+        void ReleaseInFlightRequest() override;
         void RemoveModule(ModuleID moduleId) override;
         void AddNGenInlinerModule(ModuleID moduleId) override;
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -495,6 +495,52 @@ bool RejitHandler::HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef)
     return false;
 }
 
+void RejitHandler::NotifyModuleLoaded(ModuleID moduleId)
+{
+    if (IsShutdownRequested())
+    {
+        return;
+    }
+
+    Rejitter* prev = nullptr;
+    for (size_t x = 0; x < m_rejittersCount; x++)
+    {
+        const auto current = m_rejitters[x];
+        if (current != prev)
+        {
+            current->NotifyModuleLoaded(moduleId);
+        }
+    }
+}
+
+// No shutdown check here: it must stay paired with ReleaseInFlightRequest, otherwise a release
+// would decrement a count that was never taken.
+void RejitHandler::AcquireInFlightRequest()
+{
+    Rejitter* prev = nullptr;
+    for (size_t x = 0; x < m_rejittersCount; x++)
+    {
+        const auto current = m_rejitters[x];
+        if (current != prev)
+        {
+            current->AcquireInFlightRequest();
+        }
+    }
+}
+
+void RejitHandler::ReleaseInFlightRequest()
+{
+    Rejitter* prev = nullptr;
+    for (size_t x = 0; x < m_rejittersCount; x++)
+    {
+        const auto current = m_rejitters[x];
+        if (current != prev)
+        {
+            current->ReleaseInFlightRequest();
+        }
+    }
+}
+
 void RejitHandler::RemoveModule(ModuleID moduleId)
 {
     if (IsShutdownRequested())

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -146,6 +146,9 @@ public:
     AssemblyProperty* GetCorAssemblyProperty();
 
     bool HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef);
+    void NotifyModuleLoaded(ModuleID moduleId);
+    void AcquireInFlightRequest();
+    void ReleaseInFlightRequest();
     void RemoveModule(ModuleID moduleId);
     void AddNGenInlinerModule(ModuleID moduleId);
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -8,6 +8,10 @@
 
 namespace trace
 {
+// Upper bound on RejitPreprocessor::m_unloaded_modules.
+// Handle cases where modules keep on being unloaded and loaded again.
+static constexpr size_t kMaxTrackedUnloadedModules = 4096;
+
 // Rejitter
 Rejitter::Rejitter(std::shared_ptr<RejitHandler> handler, RejitterPriority priority, bool registerRejitter) :
     m_rejitHandler(handler), m_priority(priority)
@@ -42,9 +46,11 @@ void RejitPreprocessor<RejitRequestDefinition>::Shutdown()
 
     std::lock_guard<std::mutex> moduleGuard(m_modules_lock);
     std::lock_guard<std::mutex> ngenModuleGuard(m_ngenInlinersModules_lock);
+    std::lock_guard<std::mutex> unloadedModuleGuard(m_unloaded_modules_lock);
 
     m_modules.clear();
     m_ngenInlinersModules.clear();
+    m_unloaded_modules.clear();
 }
 
 template <class RejitRequestDefinition>
@@ -60,6 +66,12 @@ RejitHandlerModule* RejitPreprocessor<RejitRequestDefinition>::GetOrAddModule(Mo
     if (find_res != m_modules.end())
     {
         return find_res->second.get();
+    }
+
+    // The CLR can reuse a ModuleID, so drop it from the unloaded set.
+    {
+        std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
+        m_unloaded_modules.erase(moduleId);
     }
 
     RejitHandlerModule* moduleHandler = new RejitHandlerModule(moduleId, m_rejit_handler.get());
@@ -102,6 +114,14 @@ void RejitPreprocessor<RejitRequestDefinition>::RemoveModule(ModuleID moduleId)
     std::lock_guard<std::mutex> inlinersGuard(m_ngenInlinersModules_lock);
     m_ngenInlinersModules.erase(std::remove(m_ngenInlinersModules.begin(), m_ngenInlinersModules.end(), moduleId),
                                 m_ngenInlinersModules.end());
+
+    // Record unloaded modules to avoid re-processing them.
+    std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
+    if (m_unloaded_modules.size() >= kMaxTrackedUnloadedModules)
+    {
+        m_unloaded_modules.clear();
+    }
+    m_unloaded_modules.insert(moduleId);
 }
 
 template <class RejitRequestDefinition>
@@ -562,6 +582,17 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::PreprocessRejitRequests(
     for (const auto& module : modules)
     {
         auto _ = trace::Stats::Instance()->CallTargetRequestRejitMeasure();
+
+        {
+            // Skip modules that have been unloaded.
+            std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
+            if (m_unloaded_modules.find(module) != m_unloaded_modules.end())
+            {
+                DBG("PreprocessRejitRequests: skipping module already unloaded: ", module);
+                continue;
+            }
+        }
+
         const ModuleInfo& moduleInfo = GetModuleInfo(corProfilerInfo, module);
         if (!moduleInfo.IsValid())
         {

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -149,7 +149,7 @@ void RejitPreprocessor<RejitRequestDefinition>::RemoveModule(ModuleID moduleId)
 
     // Removes the RejitHandlerModule instance
     //
-    // TODO: this destroys the handler (and its methods and metadata) while other threads can still
+    // TOFIX (gleocadie): this destroys the handler (and its methods and metadata) while other threads can still
     // be using it: GetOrAddModule hands out a raw pointer and drops m_modules_lock, so callers such
     // as ProcessTypeDefForRejit and RejitMethod dereference it unsynchronized with this erase.
     // The unloaded-module tracking below only stops us picking up a module that unloaded *before*

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -50,6 +50,9 @@ void RejitPreprocessor<RejitRequestDefinition>::Shutdown()
 
     m_modules.clear();
     m_ngenInlinersModules.clear();
+
+    // Nothing reads m_unloaded_modules after shutdown, but tokens can still be outstanding, so
+    // clear the set and leave m_in_flight_requests for them to unwind.
     m_unloaded_modules.clear();
 }
 
@@ -68,12 +71,9 @@ RejitHandlerModule* RejitPreprocessor<RejitRequestDefinition>::GetOrAddModule(Mo
         return find_res->second.get();
     }
 
-    // The CLR can reuse a ModuleID, so drop it from the unloaded set.
-    {
-        std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
-        m_unloaded_modules.erase(moduleId);
-    }
-
+    // Deliberately does not clear m_unloaded_modules: this runs for unloaded modules too (callers
+    // such as RemoveProbes pass stored ModuleIDs), and clearing here would unprotect in-flight
+    // requests. NotifyModuleLoaded handles ModuleID reuse.
     RejitHandlerModule* moduleHandler = new RejitHandlerModule(moduleId, m_rejit_handler.get());
     m_modules[moduleId] = std::unique_ptr<RejitHandlerModule>(moduleHandler);
     return moduleHandler;
@@ -99,6 +99,47 @@ bool RejitPreprocessor<RejitRequestDefinition>::HasModuleAndMethod(ModuleID modu
 }
 
 template <class RejitRequestDefinition>
+void RejitPreprocessor<RejitRequestDefinition>::NotifyModuleLoaded(ModuleID moduleId)
+{
+    if (m_rejit_handler->IsShutdownRequested())
+    {
+        return;
+    }
+
+    // The CLR can reuse a ModuleID, so drop it from the unloaded set.
+    std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
+    m_unloaded_modules.erase(moduleId);
+}
+
+template <class RejitRequestDefinition>
+void RejitPreprocessor<RejitRequestDefinition>::AcquireInFlightRequest()
+{
+    std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
+    ++m_in_flight_requests;
+}
+
+template <class RejitRequestDefinition>
+void RejitPreprocessor<RejitRequestDefinition>::ReleaseInFlightRequest()
+{
+    std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
+    if (--m_in_flight_requests == 0)
+    {
+        // Nothing can name an unloaded module any more.
+        m_unloaded_modules.clear();
+    }
+}
+
+template <class RejitRequestDefinition>
+std::shared_ptr<void> RejitPreprocessor<RejitRequestDefinition>::AcquireInFlightRequestToken()
+{
+    AcquireInFlightRequest();
+
+    // The deleter runs when the last owner goes away, which also covers a work item that is
+    // discarded without running.
+    return std::shared_ptr<void>(nullptr, [this](void*) { ReleaseInFlightRequest(); });
+}
+
+template <class RejitRequestDefinition>
 void RejitPreprocessor<RejitRequestDefinition>::RemoveModule(ModuleID moduleId)
 {
     if (m_rejit_handler->IsShutdownRequested())
@@ -107,6 +148,13 @@ void RejitPreprocessor<RejitRequestDefinition>::RemoveModule(ModuleID moduleId)
     }
 
     // Removes the RejitHandlerModule instance
+    //
+    // TODO: this destroys the handler (and its methods and metadata) while other threads can still
+    // be using it: GetOrAddModule hands out a raw pointer and drops m_modules_lock, so callers such
+    // as ProcessTypeDefForRejit and RejitMethod dereference it unsynchronized with this erase.
+    // The unloaded-module tracking below only stops us picking up a module that unloaded *before*
+    // the request ran; it does not protect a module that unloads mid-request. Pre-existing, and
+    // fixable by holding the handlers in shared_ptr so in-flight users keep them alive.
     std::lock_guard<std::mutex> modulesGuard(m_modules_lock);
     m_modules.erase(moduleId);
 
@@ -115,13 +163,13 @@ void RejitPreprocessor<RejitRequestDefinition>::RemoveModule(ModuleID moduleId)
     m_ngenInlinersModules.erase(std::remove(m_ngenInlinersModules.begin(), m_ngenInlinersModules.end(), moduleId),
                                 m_ngenInlinersModules.end());
 
-    // Record unloaded modules to avoid re-processing them.
+    // Record unloaded modules to avoid re-processing them. With no request in flight there is
+    // nothing holding a module list that could name this module, so there is nothing to track.
     std::lock_guard<std::mutex> unloadedGuard(m_unloaded_modules_lock);
-    if (m_unloaded_modules.size() >= kMaxTrackedUnloadedModules)
+    if (m_in_flight_requests > 0)
     {
-        m_unloaded_modules.clear();
+        m_unloaded_modules.insert(moduleId);
     }
-    m_unloaded_modules.insert(moduleId);
 }
 
 template <class RejitRequestDefinition>
@@ -452,6 +500,8 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::RequestRejitForLoadedModules(
     const std::vector<ModuleID>& modules, const std::vector<RejitRequestDefinition>& definitions,
     bool enqueueInSameThread)
 {
+    // No token taken here: every caller either already holds one for this module list, or holds
+    // CorProfiler::module_ids for the duration of the call, which blocks the unload.
     std::vector<MethodIdentifier> rejitRequests{};
     const auto rejitCount = PreprocessRejitRequests(modules, definitions, rejitRequests);
     RequestRejit(rejitRequests, enqueueInSameThread);
@@ -549,8 +599,12 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejitForLoadedModu
     DBG("RejitHandler::EnqueueRequestRejitForLoadedModules");
     auto enqueueMeasure = trace::Stats::Instance()->EnqueueRequestRejitForLoadedModulesMeasure();
 
+    // Taken before enqueuing: the modules can unload while the work item sits in the queue.
+    auto requestToken = AcquireInFlightRequestToken();
+
     std::function<void()> action = [=, modules = std::move(modulesVector), definitions = std::move(definitions),
-                                    localPromise = promise, enqueueMeasure = std::move(enqueueMeasure)]() mutable {
+                                    localPromise = promise, enqueueMeasure = std::move(enqueueMeasure),
+                                    requestToken = std::move(requestToken)]() mutable {
         // Process modules for rejit
         const auto rejitCount = RequestRejitForLoadedModules(modules, definitions, true);
 
@@ -907,8 +961,12 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueuePreprocessRejitRequests(
 
     DBG("RejitHandler::EnqueuePreprocessRejitRequests");
 
+    // Taken before enqueuing: the modules can unload while the work item sits in the queue.
+    auto requestToken = AcquireInFlightRequestToken();
+
     std::function<void()> action = [=, modules = std::move(modulesVector), definitions = std::move(definitions),
-                                    localRejitRequests = rejitRequests, localPromise = promise]() mutable {
+                                    localRejitRequests = rejitRequests, localPromise = promise,
+                                    requestToken = std::move(requestToken)]() mutable {
         // Process modules for rejit
         const auto rejitCount = PreprocessRejitRequests(modules, definitions, localRejitRequests);
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -110,11 +110,7 @@ protected:
     std::mutex m_ngenInlinersModules_lock;
     std::vector<ModuleID> m_ngenInlinersModules;
 
-    // Unloaded modules. PreprocessRejitRequests skips these so we don't call into the CLR after
-    // unload. An entry is only needed while a request that could name the module is in flight, so
-    // unloads are recorded only while m_in_flight_requests is non-zero, and the whole set is
-    // dropped once the last request completes. Counting requests rather than modules keeps this
-    // O(1) per request; the cost is that an entry outlives the request that needed it.
+    // Unloaded modules handling: prevent from calling into the CLR for an unloaded module.
     std::mutex m_unloaded_modules_lock;
     std::unordered_set<ModuleID> m_unloaded_modules;
     size_t m_in_flight_requests = 0;

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -3,6 +3,8 @@
 
 #include "integration.h"
 #include <future>
+#include <mutex>
+#include <unordered_set>
 #include "cor.h"
 #include "corprof.h"
 #include "module_metadata.h"
@@ -100,6 +102,10 @@ protected:
     std::unordered_map<ModuleID, std::unique_ptr<RejitHandlerModule>> m_modules;
     std::mutex m_ngenInlinersModules_lock;
     std::vector<ModuleID> m_ngenInlinersModules;
+
+    // Unloaded modules. PreprocessRejitRequests skips these so we don't call into the CLR after unload.
+    std::mutex m_unloaded_modules_lock;
+    std::unordered_set<ModuleID> m_unloaded_modules;
 
 public:
     RejitPreprocessor(CorProfiler* corProfiler, std::shared_ptr<RejitHandler> rejit_handler,

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -41,6 +41,9 @@ public:
     virtual void Shutdown() = 0;
     virtual RejitHandlerModule* GetOrAddModule(ModuleID moduleId) = 0;
     virtual bool HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef) = 0;
+    virtual void NotifyModuleLoaded(ModuleID moduleId) = 0;
+    virtual void AcquireInFlightRequest() = 0;
+    virtual void ReleaseInFlightRequest() = 0;
     virtual void RemoveModule(ModuleID moduleId) = 0;
     virtual void AddNGenInlinerModule(ModuleID moduleId) = 0;
 
@@ -97,15 +100,24 @@ protected:
                                   const std::vector<RejitRequestDefinition>& definitions,
                                   std::vector<MethodIdentifier>& rejitRequests);
 
+    // Counts one request as in flight until the returned token is destroyed. Must be held for as
+    // long as a module list taken from CorProfiler::module_ids is used.
+    std::shared_ptr<void> AcquireInFlightRequestToken();
+
 protected:
     std::mutex m_modules_lock;
     std::unordered_map<ModuleID, std::unique_ptr<RejitHandlerModule>> m_modules;
     std::mutex m_ngenInlinersModules_lock;
     std::vector<ModuleID> m_ngenInlinersModules;
 
-    // Unloaded modules. PreprocessRejitRequests skips these so we don't call into the CLR after unload.
+    // Unloaded modules. PreprocessRejitRequests skips these so we don't call into the CLR after
+    // unload. An entry is only needed while a request that could name the module is in flight, so
+    // unloads are recorded only while m_in_flight_requests is non-zero, and the whole set is
+    // dropped once the last request completes. Counting requests rather than modules keeps this
+    // O(1) per request; the cost is that an entry outlives the request that needed it.
     std::mutex m_unloaded_modules_lock;
     std::unordered_set<ModuleID> m_unloaded_modules;
+    size_t m_in_flight_requests = 0;
 
 public:
     RejitPreprocessor(CorProfiler* corProfiler, std::shared_ptr<RejitHandler> rejit_handler,
@@ -114,6 +126,9 @@ public:
     void Shutdown() override;
     RejitHandlerModule* GetOrAddModule(ModuleID moduleId) override;
     bool HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef) override;
+    void NotifyModuleLoaded(ModuleID moduleId) override;
+    void AcquireInFlightRequest() override;
+    void ReleaseInFlightRequest() override;
     void RemoveModule(ModuleID moduleId) override;
     void AddNGenInlinerModule(ModuleID moduleId) override;
     HRESULT RejitMethod(FunctionControlWrapper& functionControl) override;


### PR DESCRIPTION
## Summary of changes

Fix calls into CLR for an unloaded module.

## Reason for change

At shutdown, ReJit can call into the CLR for an unloaded module and this leads to a [crash](https://app.datadoghq.com/logs?query=service%3Ainstrumentation-telemetry-data-dotnet%20%28%40tags.severity%3Acrash%20OR%20%40error.is_crash%3Atrue%29%20%40uuid%3A41913d18-0e85-487c-8d75-e6d1dccdcf7f&agg_m=count&agg_m_source=base&agg_t=count&cf_lbyyhhwhyjj5l3rs65cb3w=aiugo4c9e5i04jdlqn4i&cols=source%2C%40tracer_version%2C%40language_version%2C%40org&event=AwAAAaBFEB0rz4QvTwAAABhBYUJGRUIwckFBREpoRm1LdjZkOC1RSHUAAAAkMTFhMDQ1MTEtNDMxMC00NzBlLWE1ZWQtMmRiNWZlOWFiOGNiAAG75g&messageDisplay=inline&refresh_mode=sliding&storage=live&stream_sort=desc&view=spans&viz=stream&from_ts=1787488456314&to_ts=1788784456314&live=true).

```c++
Error UnhandledException: Process was terminated due to an unknown unhandled exception of type EXCEPTION_ACCESS_VIOLATION (0xC0000005)
#0   0x00007ffb548beb4f PEFile::GetScopeName(char const**)
#1   0x00007ffb54a31d0a ProfToEEInterfaceImpl::GetModuleInfo2(uint64_t, unsigned char const**, unsigned long, unsigned long*, unsigned short* const, uint64_t*, unsigned long*)
#2   0x00007ffb2b56d2ff trace::GetModuleInfo(ICorProfilerInfo4*, unsigned long long const&) (c:\mnt\tracer\src\Datadog.Tracer.Native\clr_helpers.cpp:213)
#3   0x00007ffb2b58c3f6 trace::RejitPreprocessor<trace::IntegrationDefinition>::PreprocessRejitRequests(std::vector<unsigned __int64,std::allocator<unsigned __int64> > const&, std::vector<trace::IntegrationDefinition,std::allocator<trace::IntegrationDefinition> > const&, std::vector<trace::MethodIdentifier,std::allocator<trace::MethodIdentifier> >&) (c:\mnt\tracer\src\Datadog.Tracer.Native\rejit_preprocessor.cpp:565)
#4   0x0000000000000000 trace::RejitPreprocessor<trace::IntegrationDefinition>::RequestRejitForLoadedModules(std::vector<unsigned __int64,std::allocator<unsigned __int64> > const&, std::vector<trace::IntegrationDefinition,std::allocator<trace::IntegrationDefinition> > const&, bool) (c:\mnt\tracer\src\Datadog.Tracer.Native\rejit_preprocessor.cpp:436)
#5   0x0000000000000000 trace::RejitPreprocessor<trace::IntegrationDefinition>::EnqueueRequestRejitForLoadedModules::__l2::<lambda_1>::operator()() (c:\mnt\tracer\src\Datadog.Tracer.Native\rejit_preprocessor.cpp:535)
#6   0x0000000000000000 std::invoke(trace::RejitPreprocessor<trace::IntegrationDefinition>::EnqueueRequestRejitForLoadedModules::__l2::<lambda_1>&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\type_traits:1670)
#7   0x00007ffb2b59349a std::_Func_impl_no_alloc<`trace::RejitPreprocessor<trace::IntegrationDefinition>::EnqueueRequestRejitForLoadedModules'::`2'::<lambda_1>,void>::_Do_call() (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\functional:880)
#8   0x00007ffb2b594ac5 trace::RejitWorkOffloader::EnqueueThreadLoop(trace::RejitWorkOffloader*) (c:\mnt\tracer\src\Datadog.Tracer.Native\rejit_work_offloader.cpp:87)
#9   0x00007ffb2b594c1e std::thread::_Invoke<std::tuple<`trace::RejitWorkOffloader::RejitWorkOffloader'::`1'::<lambda_2_> >,0>(void*) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\thread:61)
#10  0x00007ffb2b61d1f4 thread_start<unsigned int (__cdecl*)(void *),1>(void* const) (minkernel\crts\ucrt\src\appcrt\startup\thread.cpp:97)
#11  0x00007ffb7c6be957 BaseThreadInitThunk
#12  0x00007ffb7dd6ad6c RtlUserThreadStart
```
## Implementation details

The idea is to handle modules clean up while we have in-flight ReJIT requests.
- Add notification mechanism to prepare `handlers`: for ReJIT handler, we remove reused module ID.
- Record when a request is in-flight. Use RAII to notify when a request ended.
- Record unloaded modules.
- When ReJIT requests are handled, check if the associated module is unloaded or not. If it's the case, just bail to avoid crashing.
- 
## Test coverage

## Other details

I reproduced the crash locally by adding a `sleep` in the `EnqueueThreadLoop` infinite-loop to simulate thread descheduling, processing slowness... and this PR actually fixes the crash.
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
