### PR TITLE
Build managed samples as AnyCPU

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1666,6 +1666,7 @@ partial class Build
                                 .SetMSBuildPath()
                                 .SetTargets("Restore", "Build")
                                 .SetConfiguration(BuildConfiguration)
+                                .SetTargetPlatformAnyCPU()
                                 .SetProperty("ApiVersion", ApiVersion)
                                 .When(Framework is not null, o => o.SetProperty("TargetFramework", Framework.ToString()))
                                 .SetProperty("BuildInParallel", "true")
@@ -1675,6 +1676,12 @@ partial class Build
               {
                   // TODO: set Samples.Trimming as don't build, as we have to explicitly build that on every platform anyway
                   DotNetBuild(config => config.SetConfiguration(BuildConfiguration)
+                                              .When(string.IsNullOrWhiteSpace(SampleName), x => x.SetProperty("Platform", "Any CPU"))
+                                              .When(!string.IsNullOrWhiteSpace(SampleName), x => x.SetTargetPlatformAnyCPU())
+                                              // Project references outside the generated samples solution can otherwise
+                                              // retain the build host's PlatformTarget and produce architecture-specific
+                                              // managed assemblies in the shared artifacts.
+                                              .SetProperty("PlatformTarget", "AnyCPU")
                                               .SetProperty("BuildInParallel", "true")
                                               .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
                                               .When(Framework is not null, x => x.SetFramework(Framework))
@@ -1790,6 +1797,7 @@ partial class Build
 
             DotNetPublish(config => config
                 .SetConfiguration(BuildConfiguration)
+                .SetTargetPlatformAnyCPU()
                 .SetRuntime(rid)
                 .SetFramework(Framework)
                 .CombineWith(projectsToPublish,


### PR DESCRIPTION
## Summary of changes

Build managed samples and trimming publications as AnyCPU.

## Reason for change

Azure and GitLab build native components with an architecture such as x64. That platform value was leaking into the later managed sample builds.

  The changes are needed because:

  - Generated solution builds require the configuration name Any CPU; inheriting x64 can cause MSB4126.
  - Individual project builds use AnyCPU and must override the native build platform.
  - PlatformTarget=AnyCPU also prevents referenced projects outside the generated solution from producing architecture-specific managed assemblies.
  - Trimming publishes still need AnyCPU for managed assemblies. The RID separately controls the platform-specific publish/R2R output.

## Implementation details

Use the appropriate `Any CPU`/`AnyCPU` platform values for solution, project, referenced-project, and trimming publish builds.

## Test coverage
