### PR TITLE
Disable Continuous Profiler in legacy security policy smoke test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxLegacySecurityPolicySmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxLegacySecurityPolicySmokeTest.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.IO;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,6 +22,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         public SandboxLegacySecurityPolicySmokeTest(ITestOutputHelper output)
             : base(output, "Sandbox.LegacySecurityPolicy")
         {
+            // This test expects instrumentation to fail gracefully, which writes an error log.
+            // Keep that expected error out of the directory scanned by CheckBuildLogsForErrors.
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, Path.GetTempPath());
         }
 
         [SkippableFact]


### PR DESCRIPTION
## Summary of changes

Disable Continuous Profiler and managed activation in the legacy security policy smoke test.

## Reason for change

This test intentionally prevents the managed tracer from loading, so it cannot provide the profiler's activation configuration. Continuous Profiler normally waits for activation configuration from that managed tracer. In this test, that configuration never arrives, causing an unrelated profiler error that can fail CI log validation. Disable profiling for this test while retaining normal CI log validation.

## Test coverage
