### PR TITLE
[Build] Disable libunwind clone progress output

### DIFF
--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -5,7 +5,7 @@ SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunw
 ExternalProject_Add(libunwind
     GIT_REPOSITORY https://github.com/DataDog/libunwind.git
     GIT_TAG gleocadie/v1.8.3-custom-1
-    GIT_PROGRESS true
+    GIT_PROGRESS false
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
## Summary of changes

Disable progress output while CMake clones the Datadog libunwind repository.

## Reason for change

Git progress output produces thousands of noisy lines in native build logs across CI systems, making useful build output harder to find.

## Implementation details

Set `GIT_PROGRESS` to `false` in the libunwind `ExternalProject_Add` configuration.

## Test coverage

Validated the CMake change with `git diff --check`. This only changes clone output verbosity and does not affect the downloaded source or native build behavior.

## Other details

None.