### PR TITLE
[tracer] Fix heap corruption

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/signature_builder.cpp
+++ b/tracer/src/Datadog.Tracer.Native/signature_builder.cpp
@@ -1,5 +1,7 @@
 #include "signature_builder.h"
 
+#include <algorithm>
+
 SignatureBuilder::SignatureBuilder()
 {
     _buffer = _stackSignatureBuffer;

--- a/tracer/src/Datadog.Tracer.Native/signature_builder.cpp
+++ b/tracer/src/Datadog.Tracer.Native/signature_builder.cpp
@@ -24,7 +24,7 @@ void SignatureBuilder::EnsureBufferSpace(size_t size)
 {
     if (_offset + size >= _length)
     {
-        auto newLength = std::max(_length * 2, _offset + size);
+        auto newLength = (std::max)(_length * 2, _offset + size);
         auto newSignatureBuffer = std::make_unique<COR_SIGNATURE[]>(newLength);
         memcpy(newSignatureBuffer.get(), _buffer, _offset);
         _heapSignatureBuffer = std::move(newSignatureBuffer);

--- a/tracer/src/Datadog.Tracer.Native/signature_builder.cpp
+++ b/tracer/src/Datadog.Tracer.Native/signature_builder.cpp
@@ -24,10 +24,11 @@ void SignatureBuilder::EnsureBufferSpace(size_t size)
 {
     if (_offset + size >= _length)
     {
-        auto newSignatureBuffer = std::make_unique<COR_SIGNATURE[]>(_length * 2);
-        memcpy(newSignatureBuffer.get(), _buffer, _length);
+        auto newLength = std::max(_length * 2, _offset + size);
+        auto newSignatureBuffer = std::make_unique<COR_SIGNATURE[]>(newLength);
+        memcpy(newSignatureBuffer.get(), _buffer, _offset);
         _heapSignatureBuffer = std::move(newSignatureBuffer);
         _buffer = _heapSignatureBuffer.get();
-        _length *= 2;
+        _length = newLength;
     }
 }

--- a/tracer/src/Datadog.Tracer.Native/signature_builder.h
+++ b/tracer/src/Datadog.Tracer.Native/signature_builder.h
@@ -8,6 +8,13 @@ class SignatureBuilder
 public:
     SignatureBuilder();
 
+    // _buffer points into this object while the signature fits in _stackSignatureBuffer, so a
+    // copied or moved instance would keep pointing at the original. Nothing needs either.
+    SignatureBuilder(const SignatureBuilder&) = delete;
+    SignatureBuilder& operator=(const SignatureBuilder&) = delete;
+    SignatureBuilder(SignatureBuilder&&) = delete;
+    SignatureBuilder& operator=(SignatureBuilder&&) = delete;
+
     void Append(const COR_SIGNATURE elementType);
     void Append(const void* elements, const size_t length);
 

--- a/tracer/test/Datadog.Tracer.Native.Tests/CMakeLists.txt
+++ b/tracer/test/Datadog.Tracer.Native.Tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(${TEST_EXECUTABLE_NAME}
     dataflow_test.cpp
     string_test.cpp
 	util_test.cpp
+    signature_builder_test.cpp
     test_link_stubs.cpp
 )
 

--- a/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj
+++ b/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj
@@ -102,6 +102,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="signature_builder_test.cpp" />
     <ClCompile Include="string_test.cpp" />
     <ClCompile Include="test_link_stubs.cpp" />
     <ClCompile Include="util_test.cpp" />

--- a/tracer/test/Datadog.Tracer.Native.Tests/signature_builder_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/signature_builder_test.cpp
@@ -1,0 +1,192 @@
+#include "pch.h"
+
+#include "../../src/Datadog.Tracer.Native/signature_builder.h"
+
+#include <type_traits>
+#include <vector>
+
+// SignatureBuilder::STACK_BUFFER_SIZE is private, so mirror it here: the builder starts on an
+// inline buffer of this size and moves to the heap once an append no longer fits.
+static constexpr size_t kStackBufferSize = 1000;
+
+// The builder holds a pointer into its own inline buffer, so copying or moving one would leave it
+// pointing at the original object.
+static_assert(!std::is_copy_constructible<SignatureBuilder>::value, "SignatureBuilder must not be copyable");
+static_assert(!std::is_copy_assignable<SignatureBuilder>::value, "SignatureBuilder must not be copyable");
+static_assert(!std::is_move_constructible<SignatureBuilder>::value, "SignatureBuilder must not be movable");
+static_assert(!std::is_move_assignable<SignatureBuilder>::value, "SignatureBuilder must not be movable");
+
+// Appends `count` bytes of a deterministic pattern, continuing from `startValue`.
+static std::vector<COR_SIGNATURE> AppendPattern(SignatureBuilder& builder, size_t count, size_t startValue = 0)
+{
+    std::vector<COR_SIGNATURE> expected;
+    expected.reserve(count);
+
+    for (size_t i = 0; i < count; i++)
+    {
+        const auto value = static_cast<COR_SIGNATURE>((startValue + i) % 256);
+        builder.Append(value);
+        expected.push_back(value);
+    }
+
+    return expected;
+}
+
+static void AssertSignatureEquals(const SignatureBuilder& builder, const std::vector<COR_SIGNATURE>& expected)
+{
+    ASSERT_EQ(expected.size(), builder.Size());
+
+    const auto* signature = builder.GetSignature();
+    for (size_t i = 0; i < expected.size(); i++)
+    {
+        ASSERT_EQ(expected[i], signature[i]) << "signature differs at index " << i;
+    }
+}
+
+TEST(SignatureBuilderTest, EmptyBuilderHasNoContent)
+{
+    SignatureBuilder builder;
+
+    ASSERT_EQ(0u, builder.Size());
+    ASSERT_NE(nullptr, builder.GetSignature());
+}
+
+TEST(SignatureBuilderTest, AppendSingleElement)
+{
+    SignatureBuilder builder;
+    builder.Append(static_cast<COR_SIGNATURE>(IMAGE_CEE_CS_CALLCONV_LOCAL_SIG));
+
+    ASSERT_EQ(1u, builder.Size());
+    ASSERT_EQ(IMAGE_CEE_CS_CALLCONV_LOCAL_SIG, builder.GetSignature()[0]);
+}
+
+TEST(SignatureBuilderTest, AppendBuffer)
+{
+    const COR_SIGNATURE elements[] = {0x01, 0x02, 0x03, 0x04};
+
+    SignatureBuilder builder;
+    builder.Append(elements, sizeof(elements));
+
+    AssertSignatureEquals(builder, {0x01, 0x02, 0x03, 0x04});
+}
+
+TEST(SignatureBuilderTest, AppendBufferOfLengthZeroKeepsContent)
+{
+    const COR_SIGNATURE elements[] = {0x99};
+
+    SignatureBuilder builder;
+    builder.Append(static_cast<COR_SIGNATURE>(0x42));
+    builder.Append(elements, 0);
+
+    AssertSignatureEquals(builder, {0x42});
+}
+
+TEST(SignatureBuilderTest, MixesSingleAndBufferAppends)
+{
+    const COR_SIGNATURE elements[] = {0x20, 0x21};
+
+    SignatureBuilder builder;
+    builder.Append(static_cast<COR_SIGNATURE>(0x10));
+    builder.Append(elements, sizeof(elements));
+    builder.Append(static_cast<COR_SIGNATURE>(0x30));
+
+    AssertSignatureEquals(builder, {0x10, 0x20, 0x21, 0x30});
+}
+
+TEST(SignatureBuilderTest, StaysOnInlineBufferBelowCapacity)
+{
+    SignatureBuilder builder;
+    const auto* inlineBuffer = builder.GetSignature();
+
+    const auto expected = AppendPattern(builder, kStackBufferSize - 1);
+
+    ASSERT_EQ(inlineBuffer, builder.GetSignature()) << "should not have allocated yet";
+    AssertSignatureEquals(builder, expected);
+}
+
+TEST(SignatureBuilderTest, MovesToHeapAtCapacity)
+{
+    SignatureBuilder builder;
+    const auto* inlineBuffer = builder.GetSignature();
+
+    // The growth check is `_offset + size >= _length`, so the last inline byte is never used and
+    // filling the whole inline buffer already allocates.
+    const auto expected = AppendPattern(builder, kStackBufferSize);
+
+    ASSERT_NE(inlineBuffer, builder.GetSignature()) << "should have moved to the heap";
+    AssertSignatureEquals(builder, expected);
+}
+
+TEST(SignatureBuilderTest, PreservesContentWhenGrowingPastInlineBuffer)
+{
+    SignatureBuilder builder;
+    auto expected = AppendPattern(builder, kStackBufferSize - 1);
+
+    // Cross the boundary one element at a time so the copy happens with a full inline buffer.
+    for (size_t i = 0; i < 10; i++)
+    {
+        const auto value = static_cast<COR_SIGNATURE>(0xA0 + i);
+        builder.Append(value);
+        expected.push_back(value);
+    }
+
+    AssertSignatureEquals(builder, expected);
+}
+
+// The new capacity is `max(_length * 2, _offset + size)`. This append needs 3001 bytes while
+// doubling would only give 2000, so the requested size wins over doubling.
+TEST(SignatureBuilderTest, GrowsForSingleAppendLargerThanInlineBuffer)
+{
+    std::vector<COR_SIGNATURE> elements;
+    for (size_t i = 0; i < kStackBufferSize * 3; i++)
+    {
+        elements.push_back(static_cast<COR_SIGNATURE>(i % 256));
+    }
+
+    SignatureBuilder builder;
+    builder.Append(static_cast<COR_SIGNATURE>(0x7F));
+    builder.Append(elements.data(), elements.size());
+
+    std::vector<COR_SIGNATURE> expected{0x7F};
+    expected.insert(expected.end(), elements.begin(), elements.end());
+
+    AssertSignatureEquals(builder, expected);
+}
+
+// Same "requested size wins over doubling" path, but growing from a heap buffer rather than from
+// the inline one, so the content is copied heap-to-heap.
+TEST(SignatureBuilderTest, GrowsForSingleAppendLargerThanDoubledHeapBuffer)
+{
+    SignatureBuilder builder;
+
+    // Move off the inline buffer first; capacity is 2000 once this append reallocates.
+    auto expected = AppendPattern(builder, kStackBufferSize);
+
+    std::vector<COR_SIGNATURE> elements;
+    for (size_t i = 0; i < kStackBufferSize * 5; i++)
+    {
+        elements.push_back(static_cast<COR_SIGNATURE>((i * 3) % 256));
+    }
+
+    builder.Append(elements.data(), elements.size());
+    expected.insert(expected.end(), elements.begin(), elements.end());
+
+    ASSERT_EQ(kStackBufferSize * 6, builder.Size());
+    AssertSignatureEquals(builder, expected);
+}
+
+TEST(SignatureBuilderTest, PreservesContentAcrossRepeatedGrowths)
+{
+    SignatureBuilder builder;
+    std::vector<COR_SIGNATURE> expected;
+
+    // Enough rounds to reallocate several times, covering the heap-to-heap copy.
+    for (size_t round = 0; round < 40; round++)
+    {
+        const auto appended = AppendPattern(builder, 250, expected.size());
+        expected.insert(expected.end(), appended.begin(), appended.end());
+    }
+
+    ASSERT_EQ(10000u, builder.Size());
+    AssertSignatureEquals(builder, expected);
+}


### PR DESCRIPTION
## Summary of changes

Fix heap corruption in signature builder. And make the `SignatureBuilder` class safer.

## Reason for change

The bug here is that we do not check if `_offset + size` is > `_length * 2`. Since we always double the size of the buffer, if the new size if bigger that the doubled'.... we will [crash](https://app.datadoghq.com/logs?query=service%3Ainstrumentation-telemetry-data-dotnet%20%28%40tags.severity%3Acrash%20OR%20%40error.is_crash%3Atrue%29%20%40uuid%3A7a64e666-3b25-4270-93dc-68601aa18954&agg_m=count&agg_m_source=base&agg_t=count&cf_lbyyhhwhyjj5l3rs65cb3w=aiugo4c9e5i04jdlqn4i&cols=source%2C%40tracer_version%2C%40language_version%2C%40org&event=AwAAAaB1AovIXhaaZAAAABhBYUIxQW92SUFBRGk4SHk4QmY2b01BRGgAAAAkMTFhMDc1NGMtNTIwMC00MWM1LWE4MDAtMjYyZmE1NjY2MDExAALizg&messageDisplay=inline&refresh_mode=sliding&storage=live&stream_sort=desc&view=spans&viz=stream&from_ts=1787488456314&to_ts=1788784456314&live=true).

```c++
#16  0x00007ffbeafeb3a1 RtlFreeHeap
#17  0x00007ffbabdfcee0 _free_base(void*) (minkernel\crts\ucrt\src\appcrt\heap\free_base.cpp:105)
#18  0x0000000000000000 std::default_delete<unsigned char [0]>::operator()(unsigned char*) const (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3323)
#19  0x0000000000000000 std::unique_ptr<unsigned char [0],std::default_delete<unsigned char [0]> >::reset(unsigned char*) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3614)
#20  0x0000000000000000 std::unique_ptr<unsigned char [0],std::default_delete<unsigned char [0]> >::operator=(std::unique_ptr<unsigned char [0],std::default_delete<unsigned char [0]> >&&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3526)
#21  0x00007ffbabdd5505 SignatureBuilder::EnsureBufferSpace(unsigned long long) (c:\mnt\tracer\src\Datadog.Tracer.Native\signature_builder.cpp:29)
#22  0x0000000000000000 SignatureBuilder::Append(void const*, const unsigned long long) (c:\mnt\tracer\src\Datadog.Tracer.Native\signature_builder.cpp:19)
#23  0x00007ffbabdc8c7f trace::CallTargetTokens::ModifyLocalSig(ILRewriter*, trace::TypeSignature*, std::vector<trace::TypeSignature,std::allocator<trace::TypeSignature> >*, trace::FunctionInfo*, unsigned long*, unsigned long*, unsigned long*, unsigned long*, unsigned long*, unsigned int*, unsigned int*, unsigned int*, std::vector<unsigned long,std::allocator<unsigned long> >&, bool) (c:\mnt\tracer\src\Datadog.Tracer.Native\calltarget_tokens.cpp:492)
#24  0x00007ffbabdc9943 trace::CallTargetTokens::ModifyLocalSigAndInitialize(void*, trace::TypeSignature*, std::vector<trace::TypeSignature,std::allocator<trace::TypeSignature> >*, trace::FunctionInfo*, unsigned long*, unsigned long*, unsigned long*, unsigned long*, unsigned long*, unsigned int*, unsigned int*, unsigned int*, ILInstr**, std::vector<unsigned long,std::allocator<unsigned long> >&, bool) (c:\mnt\tracer\src\Datadog.Tracer.Native\calltarget_tokens.cpp:910)
#25  0x00007ffbabda8b6c debugger::DebuggerMethodRewriter::Rewrite(trace::RejitHandlerModule*, trace::RejitHandlerModuleMethod*, ICorProfilerFunctionControl*, ICorProfilerInfo*, std::vector<std::shared_ptr<debugger::MethodProbeDefinition>,std::allocator<std::shared_ptr<debugger::MethodProbeDefinition> > >&, std::vector<std::shared_ptr<debugger::LineProbeDefinition>,std::allocator<std::shared_ptr<debugger::LineProbeDefinition> > >&, std::vector<std::shared_ptr<debugger::SpanProbeOnMethodDefinition>,std::allocator<std::shared_ptr<debugger::SpanProbeOnMethodDefinition> > >&) const (c:\mnt\tracer\src\Datadog.Tracer.Native\debugger_method_rewriter.cpp:2295)
#26  0x00007ffbabd9ff9f debugger::DebuggerMethodRewriter::Rewrite(trace::RejitHandlerModule*, trace::RejitHandlerModuleMethod*, ICorProfilerFunctionControl*, ICorProfilerInfo*) (c:\mnt\tracer\src\Datadog.Tracer.Native\debugger_method_rewriter.cpp:337)
#27  0x00007ffbabdcd22d fault_tolerant::FaultTolerantRewriter::RewriteInternal(trace::RejitHandlerModule*, trace::RejitHandlerModuleMethod*, ICorProfilerFunctionControl*, ICorProfilerInfo*) (c:\mnt\tracer\src\Datadog.Tracer.Native\fault_tolerant_rewriter.cpp:496)
#28  0x00007ffbabdcd613 fault_tolerant::FaultTolerantRewriter::Rewrite(trace::RejitHandlerModule*, trace::RejitHandlerModuleMethod*, ICorProfilerFunctionControl*, ICorProfilerInfo*) (c:\mnt\tracer\src\Datadog.Tracer.Native\fault_tolerant_rewriter.cpp:585)
#29  0x00007ffbabd59526 trace::RejitPreprocessor<std::shared_ptr<debugger::MethodProbeDefinition> >::RejitMethod(trace::FunctionControlWrapper&) (c:\mnt\tracer\src\Datadog.Tracer.Native\rejit_preprocessor.cpp:210)
...
```

## Implementation details

- Compute the new length 
- Mark the class as not copyable/moveable to avoid issues.

## Test coverage

- Adding new unit tests for this class (native)

## Other details
<!-- Fixes #{issue} -->


<!--  ⚠️ Note:

Where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews.

MergeQueue is NOT enabled in this repository. If you have write access to the repo, the PR has 1-2 approvals (see above), and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #apm-dotnet channel in Slack.
-->
