### PR TITLE
[CI] Skip Aerospike tests on transient Docker failures

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -43,8 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             [PackageVersionData(nameof(PackageVersions.Aerospike))] string packageVersion,
             [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
-            _aerospikeFixture.SkipIfUnavailable();
-            ConfigureContainers(_aerospikeFixture);
+            await ConfigureContainers(_aerospikeFixture);
 
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -24,11 +24,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     [UsesVerify]
     public class AerospikeTests : TracingIntegrationTest, IClassFixture<AerospikeFixture>
     {
+        private readonly AerospikeFixture _aerospikeFixture;
+
         public AerospikeTests(ITestOutputHelper output, AerospikeFixture aerospikeFixture)
             : base("Aerospike", output)
         {
+            _aerospikeFixture = aerospikeFixture;
             SetServiceVersion("1.0.0");
-            ConfigureContainers(aerospikeFixture);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsAerospike(metadataSchemaVersion);
@@ -41,6 +43,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             [PackageVersionData(nameof(PackageVersions.Aerospike))] string packageVersion,
             [MetadataSchemaVersionData] string metadataSchemaVersion)
         {
+            _aerospikeFixture.SkipIfUnavailable();
+            ConfigureContainers(_aerospikeFixture);
+
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";
             var clientSpanServiceName = isExternalSpan ? $"{EnvironmentHelper.FullSampleName}-aerospike" : EnvironmentHelper.FullSampleName;

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ContainerFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ContainerFixture.cs
@@ -8,7 +8,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
+using Docker.DotNet;
 using Xunit;
 
 namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
@@ -16,10 +18,18 @@ namespace Datadog.Trace.TestHelpers.AutoInstrumentation.Containers;
 public abstract class ContainerFixture : IAsyncLifetime
 {
     private IReadOnlyDictionary<string, object>? _resources;
+    private string? _initializationSkipReason;
 
     public async Task InitializeAsync()
     {
-        _resources = await ContainersRegistry.GetOrAdd(GetType(), InitializeResources);
+        try
+        {
+            _resources = await ContainersRegistry.GetOrAdd(GetType(), InitializeResources);
+        }
+        catch (DockerApiException ex) when (IsTransientPlatformError(ex))
+        {
+            _initializationSkipReason = $"Docker failed to start the test container because of a transient platform error: {ex.ResponseBody}";
+        }
     }
 
     // Do not implement, the ContainersRegistry is responsible for disposing the containers
@@ -27,9 +37,27 @@ public abstract class ContainerFixture : IAsyncLifetime
 
     public virtual IEnumerable<KeyValuePair<string, string>> GetEnvironmentVariables() => Enumerable.Empty<KeyValuePair<string, string>>();
 
+    public void SkipIfUnavailable()
+    {
+        if (_initializationSkipReason is not null)
+        {
+            throw new SkipException(_initializationSkipReason);
+        }
+    }
+
     protected abstract Task InitializeResources(Action<string, object> registerResource);
 
-    protected T GetResource<T>(string key) => (T)_resources![key];
+    protected T GetResource<T>(string key)
+    {
+        SkipIfUnavailable();
+
+        return (T)_resources![key];
+    }
+
+    private static bool IsTransientPlatformError(DockerApiException exception)
+        => exception.StatusCode == HttpStatusCode.InternalServerError
+        && exception.ResponseBody?.Contains("unable to apply cgroup configuration") == true
+        && exception.ResponseBody.Contains("Message recipient disconnected from message bus without replying");
 
     private async Task<IReadOnlyDictionary<string, object>> InitializeResources()
     {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -376,15 +376,19 @@ namespace Datadog.Trace.TestHelpers
             EnvironmentHelper.CustomEnvironmentVariables[key] = value;
         }
 
-        public void ConfigureContainers(params ContainerFixture[] containers)
+        public Task ConfigureContainers(params ContainerFixture[] containers)
         {
             foreach (var container in containers)
             {
+                container.SkipIfUnavailable();
+
                 foreach (var variable in container.GetEnvironmentVariables())
                 {
                     SetEnvironmentVariable(variable.Key, variable.Value);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         public void ConfigureOtlpExport(OtlpTestAgentSession otlpSession, string protocol = "http/protobuf")


### PR DESCRIPTION
## Summary of changes

Skip Aerospike integration tests when container startup hits the known transient Docker cgroup/systemd failure.

## Reason for change

A platform-level message bus disconnect can fail the shared fixture and all Aerospike test variants.

[Example of failure](https://dev.azure.com/datadoghq/a51c4863-3eb4-4c5d-878a-58b41a049e4e/_apis/build/builds/208625/logs/11854):

```
2026-09-07T17:36:36.8769663Z 17:36:36 [DBG]   Failed Datadog.Trace.ClrProfiler.IntegrationTests.AerospikeTests.SubmitTraces(packageVersion: "4.0.3", metadataSchemaVersion: "v1") [1 ms]
2026-09-07T17:36:36.8770584Z 17:36:36 [DBG]   Error Message:
2026-09-07T17:36:36.8772138Z 17:36:36 [DBG]    Docker.DotNet.DockerApiException : Docker API responded with status code=InternalServerError, response={"message":"failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: unable to start unit \"docker-2aef7591fe36e44697ab44532e6d870b0093c3585c46cc73a046a8cfc306b928.scope\" (properties [{Name:Description Value:\"libcontainer container 2aef7591fe36e44697ab44532e6d870b0093c3585c46cc73a046a8cfc306b928\"} {Name:Slice Value:\"system.slice\"} {Name:Delegate Value:true} {Name:PIDs Value:@au [12610]} {Name:MemoryAccounting Value:true} {Name:CPUAccounting Value:true} {Name:IOAccounting Value:true} {Name:TasksAccounting Value:true} {Name:DefaultDependencies Value:false}]): Message recipient disconnected from message bus without replying"}
2026-09-07T17:36:36.8773769Z 17:36:36 [DBG] 
2026-09-07T17:36:36.8774077Z 17:36:36 [DBG]   Stack Trace:
2026-09-07T17:36:36.8774500Z 17:36:36 [DBG]      at Docker.DotNet.DockerClient.HandleIfErrorResponseAsync(HttpStatusCode statusCode, HttpResponseMessage response, IEnumerable`1 handlers)
2026-09-07T17:36:36.8775078Z 17:36:36 [DBG]    at Docker.DotNet.DockerClient.MakeRequestAsync(IEnumerable`1 errorHandlers, HttpMethod method, String path, IQueryString queryString, IRequestContent body, IDictionary`2 headers, TimeSpan timeout, CancellationToken token)
2026-09-07T17:36:36.8775641Z 17:36:36 [DBG]    at Docker.DotNet.ContainerOperations.StartContainerAsync(String id, ContainerStartParameters parameters, CancellationToken cancellationToken)
2026-09-07T17:36:36.8776130Z 17:36:36 [DBG]    at DotNet.Testcontainers.Clients.TestcontainersClient.StartAsync(String id, CancellationToken ct)
2026-09-07T17:36:36.8776550Z 17:36:36 [DBG]    at DotNet.Testcontainers.Containers.DockerContainer.UnsafeStartAsync(CancellationToken ct)
2026-09-07T17:36:36.8776977Z 17:36:36 [DBG]    at DotNet.Testcontainers.Containers.DockerContainer.StartAsync(CancellationToken ct)
2026-09-07T17:36:36.8777520Z 17:36:36 [DBG]    at Datadog.Trace.TestHelpers.AutoInstrumentation.Containers.AerospikeFixture.InitializeResources(Action`2 registerResource) in /project/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/AerospikeFixture.cs:line 49
2026-09-07T17:36:36.8778151Z 17:36:36 [DBG]    at Datadog.Trace.TestHelpers.AutoInstrumentation.Containers.ContainerFixture.InitializeResources() in /project/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ContainerFixture.cs:line 38
2026-09-07T17:36:36.8778820Z 17:36:36 [DBG]    at Datadog.Trace.TestHelpers.AutoInstrumentation.Containers.ContainersRegistry.GetOrAdd(Type type, Func`1 createResources) in /project/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ContainersRegistry.cs:line 31
2026-09-07T17:36:36.8779510Z 17:36:36 [DBG]    at Datadog.Trace.TestHelpers.AutoInstrumentation.Containers.ContainersRegistry.GetOrAdd(Type type, Func`1 createResources) in /project/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ContainersRegistry.cs:line 41
2026-09-07T17:36:36.8780188Z 17:36:36 [DBG]    at Datadog.Trace.TestHelpers.AutoInstrumentation.Containers.ContainerFixture.InitializeAsync() in /project/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/Containers/ContainerFixture.cs:line 22
```

## Implementation details

Detect the specific Docker 500 response during fixture initialization, preserve the skip reason, and raise it inside the skippable Aerospike test.

## Test coverage

No new tests added; this is test infrastructure handling for a CI platform flake.