### PR TITLE
Drop specific Windows SDK dependency as in other places we use generic 10.0 version

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -49,7 +49,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>..\..\..\artifacts\native-bin\Datadog.Trace.ClrProfiler.Native\$(Configuration)\x86\</OutDir>
     <IntDir>..\..\..\artifacts\native-obj\Datadog.Trace.ClrProfiler.Native\$(Configuration)\x86\</IntDir>
@@ -59,7 +59,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>..\..\..\artifacts\native-bin\Datadog.Trace.ClrProfiler.Native\$(Configuration)\x86\</OutDir>
@@ -70,7 +70,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>..\..\..\artifacts\native-bin\Datadog.Trace.ClrProfiler.Native\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>..\..\..\artifacts\native-obj\Datadog.Trace.ClrProfiler.Native\$(Configuration)\$(Platform)\</IntDir>
@@ -80,7 +80,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>..\..\..\artifacts\native-bin\Datadog.Trace.ClrProfiler.Native\$(Configuration)\$(Platform)\</OutDir>


### PR DESCRIPTION
## Summary of changes

Use 10.x SKD version.

## Reason for change

It allows to build on any 10.x SDK without changes on our side.
SDKs are updated quite frequently, so bumping version every time is repeated job.

## Implementation details
N/A

## Test coverage
Not changed

## Other details
None