### PR TITLE
Fix UB on access to uninitialized m_refCount in AddRef/Release

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_cor_profiler_function_control.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_cor_profiler_function_control.cpp
@@ -10,6 +10,7 @@ namespace instrumented_assembly_generator
 CorProfilerFunctionControl::CorProfilerFunctionControl(ICorProfilerFunctionControl* corProfilerFunctionControl,
                                                        std::shared_ptr<ICorProfilerInfo12> corProfilerInfo12,
                                                        ModuleID moduleId, mdMethodDef methodId) :
+    m_refCount(0),
     m_corProfilerInfo(std::move(corProfilerInfo12)),
     m_moduleId(moduleId),
     m_methodId(methodId)

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_cor_profiler_info.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_cor_profiler_info.cpp
@@ -5,6 +5,7 @@
 namespace instrumented_assembly_generator
 {
 CorProfilerInfo::CorProfilerInfo(IUnknown* pICorProfilerInfoUnk)
+    : m_refCount(0)
 {
     m_pICorProfilerInfoUnk.Attach(pICorProfilerInfoUnk);
 }

--- a/tracer/src/Datadog.Tracer.Native/fault_tolerant_cor_profiler_function_control.cpp
+++ b/tracer/src/Datadog.Tracer.Native/fault_tolerant_cor_profiler_function_control.cpp
@@ -11,6 +11,7 @@ FaultTolerantCorProfilerFunctionControl::FaultTolerantCorProfilerFunctionControl
     mdMethodDef methodId,
     RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler,
     InjectSuccessfulInstrumentationLambda injectSuccessfulInstrumentation) :
+    m_refCount(0),
     m_moduleId(moduleId),
     m_methodId(methodId),
     moduleHandler(moduleHandler),


### PR DESCRIPTION
## Summary of changes

Add initialization to reference counters for COM interfaces.

## Reason for change

`std::atomic<int>` default ctor doesn't initialize it to 0 by default. Accessing uninitialized counter is UB.

## Implementation details
Set to `0` by default.

## Test coverage
Default.

## Other details
None