### PR TITLE
[Debugger] Skip nested byref-like locals after type-forward resolution

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -1702,8 +1702,8 @@ HRESULT IsTypeTokenByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMe
 
         if (FAILED(hr))
         {
-            // Callers that instantiate unmanaged-to-managed generics (e.g. LogLocal<TLocal>)
-            // must skip the value when we cannot prove it is not byref-like.
+            // Callers must fail closed when we cannot prove the type is not byref-like:
+            // skip LogArg/LogLocal, or reject the rewrite for return/containing types.
             Logger::Warn("[IsTypeTokenByRefLike] Failed to resolve TypeRef. Returning failure so callers can skip.");
             isTypeIsByRefLike = false;
             return hr;

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -565,6 +565,24 @@ std::tuple<unsigned, int> TypeSignature::GetElementTypeAndFlags() const
     return {elementType, typeFlags};
 }
 
+bool TypeSignature::MayBeByRefLike() const
+{
+    const auto [elementType, typeFlags] = GetElementTypeAndFlags();
+
+    // Ref structs are value types (including GENERICINST of a value type, e.g. Span<T>).
+    // Primitives, string, object, and classes cannot be byref-like.
+    switch (elementType)
+    {
+        case ELEMENT_TYPE_VALUETYPE:
+        case ELEMENT_TYPE_TYPEDBYREF:
+            return true;
+        case ELEMENT_TYPE_GENERICINST:
+            return (typeFlags & TypeFlagBoxedType) != 0;
+        default:
+            return false;
+    }
+}
+
 mdToken TypeSignature::GetTypeTok(const ComPtr<IMetaDataEmit2>& pEmit, mdAssemblyRef corLibRef) const
 {
     mdToken token = mdTokenNil;
@@ -1704,7 +1722,7 @@ HRESULT IsTypeTokenByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMe
         {
             // Callers must fail closed when we cannot prove the type is not byref-like:
             // skip LogArg/LogLocal, or reject the rewrite for return/containing types.
-            Logger::Warn("[IsTypeTokenByRefLike] Failed to resolve TypeRef. Returning failure so callers can skip.");
+            Logger::Warn("[IsTypeTokenByRefLike] Failed to resolve TypeRef. Returning failure to the caller.");
             isTypeIsByRefLike = false;
             return hr;
         }

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -1364,7 +1364,7 @@ HRESULT ResolveType(ICorProfilerInfo4* info,
                     ComPtr<IMetaDataImport2>& resolvedMetadataImport)
 {
     mdToken resolutionScope = mdTokenNil; // will hold either AssemblyRef or ModuleRef token
-    mdToken enclosingType = mdTokenNil;
+    std::vector<mdToken> enclosingTypeRefs;
     ULONG nameSize = 0;
     std::vector<WCHAR> refTypeName(kNameMaxSize);
 
@@ -1376,21 +1376,14 @@ HRESULT ResolveType(ICorProfilerInfo4* info,
         return E_FAIL;
     }
 
-    mdToken tempToken = mdTokenNil;
+    WCHAR unusedName[kNameMaxSize]{};
     // To avoid ending up in an infinite loop, I'm limiting the execution to 1000 (arbitrary large number that will be
     // well beyond enough)
     int retryCount = 1000;
-    while (retryCount-- > 0 && 
-        TypeFromToken(resolutionScope) != mdtAssemblyRef && 
-        TypeFromToken(resolutionScope) != mdtModuleRef &&
-        resolutionScope != mdTokenNil)
+    while (retryCount-- > 0 && TypeFromToken(resolutionScope) == mdtTypeRef)
     {
-        tempToken = resolutionScope;
-        if (enclosingType == mdTokenNil)
-        {
-            enclosingType = tempToken;
-        }
-        hr = metadata_import->GetTypeRefProps(tempToken, &resolutionScope, nullptr, 0, &nameSize);
+        enclosingTypeRefs.push_back(resolutionScope);
+        hr = metadata_import->GetTypeRefProps(resolutionScope, &resolutionScope, unusedName, kNameMaxSize, &nameSize);
         if (FAILED(hr))
         {
             Logger::Warn("[ResolveType] GetTypeRefProps [2] has failed. typeRefToken: ", typeRefToken);
@@ -1469,21 +1462,54 @@ HRESULT ResolveType(ICorProfilerInfo4* info,
     const auto& resolutionScopeName = assemblyMetadata.name;
 
     resolvedTypeDefToken = mdTokenNil;
-    if (enclosingType != mdTokenNil)
+    if (!enclosingTypeRefs.empty())
     {
-        DBG("ResolveType: Found enclosing type, try to get parent token");
-        std::vector<WCHAR> enclosingRefTypeName(kNameMaxSize);
-        hr = metadata_import->GetTypeRefProps(enclosingType, &resolutionScope, enclosingRefTypeName.data(),
-                                              kNameMaxSize, &nameSize);
+        // Nested TypeRefs (Lock+Scope, Span`1+Enumerator, ...) must be resolved in the module
+        // that actually defines the enclosing type. That module can differ from the original
+        // TypeRef assembly when the parent is type-forwarded (System.Runtime -> CoreLib).
+        DBG("ResolveType: Found enclosing type(s), resolving nested TypeRef from outermost parent");
+        for (int i = static_cast<int>(enclosingTypeRefs.size()) - 1; i >= 0; --i)
+        {
+            std::vector<WCHAR> enclosingRefTypeName(kNameMaxSize);
+            mdToken unusedScope = mdTokenNil;
+            hr = metadata_import->GetTypeRefProps(enclosingTypeRefs[i], &unusedScope, enclosingRefTypeName.data(),
+                                                  kNameMaxSize, &nameSize);
+            if (FAILED(hr))
+            {
+                Logger::Warn("[ResolveType] GetTypeRefProps [3] has failed. typeRefToken: ", typeRefToken);
+            }
+            IfFailRet(hr);
+
+            if (i == static_cast<int>(enclosingTypeRefs.size()) - 1)
+            {
+                hr = ResolveTypeInternal(info, loadedModules, enclosingRefTypeName, mdTokenNil, resolutionScopeName,
+                                         resolvedTypeDefToken, resolvedMetadataImport);
+                IfFailRet(hr);
+            }
+            else
+            {
+                mdTypeDef nestedTypeDef = mdTypeDefNil;
+                hr = resolvedMetadataImport->FindTypeDefByName(enclosingRefTypeName.data(), resolvedTypeDefToken,
+                                                               &nestedTypeDef);
+                if (FAILED(hr))
+                {
+                    Logger::Warn("[ResolveType] FindTypeDefByName for enclosing nested type has failed. typeRefToken: ",
+                                 typeRefToken);
+                }
+                IfFailRet(hr);
+                resolvedTypeDefToken = nestedTypeDef;
+            }
+        }
+
+        mdTypeDef nestedTypeDef = mdTypeDefNil;
+        hr = resolvedMetadataImport->FindTypeDefByName(refTypeName.data(), resolvedTypeDefToken, &nestedTypeDef);
         if (FAILED(hr))
         {
-            Logger::Warn("[ResolveType] GetTypeRefProps [3] has failed. typeRefToken: ", typeRefToken);
+            Logger::Warn("[ResolveType] FindTypeDefByName for nested type has failed. typeRefToken: ", typeRefToken);
         }
         IfFailRet(hr);
-
-        hr = ResolveTypeInternal(info, loadedModules, enclosingRefTypeName, mdTokenNil, resolutionScopeName,
-                                 resolvedTypeDefToken, resolvedMetadataImport);
-        IfFailRet(hr);
+        resolvedTypeDefToken = nestedTypeDef;
+        return S_OK;
     }
 
     return ResolveTypeInternal(info, loadedModules, refTypeName, resolvedTypeDefToken, resolutionScopeName,
@@ -1676,9 +1702,11 @@ HRESULT IsTypeTokenByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMe
 
         if (FAILED(hr))
         {
-            // For now we ignore issues with resolving types.
+            // Callers that instantiate unmanaged-to-managed generics (e.g. LogLocal<TLocal>)
+            // must skip the value when we cannot prove it is not byref-like.
+            Logger::Warn("[IsTypeTokenByRefLike] Failed to resolve TypeRef. Returning failure so callers can skip.");
             isTypeIsByRefLike = false;
-            return S_OK;
+            return hr;
         }
     }
 

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -1722,7 +1722,8 @@ HRESULT IsTypeTokenByRefLike(ICorProfilerInfo4* corProfilerInfo4, const ModuleMe
         {
             // Callers must fail closed when we cannot prove the type is not byref-like:
             // skip LogArg/LogLocal, or reject the rewrite for return/containing types.
-            Logger::Warn("[IsTypeTokenByRefLike] Failed to resolve TypeRef. Returning failure to the caller.");
+            // Expected when the defining module is not loaded yet.
+            DBG("[IsTypeTokenByRefLike] Failed to resolve TypeRef. Returning failure to the caller.");
             isTypeIsByRefLike = false;
             return hr;
         }

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -462,6 +462,7 @@ struct TypeSignature
     mdToken GetTypeTok(const ComPtr<IMetaDataEmit2>& pEmit, mdAssemblyRef corLibRef) const;
     shared::WSTRING GetTypeTokName(ComPtr<IMetaDataImport2>& pImport) const;
     std::tuple<unsigned, int> GetElementTypeAndFlags() const;
+    bool MayBeByRefLike() const;
     ULONG GetSignature(PCCOR_SIGNATURE& data) const;
 };
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -13,6 +13,32 @@
 namespace debugger
 {
 
+namespace
+{
+// Ref structs are valuetypes (including GENERICINST of a valuetype, e.g. Span<T>).
+// Void, primitives, string, object, and classes cannot be byref-like; calling
+// IsTypeByRefLike for those signatures can fail (nil token / synthetic TypeRef)
+// and must not reject the rewrite.
+bool SignatureMayBeByRefLike(unsigned elementType, int typeFlags)
+{
+    if ((typeFlags & TypeFlagVoid) != 0)
+    {
+        return false;
+    }
+
+    switch (elementType)
+    {
+        case ELEMENT_TYPE_VALUETYPE:
+        case ELEMENT_TYPE_TYPEDBYREF:
+            return true;
+        case ELEMENT_TYPE_GENERICINST:
+            return (typeFlags & TypeFlagBoxedType) != 0;
+        default:
+            return false;
+    }
+}
+} // namespace
+
 // Get function locals
 HRESULT DebuggerMethodRewriter::GetFunctionLocalSignature(const ModuleMetadata& module_metadata, ILRewriter& rewriter, FunctionLocalSignature& localSignature)
 {
@@ -2292,31 +2318,39 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
     {
         // In async methods, the return value can't be byref-like (it can't be Task<T> where T is byref-like, because
         // byref-like can't exist as a generic param). Therefore, we only need to worry about non-async methods.
-        // EndMethod<TReturn> instantiates a managed generic with the return type, so unknown must fail closed.
-        bool isReturnByRefLike = false;
-        hr = IsTypeByRefLike(m_corProfiler->info_, module_metadata, methodReturnType, debuggerTokens->GetCorLibAssemblyRef(), isReturnByRefLike);
-        if (FAILED(hr) || isReturnByRefLike)
+        // EndMethod<TReturn> instantiates a managed generic with the return type, so unknown must fail closed
+        // for signatures that can actually be ref structs.
+        const auto [returnElementType, returnTypeFlags] = methodReturnType.GetElementTypeAndFlags();
+        if (SignatureMayBeByRefLike(returnElementType, returnTypeFlags))
         {
-            if (FAILED(hr))
+            bool isReturnByRefLike = false;
+            hr = IsTypeByRefLike(m_corProfiler->info_, module_metadata, methodReturnType, debuggerTokens->GetCorLibAssemblyRef(), isReturnByRefLike);
+            if (FAILED(hr) || isReturnByRefLike)
             {
-                Logger::Warn("DebuggerRewriter: Failed to determine if the return value is By-Ref like.");
+                if (FAILED(hr))
+                {
+                    Logger::Warn("DebuggerRewriter: Failed to determine if the return value is By-Ref like.");
+                }
+                MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_probe_byreflike_return_not_supported);
+                return E_NOTIMPL;
             }
-            MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_probe_byreflike_return_not_supported);
-            return E_NOTIMPL;
         }
     }
 
-    bool isContainingTypeByRefLike = false;
-    hr = IsTypeTokenByRefLike(m_corProfiler->info_, module_metadata, caller->type.id, isContainingTypeByRefLike);
-
-    if (FAILED(hr) || isContainingTypeByRefLike)
+    if (caller->type.valueType)
     {
-        if (FAILED(hr))
+        bool isContainingTypeByRefLike = false;
+        hr = IsTypeTokenByRefLike(m_corProfiler->info_, module_metadata, caller->type.id, isContainingTypeByRefLike);
+
+        if (FAILED(hr) || isContainingTypeByRefLike)
         {
-            Logger::Warn("DebuggerRewriter: Failed to determine if the type we are instrumenting is By-Ref like.");
+            if (FAILED(hr))
+            {
+                Logger::Warn("DebuggerRewriter: Failed to determine if the type we are instrumenting is By-Ref like.");
+            }
+            MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_type_is_by_ref_like);
+            return E_NOTIMPL;
         }
-        MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_type_is_by_ref_like);
-        return E_NOTIMPL;
     }
 
     auto debuggerLocals = std::vector<ULONG>(debuggerTokens->GetAdditionalLocalsCount(methodArguments));

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -13,32 +13,6 @@
 namespace debugger
 {
 
-namespace
-{
-// Ref structs are valuetypes (including GENERICINST of a valuetype, e.g. Span<T>).
-// Void, primitives, string, object, and classes cannot be byref-like; calling
-// IsTypeByRefLike for those signatures can fail (nil token / synthetic TypeRef)
-// and must not reject the rewrite.
-bool SignatureMayBeByRefLike(unsigned elementType, int typeFlags)
-{
-    if ((typeFlags & TypeFlagVoid) != 0)
-    {
-        return false;
-    }
-
-    switch (elementType)
-    {
-        case ELEMENT_TYPE_VALUETYPE:
-        case ELEMENT_TYPE_TYPEDBYREF:
-            return true;
-        case ELEMENT_TYPE_GENERICINST:
-            return (typeFlags & TypeFlagBoxedType) != 0;
-        default:
-            return false;
-    }
-}
-} // namespace
-
 // Get function locals
 HRESULT DebuggerMethodRewriter::GetFunctionLocalSignature(const ModuleMetadata& module_metadata, ILRewriter& rewriter, FunctionLocalSignature& localSignature)
 {
@@ -2320,18 +2294,19 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
         // byref-like can't exist as a generic param). Therefore, we only need to worry about non-async methods.
         // EndMethod<TReturn> instantiates a managed generic with the return type, so unknown must fail closed
         // for signatures that can actually be ref structs.
-        const auto [returnElementType, returnTypeFlags] = methodReturnType.GetElementTypeAndFlags();
-        if (SignatureMayBeByRefLike(returnElementType, returnTypeFlags))
+        if (methodReturnType.MayBeByRefLike())
         {
             bool isReturnByRefLike = false;
-            hr = IsTypeByRefLike(m_corProfiler->info_, module_metadata, methodReturnType, debuggerTokens->GetCorLibAssemblyRef(), isReturnByRefLike);
+            hr = IsTypeByRefLike(m_corProfiler->info_, module_metadata, methodReturnType,
+                                 debuggerTokens->GetCorLibAssemblyRef(), isReturnByRefLike);
             if (FAILED(hr) || isReturnByRefLike)
             {
                 if (FAILED(hr))
                 {
                     Logger::Warn("DebuggerRewriter: Failed to determine if the return value is By-Ref like.");
                 }
-                MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_probe_byreflike_return_not_supported);
+                MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes,
+                                     invalid_probe_probe_byreflike_return_not_supported);
                 return E_NOTIMPL;
             }
         }
@@ -2354,9 +2329,10 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
     }
 
     auto debuggerLocals = std::vector<ULONG>(debuggerTokens->GetAdditionalLocalsCount(methodArguments));
-    hr = debuggerTokens->ModifyLocalSigAndInitialize(&rewriterWrapper, &methodReturnType, &methodArguments, caller, &callTargetStateIndex, &exceptionIndex,
-                                                     &callTargetReturnIndex, &staticValueTypeIndex, &returnValueIndex, &callTargetStateToken,
-                                                     &exceptionToken, &callTargetReturnToken, &firstInstruction, debuggerLocals, isAsyncMethod);
+    hr = debuggerTokens->ModifyLocalSigAndInitialize(
+        &rewriterWrapper, &methodReturnType, &methodArguments, caller, &callTargetStateIndex, &exceptionIndex,
+        &callTargetReturnIndex, &staticValueTypeIndex, &returnValueIndex, &callTargetStateToken, &exceptionToken,
+        &callTargetReturnToken, &firstInstruction, debuggerLocals, isAsyncMethod);
 
     ULONG lineProbeCallTargetStateIndex = debuggerLocals[0];
     ULONG spanMethodStateIndex = debuggerLocals[1];

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -2287,6 +2287,38 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
     {
         methodReturnType = caller->method_signature.GetReturnValue();
     }
+
+    if (!isAsyncMethod)
+    {
+        // In async methods, the return value can't be byref-like (it can't be Task<T> where T is byref-like, because
+        // byref-like can't exist as a generic param). Therefore, we only need to worry about non-async methods.
+        // EndMethod<TReturn> instantiates a managed generic with the return type, so unknown must fail closed.
+        bool isReturnByRefLike = false;
+        hr = IsTypeByRefLike(m_corProfiler->info_, module_metadata, methodReturnType, debuggerTokens->GetCorLibAssemblyRef(), isReturnByRefLike);
+        if (FAILED(hr) || isReturnByRefLike)
+        {
+            if (FAILED(hr))
+            {
+                Logger::Warn("DebuggerRewriter: Failed to determine if the return value is By-Ref like.");
+            }
+            MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_probe_byreflike_return_not_supported);
+            return E_NOTIMPL;
+        }
+    }
+
+    bool isContainingTypeByRefLike = false;
+    hr = IsTypeTokenByRefLike(m_corProfiler->info_, module_metadata, caller->type.id, isContainingTypeByRefLike);
+
+    if (FAILED(hr) || isContainingTypeByRefLike)
+    {
+        if (FAILED(hr))
+        {
+            Logger::Warn("DebuggerRewriter: Failed to determine if the type we are instrumenting is By-Ref like.");
+        }
+        MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_type_is_by_ref_like);
+        return E_NOTIMPL;
+    }
+
     auto debuggerLocals = std::vector<ULONG>(debuggerTokens->GetAdditionalLocalsCount(methodArguments));
     hr = debuggerTokens->ModifyLocalSigAndInitialize(&rewriterWrapper, &methodReturnType, &methodArguments, caller, &callTargetStateIndex, &exceptionIndex,
                                                      &callTargetReturnIndex, &staticValueTypeIndex, &returnValueIndex, &callTargetStateToken,
@@ -2301,36 +2333,6 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
         MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_failed_to_add_di_locals);
         // Error message is already written in ModifyLocalSigAndInitialize
         return S_FALSE; // TODO https://datadoghq.atlassian.net/browse/DEBUG-706
-    }
-
-    if (!isAsyncMethod)
-    {
-        // In async methods, the return value can't be byref-like (it can't be Task<T> where T is byref-like, because
-        // byref-like can't exist as a generic param). Therefore, we only need to worry about non-async methods.
-        bool isTypeIsByRefLike = false;
-        hr = IsTypeByRefLike(m_corProfiler->info_, module_metadata, methodReturnType, debuggerTokens->GetCorLibAssemblyRef(), isTypeIsByRefLike);
-        if (FAILED(hr))
-        {
-            Logger::Warn("DebuggerRewriter: Failed to determine if the return value is By-Ref like.");
-        }
-        else if (isTypeIsByRefLike)
-        {
-            MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_probe_byreflike_return_not_supported);
-            return E_NOTIMPL;
-        }
-    }
-
-    bool isTypeIsByRefLike = false;
-    hr = IsTypeTokenByRefLike(m_corProfiler->info_, module_metadata, caller->type.id, isTypeIsByRefLike);
-
-    if (FAILED(hr))
-    {
-        Logger::Warn("DebuggerRewriter: Failed to determine if the type we are instrumenting is By-Ref like.");
-    }
-    else if (isTypeIsByRefLike)
-    {
-        MarkAllProbesAsError(methodProbes, lineProbes, spanOnMethodProbes, invalid_probe_type_is_by_ref_like);
-        return E_NOTIMPL;
     }
 
     const auto instrumentedMethodIndex = ProbesMetadataTracker::Instance()->GetInstrumentedMethodIndex(module_id, function_token);

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NestedRefStructLocalTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NestedRefStructLocalTest.verified.txt
@@ -1,0 +1,69 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "input": {
+                "type": "Int32",
+                "value": "21"
+              },
+              "this": {
+                "type": "NestedRefStructLocalTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "input": {
+                "type": "Int32",
+                "value": "21"
+              },
+              "this": {
+                "type": "NestedRefStructLocalTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "42"
+              },
+              "fromSpan": {
+                "type": "Int32",
+                "value": "21"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.SmokeTests.NestedRefStructLocalTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.SmokeTests.NestedRefStructLocalTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NestedRefStructLockLocalTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NestedRefStructLockLocalTest.verified.txt
@@ -1,0 +1,77 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "input": {
+                "type": "Int32",
+                "value": "21"
+              },
+              "this": {
+                "type": "NestedRefStructLockLocalTest"
+              }
+            },
+            "staticFields": {
+              "Gate": {
+                "notCapturedReason": "typeInitializer",
+                "type": "Lock"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "input": {
+                "type": "Int32",
+                "value": "21"
+              },
+              "this": {
+                "type": "NestedRefStructLockLocalTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "42"
+              }
+            },
+            "staticFields": {
+              "Gate": {
+                "notCapturedReason": "typeInitializer",
+                "type": "Lock"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.SmokeTests.NestedRefStructLockLocalTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "snapshot",
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.SmokeTests.NestedRefStructLockLocalTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NestedRefStructLocalTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NestedRefStructLocalTest.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NestedRefStructLockLocalTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NestedRefStructLockLocalTest.verified.txt
@@ -1,0 +1,18 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NestedRefStructReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NestedRefStructReturnTest.verified.txt
@@ -1,0 +1,40 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": {
+          "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
+          "type": "NO_TYPE"
+        },
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "ERROR"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": {
+          "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
+          "type": "NO_TYPE"
+        },
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "ERROR"
+      }
+    },
+    "debugger.product": "di",
+    "debugger.type": "diagnostic",
+    "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
@@ -309,6 +309,25 @@ TEST_F(CLRHelperTest, TypeSignatureGetTypeTokName) {
   }
 }
 
+TEST_F(CLRHelperTest, TypeSignatureMayBeByRefLike) {
+  const auto mayBeByRefLike = [](std::initializer_list<COR_SIGNATURE> signature) {
+    const std::vector<COR_SIGNATURE> signatureBytes(signature);
+    TypeSignature typeSignature{0, static_cast<ULONG>(signatureBytes.size()), signatureBytes.data()};
+    return typeSignature.MayBeByRefLike();
+  };
+
+  EXPECT_TRUE(mayBeByRefLike({ELEMENT_TYPE_VALUETYPE}));
+  EXPECT_TRUE(mayBeByRefLike({ELEMENT_TYPE_TYPEDBYREF}));
+  EXPECT_TRUE(mayBeByRefLike({ELEMENT_TYPE_GENERICINST, ELEMENT_TYPE_VALUETYPE}));
+
+  EXPECT_FALSE(mayBeByRefLike({ELEMENT_TYPE_GENERICINST, ELEMENT_TYPE_CLASS}));
+  EXPECT_FALSE(mayBeByRefLike({ELEMENT_TYPE_VOID}));
+  EXPECT_FALSE(mayBeByRefLike({ELEMENT_TYPE_I4}));
+  EXPECT_FALSE(mayBeByRefLike({ELEMENT_TYPE_STRING}));
+  EXPECT_FALSE(mayBeByRefLike({ELEMENT_TYPE_OBJECT}));
+  EXPECT_FALSE(mayBeByRefLike({ELEMENT_TYPE_CLASS}));
+}
+
 TEST_F(CLRHelperTest, FunctionLocalSignatureTryParse) {
   COR_SIGNATURE localSignatureWithOneChar[] = {0x07, 0x01, ELEMENT_TYPE_CHAR};
   COR_SIGNATURE localSignatureWithOneByRefChar[] = {0x07, 0x01, ELEMENT_TYPE_BYREF, ELEMENT_TYPE_CHAR};

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.External/NestedRefLikeContainer.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.External/NestedRefLikeContainer.cs
@@ -1,0 +1,19 @@
+namespace Samples.Probes.External
+{
+    /// <summary>
+    /// Nested ref struct in a different assembly from the instrumented method.
+    /// Used to verify Dynamic Instrumentation skips nested byref-like TypeRefs.
+    /// </summary>
+    public class NestedRefLikeContainer
+    {
+        public readonly ref struct NestedRefLike
+        {
+            public NestedRefLike(int value)
+            {
+                Value = value;
+            }
+
+            public int Value { get; }
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructLocalTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructLocalTest.cs
@@ -21,11 +21,17 @@ namespace Samples.Probes.TestRuns.SmokeTests
         public int Method(int input)
         {
             var nested = new NestedRefLikeContainer.NestedRefLike(input);
-            int[] values = { input };
-            Span<int> span = values;
-            var enumerator = span.GetEnumerator();
+            var enumerator = CreateSpan(input).GetEnumerator();
             var fromSpan = enumerator.MoveNext() ? enumerator.Current : 0;
             return nested.Value + fromSpan;
+        }
+
+        // Keep the Span backing store out of the probed method so Windows and Linux
+        // do not disagree on a named int[] local at method exit.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Span<int> CreateSpan(int input)
+        {
+            return new[] { input };
         }
     }
 }

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructLocalTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructLocalTest.cs
@@ -1,0 +1,33 @@
+#if NET6_0_OR_GREATER
+
+using System;
+using System.Runtime.CompilerServices;
+using Samples.Probes.External;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    // Nested byref-like locals from another assembly (Span<T>.Enumerator is type-forwarded)
+    // must be skipped; LogLocal<TLocal> cannot take ref structs. GitHub issue 9132.
+    public class NestedRefStructLocalTest : IRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method(21);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData]
+        public int Method(int input)
+        {
+            var nested = new NestedRefLikeContainer.NestedRefLike(input);
+            int[] values = { input };
+            Span<int> span = values;
+            var enumerator = span.GetEnumerator();
+            var fromSpan = enumerator.MoveNext() ? enumerator.Current : 0;
+            return nested.Value + fromSpan;
+        }
+    }
+}
+
+#endif

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructLockLocalTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructLockLocalTest.cs
@@ -1,0 +1,32 @@
+#if NET9_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    // lock (System.Threading.Lock) introduces a nested ref struct local (Lock.Scope)
+    // type-forwarded from System.Runtime to CoreLib. GitHub issue 9132.
+    public class NestedRefStructLockLocalTest : IRun
+    {
+        private static readonly Lock Gate = new();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method(21);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData]
+        public int Method(int input)
+        {
+            lock (Gate)
+            {
+                return input * 2;
+            }
+        }
+    }
+}
+
+#endif

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructReturnTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructReturnTest.cs
@@ -1,9 +1,7 @@
-#if NET6_0_OR_GREATER
+#if NET9_0_OR_GREATER
 
 using System.Runtime.CompilerServices;
-#if NET9_0_OR_GREATER
 using System.Threading;
-#endif
 using Samples.Probes.External;
 
 namespace Samples.Probes.TestRuns.SmokeTests
@@ -17,9 +15,7 @@ namespace Samples.Probes.TestRuns.SmokeTests
         {
             var nested = Nested(21);
             _ = nested.Value;
-#if NET9_0_OR_GREATER
             using var scope = LockScope();
-#endif
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -29,7 +25,6 @@ namespace Samples.Probes.TestRuns.SmokeTests
             return new NestedRefLikeContainer.NestedRefLike(input);
         }
 
-#if NET9_0_OR_GREATER
         private static readonly Lock Gate = new();
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -38,7 +33,6 @@ namespace Samples.Probes.TestRuns.SmokeTests
         {
             return Gate.EnterScope();
         }
-#endif
     }
 }
 

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructReturnTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NestedRefStructReturnTest.cs
@@ -1,0 +1,45 @@
+#if NET6_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+#if NET9_0_OR_GREATER
+using System.Threading;
+#endif
+using Samples.Probes.External;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    // Nested byref-like returns must reject the rewrite. EndMethod<TReturn> cannot
+    // instantiate a managed generic with a ref struct (GitHub issue 9132).
+    public class NestedRefStructReturnTest : IRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            var nested = Nested(21);
+            _ = nested.Value;
+#if NET9_0_OR_GREATER
+            using var scope = LockScope();
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData(expectedNumberOfSnapshots: 0, expectProbeStatusFailure: true)]
+        public NestedRefLikeContainer.NestedRefLike Nested(int input)
+        {
+            return new NestedRefLikeContainer.NestedRefLike(input);
+        }
+
+#if NET9_0_OR_GREATER
+        private static readonly Lock Gate = new();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData(expectedNumberOfSnapshots: 0, expectProbeStatusFailure: true)]
+        public Lock.Scope LockScope()
+        {
+            return Gate.EnterScope();
+        }
+#endif
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes

- Skip nested byref-like locals (for example `System.Threading.Lock+Scope`) when Dynamic Instrumentation or Exception Replay instruments a method.
- Resolve nested TypeRefs in the module that actually defines the enclosing type, including after type-forwarding (`System.Runtime` → CoreLib).
- If byref-like detection cannot resolve a TypeRef, fail the check so the rewriter skips the value instead of emitting `LogLocal<TLocal>`.

## Reason for change

- Instrumenting a method that uses `lock (System.Threading.Lock)` threw `VerificationException`: `LogLocal` was instantiated with `Lock.Scope`, which is a ref struct.
- While that rewrite was in place the method could not run. Exception Replay could trigger this with no probe, because it instruments frames on the exception stack.

## Implementation details

- `ResolveType` now walks the enclosing TypeRef chain outermost-first, then looks up nested types with `FindTypeDefByName` on the parent's metadata import. Nested types live in the same module as their enclosing type; that module can differ from the original TypeRef assembly when the parent is type-forwarded.
- Resolve failure is now unknown (FAILED(hr)), not a successful “not byref-like.” The debugger already skips on that failure. CallTarget still maps failure to isByRefLike = false, so its behavior is unchanged.

## Test coverage

  - `NestedRefStructLockLocalTest` (`lock (Lock)`)
  - `NestedRefStructLocalTest` (`Span<T>.Enumerator`)
  - existing `ByRefLikeTest` and `GenericByRefLikeTest`

## Other details
Fixes #9132 