### PR TITLE
Do not read past end of string in string TrimEnd

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
@@ -480,7 +480,7 @@ namespace iast
             }
             indexTo--;
         }
-        if (indexTo < indexFrom || _IndexOf(str[indexTo], c) >= 0)
+        if (_IndexOf(str[indexTo], c) >= 0)
         {
             return EmptyWStr;
         }
@@ -537,7 +537,7 @@ namespace iast
             }
             indexTo--;
         }
-        if (indexTo < indexFrom || _IndexOf(str[indexTo], c) >= 0)
+        if (_IndexOf(str[indexTo], c) >= 0)
         {
             return "";
         }

--- a/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
@@ -472,7 +472,7 @@ namespace iast
         }
         size_t indexFrom = 0;
         auto indexTo = str.length() - 1;
-        while (indexFrom <= indexTo)
+        while (indexFrom < indexTo)
         {
             if (_IndexOf(str[indexTo], c) < 0)
             {
@@ -480,7 +480,7 @@ namespace iast
             }
             indexTo--;
         }
-        if (indexTo < indexFrom)
+        if (indexTo < indexFrom || _IndexOf(str[indexTo], c) >= 0)
         {
             return EmptyWStr;
         }
@@ -529,7 +529,7 @@ namespace iast
         }
         size_t indexFrom = 0;
         auto indexTo = str.length() - 1;
-        while (indexFrom <= indexTo)
+        while (indexFrom < indexTo)
         {
             if (_IndexOf(str[indexTo], c) < 0)
             {
@@ -537,7 +537,7 @@ namespace iast
             }
             indexTo--;
         }
-        if (indexTo < indexFrom)
+        if (indexTo < indexFrom || _IndexOf(str[indexTo], c) >= 0)
         {
             return "";
         }

--- a/tracer/test/Datadog.Tracer.Native.Tests/iast_util_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/iast_util_test.cpp
@@ -227,18 +227,38 @@ TEST(IastIntegrationTests, String_SplitType)
 
 TEST(IastIntegrationTests, String_Trim)
 {
+    EXPECT_EQ("",     iast::Trim(""));
+    EXPECT_EQ("",     iast::Trim(" "));
+    EXPECT_EQ("a",    iast::Trim("a"));
+    EXPECT_EQ("a",    iast::Trim(" a "));
+    EXPECT_EQ("",     iast::Trim("   "));
+    EXPECT_EQ("",     iast::Trim(" ** ", " *"));
+    EXPECT_EQ("Test", iast::Trim("Test"));
     EXPECT_EQ("Test", iast::Trim("  Test  "));
     EXPECT_EQ("Test", iast::Trim(" *Test* ", " *"));
 }
 
 TEST(IastIntegrationTests, String_TrimStart)
 {
+    EXPECT_EQ("",       iast::TrimStart(""));
+    EXPECT_EQ("",       iast::TrimStart(" "));
+    EXPECT_EQ("a",      iast::TrimStart("a"));
+    EXPECT_EQ("a",      iast::TrimStart(" a"));
+    EXPECT_EQ("",       iast::TrimStart("   "));
+    EXPECT_EQ("",       iast::TrimStart(" *", " *"));
+    EXPECT_EQ("Test",   iast::TrimStart("Test"));
     EXPECT_EQ("Test  ", iast::TrimStart("  Test  "));
     EXPECT_EQ("Test* ", iast::TrimStart(" *Test* ", " *"));
 }
 
 TEST(IastIntegrationTests, String_TrimEnd)
 {
+    EXPECT_EQ("",       iast::TrimEnd(""));
+    EXPECT_EQ("",       iast::TrimEnd(" "));
+    EXPECT_EQ("a",      iast::TrimEnd("a "));
+    EXPECT_EQ("",       iast::TrimEnd("   "));
+    EXPECT_EQ("",       iast::TrimEnd(" *", " *"));
+    EXPECT_EQ("Test",   iast::TrimEnd("Test"));
     EXPECT_EQ("  Test", iast::TrimEnd("  Test  "));
     EXPECT_EQ(" *Test", iast::TrimEnd(" *Test* ", " *"));
 }

--- a/tracer/test/Datadog.Tracer.Native.Tests/iast_util_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/iast_util_test.cpp
@@ -238,6 +238,19 @@ TEST(IastIntegrationTests, String_Trim)
     EXPECT_EQ("Test", iast::Trim(" *Test* ", " *"));
 }
 
+TEST(IastIntegrationTests, WString_Trim)
+{
+    EXPECT_EQ(WStr(""), iast::Trim(WStr("")));
+    EXPECT_EQ(WStr(""), iast::Trim(WStr(" ")));
+    EXPECT_EQ(WStr("a"), iast::Trim(WStr("a")));
+    EXPECT_EQ(WStr("a"), iast::Trim(WStr(" a ")));
+    EXPECT_EQ(WStr(""), iast::Trim(WStr("   ")));
+    EXPECT_EQ(WStr(""), iast::Trim(WStr(" ** "), WStr(" *")));
+    EXPECT_EQ(WStr("Test"), iast::Trim(WStr("Test")));
+    EXPECT_EQ(WStr("Test"), iast::Trim(WStr("  Test  ")));
+    EXPECT_EQ(WStr("Test"), iast::Trim(WStr(" *Test* "), WStr(" *")));
+}
+
 TEST(IastIntegrationTests, String_TrimStart)
 {
     EXPECT_EQ("",       iast::TrimStart(""));
@@ -251,6 +264,19 @@ TEST(IastIntegrationTests, String_TrimStart)
     EXPECT_EQ("Test* ", iast::TrimStart(" *Test* ", " *"));
 }
 
+TEST(IastIntegrationTests, WString_TrimStart)
+{
+    EXPECT_EQ(WStr(""), iast::TrimStart(WStr("")));
+    EXPECT_EQ(WStr(""), iast::TrimStart(WStr(" ")));
+    EXPECT_EQ(WStr("a"), iast::TrimStart(WStr("a")));
+    EXPECT_EQ(WStr("a"), iast::TrimStart(WStr(" a")));
+    EXPECT_EQ(WStr(""), iast::TrimStart(WStr("   ")));
+    EXPECT_EQ(WStr(""), iast::TrimStart(WStr(" *"), WStr(" *")));
+    EXPECT_EQ(WStr("Test"), iast::TrimStart(WStr("Test")));
+    EXPECT_EQ(WStr("Test  "), iast::TrimStart(WStr("  Test  ")));
+    EXPECT_EQ(WStr("Test* "), iast::TrimStart(WStr(" *Test* "), WStr(" *")));
+}
+
 TEST(IastIntegrationTests, String_TrimEnd)
 {
     EXPECT_EQ("",       iast::TrimEnd(""));
@@ -261,6 +287,18 @@ TEST(IastIntegrationTests, String_TrimEnd)
     EXPECT_EQ("Test",   iast::TrimEnd("Test"));
     EXPECT_EQ("  Test", iast::TrimEnd("  Test  "));
     EXPECT_EQ(" *Test", iast::TrimEnd(" *Test* ", " *"));
+}
+
+TEST(IastIntegrationTests, WString_TrimEnd)
+{
+    EXPECT_EQ(WStr(""), iast::TrimEnd(WStr("")));
+    EXPECT_EQ(WStr(""), iast::TrimEnd(WStr(" ")));
+    EXPECT_EQ(WStr("a"), iast::TrimEnd(WStr("a ")));
+    EXPECT_EQ(WStr(""), iast::TrimEnd(WStr("   ")));
+    EXPECT_EQ(WStr(""), iast::TrimEnd(WStr(" *"), WStr(" *")));
+    EXPECT_EQ(WStr("Test"), iast::TrimEnd(WStr("Test")));
+    EXPECT_EQ(WStr("  Test"), iast::TrimEnd(WStr("  Test  ")));
+    EXPECT_EQ(WStr(" *Test"), iast::TrimEnd(WStr(" *Test* "), WStr(" *")));
 }
 
 TEST(IastIntegrationTests, String_TryParseInt)


### PR DESCRIPTION
## Summary of changes

TrimEnd for string read past the array bounds when entire string consists of chars we try to trim.
Need to read only string contents.

## Reason for change

If string contains only chars which we try to trim, TrimEnd reads past string bounds. 
Added checks to read only allowed range.

## Implementation details
Do not read past array bounds in a loop, but add check for entire string has chars to trim.

## Test coverage
Added test cases

## Other details
None