### PR TITLE
Do not lost original exception info due to type slicing

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
@@ -493,7 +493,7 @@ namespace iast
                 DEL(branch);
             }
         }
-        catch (std::exception err)
+        catch (const std::exception &err)
         {
             _error = err.what();
             trace::Logger::Error("ERROR verfying ", body->GetMethodInfo()->GetFullName(), " : ", _error);
@@ -871,7 +871,7 @@ namespace iast
             DEL_MAP_VALUES(handlers);
             Log(debugLevel, "Dump end");
         }
-        catch (std::exception err)
+        catch (const std::exception &err)
         {
             trace::Logger::Error("ERROR in Dump: ", err.what());
         }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
@@ -880,6 +880,8 @@ namespace iast
 
     //----------------------------------------
 
+    static constexpr int default_branch_id_ = -1;
+
     Branch::Branch(InstructionInfo* instruction, std::vector<InstructionInfo*>* stack)
     {
         this->Instruction = instruction;
@@ -887,6 +889,7 @@ namespace iast
         {
             Stack = *stack;
         }
+        Id = default_branch_id_;
     }
 
     InstructionInfo* Branch::Pop(ILAnalysis& analysis, InstructionInfo* instruction)
@@ -927,7 +930,7 @@ namespace iast
     {
         if (force || addedBranches.find(branch->Instruction) == addedBranches.end())
         {
-            if (branch->Id == -1)
+            if (branch->Id == default_branch_id_)
             {
                 branch->Id = (int)addedBranches.size();
             }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_rewriter.cpp
@@ -101,14 +101,22 @@ namespace iast
 #undef assert
 #define assert(x)
 
-    ILRewriter::ILRewriter(MethodInfo* methodInfo) : m_fGenerateTinyHeader(false), m_pEH(nullptr), m_pOffsetToInstr(nullptr), m_pOutputBuffer(nullptr)
+    ILRewriter::ILRewriter(MethodInfo* methodInfo)
+        : m_methodInfo(methodInfo),
+        m_tkLocalVarSig(mdTokenNil),
+        m_maxStack(0),
+        m_flags(0),
+        m_fGenerateTinyHeader(false),
+        m_nEH(0),
+        m_pEH(nullptr),
+        m_pOffsetToInstr(nullptr),
+        m_nCodeSize(0),
+        m_nInstrs(0),
+        m_pOutputBuffer(nullptr)
     {
-        m_methodInfo = methodInfo;
-
         m_IL.m_pNext = &m_IL;
         m_IL.m_pPrev = &m_IL;
 
-        m_nInstrs = 0;
     }
 
     ILRewriter::~ILRewriter()

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
@@ -115,6 +115,7 @@ ILRewriter::ILRewriter(ICorProfilerInfo* pICorProfilerInfo, ICorProfilerFunction
     m_pICorProfilerFunctionControl(pICorProfilerFunctionControl),
     m_moduleId(moduleID),
     m_tkMethod(tkMethod),
+    m_tkLocalVarSig(mdTokenNil),
     m_fGenerateTinyHeader(false),
     m_pEH(nullptr),
     m_pOffsetToInstr(nullptr),

--- a/tracer/src/Datadog.Tracer.Native/tracer_tokens.h
+++ b/tracer/src/Datadog.Tracer.Native/tracer_tokens.h
@@ -13,7 +13,7 @@ namespace trace
 class TracerTokens : public CallTargetTokens
 {
 private:
-    ICorProfilerInfo4* _profiler_info;
+    ICorProfilerInfo4* _profiler_info = nullptr;
     mdMemberRef beginArrayMemberRef = mdMemberRefNil;
     mdMemberRef beginMethodFastPathRefs[FASTPATH_COUNT];
     mdMemberRef endVoidMemberRef = mdMemberRefNil;


### PR DESCRIPTION
## Summary of changes

Need to catch exceptions by const reference or type info and additional details will be lost.

## Reason for change

Exceptions catched by value causes type slicing: real exception type and additional properties are lost, because assignment to `std::exception` by value causes copy constructor to be invoked instead.

## Implementation details

## Test coverage
Not changed.

## Other details
None.