### PR TITLE
[DuckTyping] Work around concurrent ExceptionDispatchInfo runtime crash

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -1530,52 +1530,21 @@ namespace Datadog.Trace.DuckTyping
                     return;
                 }
 
-#if !NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
+                exceptionInfo.Throw();
+#else
                 // WORKAROUND: https://github.com/dotnet/runtime/issues/45929
                 // Fixed in the runtime by https://github.com/dotnet/runtime/pull/46636.
                 //
                 // Failed proxy creations are cached, so every caller for the same proxy/target type pair receives
                 // the same ExceptionDispatchInfo and therefore the same Exception instance. Windows CoreCLR
-                // versions before .NET 6 have a confirmed race when that instance is rethrown concurrently.
-                // ExceptionDispatchInfo.Throw() restores mutable stack-trace and Watson-bucket fields on the
-                // Exception while another thread may be reading those fields to construct a reflection exception
-                // wrapper. The old runtime checks that the Watson-bucket reference is non-null, reads the field
-                // again later, and can dereference null after the concurrent restore. The result is an access
-                // violation followed by a fatal 0x80131506 internal CLR error; managed code cannot catch it.
-                //
-                // Do not serialize ExceptionDispatchInfo.Throw() with a monitor. FirstChanceException callbacks
-                // and exception filters run synchronously before the throw unwinds through the monitor's finally
-                // block. If such customer code waits for another thread that reaches this cached failure, that
-                // thread blocks on the monitor and the process deadlocks. The non-generic API would require an
-                // even wider monitor around DynamicInvoke because Reflection constructs TargetInvocationException
-                // from the shared inner exception before returning control to this code.
+                // versions before .NET 6 have a confirmed race when that instance is rethrown concurrently,
+                // which can cause a crash.
                 //
                 // Instead, make a shallow copy of the cached DuckTypeException and capture that copy immediately
-                // before every throw. MemberwiseClone preserves the exact internal exception subtype, message,
-                // inner exception, HResult, Data, and captured diagnostic state, while giving the runtime a
-                // distinct Exception object with independent mutable field slots. Concurrent throws can therefore
-                // no longer restore the same object's stack-trace or Watson-bucket fields. DynamicInvoke also sees
-                // a distinct inner exception for each call, so construction of TargetInvocationException is safe
-                // without holding a lock while callbacks or filters execute.
-                //
-                // .NET Framework's Reference Source uses the same relevant managed sequence as the affected
-                // CoreCLR: it restores ExceptionDispatchInfo state under an internal lock, releases that lock,
-                // and only then throws the shared Exception through Reflection. Its native clr.dll Watson-bucket
-                // copy implementation is not public, so it cannot prove that .NET Framework is safe. Apply this
-                // process-safety workaround to .NET Framework too. See:
-                // https://github.com/microsoft/referencesource/blob/main/mscorlib/system/exception.cs
-                //
-                // This branch is compiled into the net461, netstandard2.0, and netcoreapp3.1 tracer assets. The
-                // net6.0 asset is excluded because .NET 6 is the first runtime line containing Microsoft's
-                // confirmed native fix. Proxy creation failures are exceptional, so the extra exception and
-                // ExceptionDispatchInfo allocations do not affect successful proxy creation or invocation.
+                // before every throw. MemberwiseClone preserves the exact internal details, so concurrent
+                // throws no longer cause a crash. Fixed in .NET 6+.
                 ExceptionDispatchInfo.Capture(((DuckTypeException)exceptionInfo.SourceException).CloneForThrow()).Throw();
-#else
-                // .NET 6 and later contain the runtime fix, so deliberately preserve the original concurrent
-                // behavior there. ConcurrentFailureTests exercises the same shared-exception scenario on these
-                // targets: the process must remain healthy and every caller must still receive the expected
-                // exception.
-                exceptionInfo.Throw();
 #endif
             }
         }

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -1417,6 +1417,7 @@ namespace Datadog.Trace.DuckTyping
             private readonly Delegate? _activator;
             private readonly ExceptionDispatchInfo? _exceptionInfo;
 
+#if !NETFRAMEWORK && !NET6_0_OR_GREATER
             // WORKAROUND: https://github.com/dotnet/runtime/issues/45929
             // Fixed in the runtime by https://github.com/dotnet/runtime/pull/46636.
             //
@@ -1433,9 +1434,16 @@ namespace Datadog.Trace.DuckTyping
             // This reference is deliberately shared by all copies of the readonly struct, including the
             // boxed copy used as the failure delegate's target. It lets us serialize every rethrow of one
             // cached failure. Do not lock on `this`: CreateTypeResult is a value type, so doing so would box
-            // each copy independently and would not provide mutual exclusion. Successful results keep this
-            // field null, so the workaround allocates a lock only for failed proxy creation results.
+            // each copy independently and would not provide mutual exclusion.
+            //
+            // The workaround is compiled only into the netstandard2.0 and netcoreapp3.1 tracer assets. Those
+            // are the assets selected for the affected pre-.NET 6 CoreCLR runtimes. The net461 asset does not
+            // need it because the runtime bug is not present on .NET Framework, and the net6.0 asset does not
+            // need it because that is the first runtime line containing Microsoft's fix. Successful results
+            // on the affected assets keep this field null, so even there a lock is allocated only for failed
+            // proxy creation results.
             private readonly object? _failureLock;
+#endif
 
             /// <summary>
             /// Initializes a new instance of the <see cref="CreateTypeResult"/> struct.
@@ -1450,7 +1458,9 @@ namespace Datadog.Trace.DuckTyping
                 _activator = activator;
                 _proxyType = proxyType;
                 _exceptionInfo = exceptionInfo;
+#if !NETFRAMEWORK && !NET6_0_OR_GREATER
                 _failureLock = exceptionInfo is null ? null : new object();
+#endif
                 TargetType = targetType;
                 Success = proxyType != null && exceptionInfo == null;
                 if (exceptionInfo is not null)
@@ -1532,6 +1542,7 @@ namespace Datadog.Trace.DuckTyping
                     ThrowHelper.ThrowNullReferenceException("The activator for this proxy type is null, check if the type can be created by calling 'CanCreate()'");
                 }
 
+#if !NETFRAMEWORK && !NET6_0_OR_GREATER
                 // The non-generic API invokes the failure delegate through reflection. DynamicInvoke catches
                 // the exception raised by ThrowOnError<T> and creates a TargetInvocationException around it.
                 // The Windows CoreCLR crash described above occurs while the runtime copies Watson buckets
@@ -1548,6 +1559,7 @@ namespace Datadog.Trace.DuckTyping
                         return _activator.DynamicInvoke(instance)!;
                     }
                 }
+#endif
 
                 return _activator.DynamicInvoke(instance)!;
             }
@@ -1568,6 +1580,7 @@ namespace Datadog.Trace.DuckTyping
                     return;
                 }
 
+#if !NETFRAMEWORK && !NET6_0_OR_GREATER
                 // Keep the monitor held for the complete dispatch of the shared exception. This protects the
                 // direct generic failure path and ProxyType getter. The non-generic path additionally acquires
                 // this lock around DynamicInvoke so that reflection's TargetInvocationException wrapper is also
@@ -1576,6 +1589,13 @@ namespace Datadog.Trace.DuckTyping
                 {
                     exceptionInfo.Throw();
                 }
+#else
+                // .NET Framework does not contain the Watson-bucket race described above. .NET 6 and later
+                // contain the runtime fix, so deliberately preserve the original concurrent behavior there.
+                // ConcurrentFailureTests exercises the same shared-exception scenario on these targets: the
+                // process must remain healthy and every caller must still receive the expected exception.
+                exceptionInfo.Throw();
+#endif
             }
         }
 

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -1417,31 +1417,38 @@ namespace Datadog.Trace.DuckTyping
             private readonly Delegate? _activator;
             private readonly ExceptionDispatchInfo? _exceptionInfo;
 
-#if !NETFRAMEWORK && !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
             // WORKAROUND: https://github.com/dotnet/runtime/issues/45929
             // Fixed in the runtime by https://github.com/dotnet/runtime/pull/46636.
             //
             // Failed proxy creations are cached, so every caller for the same proxy/target type pair
             // receives a copy of this CreateTypeResult containing the same ExceptionDispatchInfo and
-            // therefore the same Exception instance. Windows CoreCLR versions before .NET 6 have a race
-            // when that same exception is rethrown concurrently. ExceptionDispatchInfo.Throw() restores
-            // mutable stack-trace and Watson-bucket fields on the Exception. At the same time, another
-            // thread may be reading those fields while constructing a reflection exception wrapper. The
-            // old runtime checks that the Watson-bucket reference is non-null, reads it again later, and
-            // can then dereference null after the concurrent restore. The result is an access violation
-            // followed by a fatal 0x80131506 internal CLR error; managed code cannot catch it.
+            // therefore the same Exception instance. Windows CoreCLR versions before .NET 6 have a confirmed
+            // race when that same exception is rethrown concurrently. ExceptionDispatchInfo.Throw() restores
+            // mutable stack-trace and Watson-bucket fields on the Exception. At the same time, another thread
+            // may be reading those fields while constructing a reflection exception wrapper. The old runtime
+            // checks that the Watson-bucket reference is non-null, reads it again later, and can then dereference
+            // null after the concurrent restore. The result is an access violation followed by a fatal
+            // 0x80131506 internal CLR error; managed code cannot catch it.
+            //
+            // .NET Framework's Reference Source uses the same relevant managed sequence as the affected
+            // CoreCLR: it restores the mutable ExceptionDispatchInfo state under an internal lock, releases
+            // that lock, and only then throws the shared Exception through Reflection. The Reference Source
+            // does not include the native clr.dll Watson-bucket copy implementation, so it cannot demonstrate
+            // that the native part of this race is absent from .NET Framework. We therefore apply the
+            // process-safety workaround to .NET Framework as well instead of relying on an unverified native
+            // implementation detail. See:
+            // https://github.com/microsoft/referencesource/blob/main/mscorlib/system/exception.cs
             //
             // This reference is deliberately shared by all copies of the readonly struct, including the
             // boxed copy used as the failure delegate's target. It lets us serialize every rethrow of one
             // cached failure. Do not lock on `this`: CreateTypeResult is a value type, so doing so would box
             // each copy independently and would not provide mutual exclusion.
             //
-            // The workaround is compiled only into the netstandard2.0 and netcoreapp3.1 tracer assets. Those
-            // are the assets selected for the affected pre-.NET 6 CoreCLR runtimes. The net461 asset does not
-            // need it because the runtime bug is not present on .NET Framework, and the net6.0 asset does not
-            // need it because that is the first runtime line containing Microsoft's fix. Successful results
-            // on the affected assets keep this field null, so even there a lock is allocated only for failed
-            // proxy creation results.
+            // The workaround is compiled into the net461, netstandard2.0, and netcoreapp3.1 tracer assets. The
+            // net6.0 asset is the only one excluded because .NET 6 is the first runtime line containing
+            // Microsoft's confirmed native fix. Successful results on the affected assets keep this field
+            // null, so even there a lock is allocated only for failed proxy creation results.
             private readonly object? _failureLock;
 #endif
 
@@ -1458,7 +1465,7 @@ namespace Datadog.Trace.DuckTyping
                 _activator = activator;
                 _proxyType = proxyType;
                 _exceptionInfo = exceptionInfo;
-#if !NETFRAMEWORK && !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
                 _failureLock = exceptionInfo is null ? null : new object();
 #endif
                 TargetType = targetType;
@@ -1542,7 +1549,7 @@ namespace Datadog.Trace.DuckTyping
                     ThrowHelper.ThrowNullReferenceException("The activator for this proxy type is null, check if the type can be created by calling 'CanCreate()'");
                 }
 
-#if !NETFRAMEWORK && !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
                 // The non-generic API invokes the failure delegate through reflection. DynamicInvoke catches
                 // the exception raised by ThrowOnError<T> and creates a TargetInvocationException around it.
                 // The Windows CoreCLR crash described above occurs while the runtime copies Watson buckets
@@ -1580,7 +1587,7 @@ namespace Datadog.Trace.DuckTyping
                     return;
                 }
 
-#if !NETFRAMEWORK && !NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
                 // Keep the monitor held for the complete dispatch of the shared exception. This protects the
                 // direct generic failure path and ProxyType getter. The non-generic path additionally acquires
                 // this lock around DynamicInvoke so that reflection's TargetInvocationException wrapper is also
@@ -1590,10 +1597,10 @@ namespace Datadog.Trace.DuckTyping
                     exceptionInfo.Throw();
                 }
 #else
-                // .NET Framework does not contain the Watson-bucket race described above. .NET 6 and later
-                // contain the runtime fix, so deliberately preserve the original concurrent behavior there.
-                // ConcurrentFailureTests exercises the same shared-exception scenario on these targets: the
-                // process must remain healthy and every caller must still receive the expected exception.
+                // .NET 6 and later contain the runtime fix, so deliberately preserve the original concurrent
+                // behavior there. ConcurrentFailureTests exercises the same shared-exception scenario on these
+                // targets: the process must remain healthy and every caller must still receive the expected
+                // exception.
                 exceptionInfo.Throw();
 #endif
             }

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -1417,6 +1417,26 @@ namespace Datadog.Trace.DuckTyping
             private readonly Delegate? _activator;
             private readonly ExceptionDispatchInfo? _exceptionInfo;
 
+            // WORKAROUND: https://github.com/dotnet/runtime/issues/45929
+            // Fixed in the runtime by https://github.com/dotnet/runtime/pull/46636.
+            //
+            // Failed proxy creations are cached, so every caller for the same proxy/target type pair
+            // receives a copy of this CreateTypeResult containing the same ExceptionDispatchInfo and
+            // therefore the same Exception instance. Windows CoreCLR versions before .NET 6 have a race
+            // when that same exception is rethrown concurrently. ExceptionDispatchInfo.Throw() restores
+            // mutable stack-trace and Watson-bucket fields on the Exception. At the same time, another
+            // thread may be reading those fields while constructing a reflection exception wrapper. The
+            // old runtime checks that the Watson-bucket reference is non-null, reads it again later, and
+            // can then dereference null after the concurrent restore. The result is an access violation
+            // followed by a fatal 0x80131506 internal CLR error; managed code cannot catch it.
+            //
+            // This reference is deliberately shared by all copies of the readonly struct, including the
+            // boxed copy used as the failure delegate's target. It lets us serialize every rethrow of one
+            // cached failure. Do not lock on `this`: CreateTypeResult is a value type, so doing so would box
+            // each copy independently and would not provide mutual exclusion. Successful results keep this
+            // field null, so the workaround allocates a lock only for failed proxy creation results.
+            private readonly object? _failureLock;
+
             /// <summary>
             /// Initializes a new instance of the <see cref="CreateTypeResult"/> struct.
             /// </summary>
@@ -1430,6 +1450,7 @@ namespace Datadog.Trace.DuckTyping
                 _activator = activator;
                 _proxyType = proxyType;
                 _exceptionInfo = exceptionInfo;
+                _failureLock = exceptionInfo is null ? null : new object();
                 TargetType = targetType;
                 Success = proxyType != null && exceptionInfo == null;
                 if (exceptionInfo is not null)
@@ -1451,7 +1472,7 @@ namespace Datadog.Trace.DuckTyping
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 get
                 {
-                    _exceptionInfo?.Throw();
+                    ThrowCachedException();
                     return _proxyType;
                 }
             }
@@ -1511,14 +1532,50 @@ namespace Datadog.Trace.DuckTyping
                     ThrowHelper.ThrowNullReferenceException("The activator for this proxy type is null, check if the type can be created by calling 'CanCreate()'");
                 }
 
+                // The non-generic API invokes the failure delegate through reflection. DynamicInvoke catches
+                // the exception raised by ThrowOnError<T> and creates a TargetInvocationException around it.
+                // The Windows CoreCLR crash described above occurs while the runtime copies Watson buckets
+                // from that shared inner exception into the new wrapper. Locking only inside ThrowOnError<T>
+                // would release the lock before DynamicInvoke constructs and throws the wrapper, leaving the
+                // crashing portion of the runtime path unprotected. Keep the same shared lock around the whole
+                // DynamicInvoke operation so it covers both the ExceptionDispatchInfo.Throw() and the runtime's
+                // subsequent TargetInvocationException construction. Monitor locks are re-entrant, so the
+                // failure delegate can safely acquire the same lock again in ThrowCachedException().
+                if (_failureLock is { } failureLock)
+                {
+                    lock (failureLock)
+                    {
+                        return _activator.DynamicInvoke(instance)!;
+                    }
+                }
+
                 return _activator.DynamicInvoke(instance)!;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private T? ThrowOnError<T>(object? instance)
             {
-                _exceptionInfo?.Throw();
+                ThrowCachedException();
                 return default;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void ThrowCachedException()
+            {
+                var exceptionInfo = _exceptionInfo;
+                if (exceptionInfo is null)
+                {
+                    return;
+                }
+
+                // Keep the monitor held for the complete dispatch of the shared exception. This protects the
+                // direct generic failure path and ProxyType getter. The non-generic path additionally acquires
+                // this lock around DynamicInvoke so that reflection's TargetInvocationException wrapper is also
+                // created while concurrent restores of the shared ExceptionDispatchInfo are excluded.
+                lock (_failureLock!)
+                {
+                    exceptionInfo.Throw();
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -1417,41 +1417,6 @@ namespace Datadog.Trace.DuckTyping
             private readonly Delegate? _activator;
             private readonly ExceptionDispatchInfo? _exceptionInfo;
 
-#if !NET6_0_OR_GREATER
-            // WORKAROUND: https://github.com/dotnet/runtime/issues/45929
-            // Fixed in the runtime by https://github.com/dotnet/runtime/pull/46636.
-            //
-            // Failed proxy creations are cached, so every caller for the same proxy/target type pair
-            // receives a copy of this CreateTypeResult containing the same ExceptionDispatchInfo and
-            // therefore the same Exception instance. Windows CoreCLR versions before .NET 6 have a confirmed
-            // race when that same exception is rethrown concurrently. ExceptionDispatchInfo.Throw() restores
-            // mutable stack-trace and Watson-bucket fields on the Exception. At the same time, another thread
-            // may be reading those fields while constructing a reflection exception wrapper. The old runtime
-            // checks that the Watson-bucket reference is non-null, reads it again later, and can then dereference
-            // null after the concurrent restore. The result is an access violation followed by a fatal
-            // 0x80131506 internal CLR error; managed code cannot catch it.
-            //
-            // .NET Framework's Reference Source uses the same relevant managed sequence as the affected
-            // CoreCLR: it restores the mutable ExceptionDispatchInfo state under an internal lock, releases
-            // that lock, and only then throws the shared Exception through Reflection. The Reference Source
-            // does not include the native clr.dll Watson-bucket copy implementation, so it cannot demonstrate
-            // that the native part of this race is absent from .NET Framework. We therefore apply the
-            // process-safety workaround to .NET Framework as well instead of relying on an unverified native
-            // implementation detail. See:
-            // https://github.com/microsoft/referencesource/blob/main/mscorlib/system/exception.cs
-            //
-            // This reference is deliberately shared by all copies of the readonly struct, including the
-            // boxed copy used as the failure delegate's target. It lets us serialize every rethrow of one
-            // cached failure. Do not lock on `this`: CreateTypeResult is a value type, so doing so would box
-            // each copy independently and would not provide mutual exclusion.
-            //
-            // The workaround is compiled into the net461, netstandard2.0, and netcoreapp3.1 tracer assets. The
-            // net6.0 asset is the only one excluded because .NET 6 is the first runtime line containing
-            // Microsoft's confirmed native fix. Successful results on the affected assets keep this field
-            // null, so even there a lock is allocated only for failed proxy creation results.
-            private readonly object? _failureLock;
-#endif
-
             /// <summary>
             /// Initializes a new instance of the <see cref="CreateTypeResult"/> struct.
             /// </summary>
@@ -1465,9 +1430,6 @@ namespace Datadog.Trace.DuckTyping
                 _activator = activator;
                 _proxyType = proxyType;
                 _exceptionInfo = exceptionInfo;
-#if !NET6_0_OR_GREATER
-                _failureLock = exceptionInfo is null ? null : new object();
-#endif
                 TargetType = targetType;
                 Success = proxyType != null && exceptionInfo == null;
                 if (exceptionInfo is not null)
@@ -1549,25 +1511,6 @@ namespace Datadog.Trace.DuckTyping
                     ThrowHelper.ThrowNullReferenceException("The activator for this proxy type is null, check if the type can be created by calling 'CanCreate()'");
                 }
 
-#if !NET6_0_OR_GREATER
-                // The non-generic API invokes the failure delegate through reflection. DynamicInvoke catches
-                // the exception raised by ThrowOnError<T> and creates a TargetInvocationException around it.
-                // The Windows CoreCLR crash described above occurs while the runtime copies Watson buckets
-                // from that shared inner exception into the new wrapper. Locking only inside ThrowOnError<T>
-                // would release the lock before DynamicInvoke constructs and throws the wrapper, leaving the
-                // crashing portion of the runtime path unprotected. Keep the same shared lock around the whole
-                // DynamicInvoke operation so it covers both the ExceptionDispatchInfo.Throw() and the runtime's
-                // subsequent TargetInvocationException construction. Monitor locks are re-entrant, so the
-                // failure delegate can safely acquire the same lock again in ThrowCachedException().
-                if (_failureLock is { } failureLock)
-                {
-                    lock (failureLock)
-                    {
-                        return _activator.DynamicInvoke(instance)!;
-                    }
-                }
-#endif
-
                 return _activator.DynamicInvoke(instance)!;
             }
 
@@ -1588,14 +1531,45 @@ namespace Datadog.Trace.DuckTyping
                 }
 
 #if !NET6_0_OR_GREATER
-                // Keep the monitor held for the complete dispatch of the shared exception. This protects the
-                // direct generic failure path and ProxyType getter. The non-generic path additionally acquires
-                // this lock around DynamicInvoke so that reflection's TargetInvocationException wrapper is also
-                // created while concurrent restores of the shared ExceptionDispatchInfo are excluded.
-                lock (_failureLock!)
-                {
-                    exceptionInfo.Throw();
-                }
+                // WORKAROUND: https://github.com/dotnet/runtime/issues/45929
+                // Fixed in the runtime by https://github.com/dotnet/runtime/pull/46636.
+                //
+                // Failed proxy creations are cached, so every caller for the same proxy/target type pair receives
+                // the same ExceptionDispatchInfo and therefore the same Exception instance. Windows CoreCLR
+                // versions before .NET 6 have a confirmed race when that instance is rethrown concurrently.
+                // ExceptionDispatchInfo.Throw() restores mutable stack-trace and Watson-bucket fields on the
+                // Exception while another thread may be reading those fields to construct a reflection exception
+                // wrapper. The old runtime checks that the Watson-bucket reference is non-null, reads the field
+                // again later, and can dereference null after the concurrent restore. The result is an access
+                // violation followed by a fatal 0x80131506 internal CLR error; managed code cannot catch it.
+                //
+                // Do not serialize ExceptionDispatchInfo.Throw() with a monitor. FirstChanceException callbacks
+                // and exception filters run synchronously before the throw unwinds through the monitor's finally
+                // block. If such customer code waits for another thread that reaches this cached failure, that
+                // thread blocks on the monitor and the process deadlocks. The non-generic API would require an
+                // even wider monitor around DynamicInvoke because Reflection constructs TargetInvocationException
+                // from the shared inner exception before returning control to this code.
+                //
+                // Instead, make a shallow copy of the cached DuckTypeException and capture that copy immediately
+                // before every throw. MemberwiseClone preserves the exact internal exception subtype, message,
+                // inner exception, HResult, Data, and captured diagnostic state, while giving the runtime a
+                // distinct Exception object with independent mutable field slots. Concurrent throws can therefore
+                // no longer restore the same object's stack-trace or Watson-bucket fields. DynamicInvoke also sees
+                // a distinct inner exception for each call, so construction of TargetInvocationException is safe
+                // without holding a lock while callbacks or filters execute.
+                //
+                // .NET Framework's Reference Source uses the same relevant managed sequence as the affected
+                // CoreCLR: it restores ExceptionDispatchInfo state under an internal lock, releases that lock,
+                // and only then throws the shared Exception through Reflection. Its native clr.dll Watson-bucket
+                // copy implementation is not public, so it cannot prove that .NET Framework is safe. Apply this
+                // process-safety workaround to .NET Framework too. See:
+                // https://github.com/microsoft/referencesource/blob/main/mscorlib/system/exception.cs
+                //
+                // This branch is compiled into the net461, netstandard2.0, and netcoreapp3.1 tracer assets. The
+                // net6.0 asset is excluded because .NET 6 is the first runtime line containing Microsoft's
+                // confirmed native fix. Proxy creation failures are exceptional, so the extra exception and
+                // ExceptionDispatchInfo allocations do not affect successful proxy creation or invocation.
+                ExceptionDispatchInfo.Capture(((DuckTypeException)exceptionInfo.SourceException).CloneForThrow()).Throw();
 #else
                 // .NET 6 and later contain the runtime fix, so deliberately preserve the original concurrent
                 // behavior there. ConcurrentFailureTests exercises the same shared-exception scenario on these

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExceptions.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExceptions.cs
@@ -38,6 +38,10 @@ namespace Datadog.Trace.DuckTyping
         [DebuggerHidden]
         [DoesNotReturn]
         internal static void Throw(string message) => throw Create(message);
+
+#if !NET6_0_OR_GREATER
+        internal DuckTypeException CloneForThrow() => (DuckTypeException)MemberwiseClone();
+#endif
     }
 
     /// <summary>

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
@@ -56,14 +56,15 @@ public class ConcurrentFailureTests
     // thread briefly in that callback, the test deterministically observes whether the exact same cached
     // Exception can be thrown concurrently and validates the appropriate contract for each target:
     //
-    // - Every pre-.NET 6 target, including .NET Framework, must serialize the dispatches. The native CoreCLR
-    //   race is confirmed on old runtimes, while the public .NET Framework Reference Source exposes the same
-    //   managed race window but not the native clr.dll implementation needed to prove that it is safe.
-    // - .NET 6+ must allow the dispatches to overlap. Requiring overlap proves that those tests are exercising
-    //   the runtime fix rather than accidentally remaining protected by our workaround. If the runtime
-    //   regressed, the non-generic test would terminate the test process while reflection copies Watson buckets
-    //   into TargetInvocationException. Otherwise, all calls must complete with the expected cached exception
-    //   and exception-wrapper contracts.
+    // - Every pre-.NET 6 target, including .NET Framework, must throw a distinct copy of the cached exception.
+    //   The native CoreCLR race is confirmed on old runtimes, while the public .NET Framework Reference Source
+    //   exposes the same managed race window but not the native clr.dll implementation needed to prove it safe.
+    // - .NET 6+ must continue throwing the cached exception itself. Requiring the callbacks to overlap proves
+    //   that those tests exercise the runtime fix rather than accidentally retaining a serialization workaround.
+    // - Every target must allow callbacks to overlap. This guards against holding a monitor while synchronous
+    //   FirstChanceException callbacks or exception filters execute, which could deadlock customer processes.
+    //   If a runtime regressed, the non-generic test could additionally terminate the test process while
+    //   reflection copies Watson buckets into TargetInvocationException.
     private static void AssertConcurrentThrowsAreSafe(Func<Exception> invoke, Func<Exception, Exception> unwrap)
     {
         var firstException = invoke();
@@ -75,7 +76,7 @@ public class ConcurrentFailureTests
         var maximumConcurrentThrows = 0;
         EventHandler<FirstChanceExceptionEventArgs> handler = (_, args) =>
         {
-            if (!ReferenceEquals(args.Exception, cachedException))
+            if (args.Exception.GetType() != cachedException.GetType() || args.Exception.Message != cachedException.Message)
             {
                 return;
             }
@@ -128,21 +129,41 @@ public class ConcurrentFailureTests
             AppDomain.CurrentDomain.FirstChanceException -= handler;
         }
 
-        foreach (var exception in exceptions)
+        var unwrappedExceptions = new Exception[exceptions.Length];
+        for (var i = 0; i < exceptions.Length; i++)
         {
+            var exception = exceptions[i];
             exception.Should().NotBeNull();
-            unwrap(exception!).Should().BeSameAs(cachedException);
+            var unwrapped = unwrap(exception!);
+            unwrappedExceptions[i] = unwrapped;
+            unwrapped.Should().BeOfType(cachedException.GetType());
+            unwrapped.Message.Should().Be(cachedException.Message);
+#if NET6_0_OR_GREATER
+            unwrapped.Should().BeSameAs(
+                cachedException,
+                "the fixed runtime should preserve the existing cached-exception behavior without the workaround");
+#else
+            unwrapped.Should().NotBeSameAs(
+                cachedException,
+                "targets without a confirmed runtime fix must throw independent copies of the cached exception");
+#endif
         }
 
-#if NET6_0_OR_GREATER
+#if !NET6_0_OR_GREATER
+        for (var i = 0; i < unwrappedExceptions.Length; i++)
+        {
+            for (var j = i + 1; j < unwrappedExceptions.Length; j++)
+            {
+                unwrappedExceptions[i].Should().NotBeSameAs(
+                    unwrappedExceptions[j],
+                    "concurrent callers must never share an exception instance on targets without the runtime fix");
+            }
+        }
+#endif
+
         maximumConcurrentThrows.Should().BeGreaterThan(
             1,
-            "the fixed runtime should safely support concurrent dispatches without the workaround");
-#else
-        maximumConcurrentThrows.Should().Be(
-            1,
-            "targets without a confirmed runtime fix require the workaround to serialize dispatches of a cached exception");
-#endif
+            "exception dispatch must not hold a monitor while synchronous callbacks or exception filters execute");
     }
 
     private static Exception CaptureException(Action action)

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,6 +49,46 @@ public class ConcurrentFailureTests
         AssertConcurrentThrowsAreSafe(
             () => CaptureException(() => _ = result.ProxyType),
             exception => exception);
+    }
+
+    [Fact]
+    public void CachedFailureThrowPreservesOriginalStackTrace()
+    {
+        var originalException = CaptureOriginalFailure();
+        var originalStackTrace = originalException.StackTrace;
+        originalStackTrace.Should().NotBeNull();
+        originalStackTrace.Should().Contain(nameof(ThrowOriginalFailure));
+
+        var result = new DuckType.CreateTypeResult(
+            typeof(IWrongFieldName.IProtectedValueTypeField),
+            proxyType: null,
+            targetType: typeof(object),
+            activator: null,
+            ExceptionDispatchInfo.Capture(originalException));
+
+        var thrownException = CaptureCachedProxyTypeFailure(result);
+        thrownException.Should().BeOfType(originalException.GetType());
+#if NET6_0_OR_GREATER
+        thrownException.Should().BeSameAs(
+            originalException,
+            "the fixed runtime should preserve the existing cached-exception behavior without the workaround");
+#else
+        thrownException.Should().NotBeSameAs(
+            originalException,
+            "targets without a confirmed runtime fix must throw an independent copy of the cached exception");
+#endif
+
+        // The workaround copies the Exception before capturing and throwing it. Verify that the complete
+        // original trace survives that sequence and that ExceptionDispatchInfo appends the current dispatch
+        // path, rather than replacing the diagnostic information from the proxy-creation failure.
+        thrownException.StackTrace.Should().Contain(originalStackTrace!);
+        thrownException.StackTrace.Should().Contain(nameof(CaptureCachedProxyTypeFailure));
+
+#if !NET6_0_OR_GREATER
+        // Throwing the copy must not mutate the cached source exception. Besides preserving diagnostics for
+        // later callers, this separation is what prevents concurrent throws from racing over its CLR fields.
+        originalException.StackTrace.Should().Be(originalStackTrace);
+#endif
     }
 
     // The CoreCLR access violation is Windows-only and timing-dependent, so trying to provoke the native
@@ -178,6 +219,27 @@ public class ConcurrentFailureTests
             return exception;
         }
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static DuckTypeException CaptureOriginalFailure()
+    {
+        try
+        {
+            ThrowOriginalFailure();
+            return null;
+        }
+        catch (DuckTypeException exception)
+        {
+            return exception;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowOriginalFailure() => throw DuckTypeException.Create("Original proxy-creation failure");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Exception CaptureCachedProxyTypeFailure(DuckType.CreateTypeResult result)
+        => CaptureException(() => _ = result.ProxyType);
 
     private static Exception UnwrapTargetInvocationException(Exception exception)
     {

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
@@ -56,12 +56,14 @@ public class ConcurrentFailureTests
     // thread briefly in that callback, the test deterministically observes whether the exact same cached
     // Exception can be thrown concurrently and validates the appropriate contract for each target:
     //
-    // - Pre-.NET 6 CoreCLR targets must serialize the dispatches because they contain the runtime bug.
-    // - .NET Framework and .NET 6+ must allow the dispatches to overlap. Requiring overlap proves that those
-    //   tests are exercising the runtime fix rather than accidentally remaining protected by our workaround.
-    //   If the runtime regressed, the non-generic test would terminate the test process while reflection copies
-    //   Watson buckets into TargetInvocationException. Otherwise, all calls must complete with the expected
-    //   cached exception and exception-wrapper contracts.
+    // - Every pre-.NET 6 target, including .NET Framework, must serialize the dispatches. The native CoreCLR
+    //   race is confirmed on old runtimes, while the public .NET Framework Reference Source exposes the same
+    //   managed race window but not the native clr.dll implementation needed to prove that it is safe.
+    // - .NET 6+ must allow the dispatches to overlap. Requiring overlap proves that those tests are exercising
+    //   the runtime fix rather than accidentally remaining protected by our workaround. If the runtime
+    //   regressed, the non-generic test would terminate the test process while reflection copies Watson buckets
+    //   into TargetInvocationException. Otherwise, all calls must complete with the expected cached exception
+    //   and exception-wrapper contracts.
     private static void AssertConcurrentThrowsAreSafe(Func<Exception> invoke, Func<Exception, Exception> unwrap)
     {
         var firstException = invoke();
@@ -132,14 +134,14 @@ public class ConcurrentFailureTests
             unwrap(exception!).Should().BeSameAs(cachedException);
         }
 
-#if NETFRAMEWORK || NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
         maximumConcurrentThrows.Should().BeGreaterThan(
             1,
             "the fixed runtime should safely support concurrent dispatches without the workaround");
 #else
         maximumConcurrentThrows.Should().Be(
             1,
-            "pre-.NET 6 CoreCLR requires the workaround to serialize dispatches of a cached exception");
+            "targets without a confirmed runtime fix require the workaround to serialize dispatches of a cached exception");
 #endif
     }
 

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
@@ -1,0 +1,166 @@
+// <copyright file="ConcurrentFailureTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.DuckTyping.Tests.Errors.Fields.ValueType.ProxiesDefinitions.WrongFieldName;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests;
+
+public class ConcurrentFailureTests
+{
+    private const int ConcurrentCallCount = 4;
+
+    [Fact]
+    public void ConcurrentFailedGenericCreateInstanceCallsAreSerialized()
+    {
+        var target = ObscureObject.GetObject(nameof(ObscureObject.GetFieldInternalObject));
+
+        AssertConcurrentThrowsAreSerialized(
+            () => CaptureException(() => target.DuckCast<IWrongFieldName.IProtectedValueTypeField>()),
+            exception => exception);
+    }
+
+    [Fact]
+    public void ConcurrentFailedNonGenericCreateInstanceCallsAreSerialized()
+    {
+        var target = ObscureObject.GetObject(nameof(ObscureObject.GetFieldInternalObject));
+        var proxyType = typeof(IWrongFieldName.IProtectedValueTypeField);
+
+        AssertConcurrentThrowsAreSerialized(
+            () => CaptureException(() => target.DuckCast(proxyType)),
+            UnwrapTargetInvocationException);
+    }
+
+    [Fact]
+    public void ConcurrentFailedProxyTypeCallsAreSerialized()
+    {
+        var target = ObscureObject.GetObject(nameof(ObscureObject.GetFieldInternalObject));
+        var result = DuckType.GetOrCreateProxyType(typeof(IWrongFieldName.IProtectedValueTypeField), target.GetType());
+
+        AssertConcurrentThrowsAreSerialized(
+            () => CaptureException(() => _ = result.ProxyType),
+            exception => exception);
+    }
+
+    // The CoreCLR access violation is Windows-only and timing-dependent, so trying to provoke the native
+    // crash directly would make this regression test both platform-specific and flaky. FirstChanceException
+    // runs synchronously on the throwing thread before the exception is caught. By holding each participating
+    // thread briefly in that callback, the test deterministically observes whether the same cached Exception
+    // can be thrown concurrently. That is the exact precondition for the runtime race, while remaining safe
+    // and meaningful on every target framework and operating system.
+    private static void AssertConcurrentThrowsAreSerialized(Func<Exception> invoke, Func<Exception, Exception> unwrap)
+    {
+        var firstException = invoke();
+        firstException.Should().NotBeNull();
+        var cachedException = unwrap(firstException!);
+        cachedException.Should().BeAssignableTo<DuckTypeException>();
+
+        var activeThrows = 0;
+        var maximumConcurrentThrows = 0;
+        EventHandler<FirstChanceExceptionEventArgs> handler = (_, args) =>
+        {
+            if (!ReferenceEquals(args.Exception, cachedException))
+            {
+                return;
+            }
+
+            var currentActiveThrows = Interlocked.Increment(ref activeThrows);
+            try
+            {
+                UpdateMaximum(ref maximumConcurrentThrows, currentActiveThrows);
+
+                // Keep each throwing thread inside the first-chance callback long enough for the other
+                // dedicated threads to enter it too. Without serialization, this makes the overlap
+                // deterministic instead of relying on the much narrower CoreCLR Watson-bucket race.
+                Thread.Sleep(50);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref activeThrows);
+            }
+        };
+
+        var exceptions = new Exception[ConcurrentCallCount];
+        using var ready = new CountdownEvent(ConcurrentCallCount);
+        using var start = new ManualResetEventSlim();
+        var tasks = new Task[ConcurrentCallCount];
+
+        AppDomain.CurrentDomain.FirstChanceException += handler;
+        try
+        {
+            for (var i = 0; i < tasks.Length; i++)
+            {
+                var index = i;
+                tasks[index] = Task.Factory.StartNew(
+                    () =>
+                    {
+                        ready.Signal();
+                        start.Wait();
+                        exceptions[index] = invoke();
+                    },
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default);
+            }
+
+            ready.Wait();
+            start.Set();
+            Task.WaitAll(tasks);
+        }
+        finally
+        {
+            AppDomain.CurrentDomain.FirstChanceException -= handler;
+        }
+
+        foreach (var exception in exceptions)
+        {
+            exception.Should().NotBeNull();
+            unwrap(exception!).Should().BeSameAs(cachedException);
+        }
+
+        maximumConcurrentThrows.Should().Be(1);
+    }
+
+    private static Exception CaptureException(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+
+    private static Exception UnwrapTargetInvocationException(Exception exception)
+    {
+        exception.Should().BeOfType<TargetInvocationException>();
+        exception.InnerException.Should().NotBeNull();
+        return exception.InnerException!;
+    }
+
+    private static void UpdateMaximum(ref int maximum, int candidate)
+    {
+        var observedMaximum = Volatile.Read(ref maximum);
+        while (candidate > observedMaximum)
+        {
+            var previousMaximum = Interlocked.CompareExchange(ref maximum, candidate, observedMaximum);
+            if (previousMaximum == observedMaximum)
+            {
+                return;
+            }
+
+            observedMaximum = previousMaximum;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/ConcurrentFailureTests.cs
@@ -19,44 +19,50 @@ public class ConcurrentFailureTests
     private const int ConcurrentCallCount = 4;
 
     [Fact]
-    public void ConcurrentFailedGenericCreateInstanceCallsAreSerialized()
+    public void ConcurrentFailedGenericCreateInstanceCallsAreSafe()
     {
         var target = ObscureObject.GetObject(nameof(ObscureObject.GetFieldInternalObject));
 
-        AssertConcurrentThrowsAreSerialized(
+        AssertConcurrentThrowsAreSafe(
             () => CaptureException(() => target.DuckCast<IWrongFieldName.IProtectedValueTypeField>()),
             exception => exception);
     }
 
     [Fact]
-    public void ConcurrentFailedNonGenericCreateInstanceCallsAreSerialized()
+    public void ConcurrentFailedNonGenericCreateInstanceCallsAreSafe()
     {
         var target = ObscureObject.GetObject(nameof(ObscureObject.GetFieldInternalObject));
         var proxyType = typeof(IWrongFieldName.IProtectedValueTypeField);
 
-        AssertConcurrentThrowsAreSerialized(
+        AssertConcurrentThrowsAreSafe(
             () => CaptureException(() => target.DuckCast(proxyType)),
             UnwrapTargetInvocationException);
     }
 
     [Fact]
-    public void ConcurrentFailedProxyTypeCallsAreSerialized()
+    public void ConcurrentFailedProxyTypeCallsAreSafe()
     {
         var target = ObscureObject.GetObject(nameof(ObscureObject.GetFieldInternalObject));
         var result = DuckType.GetOrCreateProxyType(typeof(IWrongFieldName.IProtectedValueTypeField), target.GetType());
 
-        AssertConcurrentThrowsAreSerialized(
+        AssertConcurrentThrowsAreSafe(
             () => CaptureException(() => _ = result.ProxyType),
             exception => exception);
     }
 
     // The CoreCLR access violation is Windows-only and timing-dependent, so trying to provoke the native
-    // crash directly would make this regression test both platform-specific and flaky. FirstChanceException
-    // runs synchronously on the throwing thread before the exception is caught. By holding each participating
-    // thread briefly in that callback, the test deterministically observes whether the same cached Exception
-    // can be thrown concurrently. That is the exact precondition for the runtime race, while remaining safe
-    // and meaningful on every target framework and operating system.
-    private static void AssertConcurrentThrowsAreSerialized(Func<Exception> invoke, Func<Exception, Exception> unwrap)
+    // crash directly on an affected runtime would make the result flaky. FirstChanceException runs
+    // synchronously on the throwing thread before the exception is caught. By holding each participating
+    // thread briefly in that callback, the test deterministically observes whether the exact same cached
+    // Exception can be thrown concurrently and validates the appropriate contract for each target:
+    //
+    // - Pre-.NET 6 CoreCLR targets must serialize the dispatches because they contain the runtime bug.
+    // - .NET Framework and .NET 6+ must allow the dispatches to overlap. Requiring overlap proves that those
+    //   tests are exercising the runtime fix rather than accidentally remaining protected by our workaround.
+    //   If the runtime regressed, the non-generic test would terminate the test process while reflection copies
+    //   Watson buckets into TargetInvocationException. Otherwise, all calls must complete with the expected
+    //   cached exception and exception-wrapper contracts.
+    private static void AssertConcurrentThrowsAreSafe(Func<Exception> invoke, Func<Exception, Exception> unwrap)
     {
         var firstException = invoke();
         firstException.Should().NotBeNull();
@@ -126,7 +132,15 @@ public class ConcurrentFailureTests
             unwrap(exception!).Should().BeSameAs(cachedException);
         }
 
-        maximumConcurrentThrows.Should().Be(1);
+#if NETFRAMEWORK || NET6_0_OR_GREATER
+        maximumConcurrentThrows.Should().BeGreaterThan(
+            1,
+            "the fixed runtime should safely support concurrent dispatches without the workaround");
+#else
+        maximumConcurrentThrows.Should().Be(
+            1,
+            "pre-.NET 6 CoreCLR requires the workaround to serialize dispatches of a cached exception");
+#endif
     }
 
     private static Exception CaptureException(Action action)


### PR DESCRIPTION
## Summary of changes

- Avoids concurrently rethrowing the same cached DuckTyping failure in the `net461`, `netstandard2.0`, and `netcoreapp3.1` tracer assets.
- Creates an independent shallow copy of the cached `DuckTypeException` for every throw on those targets, preserving its exact subtype and diagnostic content without holding a lock across exception dispatch.
- Covers the generic failure delegate, the `ProxyType` getter, and the non-generic `DynamicInvoke` path.
- Keeps deterministic concurrency regression tests for all three routes on every test TFM, including .NET 6 and later where the workaround must not be present.

## Reason for change

Windows unit tests intermittently crashed on .NET Core 3.1 and .NET 5 in [pipeline 208654](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=208654) with:

```text
Fatal error. Internal CLR error. (0x80131506)
```

The managed stack ended in the non-generic DuckTyping failure path:

```text
System.RuntimeMethodHandle.InvokeMethod
System.Reflection.RuntimeMethodInfo.Invoke
System.Delegate.DynamicInvokeImpl
System.Delegate.DynamicInvoke
Datadog.Trace.DuckTyping.DuckType.CreateTypeResult.CreateInstance(object)
Datadog.Trace.DuckTyping.DuckType.Create(Type, object)
Datadog.Trace.DuckTyping.DuckTypeExtensions.DuckCast(object, Type)
CanCreateConsistencyTests.CaptureCreationFailure(...)
```

The .NET 5 dump was symbolized using the exact `coreclr.dll` and private PDB downloaded for runtime 5.0.17. The native stack identifies the fatal access violation:

```text
ThrowInvokeMethodException
StackTraceInfo::AppendElement
SetupInitialThrowBucketDetails
CopyWatsonBucketsFromThrowableToCurrentThrowable
CopyWatsonBucketsBetweenThrowables    excep.cpp:10165
CLRVectoredExceptionHandler
EEPolicy::HandleFatalError
WatsonLastChance
```

A failed proxy creation is stored in the global DuckTyping cache as one `CreateTypeResult`. That result contains an `ExceptionDispatchInfo` and a failure delegate. Although `CreateTypeResult` is a readonly struct and callers receive copies, those copies retain references to the same `ExceptionDispatchInfo` and underlying `Exception`. Concurrent attempts to create the same invalid proxy therefore rethrow the same exception object.

This triggers a known race in Windows CoreCLR versions before .NET 6: [dotnet/runtime#45929](https://github.com/dotnet/runtime/issues/45929). While one thread is copying Watson crash-reporting metadata from an exception, another `ExceptionDispatchInfo.Throw()` can restore the same exception's captured mutable fields and reset its Watson-bucket reference to null. Older CoreCLR code checks the reference for null and reads it again later; if the second read observes null, CoreCLR dereferences it and terminates the process with an access violation.

Microsoft's regression test uses the same essential pattern as DuckTyping: a cached `ExceptionDispatchInfo` is thrown concurrently through `MethodInfo.Invoke()`. Microsoft fixed the race in [dotnet/runtime#46636](https://github.com/dotnet/runtime/pull/46636) by reading the Watson-bucket reference once, keeping that reference GC-protected, and passing the captured value through the copy operations. They subsequently added further hardening for multiple threads throwing the same exception in [dotnet/runtime#57959](https://github.com/dotnet/runtime/pull/57959). These changes shipped in .NET 6 but are absent from the affected .NET Core 3.1 and .NET 5 runtimes.

.NET Framework's public Reference Source shows the same relevant managed sequence as affected CoreCLR 3.1: `ExceptionDispatchInfo.Throw()` restores mutable exception state under an internal global lock, releases that lock, and only then throws the shared exception through Reflection. The affected CoreCLR 3.1 code had an equivalent lock, so that lock does not close the native race window. Reference Source does not publish the native `clr.dll` Watson-bucket copy implementation required to prove that .NET Framework is safe. The workaround therefore includes .NET Framework conservatively instead of relying on an unverified native implementation detail.

The Watson path is Windows-specific. This explains why repeated x64 runs through Rosetta did not reproduce the native crash: Rosetta changes the architecture, but the process still executes the Unix CoreCLR exception path.

## Implementation details

On targets without a confirmed runtime fix, `ThrowCachedException()` uses `MemberwiseClone()` to make a new object from the cached `DuckTypeException`, immediately captures that copy in a new `ExceptionDispatchInfo`, and throws the copy. A shallow copy is intentional:

- It preserves the exact internal exception subtype, message, inner exception, `HResult`, `Data`, and captured diagnostic state.
- It gives the runtime independent mutable exception field slots for every call, so concurrent `ExceptionDispatchInfo.Throw()` operations cannot reset the same stack-trace or Watson-bucket fields.
- The generic route and `ProxyType` getter throw independent exception objects directly.
- The non-generic failure delegate gives each `DynamicInvoke()` call an independent inner exception, so Reflection can construct its `TargetInvocationException` wrapper without racing another call.

The first implementation serialized throws with a monitor. That closes the runtime race, but it can deadlock an instrumented process: `FirstChanceException` subscribers and exception filters execute synchronously before exception dispatch unwinds through the monitor's `finally`. If such code waits for another thread that reaches the same cached failure, the second thread waits for the monitor while the first waits for the second. Creating distinct exception objects removes the runtime race without running callbacks or filters while holding a DuckTyping lock.

The workaround is compiled under `#if !NET6_0_OR_GREATER`:

- .NET Framework consumes the `net461` asset, which includes the workaround because its managed race window matches affected CoreCLR and the native implementation needed to prove safety is not public.
- `netcoreapp2.1` and `netcoreapp3.0` consume the `netstandard2.0` asset.
- `netcoreapp3.1` and .NET 5 consume the `netcoreapp3.1` asset.
- .NET 6 and later consume the `net6.0` asset and are excluded because they contain Microsoft's confirmed runtime fix.

Successful proxy creation and invocation are unchanged. Only a cached failure throw on protected targets allocates the exception copy and its `ExceptionDispatchInfo`. On .NET 6 and later, the original cached-exception behavior is preserved without the workaround.

The source comments include links to the CoreCLR issue and fix and to the .NET Framework Reference Source, and document both the native race and why the workaround must not hold a lock across exception dispatch.

## Test coverage

Added `ConcurrentFailureTests`, covering:

- Concurrent generic proxy creation failures.
- Concurrent non-generic proxy creation failures and their `TargetInvocationException` wrapper.
- Concurrent access to `CreateTypeResult.ProxyType` after proxy creation failed.
- Preservation of the complete original proxy-creation stack trace across cached failure dispatch.

The native access violation is Windows-only and timing-dependent, so the regression tests do not rely solely on reproducing the crash. They use the synchronous `FirstChanceException` callback to widen the dispatch window and deterministically measure concurrent throws of the matching failure.

The assertions intentionally differ by target:

- Every target without a confirmed runtime fix, including .NET Framework, requires a distinct exception object for the initial call and every concurrent caller, while preserving the exact subtype and message.
- .NET 6 and later require every caller to receive the same cached exception object, proving the workaround is not compiled into the fixed runtime asset.
- Every target requires overlapping first-chance callbacks, proving that DuckTyping does not hold a monitor while synchronous callbacks or exception filters execute.
- The non-generic route must preserve its `TargetInvocationException` wrapper and expected inner `DuckTypeException` contract.
- The copied-exception route must preserve every original stack-trace frame, append the current dispatch path, and leave the cached source exception unchanged.

Local verification:

- Full DuckTyping suite on .NET Core 3.1 x64 through Rosetta: 10,930 passed, 5 skipped.
- Full DuckTyping suite on .NET 8 arm64: 10,930 passed, 5 skipped.
- Focused concurrency tests passed on `netcoreapp2.1`, `netcoreapp3.0`, `netcoreapp3.1`, `net5.0`, `net6.0`, and `net8.0`: 4 passed on every target.
- `Datadog.Trace` `net461` asset build: succeeded with 0 warnings and 0 errors.
- DuckTyping test project `net48` build: succeeded with 0 warnings and 0 errors. The .NET Framework CLR cannot be executed on the macOS development host.

Windows CI remains the platform-specific validation of the original Watson path and the new distinct-exception assertions on .NET Framework.

## Other details

No public API changes. Existing exception subtypes, messages, inner exceptions, and the non-generic reflection wrapper are preserved. This is a narrowly scoped managed workaround for cached failure dispatch on runtime targets without a confirmed native fix; it does not change .NET 6 or later production code.
