### PR TITLE
Ensure iast::Contains test checks vector, set and unordered_map and reduce test allocations

### DIFF
--- a/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
@@ -4,6 +4,7 @@
 #include "test_helpers.h"
 #include "../../../shared/src/native-src/pal.h"
 
+#include <array>
 #include <vector>
 
 using namespace trace;
@@ -216,7 +217,7 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromMethods) {
 }
 
 TEST_F(CLRHelperTest, FindTypeDefsByName) {
-  std::vector<shared::WSTRING> expected_types = {
+  const std::array<shared::WSTRING, 10> expected_types = {
       WStr("Samples.ExampleLibrary.Class1"),
       WStr("Samples.ExampleLibrary.GenericTests.ComprehensiveCaller`2"),
       WStr("Samples.ExampleLibrary.GenericTests.GenericTarget`2"),
@@ -238,7 +239,7 @@ TEST_F(CLRHelperTest, FindTypeDefsByName) {
 }
 
 TEST_F(CLRHelperTest, FindNestedTypeDefsByName) {
-  std::vector<shared::WSTRING> expected_types = {
+  const std::array<shared::WSTRING, 2> expected_types = {
       WStr("Samples.ExampleLibrary.FakeClient.Biscuit+Cookie"),
       WStr("Samples.ExampleLibrary.FakeClient.StructBiscuit+Cookie")};
 

--- a/tracer/test/Datadog.Tracer.Native.Tests/dataflow_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/dataflow_test.cpp
@@ -23,11 +23,9 @@ TEST(DataflowTests, PreloadedModulesAreNotResolvedFromTheConstructor)
     auto runtimeInfo = MakeTestRuntimeInformation();
     std::vector<ModuleID> preloadedModules{42};
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
 
     EXPECT_EQ(0, mockProfiler.getModuleInfo2CallCount);
-
-    delete dataflow;
 }
 
 TEST(DataflowTests, PreloadedModulesAreResolvedOnTheNextModuleLoaded)
@@ -36,18 +34,16 @@ TEST(DataflowTests, PreloadedModulesAreResolvedOnTheNextModuleLoaded)
     auto runtimeInfo = MakeTestRuntimeInformation();
     std::vector<ModuleID> preloadedModules{42};
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
 
-    dataflow->ModuleLoaded(99);
+    dataflow.ModuleLoaded(99);
 
     // The preloaded module and the newly loaded one, once each.
     EXPECT_EQ(2, mockProfiler.getModuleInfo2CallCount);
 
     // The preloaded list is drained, so a later ModuleLoaded only resolves its own module.
-    dataflow->ModuleLoaded(100);
+    dataflow.ModuleLoaded(100);
     EXPECT_EQ(3, mockProfiler.getModuleInfo2CallCount);
-
-    delete dataflow;
 }
 
 TEST(DataflowTests, UnloadedModulesAreDroppedFromThePendingPreloadList)
@@ -58,15 +54,13 @@ TEST(DataflowTests, UnloadedModulesAreDroppedFromThePendingPreloadList)
     auto runtimeInfo = MakeTestRuntimeInformation();
     std::vector<ModuleID> preloadedModules{42};
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
 
-    dataflow->ModuleUnloaded(42);
-    dataflow->ModuleLoaded(99);
+    dataflow.ModuleUnloaded(42);
+    dataflow.ModuleLoaded(99);
 
     // Only the newly loaded module is resolved; the unloaded one is never touched.
     EXPECT_EQ(1, mockProfiler.getModuleInfo2CallCount);
-
-    delete dataflow;
 }
 
 TEST(DataflowTests, ModuleLoadedResolvesNewlyLoadedModules)
@@ -75,14 +69,12 @@ TEST(DataflowTests, ModuleLoadedResolvesNewlyLoadedModules)
     auto runtimeInfo = MakeTestRuntimeInformation();
     std::vector<ModuleID> preloadedModules{};
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
     EXPECT_EQ(0, mockProfiler.getModuleInfo2CallCount);
 
-    dataflow->ModuleLoaded(99);
+    dataflow.ModuleLoaded(99);
 
     EXPECT_EQ(1, mockProfiler.getModuleInfo2CallCount);
-
-    delete dataflow;
 }
 
 TEST(DataflowTests, UnresolvedModulesAreResolvedOnDemand)
@@ -94,18 +86,16 @@ TEST(DataflowTests, UnresolvedModulesAreResolvedOnDemand)
     auto runtimeInfo = MakeTestRuntimeInformation();
     std::vector<ModuleID> preloadedModules{42};
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
 
-    auto moduleInfo = dataflow->GetModuleInfo(42);
+    auto moduleInfo = dataflow.GetModuleInfo(42);
 
     EXPECT_NE(nullptr, moduleInfo);
     EXPECT_EQ(1, mockProfiler.getModuleInfo2CallCount);
 
     // Served from cache the second time.
-    EXPECT_EQ(moduleInfo, dataflow->GetModuleInfo(42));
+    EXPECT_EQ(moduleInfo, dataflow.GetModuleInfo(42));
     EXPECT_EQ(1, mockProfiler.getModuleInfo2CallCount);
-
-    delete dataflow;
 }
 
 TEST(DataflowTests, ResolvingAModuleOnlyAsksForReadAccess)
@@ -117,10 +107,10 @@ TEST(DataflowTests, ResolvingAModuleOnlyAsksForReadAccess)
     MockCorProfilerInfo mockProfiler;
     auto runtimeInfo = MakeTestRuntimeInformation();
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, std::vector<ModuleID>{42}, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, std::vector<ModuleID>{42}, runtimeInfo);
 
-    dataflow->ModuleLoaded(99);
-    dataflow->GetModuleInfo(100);
+    dataflow.ModuleLoaded(99);
+    dataflow.GetModuleInfo(100);
 
     EXPECT_FALSE(mockProfiler.moduleMetaDataOpenFlags.empty());
     EXPECT_FALSE(mockProfiler.AskedForWriteAccess());
@@ -128,8 +118,6 @@ TEST(DataflowTests, ResolvingAModuleOnlyAsksForReadAccess)
     {
         EXPECT_EQ(static_cast<DWORD>(ofRead), flags);
     }
-
-    delete dataflow;
 }
 
 TEST(DataflowTests, FailedResolutionIsCachedAndNotRetried)
@@ -164,12 +152,10 @@ TEST(DataflowTests, UnloadingAModuleWithACachedFailureDoesNotDereferenceIt)
     auto runtimeInfo = MakeTestRuntimeInformation();
     std::vector<ModuleID> preloadedModules{};
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
 
-    EXPECT_EQ(nullptr, dataflow->GetModuleInfo(42));
-    EXPECT_EQ(S_OK, dataflow->ModuleUnloaded(42));
-
-    delete dataflow;
+    EXPECT_EQ(nullptr, dataflow.GetModuleInfo(42));
+    EXPECT_EQ(S_OK, dataflow.ModuleUnloaded(42));
 }
 
 TEST(DataflowTests, NothingIsResolvedWhenTheProfilerQueryInterfaceFailed)
@@ -181,11 +167,9 @@ TEST(DataflowTests, NothingIsResolvedWhenTheProfilerQueryInterfaceFailed)
     auto runtimeInfo = MakeTestRuntimeInformation();
     std::vector<ModuleID> preloadedModules{42};
 
-    auto dataflow = new iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
+    auto dataflow = iast::Dataflow(&mockProfiler, nullptr, preloadedModules, runtimeInfo);
 
-    EXPECT_EQ(nullptr, dataflow->GetModuleInfo(42));
-    dataflow->ModuleLoaded(99);
+    EXPECT_EQ(nullptr, dataflow.GetModuleInfo(42));
+    dataflow.ModuleLoaded(99);
     EXPECT_EQ(0, mockProfiler.getModuleInfo2CallCount);
-
-    delete dataflow;
 }

--- a/tracer/test/Datadog.Tracer.Native.Tests/iast_util_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/iast_util_test.cpp
@@ -117,13 +117,13 @@ TEST(IastIntegrationTests, Contains)
     EXPECT_FALSE(iast::Contains(stringVector, "String4"));
 
     const std::set<std::string> stringSet = {"String1", "String2", "String3"};
-    EXPECT_TRUE(iast::Contains(stringVector, "String1"));
-    EXPECT_FALSE(iast::Contains(stringVector, "String5"));
+    EXPECT_TRUE(iast::Contains(stringSet, "String1"));
+    EXPECT_FALSE(iast::Contains(stringSet, "String5"));
 
     const std::unordered_map<std::string, std::string> stringMap = {
         {"String1", "1"}, {"String2", "2"}, {"String3", "3"}};
-    EXPECT_TRUE(iast::Contains(stringVector, "String3"));
-    EXPECT_FALSE(iast::Contains(stringVector, "String0"));
+    EXPECT_TRUE(iast::Contains(stringMap, std::make_pair("String3", "3")));
+    EXPECT_FALSE(iast::Contains(stringMap, std::make_pair("String0", "0")));
 }
 
 TEST(IastIntegrationTests, Vector_AddRange)


### PR DESCRIPTION
## Summary of changes
Add missed tests for iast::Contains in set and unordered_map.

## Reason for change
iast::Contains test allocated vector, set and unordered_map, but checked only vector.

## Implementation details
Just used created but unused variables.

## Test coverage
Not changed.

## Other details
None
