### PR TITLE
[ASP.NET MVC] Handle malformed request URLs when creating scopes

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -120,9 +120,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                         actionName = (routeValues?.GetValueOrDefault("action") as string)?.ToLowerInvariant();
                     }
 
-                    if (string.IsNullOrEmpty(resourceName) && httpContext.Request.Url != null)
+                    if (string.IsNullOrEmpty(resourceName) && RequestDataHelper.GetUrl(httpContext.Request) is { } requestUrl)
                     {
-                        var cleanUri = UriHelpers.GetCleanUriPath(httpContext.Request.Url, httpContext.Request.ApplicationPath);
+                        var cleanUri = UriHelpers.GetCleanUriPath(requestUrl, httpContext.Request.ApplicationPath);
                         resourceName = $"{httpMethod} {cleanUri.ToLowerInvariant()}";
                     }
 

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -17,8 +17,11 @@ namespace Datadog.Trace.Util.Http
         internal static string GetUrlForSpan(this IHttpRequestMessage request, QueryStringManager queryStringManager)
             => HttpRequestUtils.GetUrl(request.RequestUri, queryStringManager);
 
-        internal static string GetUrlForSpan(this HttpRequestBase request, QueryStringManager queryStringManager)
-            => HttpRequestUtils.GetUrl(request.Url, queryStringManager);
+        internal static string? GetUrlForSpan(this HttpRequestBase request, QueryStringManager queryStringManager)
+        {
+            var url = RequestDataHelper.GetUrl(request);
+            return url is null ? null : HttpRequestUtils.GetUrl(url, queryStringManager);
+        }
 
         /// <summary>
         /// Gets the Url from the <paramref name="request"/>.

--- a/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
@@ -175,6 +175,11 @@ internal static class RequestDataHelper
 
     /// <summary>
     /// Gets the Uri from the <paramref name="request"/>.
+    /// <para>
+    /// Note that this will <em>CACHE</em> the <c>Uri</c> of the underlying <see cref="HttpRequest"/>
+    /// for all future callers (example the customer's application) if the <paramref name="request"/>
+    /// is an <see cref="HttpRequestWrapper"/> and we are the first to call <see cref="HttpRequest.Url"/>.
+    /// </para>
     /// </summary>
     /// <param name="request">The <see cref="HttpRequestBase"/> to get the <c>Uri</c> of.</param>
     /// <returns>The <c>Uri</c>; otherwise <see langword="null"/>.</returns>

--- a/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
@@ -187,7 +187,7 @@ internal static class RequestDataHelper
         }
         catch (Exception ex) when (ex is HttpRequestValidationException || ex is UriFormatException)
         {
-            Log.Debug("Error reading request.Url from the request.");
+            Log.Debug(ex, "Error reading request.Url from the request.");
             return null;
         }
     }

--- a/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/RequestDataHelper.cs
@@ -174,6 +174,25 @@ internal static class RequestDataHelper
     }
 
     /// <summary>
+    /// Gets the Uri from the <paramref name="request"/>.
+    /// </summary>
+    /// <param name="request">The <see cref="HttpRequestBase"/> to get the <c>Uri</c> of.</param>
+    /// <returns>The <c>Uri</c>; otherwise <see langword="null"/>.</returns>
+    internal static Uri? GetUrl(HttpRequestBase request)
+    {
+        // UriFormatException can happen if, for example, the request contains the variable "SERVER_NAME" with an invalid value.
+        try
+        {
+            return request.Url;
+        }
+        catch (Exception ex) when (ex is HttpRequestValidationException || ex is UriFormatException)
+        {
+            Log.Debug("Error reading request.Url from the request.");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Builds the Uri from the <paramref name="request"/>.
     /// <para>
     /// Note that this will <em>bypass</em> the caching behavior of the <see cref="HttpRequest.Url"/> property.

--- a/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/RequestDataHelperTests.cs
@@ -19,6 +19,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Util;
+using Datadog.Trace.Util.Http;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -55,6 +56,8 @@ public class RequestDataHelperTests
         var workerRequest = new SimpleWorkerInvalidHost("/test", "/test", "test.aspx", null, new StringWriter());
         var context = new HttpContext(workerRequest);
         var request = context.Request;
+        var requestBase = new HttpRequestWrapper(request);
+        var queryStringManager = new QueryStringManager(reportQueryString: false, timeout: 200, maxSizeBeforeObfuscation: 5_000, pattern: string.Empty);
 
         try
         {
@@ -65,6 +68,8 @@ public class RequestDataHelperTests
         {
             RequestDataHelper.BuildUrl(request).Should().BeNull();
             RequestDataHelper.GetUrl(request).Should().BeNull();
+            RequestDataHelper.GetUrl(requestBase).Should().BeNull();
+            requestBase.GetUrlForSpan(queryStringManager).Should().BeNull();
         }
     }
 #endif


### PR DESCRIPTION
## Summary of changes

Prevents malformed ASP.NET request URL data from aborting ASP.NET MVC scope creation with a `UriFormatException`.

## Reason for change

Some customers are hitting [the following error](https://app.datadoghq.com/error-tracking?query=%40lib_language%3Adotnet%20%2Adatadog%2A%20%40tracer_version%3A3.5%2A&fromUser=false&refresh_mode=sliding&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22936881e2-3ae6-11f0-b58c-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1787653820738&to_ts=1788863420738&live=true) while the ASP.NET MVC integration creates a scope:

```text
Error creating or populating scope.
System.UriFormatException
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind)
   at System.Web.Util.UriUtil.BuildUriImpl(String scheme, String serverName, String port, String path, String queryString, Boolean useLegacyRequestUrlGeneration)
   at System.Web.HttpRequest.BuildUrl(Func`1 pathAccessor)
   at System.Web.HttpRequest.get_Url()
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet.AspNetMvcIntegration.CreateScope(ControllerContextStruct controllerContext)
```

`HttpRequest.Url` is built lazily from ASP.NET server variables and can throw when values such as `SERVER_NAME` or the port do not form a valid URI.

One plausible production scenario is a proxy-related HTTP module copying `X-Forwarded-Host` into `SERVER_NAME` without validating it:

```csharp
application.BeginRequest += (_, _) =>
{
    var request = application.Context.Request;
    var forwardedHost = request.Headers["X-Forwarded-Host"];

    if (!string.IsNullOrEmpty(forwardedHost))
    {
        request.ServerVariables.Set("SERVER_NAME", forwardedHost);
    }
};
```

A request sent to a valid IIS URL with a malformed forwarded host, for example `X-Forwarded-Host: localhost:4444ide`, is accepted by IIS first. The module then changes the server variable, and the deferred `Request.Url` construction throws when MVC instrumentation accesses it.

This is also reproducible deterministically with a `SimpleWorkerRequest` whose `GetServerName()` returns `invalid:rrr`, wrapped in `HttpRequestWrapper` to match the `HttpRequestBase` abstraction used by MVC.

## Implementation details

- Adds a safe `RequestDataHelper.GetUrl(HttpRequestBase)` overload that catches `UriFormatException` and `HttpRequestValidationException`, matching the existing protection for `HttpRequest`.
- Uses the safe helper when generating the MVC span URL.
- Uses the same protection in the fallback resource-name calculation, removing the remaining direct `HttpRequestBase.Url` access.

When URL construction fails, `http.url` is omitted and scope creation continues using the route or controller/action resource-name fallback.

## Test coverage

Extended `GivenAIncorrectHost_WhenGetUrl_HelperAvoidsException` to cover:

- URL retrieval through `HttpRequestBase`/`HttpRequestWrapper`.
- The `GetUrlForSpan()` path used by ASP.NET MVC.

Validated on .NET Framework 4.8: all 12 `RequestDataHelperTests` pass.

## Other details

This complements the equivalent protection previously added for the ASP.NET `TracingHttpModule` in #7550.