### PR TITLE
Generic performance optimizations in native tracer and profiler

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/member_signature.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/member_signature.cpp
@@ -203,7 +203,6 @@ shared::WSTRING MemberSignature::GetTypeSigName(PCCOR_SIGNATURE& pSig, const Com
 
 shared::WSTRING MemberSignature::GetMethodSigName(PCCOR_SIGNATURE& pSig, const ComPtr<IMetaDataImport>& metadataImport)
 {
-    shared::WSTRING tokenName;
     if (*pSig == ELEMENT_TYPE_BYREF)
     {
         pSig++;

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -51,8 +51,6 @@ HRESULT SingleStepGuardRails::CheckRuntime(const RuntimeInformation& runtimeInfo
     // We're doing single-step instrumentation, check if we're in an EOL environment
     
     IUnknown* tstVerProfilerInfo;
-    std::string unsupportedRuntimeVersion;
-    std::string unsupportedSummary;
 
     if (runtimeInformation.is_core())
     {

--- a/shared/src/native-src/logger.h
+++ b/shared/src/native-src/logger.h
@@ -88,7 +88,7 @@ inline Logger Logger::Create()
 
 inline std::string Logger::SanitizeProcessName(std::string const& processName)
 {
-    const auto process_name_without_extension = processName.substr(0, processName.find_last_of("."));
+    const auto process_name_without_extension = processName.substr(0, processName.find_last_of('.'));
     const std::regex dash_or_space_or_tab("-|\\s|\\t");
     return std::regex_replace(process_name_without_extension, dash_or_space_or_tab, "_");
 }

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -318,7 +318,7 @@ TypeInfoLeaf ResolveTypeInfoLeaf(const ComPtr<IMetaDataImport2>& metadata_import
         leaf.type_spec = typeSpec;
         leaf.token_type = typeSpec != mdTypeSpecNil ? mdtTypeSpec : token_type;
 
-        const auto generic_token_index = leaf.name.rfind(WStr("`"));
+        const auto generic_token_index = leaf.name.rfind(WStr('`'));
         if (generic_token_index != std::string::npos)
         {
             const auto idxFromRight = leaf.name.length() - generic_token_index - 1;

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -572,9 +572,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
             // Push integration definitions from the given module
             for (const auto& methodReference : methodReferences)
             {
-                integration_definitions_.push_back(
-                    IntegrationDefinition(methodReference, *trace_annotation_integration_type.get(), false, false,
-                                          false));
+                integration_definitions_.emplace_back(
+                    methodReference, *trace_annotation_integration_type.get(), false, false,
+                                          false);
             }
 
             rejit_module_method_pairs.pop_front();
@@ -1143,10 +1143,10 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                             // As we are in the right method, we gather all information we need and stored it in to
                             // the ReJIT handler.
                             std::vector<shared::WSTRING> signatureTypes;
-                            methodReferences.push_back(MethodReference(
+                            methodReferences.emplace_back(
                                 tracemethodintegration_assemblyname, caller.type.name, caller.name,
                                 Version(0, 0, 0, 0), Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX),
-                                signatureTypes));
+                                signatureTypes);
                         }
                     }
                 }
@@ -1177,8 +1177,8 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                 // Push integration definitions from this module
                 for (const auto& methodReference : methodReferences)
                 {
-                    integration_definitions_.push_back(IntegrationDefinition(
-                        methodReference, *trace_annotation_integration_type.get(), false, false, false));
+                    integration_definitions_.emplace_back(
+                        methodReference, *trace_annotation_integration_type.get(), false, false, false);
                 }
             }
         }
@@ -1847,7 +1847,7 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
                 const auto& currentSignature = current.signatureTypes[sIdx];
                 if (currentSignature != nullptr)
                 {
-                    signatureTypes.push_back(shared::WSTRING(currentSignature));
+                    signatureTypes.emplace_back(currentSignature);
                 }
             }
 
@@ -1965,7 +1965,7 @@ long CorProfiler::RegisterCallTargetDefinitions(WCHAR* id, CallTargetDefinition3
                 const auto& currentSignature = current.signatureTypes[sIdx];
                 if (currentSignature != nullptr)
                 {
-                    signatureTypes.push_back(shared::WSTRING(currentSignature));
+                    signatureTypes.emplace_back(currentSignature);
                 }
             }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
@@ -499,7 +499,7 @@ void DebuggerProbesInstrumentationRequester::AddMethodProbes(debugger::DebuggerM
                 const auto& currentSignature = current.targetParameterTypes[sIdx];
                 if (currentSignature != nullptr)
                 {
-                    signatureTypes.push_back(shared::WSTRING(currentSignature));
+                    signatureTypes.emplace_back(currentSignature);
                 }
             }
 
@@ -549,7 +549,7 @@ void DebuggerProbesInstrumentationRequester::AddMethodProbes(debugger::DebuggerM
                 const auto& currentSignature = current.targetParameterTypes[sIdx];
                 if (currentSignature != nullptr)
                 {
-                    signatureTypes.push_back(shared::WSTRING(currentSignature));
+                    signatureTypes.emplace_back(currentSignature);
                 }
             }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
@@ -58,7 +58,6 @@ WSTRING DebuggerProbesInstrumentationRequester::GenerateRandomProbeId()
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<> dis(0, 15);
-    std::uniform_int_distribution<> dis8(8, 11);
 
     std::wstringstream ss;
     int i;

--- a/tracer/src/Datadog.Tracer.Native/iast/aspect.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/aspect.cpp
@@ -37,7 +37,7 @@ std::vector<VulnerabilityType> ParseVulnerabilityTypes(const std::string& txt)
     std::vector<VulnerabilityType> res;
     res.reserve(2);
     auto parts = Split(TrimEnd(TrimStart(txt, "["), "]"), ",");
-    for (auto part : parts)
+    for (auto &part : parts)
     {
         res.push_back(ParseVulnerabilityType(Trim(part)));
     }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -233,7 +233,7 @@ namespace iast
         }
         if ((int)parts.size() > ++part) // TargetType
         {
-            WSTRING assembliesPart, targetParams;
+            WSTRING assembliesPart;
 
             SplitType(parts[part], &assembliesPart, &_targetType);
             if (assembliesPart.length() > 0)

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -39,7 +39,7 @@ namespace iast
     {
         std::vector<DataflowAspectFilterValue> res;
         auto parts = Split(TrimEnd(TrimStart(filter, WStr("[")), WStr("]")), WStr(","));
-        for(auto part : parts)
+        for(auto &part : parts)
         {
             res.push_back(ParseAspectFilterValue(Trim(part)));
         }
@@ -360,7 +360,7 @@ namespace iast
                 {
                     if (auto sig = memberRefInfo->GetSignature())
                     {
-                        auto sigRepresentation = sig->GetParamsRepresentation();
+                        const auto &sigRepresentation = sig->GetParamsRepresentation();
                         if (sigRepresentation == _targetMethodParams)
                         {
                             //Found the method

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -333,17 +333,17 @@ namespace iast
         mdTypeRef targetTypeRef = 0; 
         std::vector<mdTypeRef> paramTypeRefs; 
         std::vector<mdMemberRef> targetMethodRefCandidates;
-        hr = module->FindTypeRefByName(_targetMethodType.c_str(), &targetMethodTypeRef);
+        hr = module->FindTypeRefByName(_targetMethodType, &targetMethodTypeRef);
         if (SUCCEEDED(hr))
         {
-            module->FindMemberRefsByName(targetMethodTypeRef, _targetMethodName.c_str(), targetMethodRefCandidates);
+            module->FindMemberRefsByName(targetMethodTypeRef, _targetMethodName, targetMethodRefCandidates);
         }
         else if (this->IsTargetModule(module))
         {
-            hr = module->GetTypeDef(_targetMethodType.c_str(), &targetMethodTypeRef);
+            hr = module->GetTypeDef(_targetMethodType, &targetMethodTypeRef);
             if (SUCCEEDED(hr))
             {
-                auto methods = module->GetMethods(targetMethodTypeRef, _targetMethodName.c_str());
+                auto methods = module->GetMethods(targetMethodTypeRef, _targetMethodName);
                 for (auto method : methods)
                 {
                     targetMethodRefCandidates.push_back(method->GetMethodDef());
@@ -395,7 +395,7 @@ namespace iast
             if (targetMethodRef != 0 && _isVirtual)
             {
                 //Look for virtual target typeRef
-                if (FAILED(module->FindTypeRefByName(_targetType.c_str(), &targetTypeRef)))
+                if (FAILED(module->FindTypeRefByName(_targetType, &targetTypeRef)))
                 {
                     targetMethodRef = 0;
                 }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -659,7 +659,7 @@ namespace iast
                 {
                     if (IsReplace(_aspect->_behavior) || _aspect->_paramShift[x] == 0)
                     {
-                        instructionsToProcess.push_back(InstructionProcessInfo(instruction, x, _aspect->_behavior));
+                        instructionsToProcess.emplace_back(instruction, x, _aspect->_behavior);
                     }
                     else if (!IsReplace(_aspect->_behavior) && _aspect->_paramShift[x] > 0)
                     {
@@ -669,7 +669,7 @@ namespace iast
                         int paramCount = methodSig->GetEffectiveParamCount();
                         for (auto iInfo : processor->StackAnalysis()->LocateCallParamInstructions(instruction, paramCount - _aspect->_paramShift[x] - 1)) //Locate param load instruction
                         {
-                            instructionsToProcess.push_back(InstructionProcessInfo(iInfo->_instruction, x, AspectBehavior::InsertAfter)); //Insert after the target param load always
+                            instructionsToProcess.emplace_back(iInfo->_instruction, x, AspectBehavior::InsertAfter); //Insert after the target param load always
                         }
                         if (instructionsToProcess.size() == 0)
                         {

--- a/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
@@ -360,7 +360,7 @@ namespace iast
     std::vector<WSTRING> SplitParams(const WSTRING& subject)
     {
         std::vector<WSTRING> res;
-        for (auto part : SplitParams(ToString(subject)))
+        for (auto &part : SplitParams(ToString(subject)))
         {
             res.push_back(ToWSTRING(part));
         }
@@ -653,7 +653,7 @@ namespace iast
         auto in = Trim(str, WStr("[]"));
         if (in.length() > 0)
         {
-            for (auto v : Split(in, WStr(',')))
+            for (auto &v : Split(in, WStr(',')))
             {
                 res.push_back(ConvertToInt(v));
             }
@@ -666,7 +666,7 @@ namespace iast
         auto in = Trim(str, WStr("[]"));
         if (in.length() > 0)
         {
-            for (auto v : Split(in, WStr(',')))
+            for (auto &v : Split(in, WStr(',')))
             {
                 res.push_back(ConvertToBool(v));
             }

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -228,7 +228,7 @@ namespace iast
         _isExcluded = _module->_dataflow->IsMethodExcluded(GetFullName());
         if (!_isExcluded && _module->_dataflow->HasMethodAttributeExclusions())
         {
-            for (auto methodAttribute : GetCustomAttributes())
+            for (auto &methodAttribute : GetCustomAttributes())
             {
                 if (_module->_dataflow->IsMethodAttributeExcluded(methodAttribute))
                 {

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -451,7 +451,7 @@ MethodInfo* ModuleInfo::GetMethod(mdTypeDef typeDef, const WSTRING& methodName, 
     {
         if (auto sig = method->GetSignature())
         {
-            auto sigRepresentation = sig->GetParamsRepresentation();
+            const auto &sigRepresentation = sig->GetParamsRepresentation();
             if (sigRepresentation == methodParams)
             {
                 return method;

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_info.cpp
@@ -649,8 +649,8 @@ namespace iast
     {
         if (_signatureType == SignatureTypes::Method)
         {
-            auto paramsStr = GetParamsRepresentation();
-            return memberName.c_str() + paramsStr;
+            const auto &paramsStr = GetParamsRepresentation();
+            return memberName + paramsStr;
         }
         return memberName;
     }

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.cpp
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.cpp
@@ -1,5 +1,7 @@
 #include "il_rewriter_wrapper.h"
 
+#include <array>
+
 ILRewriter* ILRewriterWrapper::GetILRewriter() const
 {
     return m_ILRewriter;
@@ -42,7 +44,7 @@ ILInstr* ILRewriterWrapper::LoadInt64(const INT64 value) const
 
 ILInstr* ILRewriterWrapper::LoadInt32(const INT32 value) const
 {
-    static const std::vector<OPCODE> opcodes = {
+    static constexpr std::array<OPCODE, 9> opcodes = {
         CEE_LDC_I4_0, CEE_LDC_I4_1, CEE_LDC_I4_2, CEE_LDC_I4_3, CEE_LDC_I4_4,
         CEE_LDC_I4_5, CEE_LDC_I4_6, CEE_LDC_I4_7, CEE_LDC_I4_8,
     };
@@ -70,7 +72,7 @@ ILInstr* ILRewriterWrapper::LoadInt32(const INT32 value) const
 
 ILInstr* ILRewriterWrapper::LoadArgument(const UINT16 index) const
 {
-    static const std::vector<OPCODE> opcodes = {
+    static constexpr std::array<OPCODE, 4> opcodes = {
         CEE_LDARG_0,
         CEE_LDARG_1,
         CEE_LDARG_2,
@@ -264,7 +266,7 @@ ILInstr* ILRewriterWrapper::LoadStr(mdString token) const
 
 ILInstr* ILRewriterWrapper::StLocal(unsigned index) const
 {
-    static const std::vector<OPCODE> opcodes = {
+    static constexpr std::array<OPCODE, 4> opcodes = {
         CEE_STLOC_0,
         CEE_STLOC_1,
         CEE_STLOC_2,
@@ -292,7 +294,7 @@ ILInstr* ILRewriterWrapper::StLocal(unsigned index) const
 
 ILInstr* ILRewriterWrapper::LoadLocal(unsigned index) const
 {
-    static const std::vector<OPCODE> opcodes = {
+    static constexpr std::array<OPCODE, 4> opcodes = {
         CEE_LDLOC_0,
         CEE_LDLOC_1,
         CEE_LDLOC_2,

--- a/tracer/src/Datadog.Tracer.Native/tracer_integration_definition.cpp
+++ b/tracer/src/Datadog.Tracer.Native/tracer_integration_definition.cpp
@@ -44,10 +44,10 @@ GetIntegrationsFromTraceMethodsConfiguration(const TypeReference& integration_ty
         for (const shared::WSTRING& method_definition : method_definitions_array)
         {
             std::vector<shared::WSTRING> signatureTypes;
-            integrationDefinitions.push_back(IntegrationDefinition(
+            integrationDefinitions.emplace_back(
                 MethodReference(tracemethodintegration_assemblyname, type_name, method_definition, Version(0, 0, 0, 0),
                                 Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX), signatureTypes),
-                integration_type, false, false, false));
+                integration_type, false, false, false);
 
             if (Logger::IsDebugEnabled())
             {


### PR DESCRIPTION
## Summary of changes

A lot of small safe performance optimizations.

## Reason for change

Profiler and tracer are preloaded, their performance affects host app.
Make them as fast as possible.

## Implementation details
None.

## Test coverage
Not changed

## Other details
None