### PR TITLE
[CI Visibility] Preserve oversized test parameters for ITR

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -967,6 +967,7 @@
       <type fullname="System.StringSplitOptions" />
       <type fullname="System.Text.Decoder" />
       <type fullname="System.Text.Encoder" />
+      <type fullname="System.Text.EncoderFallbackException" />
       <type fullname="System.Text.Encoding" />
       <type fullname="System.Text.StringBuilder" />
       <type fullname="System.Text.StringBuilder/AppendInterpolatedStringHandler" />

--- a/tracer/src/Datadog.Trace/Ci/SkippableTest.cs
+++ b/tracer/src/Datadog.Trace/Ci/SkippableTest.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Util;
 using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -51,19 +52,26 @@ internal readonly struct SkippableTest
     /// <summary>
     /// Tries to parse test parameters for matching framework test cases to backend skippable candidates.
     /// </summary>
-    /// <param name="parameters">Parsed test parameters, or null when the backend candidate has no parameter payload.</param>
-    /// <returns>True when the payload is empty or valid JSON; otherwise, false.</returns>
-    public bool TryGetParameters(out TestParameters? parameters)
+    /// <param name="parameters">Parsed test parameters when the method returns true; otherwise, null.</param>
+    /// <returns>True when the payload contains valid test parameters; otherwise, false.</returns>
+    public bool TryGetParameters([NotNullWhen(true)] out TestParameters? parameters)
     {
         if (StringUtil.IsNullOrWhiteSpace(RawParameters))
         {
             parameters = null;
-            return true;
+            return false;
         }
 
         try
         {
-            parameters = JsonHelper.DeserializeObject<TestParameters>(RawParameters!);
+            var parsedParameters = JsonHelper.DeserializeObject<TestParameters>(RawParameters);
+            if (parsedParameters is null)
+            {
+                parameters = null;
+                return false;
+            }
+
+            parameters = parsedParameters;
             return true;
         }
         catch (JsonException)

--- a/tracer/src/Datadog.Trace/Ci/SkippableTest.cs
+++ b/tracer/src/Datadog.Trace/Ci/SkippableTest.cs
@@ -49,12 +49,28 @@ internal readonly struct SkippableTest
     }
 
     /// <summary>
-    /// Gets parsed test parameters for matching framework test cases to backend skippable candidates.
+    /// Tries to parse test parameters for matching framework test cases to backend skippable candidates.
     /// </summary>
-    /// <returns>Parsed test parameters, or null when the backend candidate has no parameter payload.</returns>
-    public TestParameters? GetParameters()
+    /// <param name="parameters">Parsed test parameters, or null when the backend candidate has no parameter payload.</param>
+    /// <returns>True when the payload is empty or valid JSON; otherwise, false.</returns>
+    public bool TryGetParameters(out TestParameters? parameters)
     {
-        return StringUtil.IsNullOrWhiteSpace(RawParameters) ? null : JsonHelper.DeserializeObject<TestParameters>(RawParameters!);
+        if (StringUtil.IsNullOrWhiteSpace(RawParameters))
+        {
+            parameters = null;
+            return true;
+        }
+
+        try
+        {
+            parameters = JsonHelper.DeserializeObject<TestParameters>(RawParameters!);
+            return true;
+        }
+        catch (JsonException)
+        {
+            parameters = null;
+            return false;
+        }
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Ci/TestParameters.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestParameters.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Ci
             var fingerprintParameters = new TestParameters
             {
                 Metadata = new Dictionary<string, object?> { [FingerprintFormatMetadataKey] = FingerprintFormat },
-                Arguments = new Dictionary<string, object?> { [FingerprintArgumentKey] = Sha256Helper.ComputeHashAsHexString(json, Encoding.UTF8) }
+                Arguments = new Dictionary<string, object?> { [FingerprintArgumentKey] = ComputeFingerprint(json) }
             };
             return JsonHelper.SerializeObject(fingerprintParameters);
         }
@@ -72,7 +72,22 @@ namespace Datadog.Trace.Ci
 
         internal string GetFingerprint()
         {
-            return Sha256Helper.ComputeHashAsHexString(JsonHelper.SerializeObject(this), Encoding.UTF8);
+            return ComputeFingerprint(JsonHelper.SerializeObject(this));
+        }
+
+        private static string ComputeFingerprint(string json)
+        {
+            try
+            {
+                return Sha256Helper.ComputeHashAsHexString(json);
+            }
+            catch (EncoderFallbackException)
+            {
+                // Sha256Helper uses strict UTF-8, but test parameters can contain unpaired surrogates.
+                // Match the replacement fallback used when the JSON is encoded for transport.
+                var normalizedJson = Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(json));
+                return Sha256Helper.ComputeHashAsHexString(normalizedJson);
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/TestParameters.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestParameters.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Datadog.Trace.Processors;
 using Datadog.Trace.Util;
@@ -52,7 +53,7 @@ namespace Datadog.Trace.Ci
             return JsonHelper.SerializeObject(fingerprintParameters);
         }
 
-        internal bool TryGetFingerprint(out string fingerprint)
+        internal bool TryGetFingerprint([NotNullWhen(true)] out string? fingerprint)
         {
             if (Metadata is { Count: 1 } &&
                 Metadata.TryGetValue(FingerprintFormatMetadataKey, out var format) &&
@@ -65,7 +66,7 @@ namespace Datadog.Trace.Ci
                 return true;
             }
 
-            fingerprint = string.Empty;
+            fingerprint = null;
             return false;
         }
 

--- a/tracer/src/Datadog.Trace/Ci/TestParameters.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestParameters.cs
@@ -5,6 +5,9 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Text;
+using Datadog.Trace.Processors;
+using Datadog.Trace.Util;
 using Datadog.Trace.Util.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
@@ -15,6 +18,10 @@ namespace Datadog.Trace.Ci
     /// </summary>
     public sealed class TestParameters
     {
+        private const string FingerprintFormatMetadataKey = "_dd.parameters_format";
+        private const string FingerprintFormat = "sha256-v1";
+        private const string FingerprintArgumentKey = "_dd.parameters_fingerprint";
+
         /// <summary>
         /// Gets or sets the test parameters metadata
         /// </summary>
@@ -29,7 +36,42 @@ namespace Datadog.Trace.Ci
 
         internal string ToJSON()
         {
-            return JsonHelper.SerializeObject(this);
+            var json = JsonHelper.SerializeObject(this);
+            if (Encoding.UTF8.GetByteCount(json) <= TruncatorTagsProcessor.MaxMetaValLen)
+            {
+                return json;
+            }
+
+            // test.parameters is a span meta value, so a longer value would be truncated into invalid JSON.
+            // Preserve a compact, versioned identity that the ITR matcher can reproduce instead.
+            var fingerprintParameters = new TestParameters
+            {
+                Metadata = new Dictionary<string, object?> { [FingerprintFormatMetadataKey] = FingerprintFormat },
+                Arguments = new Dictionary<string, object?> { [FingerprintArgumentKey] = Sha256Helper.ComputeHashAsHexString(json, Encoding.UTF8) }
+            };
+            return JsonHelper.SerializeObject(fingerprintParameters);
+        }
+
+        internal bool TryGetFingerprint(out string fingerprint)
+        {
+            if (Metadata is { Count: 1 } &&
+                Metadata.TryGetValue(FingerprintFormatMetadataKey, out var format) &&
+                string.Equals(format as string, FingerprintFormat, System.StringComparison.Ordinal) &&
+                Arguments is { Count: 1 } &&
+                Arguments.TryGetValue(FingerprintArgumentKey, out var fingerprintValue) &&
+                fingerprintValue is string { Length: 64 } fingerprintString)
+            {
+                fingerprint = fingerprintString;
+                return true;
+            }
+
+            fingerprint = string.Empty;
+            return false;
+        }
+
+        internal string GetFingerprint()
+        {
+            return Sha256Helper.ComputeHashAsHexString(JsonHelper.SerializeObject(this), Encoding.UTF8);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using System.Threading;
 using Datadog.Trace.Ci;
@@ -83,7 +84,7 @@ internal static class Common
         return paramValue.ToString() ?? "(null)";
     }
 
-    internal static TestParameters CreateTestParameters(object[]? testMethodArguments, ParameterInfo[]? methodParameters, string? metadataTestName)
+    internal static TestParameters CreateTestParameters(object[]? testMethodArguments, ParameterInfo[]? methodParameters, string? metadataTestName, bool useParameterIndexForUnnamedParameters = false)
     {
         var testParameters = new TestParameters
         {
@@ -103,7 +104,7 @@ internal static class Common
 
         for (var i = 0; i < methodParameters.Length; i++)
         {
-            var key = methodParameters[i].Name ?? string.Empty;
+            var key = methodParameters[i].Name ?? (useParameterIndexForUnnamedParameters ? i.ToString(CultureInfo.InvariantCulture) : string.Empty);
             testParameters.Arguments[key] = testMethodArguments is not null && i < testMethodArguments.Length
                                                 ? GetParametersValueData(testMethodArguments[i])
                                                 : "(default)";
@@ -112,10 +113,10 @@ internal static class Common
         return testParameters;
     }
 
-    internal static bool ShouldSkip(string testSuite, string testName, object[]? testMethodArguments, ParameterInfo[]? methodParameters, string? moduleName = null, string? metadataTestName = null, bool allowParametersMetadataMismatch = false)
-        => ShouldSkip(testSuite, testName, testMethodArguments, methodParameters, out _, moduleName, metadataTestName, allowParametersMetadataMismatch);
+    internal static bool ShouldSkip(string testSuite, string testName, object[]? testMethodArguments, ParameterInfo[]? methodParameters, string? moduleName = null, string? metadataTestName = null, bool allowParametersMetadataMismatch = false, bool includeMetadataTestNameInFingerprint = true, bool useParameterIndexForUnnamedParameters = false)
+        => ShouldSkip(testSuite, testName, testMethodArguments, methodParameters, out _, moduleName, metadataTestName, allowParametersMetadataMismatch, includeMetadataTestNameInFingerprint, useParameterIndexForUnnamedParameters);
 
-    internal static bool ShouldSkip(string testSuite, string testName, object[]? testMethodArguments, ParameterInfo[]? methodParameters, out SkippableTest? skippableTest, string? moduleName = null, string? metadataTestName = null, bool allowParametersMetadataMismatch = false)
+    internal static bool ShouldSkip(string testSuite, string testName, object[]? testMethodArguments, ParameterInfo[]? methodParameters, out SkippableTest? skippableTest, string? moduleName = null, string? metadataTestName = null, bool allowParametersMetadataMismatch = false, bool includeMetadataTestNameInFingerprint = true, bool useParameterIndexForUnnamedParameters = false)
     {
         skippableTest = null;
         var currentContext = SynchronizationContext.Current;
@@ -140,7 +141,11 @@ internal static class Common
 
                     if (parameters?.TryGetFingerprint(out var expectedFingerprint) == true)
                     {
-                        localTestParameters ??= CreateTestParameters(testMethodArguments, methodParameters, metadataTestName);
+                        localTestParameters ??= CreateTestParameters(
+                            testMethodArguments,
+                            methodParameters,
+                            includeMetadataTestNameInFingerprint ? metadataTestName : null,
+                            useParameterIndexForUnnamedParameters);
                         localTestParametersFingerprint ??= localTestParameters.GetFingerprint();
                         if (string.Equals(expectedFingerprint, localTestParametersFingerprint, StringComparison.Ordinal))
                         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -130,7 +130,9 @@ internal static class Common
                 string? localTestParametersFingerprint = null;
                 foreach (var candidate in skippableTests)
                 {
-                    if (!candidate.TryGetParameters(out var parameters))
+                    TestParameters? parameters = null;
+                    if (!StringUtil.IsNullOrWhiteSpace(candidate.RawParameters) &&
+                        !candidate.TryGetParameters(out parameters))
                     {
                         Log.Debug("Common: Ignoring a skippable test candidate because its parameters are not valid JSON.");
                         continue;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -83,6 +83,35 @@ internal static class Common
         return paramValue.ToString() ?? "(null)";
     }
 
+    internal static TestParameters CreateTestParameters(object[]? testMethodArguments, ParameterInfo[]? methodParameters, string? metadataTestName)
+    {
+        var testParameters = new TestParameters
+        {
+            Metadata = new Dictionary<string, object?>(),
+            Arguments = new Dictionary<string, object?>()
+        };
+
+        if (metadataTestName is not null)
+        {
+            testParameters.Metadata[TestTags.MetadataTestName] = metadataTestName;
+        }
+
+        if (methodParameters is null)
+        {
+            return testParameters;
+        }
+
+        for (var i = 0; i < methodParameters.Length; i++)
+        {
+            var key = methodParameters[i].Name ?? string.Empty;
+            testParameters.Arguments[key] = testMethodArguments is not null && i < testMethodArguments.Length
+                                                ? GetParametersValueData(testMethodArguments[i])
+                                                : "(default)";
+        }
+
+        return testParameters;
+    }
+
     internal static bool ShouldSkip(string testSuite, string testName, object[]? testMethodArguments, ParameterInfo[]? methodParameters, string? moduleName = null, string? metadataTestName = null, bool allowParametersMetadataMismatch = false)
         => ShouldSkip(testSuite, testName, testMethodArguments, methodParameters, out _, moduleName, metadataTestName, allowParametersMetadataMismatch);
 
@@ -97,9 +126,27 @@ internal static class Common
             var skippableTests = GetSkippableTestsFromSuiteAndNames(testSuite, testName, moduleName, metadataTestName);
             if (skippableTests.Count > 0)
             {
+                TestParameters? localTestParameters = null;
+                string? localTestParametersFingerprint = null;
                 foreach (var candidate in skippableTests)
                 {
-                    var parameters = candidate.GetParameters();
+                    if (!candidate.TryGetParameters(out var parameters))
+                    {
+                        Log.Debug("Common: Ignoring a skippable test candidate because its parameters are not valid JSON.");
+                        continue;
+                    }
+
+                    if (parameters?.TryGetFingerprint(out var expectedFingerprint) == true)
+                    {
+                        localTestParameters ??= CreateTestParameters(testMethodArguments, methodParameters, metadataTestName);
+                        localTestParametersFingerprint ??= localTestParameters.GetFingerprint();
+                        if (string.Equals(expectedFingerprint, localTestParametersFingerprint, StringComparison.Ordinal))
+                        {
+                            return CanSkipForCoverage(candidate, moduleName, out skippableTest);
+                        }
+
+                        continue;
+                    }
 
                     // Same test name and no parameters
                     if ((parameters?.Arguments is null || parameters.Arguments.Count == 0) &&

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -170,33 +169,7 @@ internal static class MsTestIntegration
         var hasDisplayName = !string.IsNullOrEmpty(displayName) && displayName != testName;
         if (methodParameters?.Length > 0 || hasDisplayName)
         {
-            var testParameters = new TestParameters
-            {
-                Metadata = new Dictionary<string, object?>(),
-                Arguments = new Dictionary<string, object?>()
-            };
-
-            if (hasDisplayName)
-            {
-                testParameters.Metadata[TestTags.MetadataTestName] = displayName;
-            }
-
-            if (methodParameters is not null)
-            {
-                for (var i = 0; i < methodParameters.Length; i++)
-                {
-                    if (testMethodArguments != null && i < testMethodArguments.Length)
-                    {
-                        testParameters.Arguments[methodParameters[i].Name ?? i.ToString(CultureInfo.InvariantCulture)] = Common.GetParametersValueData(testMethodArguments[i]);
-                    }
-                    else
-                    {
-                        testParameters.Arguments[methodParameters[i].Name ?? i.ToString(CultureInfo.InvariantCulture)] = "(default)";
-                    }
-                }
-            }
-
-            test.SetParameters(testParameters);
+            test.SetParameters(Common.CreateTestParameters(testMethodArguments, methodParameters, hasDisplayName ? displayName : null, useParameterIndexForUnnamedParameters: true));
         }
     }
 
@@ -311,7 +284,9 @@ internal static class MsTestIntegration
             out var matchedSkippableTest,
             moduleName,
             metadataTestName: hasResolvedDisplayName ? metadataTestName : null,
-            allowParametersMetadataMismatch: !hasResolvedDisplayName && hasRowIdentity);
+            allowParametersMetadataMismatch: !hasResolvedDisplayName && hasRowIdentity,
+            includeMetadataTestNameInFingerprint: false,
+            useParameterIndexForUnnamedParameters: true);
         traits ??= GetTraits(testMethod);
         isUnskippable = traits?.TryGetValue(IntelligentTestRunnerTags.UnskippableTraitName, out _) == true;
         isForcedRun = matchedSkippableTest is not null && isUnskippable;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -182,7 +182,7 @@ internal static class NUnitIntegration
         var testSuite = testMethod.DeclaringType?.FullName ?? string.Empty;
         var module = GetTestModuleFrom(currentTest);
         var moduleName = module?.Tags.Bundle ?? module?.Tags.Module;
-        var itrShouldSkip = Common.ShouldSkip(testSuite, testMethod.Name, currentTest.Arguments, testMethod.GetParameters(), out var matchedSkippableTest, moduleName, currentTest.Name);
+        var itrShouldSkip = Common.ShouldSkip(testSuite, testMethod.Name, currentTest.Arguments, testMethod.GetParameters(), out var matchedSkippableTest, moduleName, currentTest.Name ?? string.Empty);
         if (traits is null)
         {
             ExtractTraits(currentTest, ref traits);
@@ -252,27 +252,7 @@ internal static class NUnitIntegration
         var methodParameters = testMethod.GetParameters();
         if (methodParameters?.Length > 0)
         {
-            var testParameters = new TestParameters
-            {
-                Metadata = new Dictionary<string, object?>(),
-                Arguments = new Dictionary<string, object?>()
-            };
-            testParameters.Metadata[TestTags.MetadataTestName] = currentTest.Name ?? string.Empty;
-
-            for (int i = 0; i < methodParameters.Length; i++)
-            {
-                var key = methodParameters[i].Name ?? string.Empty;
-                if (testMethodArguments != null && i < testMethodArguments.Length)
-                {
-                    testParameters.Arguments[key] = Common.GetParametersValueData(testMethodArguments[i]);
-                }
-                else
-                {
-                    testParameters.Arguments[key] = "(default)";
-                }
-            }
-
-            test.SetParameters(testParameters);
+            test.SetParameters(Common.CreateTestParameters(testMethodArguments, methodParameters, currentTest.Name ?? string.Empty));
         }
 
         // Get traits

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -63,27 +63,7 @@ internal static class XUnitIntegration
         var methodParameters = testMethod?.GetParameters();
         if (methodParameters?.Length > 0 && testMethodArguments?.Length > 0)
         {
-            var testParameters = new TestParameters
-            {
-                Metadata = new Dictionary<string, object?>(),
-                Arguments = new Dictionary<string, object?>()
-            };
-            testParameters.Metadata[TestTags.MetadataTestName] = runnerInstance.TestCase.DisplayName ?? string.Empty;
-
-            for (var i = 0; i < methodParameters.Length; i++)
-            {
-                var key = methodParameters[i].Name ?? string.Empty;
-                if (i < testMethodArguments.Length)
-                {
-                    testParameters.Arguments[key] = Common.GetParametersValueData(testMethodArguments[i]);
-                }
-                else
-                {
-                    testParameters.Arguments[key] = "(default)";
-                }
-            }
-
-            test.SetParameters(testParameters);
+            test.SetParameters(Common.CreateTestParameters(testMethodArguments, methodParameters, runnerInstance.TestCase.DisplayName ?? string.Empty));
         }
 
         // Get traits
@@ -504,7 +484,7 @@ internal static class XUnitIntegration
         var testClassName = runnerInstance.TestClass?.ToString() ?? string.Empty;
         var testMethod = runnerInstance.TestMethod;
         var moduleName = GetTestModuleName(ref runnerInstance);
-        var itrShouldSkip = Common.ShouldSkip(testClassName, testMethod?.Name ?? string.Empty, runnerInstance.TestMethodArguments, testMethod?.GetParameters(), out var matchedSkippableTest, moduleName, metadataTestName: runnerInstance.TestCase.DisplayName);
+        var itrShouldSkip = Common.ShouldSkip(testClassName, testMethod?.Name ?? string.Empty, runnerInstance.TestMethodArguments, testMethod?.GetParameters(), out var matchedSkippableTest, moduleName, metadataTestName: runnerInstance.TestCase.DisplayName ?? string.Empty);
         traits ??= runnerInstance.TestCase.Traits;
         isUnskippable = traits?.TryGetValue(IntelligentTestRunnerTags.UnskippableTraitName, out _) == true;
         isForcedRun = matchedSkippableTest is not null && isUnskippable;

--- a/tracer/src/Datadog.Trace/Util/Sha256Helper.cs
+++ b/tracer/src/Datadog.Trace/Util/Sha256Helper.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Datadog.Trace.Util;
 
@@ -19,35 +18,25 @@ internal static class Sha256Helper
 
     public static string ComputeHashAsHexString(string input)
     {
-        return ComputeHashAsHexString(input, EncodingHelpers.Utf8NoBom);
-    }
-
-    public static string ComputeHashAsHexString(string input, Encoding encoding)
-    {
 #if NETCOREAPP
         Span<byte> hash = stackalloc byte[Sha256HashSizeBytes];
-        ComputeHash(input, encoding, hash);
+        ComputeHash(input, hash);
         return HexString.ToHexString(hash);
 #else
-        return HexString.ToHexString(ComputeHash(input, encoding));
+        return HexString.ToHexString(ComputeHash(input));
 #endif
     }
 
 #if NETCOREAPP
     public static int ComputeHash(string input, Span<byte> buffer)
     {
-        return ComputeHash(input, EncodingHelpers.Utf8NoBom, buffer);
-    }
-
-    private static int ComputeHash(string input, Encoding encoding, Span<byte> buffer)
-    {
         System.Diagnostics.Debug.Assert(buffer.Length >= Sha256HashSizeBytes, "buffer.Length must be at least 32");
 
-        var inputSize = encoding.GetByteCount(input);
-        var inputBuffer = inputSize <= 512
+        var maxInputSize = EncodingHelpers.Utf8NoBom.GetMaxByteCount(input.Length);
+        var inputBuffer = maxInputSize <= 512
                               ? stackalloc byte[512]
-                              : new byte[inputSize];
-        var encodeCount = encoding.GetBytes(input, inputBuffer);
+                              : new byte[maxInputSize];
+        var encodeCount = EncodingHelpers.Utf8NoBom.GetBytes(input, inputBuffer);
         var encodedInput = inputBuffer.Slice(0, encodeCount);
 
 #if NET6_0_OR_GREATER
@@ -66,17 +55,12 @@ internal static class Sha256Helper
 #else
     public static byte[] ComputeHash(string input)
     {
-        return ComputeHash(input, EncodingHelpers.Utf8NoBom);
-    }
-
-    private static byte[] ComputeHash(string input, Encoding encoding)
-    {
-        var inputSize = encoding.GetByteCount(input);
+        var maxInputSize = EncodingHelpers.Utf8NoBom.GetMaxByteCount(input.Length);
         byte[]? pooledArray = null;
         try
         {
-            pooledArray = ArrayPool<byte>.Shared.Rent(inputSize);
-            var encodeCount = encoding.GetBytes(input, charIndex: 0, charCount: input.Length, pooledArray, byteIndex: 0);
+            pooledArray = ArrayPool<byte>.Shared.Rent(maxInputSize);
+            var encodeCount = EncodingHelpers.Utf8NoBom.GetBytes(input, charIndex: 0, charCount: input.Length, pooledArray, byteIndex: 0);
 
             using var sha256 = SHA256.Create();
             return sha256.ComputeHash(pooledArray, offset: 0, count: encodeCount);

--- a/tracer/src/Datadog.Trace/Util/Sha256Helper.cs
+++ b/tracer/src/Datadog.Trace/Util/Sha256Helper.cs
@@ -43,10 +43,10 @@ internal static class Sha256Helper
     {
         System.Diagnostics.Debug.Assert(buffer.Length >= Sha256HashSizeBytes, "buffer.Length must be at least 32");
 
-        var maxInputSize = encoding.GetMaxByteCount(input.Length);
-        var inputBuffer = maxInputSize <= 512
+        var inputSize = encoding.GetByteCount(input);
+        var inputBuffer = inputSize <= 512
                               ? stackalloc byte[512]
-                              : new byte[maxInputSize];
+                              : new byte[inputSize];
         var encodeCount = encoding.GetBytes(input, inputBuffer);
         var encodedInput = inputBuffer.Slice(0, encodeCount);
 
@@ -71,11 +71,11 @@ internal static class Sha256Helper
 
     private static byte[] ComputeHash(string input, Encoding encoding)
     {
-        var maxInputSize = encoding.GetMaxByteCount(input.Length);
+        var inputSize = encoding.GetByteCount(input);
         byte[]? pooledArray = null;
         try
         {
-            pooledArray = ArrayPool<byte>.Shared.Rent(maxInputSize);
+            pooledArray = ArrayPool<byte>.Shared.Rent(inputSize);
             var encodeCount = encoding.GetBytes(input, charIndex: 0, charCount: input.Length, pooledArray, byteIndex: 0);
 
             using var sha256 = SHA256.Create();

--- a/tracer/src/Datadog.Trace/Util/Sha256Helper.cs
+++ b/tracer/src/Datadog.Trace/Util/Sha256Helper.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace Datadog.Trace.Util;
 
@@ -18,25 +19,35 @@ internal static class Sha256Helper
 
     public static string ComputeHashAsHexString(string input)
     {
+        return ComputeHashAsHexString(input, EncodingHelpers.Utf8NoBom);
+    }
+
+    public static string ComputeHashAsHexString(string input, Encoding encoding)
+    {
 #if NETCOREAPP
         Span<byte> hash = stackalloc byte[Sha256HashSizeBytes];
-        ComputeHash(input, hash);
+        ComputeHash(input, encoding, hash);
         return HexString.ToHexString(hash);
 #else
-        return HexString.ToHexString(ComputeHash(input));
+        return HexString.ToHexString(ComputeHash(input, encoding));
 #endif
     }
 
 #if NETCOREAPP
     public static int ComputeHash(string input, Span<byte> buffer)
     {
+        return ComputeHash(input, EncodingHelpers.Utf8NoBom, buffer);
+    }
+
+    private static int ComputeHash(string input, Encoding encoding, Span<byte> buffer)
+    {
         System.Diagnostics.Debug.Assert(buffer.Length >= Sha256HashSizeBytes, "buffer.Length must be at least 32");
 
-        var maxInputSize = EncodingHelpers.Utf8NoBom.GetMaxByteCount(input.Length);
+        var maxInputSize = encoding.GetMaxByteCount(input.Length);
         var inputBuffer = maxInputSize <= 512
                               ? stackalloc byte[512]
                               : new byte[maxInputSize];
-        var encodeCount = EncodingHelpers.Utf8NoBom.GetBytes(input, inputBuffer);
+        var encodeCount = encoding.GetBytes(input, inputBuffer);
         var encodedInput = inputBuffer.Slice(0, encodeCount);
 
 #if NET6_0_OR_GREATER
@@ -55,12 +66,17 @@ internal static class Sha256Helper
 #else
     public static byte[] ComputeHash(string input)
     {
-        var maxInputSize = EncodingHelpers.Utf8NoBom.GetMaxByteCount(input.Length);
+        return ComputeHash(input, EncodingHelpers.Utf8NoBom);
+    }
+
+    private static byte[] ComputeHash(string input, Encoding encoding)
+    {
+        var maxInputSize = encoding.GetMaxByteCount(input.Length);
         byte[]? pooledArray = null;
         try
         {
             pooledArray = ArrayPool<byte>.Shared.Rent(maxInputSize);
-            var encodeCount = EncodingHelpers.Utf8NoBom.GetBytes(input, charIndex: 0, charCount: input.Length, pooledArray, byteIndex: 0);
+            var encodeCount = encoding.GetBytes(input, charIndex: 0, charCount: input.Length, pooledArray, byteIndex: 0);
 
             using var sha256 = SHA256.Create();
             return sha256.ComputeHash(pooledArray, offset: 0, count: encodeCount);

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
@@ -937,6 +937,29 @@ public class TestOptimizationFeatureTests : SettingsTestsBase
         }
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("null")]
+    [InlineData("{\"arguments\":")]
+    public void SkippableTestTryGetParametersReturnsFalseWithoutParsedParameters(string rawParameters)
+    {
+        var candidate = new SkippableTest(nameof(SampleParameterizedItrTest), typeof(TestOptimizationFeatureTests).FullName!, rawParameters, configurations: null);
+
+        candidate.TryGetParameters(out var parameters).Should().BeFalse();
+        parameters.Should().BeNull();
+    }
+
+    [Fact]
+    public void SkippableTestTryGetParametersReturnsNonNullParametersOnSuccess()
+    {
+        var candidate = new SkippableTest(nameof(SampleParameterizedItrTest), typeof(TestOptimizationFeatureTests).FullName!, """{"arguments":{"value":"1"}}""", configurations: null);
+
+        candidate.TryGetParameters(out var parameters).Should().BeTrue();
+        parameters.Should().NotBeNull();
+    }
+
     [Fact]
     public void CommonShouldSkipContinuesAfterMalformedParameters()
     {

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
@@ -1085,7 +1085,7 @@ public class TestOptimizationFeatureTests : SettingsTestsBase
         try
         {
             Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [value], method.GetParameters(), metadataTestName: displayName).Should().BeTrue();
-            Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [value[..^1] + "b"], method.GetParameters(), metadataTestName: displayName).Should().BeFalse();
+            Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [value.Substring(0, value.Length - 1) + "b"], method.GetParameters(), metadataTestName: displayName).Should().BeFalse();
             Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [value], method.GetParameters(), metadataTestName: displayName + " changed").Should().BeFalse();
         }
         finally

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
@@ -1367,6 +1367,39 @@ public class TestOptimizationFeatureTests : SettingsTestsBase
     }
 
     [Fact]
+    public void MsTestShouldSkipMatchesOversizedParametersWithoutEmittedDisplayNameMetadata()
+    {
+        var skippableFeature = new Mock<ITestOptimizationSkippableFeature>();
+        var testOptimization = CreateTestOptimization(CreateSettings(), Directory.GetCurrentDirectory());
+        testOptimization.Setup(x => x.SkippableFeature).Returns(skippableFeature.Object);
+
+        var method = typeof(TestOptimizationFeatureTests).GetMethod(nameof(SampleParameterizedItrTest), BindingFlags.NonPublic | BindingFlags.Static)!;
+        var testSuite = typeof(TestOptimizationFeatureTests).FullName!;
+        var value = new string('a', 6_000);
+        const string DisplayName = "Custom display name";
+        var parameters = Common.CreateTestParameters([value], method.GetParameters(), metadataTestName: null, useParameterIndexForUnnamedParameters: true).ToJSON();
+        var candidate = new SkippableTest(nameof(SampleParameterizedItrTest), testSuite, parameters, configurations: null);
+        var testMethod = new MsTestMethodStub(method, [value], DisplayName);
+
+        parameters.Should().Contain("_dd.parameters_fingerprint");
+        skippableFeature.Setup(x => x.GetSkippableTestsFromSuiteAndName(testSuite, nameof(SampleParameterizedItrTest), It.IsAny<string>())).Returns([candidate]);
+        TestOptimization.Instance = testOptimization.Object;
+
+        try
+        {
+            MsTestIntegration.ShouldSkip(testMethod, out var isUnskippable, out var isForcedRun, traits: []).Should().BeTrue();
+
+            isUnskippable.Should().BeFalse();
+            isForcedRun.Should().BeFalse();
+        }
+        finally
+        {
+            TestOptimization.Instance = new TestOptimization();
+            TestOptimization.Instance.Reset();
+        }
+    }
+
+    [Fact]
     public void MsTestShouldSkipRejectsLateDisplayNameMetadataUntilDisplayNameIsResolved()
     {
         var skippableFeature = new Mock<ITestOptimizationSkippableFeature>();

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
@@ -996,6 +996,8 @@ public class TestOptimizationFeatureTests : SettingsTestsBase
         };
 
         testParameters.ToJSON().Should().Be("""{"metadata":{},"arguments":{"value":"1"}}""");
+        testParameters.TryGetFingerprint(out var fingerprint).Should().BeFalse();
+        fingerprint.Should().BeNull();
     }
 
     [Fact]
@@ -1032,7 +1034,10 @@ public class TestOptimizationFeatureTests : SettingsTestsBase
 
         Encoding.UTF8.GetByteCount(json).Should().BeLessThanOrEqualTo(TruncatorTagsProcessor.MaxMetaValLen);
         json.Should().Contain("\"_dd.parameters_format\":\"sha256-v1\"");
-        JsonHelper.DeserializeObject<TestParameters>(json).Should().NotBeNull();
+        var serializedParameters = JsonHelper.DeserializeObject<TestParameters>(json);
+        serializedParameters.Should().NotBeNull();
+        serializedParameters.TryGetFingerprint(out var fingerprint).Should().BeTrue();
+        fingerprint.Should().NotBeNull();
 
         var processedJson = json;
         var key = TestTags.Parameters;

--- a/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/TestOptimizationFeatureTests.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.CiEnvironment;
@@ -20,7 +21,9 @@ using Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Processors;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Util.Json;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -898,6 +901,164 @@ public class TestOptimizationFeatureTests : SettingsTestsBase
             matchedSkippableTest.Should().Be(candidate);
             skippableFeature.Verify(x => x.GetSkippableTestsFromSuiteAndName(TestSuite, TestName, ModuleName), Times.Once);
             skippableFeature.Verify(x => x.CanSkipWithCoverageBackfill(candidate, ModuleName, out reason), Times.Once);
+        }
+        finally
+        {
+            TestOptimization.Instance = new TestOptimization();
+            TestOptimization.Instance.Reset();
+        }
+    }
+
+    [Fact]
+    public void CommonShouldSkipIgnoresMalformedParameters()
+    {
+        var skippableFeature = new Mock<ITestOptimizationSkippableFeature>();
+        var testOptimization = CreateTestOptimization(CreateSettings(), Directory.GetCurrentDirectory());
+        testOptimization.Setup(x => x.SkippableFeature).Returns(skippableFeature.Object);
+
+        var method = typeof(TestOptimizationFeatureTests).GetMethod(nameof(SampleParameterizedItrTest), BindingFlags.NonPublic | BindingFlags.Static)!;
+        var testSuite = typeof(TestOptimizationFeatureTests).FullName!;
+        const string ParametersPrefix = "{\"arguments\":{\"value\":\"";
+        var parameters = ParametersPrefix + new string('a', 5_000 - ParametersPrefix.Length - 3) + "...";
+        var candidate = new SkippableTest(nameof(SampleParameterizedItrTest), testSuite, parameters, configurations: null);
+
+        parameters.Should().HaveLength(5_000);
+        skippableFeature.Setup(x => x.GetSkippableTestsFromSuiteAndName(testSuite, nameof(SampleParameterizedItrTest), It.IsAny<string>())).Returns([candidate]);
+        TestOptimization.Instance = testOptimization.Object;
+
+        try
+        {
+            Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [1], method.GetParameters()).Should().BeFalse();
+        }
+        finally
+        {
+            TestOptimization.Instance = new TestOptimization();
+            TestOptimization.Instance.Reset();
+        }
+    }
+
+    [Fact]
+    public void CommonShouldSkipContinuesAfterMalformedParameters()
+    {
+        var skippableFeature = new Mock<ITestOptimizationSkippableFeature>();
+        var testOptimization = CreateTestOptimization(CreateSettings(), Directory.GetCurrentDirectory());
+        testOptimization.Setup(x => x.SkippableFeature).Returns(skippableFeature.Object);
+
+        var method = typeof(TestOptimizationFeatureTests).GetMethod(nameof(SampleParameterizedItrTest), BindingFlags.NonPublic | BindingFlags.Static)!;
+        var testSuite = typeof(TestOptimizationFeatureTests).FullName!;
+        var malformedCandidate = new SkippableTest(nameof(SampleParameterizedItrTest), testSuite, "{\"arguments\":{\"value\":\"...", configurations: null);
+        var validCandidate = new SkippableTest(nameof(SampleParameterizedItrTest), testSuite, """{"arguments":{"value":"1"}}""", configurations: null);
+
+        skippableFeature.Setup(x => x.GetSkippableTestsFromSuiteAndName(testSuite, nameof(SampleParameterizedItrTest), It.IsAny<string>())).Returns([malformedCandidate, validCandidate]);
+        TestOptimization.Instance = testOptimization.Object;
+
+        try
+        {
+            Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [1], method.GetParameters()).Should().BeTrue();
+        }
+        finally
+        {
+            TestOptimization.Instance = new TestOptimization();
+            TestOptimization.Instance.Reset();
+        }
+    }
+
+    [Fact]
+    public void SmallTestParametersKeepOriginalJson()
+    {
+        var testParameters = new TestParameters
+        {
+            Metadata = new Dictionary<string, object>(),
+            Arguments = new Dictionary<string, object> { ["value"] = "1" }
+        };
+
+        testParameters.ToJSON().Should().Be("""{"metadata":{},"arguments":{"value":"1"}}""");
+    }
+
+    [Fact]
+    public void TestParametersUseFingerprintOnlyAboveMetaValueLimit()
+    {
+        var testParameters = new TestParameters
+        {
+            Metadata = new Dictionary<string, object>(),
+            Arguments = new Dictionary<string, object> { ["value"] = string.Empty }
+        };
+        var emptyValueJson = JsonHelper.SerializeObject(testParameters);
+        testParameters.Arguments["value"] = new string('a', TruncatorTagsProcessor.MaxMetaValLen - Encoding.UTF8.GetByteCount(emptyValueJson));
+
+        var maximumLengthJson = testParameters.ToJSON();
+
+        Encoding.UTF8.GetByteCount(maximumLengthJson).Should().Be(TruncatorTagsProcessor.MaxMetaValLen);
+        maximumLengthJson.Should().NotContain("_dd.parameters_fingerprint");
+
+        testParameters.Arguments["value"] += "a";
+
+        testParameters.ToJSON().Should().Contain("_dd.parameters_fingerprint");
+    }
+
+    [Fact]
+    public void OversizedTestParametersUseBoundedFingerprintJson()
+    {
+        var testParameters = new TestParameters
+        {
+            Metadata = new Dictionary<string, object> { [TestTags.MetadataTestName] = "SampleParameterizedItrTest(value: long)" },
+            Arguments = new Dictionary<string, object> { ["value"] = new string('\u00e9', 3_000) }
+        };
+
+        var json = testParameters.ToJSON();
+
+        Encoding.UTF8.GetByteCount(json).Should().BeLessThanOrEqualTo(TruncatorTagsProcessor.MaxMetaValLen);
+        json.Should().Contain("\"_dd.parameters_format\":\"sha256-v1\"");
+        JsonHelper.DeserializeObject<TestParameters>(json).Should().NotBeNull();
+
+        var processedJson = json;
+        var key = TestTags.Parameters;
+        new TruncatorTagsProcessor().ProcessMeta(ref key, ref processedJson);
+        processedJson.Should().Be(json);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3_000)]
+    public void TestParametersWithInvalidUtf16DoNotThrow(int argumentLength)
+    {
+        var testParameters = new TestParameters
+        {
+            Metadata = new Dictionary<string, object>(),
+            Arguments = new Dictionary<string, object> { ["value"] = new string('\uD83D', argumentLength) }
+        };
+
+        var action = testParameters.ToJSON;
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CommonShouldSkipMatchesOversizedParametersByFingerprint()
+    {
+        var skippableFeature = new Mock<ITestOptimizationSkippableFeature>();
+        var testOptimization = CreateTestOptimization(CreateSettings(), Directory.GetCurrentDirectory());
+        testOptimization.Setup(x => x.SkippableFeature).Returns(skippableFeature.Object);
+
+        var method = typeof(TestOptimizationFeatureTests).GetMethod(nameof(SampleParameterizedItrTest), BindingFlags.NonPublic | BindingFlags.Static)!;
+        var testSuite = typeof(TestOptimizationFeatureTests).FullName!;
+        var value = new string('a', 6_000);
+        var displayName = $"SampleParameterizedItrTest(value: {value})";
+        var testParameters = new TestParameters
+        {
+            Metadata = new Dictionary<string, object> { [TestTags.MetadataTestName] = displayName },
+            Arguments = new Dictionary<string, object> { ["value"] = value }
+        };
+        var candidate = new SkippableTest(nameof(SampleParameterizedItrTest), testSuite, testParameters.ToJSON(), configurations: null);
+
+        skippableFeature.Setup(x => x.GetSkippableTestsFromSuiteAndName(testSuite, nameof(SampleParameterizedItrTest), It.IsAny<string>())).Returns([candidate]);
+        TestOptimization.Instance = testOptimization.Object;
+
+        try
+        {
+            Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [value], method.GetParameters(), metadataTestName: displayName).Should().BeTrue();
+            Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [value[..^1] + "b"], method.GetParameters(), metadataTestName: displayName).Should().BeFalse();
+            Common.ShouldSkip(testSuite, nameof(SampleParameterizedItrTest), [value], method.GetParameters(), metadataTestName: displayName + " changed").Should().BeFalse();
         }
         finally
         {


### PR DESCRIPTION
## Summary of changes

- Preserve valid `test.parameters` JSON when parameterized test metadata exceeds the span meta-value limit.
- Match oversized parameter sets by a compact SHA-256 fingerprint instead of a truncated JSON prefix.
- Ignore malformed legacy parameter payloads during ITR matching so they cannot fail the customer test run.

## Reason for change

`test.parameters` is serialized as JSON and stored in a span meta value. The tracer's generic meta-value processor truncates values above 4,997 UTF-8 bytes and appends `...`, producing a 5,000-byte value that is no longer valid JSON.

When that value is later returned as an ITR skippable-test candidate, `Common.ShouldSkip()` deserializes it while the test runner is executing. The resulting `JsonReaderException` escapes the skip-matching path and can fail the test instead of simply deciding not to skip it.

## Implementation details

- Keep the existing `test.parameters` representation unchanged when the serialized JSON fits within the transport limit.
- For oversized values, emit a small, valid, versioned JSON envelope containing a SHA-256 fingerprint of the complete UTF-8 parameter JSON.
- Recreate the local parameter model during ITR matching and require an exact fingerprint match. The fingerprint includes both arguments and parameter metadata, so rows with a shared prefix or a different display name remain distinct.
- Centralize framework parameter construction and reproduce MSTest's emitted metadata and unnamed-parameter index fallback during fingerprint matching.
- Treat malformed parameter JSON from older/truncated data as a non-match and continue checking other candidates.
- Expose nullable `TryGet` contracts: successful calls always provide a parsed value, while unsuccessful calls return null.
- Reuse the existing `Sha256Helper` UTF-8 implementation and its intentional `GetMaxByteCount()` sizing heuristic instead of adding a configurable encoding path.
- If parameter JSON contains unpaired UTF-16 surrogates, normalize it locally in `TestParameters` with the same replacement fallback used for transport encoding before hashing. The shared SHA-256 helper remains unchanged.

## Test coverage

- `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj -c Release -f net8.0 --filter 'FullyQualifiedName~Datadog.Trace.Tests.Ci.TestOptimizationFeatureTests|FullyQualifiedName~Datadog.Trace.Tests.FeatureFlags.Sha256HelperTests' --no-restore`
  - 87 passed, 0 failed on the current head.
- The same filtered suite on `net6.0`:
  - 87 passed, 0 failed on the current head.
- `dotnet build tracer/src/Datadog.Trace/Datadog.Trace.csproj -c Release --no-restore`
  - Succeeded on the current head for all configured target frameworks with 0 warnings and 0 errors.
- The full net8 unit-test suite was run twice on the initial implementation. Both runs reported 12,828 passed, 91 skipped, and the same 10 failures in unrelated ASP.NET Core route-normalization and native hands-off configuration tests. Running those classes in isolation reproduced the same 10 failures; no CI Visibility or SHA-256 tests failed.

Coverage includes the original 5,000-character malformed payload, nullable `TryGet` contracts, continuing after a malformed candidate, the exact 4,997/4,998-byte boundary, multibyte UTF-8 values, invalid UTF-16 input, transport processing, exact oversized matches, MSTest's emitted parameter shape, and mismatches in both the argument tail and parameter display-name metadata.

## Other details

This is fail-safe across mixed data versions: legacy malformed candidates no longer crash and are not skipped, while older tracers can parse the new envelope but will treat it as a non-matching parameter set. Small parameter payloads retain their existing wire representation.
