### PR TITLE
[Native] Downgrade high-frequency ReJIT logs to debug

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -96,8 +96,8 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
             if (total > 0)
             {
                 handler->EnqueueForRejit(modules, methods);
-                Logger::Info("NGEN:: Processed with ", total, " inliners [ModuleId=", currentModuleId,
-                             ",MethodDef=", currentMethodDef, "]");
+                Logger::Debug("NGEN:: Processed with ", total, " inliners [ModuleId=", currentModuleId,
+                              ",MethodDef=", currentMethodDef, "]");
             }
 
             if (incompleteData)
@@ -288,7 +288,7 @@ void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector, std::vecto
         }
         if (SUCCEEDED(hr))
         {
-            Logger::Info("Request ReJIT done for ", modulesVector.size(), " methods");
+            Logger::Debug("Request ReJIT done for ", modulesVector.size(), " methods");
 
             if (enable_rejit_tracking)
             {


### PR DESCRIPTION
## Summary of changes

Changes two native log calls in `rejit_handler.cpp` from `Logger::Info` to `Logger::Debug`:

- `"NGEN:: Processed with N inliners"`
- `"Request ReJIT done for N methods"`

## Reason for change

These are the two highest-frequency native info logs we've sampled, and they are written unconditionally (not gated on `DD_TRACE_DEBUG`). Customers on Azure Functions accumulate gigabytes of native tracer logs in Kudu storage with debug logging off. See SLES-2871 for a concrete example: ~32K log files / ~20 GB filled a customer's disk and broke deploys, with `DD_TRACE_DEBUG` not enabled. These two messages are the biggest single contributors to that volume.

## Implementation details

Two-line change; no API or config surface changes. In-repo precedent: #8618 downgraded similar high-frequency debugger-probe logs to debug.

## Test coverage

It builds?

## Other details

Out of scope (follow-ups if wanted): a general verbosity knob for the native logger (today it's a binary debug toggle fed solely from `DD_TRACE_DEBUG`)