### PR TITLE
[DuckTyping] Prevent memory corruption for by-ref value types

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -861,7 +861,7 @@ namespace Datadog.Trace.DuckTyping
                                 il.WriteLoadArgument(idx, false);
 
                                 // Load the value inside the ref
-                                if (outerParamTypeElementType.IsGenericParameter)
+                                if (outerParamTypeElementType.IsGenericParameter || outerParamTypeElementType.IsValueType)
                                 {
                                     il.Emit(OpCodes.Ldobj, outerParamTypeElementType);
                                 }
@@ -1065,7 +1065,7 @@ namespace Datadog.Trace.DuckTyping
                     }
 
                     // We store the value
-                    if (proxyArgumentType.IsGenericParameter)
+                    if (proxyArgumentType.IsGenericParameter || proxyArgumentType.IsValueType)
                     {
                         il.Emit(OpCodes.Stobj, proxyArgumentType);
                     }

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -1058,7 +1058,14 @@ namespace Datadog.Trace.DuckTyping
                     }
 
                     // We store the value
-                    il.Emit(OpCodes.Stind_Ref);
+                    if (proxyArgumentType.IsGenericParameter)
+                    {
+                        il.Emit(OpCodes.Stobj, proxyArgumentType);
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Stind_Ref);
+                    }
                 }
 
                 return null;

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -861,7 +861,14 @@ namespace Datadog.Trace.DuckTyping
                                 il.WriteLoadArgument(idx, false);
 
                                 // Load the value inside the ref
-                                il.Emit(OpCodes.Ldind_Ref);
+                                if (outerParamTypeElementType.IsGenericParameter)
+                                {
+                                    il.Emit(OpCodes.Ldobj, outerParamTypeElementType);
+                                }
+                                else
+                                {
+                                    il.Emit(OpCodes.Ldind_Ref);
+                                }
 
                                 // Check if the type can be converted of if we need to enable duck chaining
                                 if (needsDuckChaining(innerParamTypeElementType, outerParamTypeElementType))

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -52,22 +52,22 @@ namespace Datadog.Trace.DuckTyping.Tests
             if (!TestOptimization.Instance.IsRunning)
             {
 #if NETFRAMEWORK
-                asmDuckTypes.Should().Be(1511);
+                asmDuckTypes.Should().Be(1519);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().Be(1521);
+                asmDuckTypes.Should().Be(1529);
 #else
-                asmDuckTypes.Should().Be(1522);
+                asmDuckTypes.Should().Be(1530);
 #endif
             }
             else
             {
                 // When running inside CI Visibility, we will generate additional duck types
 #if NETFRAMEWORK
-                asmDuckTypes.Should().BeGreaterThan(1511);
+                asmDuckTypes.Should().BeGreaterThan(1519);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().BeGreaterThan(1521);
+                asmDuckTypes.Should().BeGreaterThan(1529);
 #else
-                asmDuckTypes.Should().BeGreaterThan(1522);
+                asmDuckTypes.Should().BeGreaterThan(1530);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -52,22 +52,22 @@ namespace Datadog.Trace.DuckTyping.Tests
             if (!TestOptimization.Instance.IsRunning)
             {
 #if NETFRAMEWORK
-                asmDuckTypes.Should().Be(1510);
+                asmDuckTypes.Should().Be(1511);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().Be(1520);
-#else
                 asmDuckTypes.Should().Be(1521);
+#else
+                asmDuckTypes.Should().Be(1522);
 #endif
             }
             else
             {
                 // When running inside CI Visibility, we will generate additional duck types
 #if NETFRAMEWORK
-                asmDuckTypes.Should().BeGreaterThan(1510);
+                asmDuckTypes.Should().BeGreaterThan(1511);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().BeGreaterThan(1520);
-#else
                 asmDuckTypes.Should().BeGreaterThan(1521);
+#else
+                asmDuckTypes.Should().BeGreaterThan(1522);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericOutParameterTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericOutParameterTests.cs
@@ -13,6 +13,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
     {
         private const byte BeforeSentinel = 0xA5;
         private const byte AfterSentinel = 0x5A;
+        private const ulong NonGenericAfterSentinel = 0x1122334455667788UL;
 
         public enum GenericOutParameterType
         {
@@ -36,11 +37,80 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             Object,
         }
 
+        private enum ByteEnum : byte
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
+        private enum SByteEnum : sbyte
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
+        private enum Int16Enum : short
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
+        private enum UInt16Enum : ushort
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
+        private enum Int32Enum : int
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
+        private enum UInt32Enum : uint
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
+        private enum Int64Enum : long
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
+        private enum UInt64Enum : ulong
+        {
+            Initial = 0x7B,
+            Changed = 0x42,
+        }
+
         private interface IGenericOutParameterProxy
         {
             void GetDefault<T>(out T output);
 
             void Preserve<T>(ref T value);
+        }
+
+        private interface INonGenericEnumProxy<T>
+            where T : struct, Enum
+        {
+            void Preserve(ref T value);
+
+            void Set(out T value);
+        }
+
+        [Fact]
+        public void NonGenericEnumOutAndRefParametersDoNotCorruptAdjacentFields()
+        {
+            AssertNonGenericEnumByRefParameters(ByteEnum.Initial, ByteEnum.Changed, (byte)ByteEnum.Changed);
+            AssertNonGenericEnumByRefParameters(SByteEnum.Initial, SByteEnum.Changed, (sbyte)SByteEnum.Changed);
+            AssertNonGenericEnumByRefParameters(Int16Enum.Initial, Int16Enum.Changed, (short)Int16Enum.Changed);
+            AssertNonGenericEnumByRefParameters(UInt16Enum.Initial, UInt16Enum.Changed, (ushort)UInt16Enum.Changed);
+            AssertNonGenericEnumByRefParameters(Int32Enum.Initial, Int32Enum.Changed, (int)Int32Enum.Changed);
+            AssertNonGenericEnumByRefParameters(UInt32Enum.Initial, UInt32Enum.Changed, (uint)UInt32Enum.Changed);
+            AssertNonGenericEnumByRefParameters(Int64Enum.Initial, Int64Enum.Changed, (long)Int64Enum.Changed);
+            AssertNonGenericEnumByRefParameters(UInt64Enum.Initial, UInt64Enum.Changed, (ulong)UInt64Enum.Changed);
         }
 
         [Theory]
@@ -127,6 +197,39 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             }
         }
 
+        private static void AssertNonGenericEnumByRefParameters<TEnum, TUnderlying>(TEnum initialValue, TEnum changedValue, TUnderlying underlyingChangedValue)
+            where TEnum : struct, Enum
+            where TUnderlying : struct
+        {
+            var proxy = new NonGenericEnumTarget<TUnderlying>(underlyingChangedValue).DuckCast<INonGenericEnumProxy<TEnum>>();
+
+            var refGuarded = new NonGenericGuardedValue<TEnum>
+            {
+                Before = BeforeSentinel,
+                Value = initialValue,
+                After = NonGenericAfterSentinel,
+            };
+
+            proxy.Preserve(ref refGuarded.Value);
+
+            Assert.Equal(BeforeSentinel, refGuarded.Before);
+            Assert.Equal(initialValue, refGuarded.Value);
+            Assert.Equal(NonGenericAfterSentinel, refGuarded.After);
+
+            var outGuarded = new NonGenericGuardedValue<TEnum>
+            {
+                Before = BeforeSentinel,
+                Value = initialValue,
+                After = NonGenericAfterSentinel,
+            };
+
+            proxy.Set(out outGuarded.Value);
+
+            Assert.Equal(BeforeSentinel, outGuarded.Before);
+            Assert.Equal(changedValue, outGuarded.Value);
+            Assert.Equal(NonGenericAfterSentinel, outGuarded.After);
+        }
+
         private static void AssertGenericByRefParameters<T>(IGenericOutParameterProxy proxy, T initialValue)
         {
             var outGuarded = new GuardedValue<T>
@@ -154,6 +257,15 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             Assert.Equal(BeforeSentinel, refGuarded.Before);
             Assert.Equal(initialValue, refGuarded.Value);
             Assert.Equal(AfterSentinel, refGuarded.After);
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct NonGenericGuardedValue<T>
+            where T : struct, Enum
+        {
+            public byte Before;
+            public T Value;
+            public ulong After;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -190,6 +302,23 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
                 _first = first;
                 _second = second;
             }
+        }
+
+        private class NonGenericEnumTarget<T>
+            where T : struct
+        {
+            private readonly T _changedValue;
+
+            public NonGenericEnumTarget(T changedValue)
+            {
+                _changedValue = changedValue;
+            }
+
+            public void Preserve(ref T value)
+            {
+            }
+
+            public void Set(out T value) => value = _changedValue;
         }
 
         private class GenericOutParameterTarget

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericOutParameterTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericOutParameterTests.cs
@@ -39,6 +39,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         private interface IGenericOutParameterProxy
         {
             void GetDefault<T>(out T output);
+
+            void Preserve<T>(ref T value);
         }
 
         [Theory]
@@ -60,85 +62,98 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         [InlineData(GenericOutParameterType.TwelveByteStruct)]
         [InlineData(GenericOutParameterType.String)]
         [InlineData(GenericOutParameterType.Object)]
-        public void GenericOutParameterDoesNotCorruptAdjacentFields(GenericOutParameterType parameterType)
+        public void GenericOutAndRefParametersDoNotCorruptAdjacentFields(GenericOutParameterType parameterType)
         {
             var proxy = new GenericOutParameterTarget().DuckCast<IGenericOutParameterProxy>();
 
             switch (parameterType)
             {
                 case GenericOutParameterType.Boolean:
-                    AssertGenericOutParameter(proxy, true);
+                    AssertGenericByRefParameters(proxy, true);
                     break;
                 case GenericOutParameterType.Byte:
-                    AssertGenericOutParameter(proxy, byte.MaxValue);
+                    AssertGenericByRefParameters(proxy, byte.MaxValue);
                     break;
                 case GenericOutParameterType.SByte:
-                    AssertGenericOutParameter(proxy, sbyte.MinValue);
+                    AssertGenericByRefParameters(proxy, sbyte.MinValue);
                     break;
                 case GenericOutParameterType.Int16:
-                    AssertGenericOutParameter(proxy, short.MinValue);
+                    AssertGenericByRefParameters(proxy, short.MinValue);
                     break;
                 case GenericOutParameterType.UInt16:
-                    AssertGenericOutParameter(proxy, ushort.MaxValue);
+                    AssertGenericByRefParameters(proxy, ushort.MaxValue);
                     break;
                 case GenericOutParameterType.Char:
-                    AssertGenericOutParameter(proxy, '\u1234');
+                    AssertGenericByRefParameters(proxy, '\u1234');
                     break;
                 case GenericOutParameterType.Int32:
-                    AssertGenericOutParameter(proxy, int.MinValue);
+                    AssertGenericByRefParameters(proxy, int.MinValue);
                     break;
                 case GenericOutParameterType.UInt32:
-                    AssertGenericOutParameter(proxy, uint.MaxValue);
+                    AssertGenericByRefParameters(proxy, uint.MaxValue);
                     break;
                 case GenericOutParameterType.Single:
-                    AssertGenericOutParameter(proxy, 123.5f);
+                    AssertGenericByRefParameters(proxy, 123.5f);
                     break;
                 case GenericOutParameterType.Int64:
-                    AssertGenericOutParameter(proxy, long.MinValue);
+                    AssertGenericByRefParameters(proxy, long.MinValue);
                     break;
                 case GenericOutParameterType.UInt64:
-                    AssertGenericOutParameter(proxy, ulong.MaxValue);
+                    AssertGenericByRefParameters(proxy, ulong.MaxValue);
                     break;
                 case GenericOutParameterType.Double:
-                    AssertGenericOutParameter(proxy, 123.5d);
+                    AssertGenericByRefParameters(proxy, 123.5d);
                     break;
                 case GenericOutParameterType.Decimal:
-                    AssertGenericOutParameter(proxy, 123.5m);
+                    AssertGenericByRefParameters(proxy, 123.5m);
                     break;
                 case GenericOutParameterType.Guid:
-                    AssertGenericOutParameter(proxy, new Guid("00112233-4455-6677-8899-aabbccddeeff"));
+                    AssertGenericByRefParameters(proxy, new Guid("00112233-4455-6677-8899-aabbccddeeff"));
                     break;
                 case GenericOutParameterType.ThreeByteStruct:
-                    AssertGenericOutParameter(proxy, new ThreeByteStruct(0x12, 0x34, 0x56));
+                    AssertGenericByRefParameters(proxy, new ThreeByteStruct(0x12, 0x34, 0x56));
                     break;
                 case GenericOutParameterType.TwelveByteStruct:
-                    AssertGenericOutParameter(proxy, new TwelveByteStruct(0x0123456789abcdef, 0x12345678));
+                    AssertGenericByRefParameters(proxy, new TwelveByteStruct(0x0123456789abcdef, 0x12345678));
                     break;
                 case GenericOutParameterType.String:
-                    AssertGenericOutParameter(proxy, "expected");
+                    AssertGenericByRefParameters(proxy, "expected");
                     break;
                 case GenericOutParameterType.Object:
-                    AssertGenericOutParameter(proxy, new object());
+                    AssertGenericByRefParameters(proxy, new object());
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(parameterType), parameterType, null);
             }
         }
 
-        private static void AssertGenericOutParameter<T>(IGenericOutParameterProxy proxy, T initialValue)
+        private static void AssertGenericByRefParameters<T>(IGenericOutParameterProxy proxy, T initialValue)
         {
-            var guarded = new GuardedValue<T>
+            var outGuarded = new GuardedValue<T>
             {
                 Before = BeforeSentinel,
                 Value = initialValue,
                 After = AfterSentinel,
             };
 
-            proxy.GetDefault<T>(out guarded.Value);
+            proxy.GetDefault<T>(out outGuarded.Value);
 
-            Assert.Equal(BeforeSentinel, guarded.Before);
-            Assert.Equal(default(T), guarded.Value);
-            Assert.Equal(AfterSentinel, guarded.After);
+            Assert.Equal(BeforeSentinel, outGuarded.Before);
+            Assert.Equal(default(T), outGuarded.Value);
+            Assert.Equal(AfterSentinel, outGuarded.After);
+
+            var refGuarded = new GuardedValue<T>
+            {
+                Before = BeforeSentinel,
+                Value = initialValue,
+                After = AfterSentinel,
+            };
+
+            proxy.Preserve<T>(ref refGuarded.Value);
+
+            Assert.Equal(BeforeSentinel, refGuarded.Before);
+            Assert.Equal(initialValue, refGuarded.Value);
+            Assert.Equal(AfterSentinel, refGuarded.After);
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -180,6 +195,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         private class GenericOutParameterTarget
         {
             public void GetDefault<T>(out T output) => output = default;
+
+            public void Preserve<T>(ref T value)
+            {
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericOutParameterTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericOutParameterTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="GenericOutParameterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests.Methods
+{
+    public class GenericOutParameterTests
+    {
+        private const byte BeforeSentinel = 0xA5;
+        private const byte AfterSentinel = 0x5A;
+
+        public enum GenericOutParameterType
+        {
+            Boolean,
+            Byte,
+            SByte,
+            Int16,
+            UInt16,
+            Char,
+            Int32,
+            UInt32,
+            Single,
+            Int64,
+            UInt64,
+            Double,
+            Decimal,
+            Guid,
+            ThreeByteStruct,
+            TwelveByteStruct,
+            String,
+            Object,
+        }
+
+        private interface IGenericOutParameterProxy
+        {
+            void GetDefault<T>(out T output);
+        }
+
+        [Theory]
+        [InlineData(GenericOutParameterType.Boolean)]
+        [InlineData(GenericOutParameterType.Byte)]
+        [InlineData(GenericOutParameterType.SByte)]
+        [InlineData(GenericOutParameterType.Int16)]
+        [InlineData(GenericOutParameterType.UInt16)]
+        [InlineData(GenericOutParameterType.Char)]
+        [InlineData(GenericOutParameterType.Int32)]
+        [InlineData(GenericOutParameterType.UInt32)]
+        [InlineData(GenericOutParameterType.Single)]
+        [InlineData(GenericOutParameterType.Int64)]
+        [InlineData(GenericOutParameterType.UInt64)]
+        [InlineData(GenericOutParameterType.Double)]
+        [InlineData(GenericOutParameterType.Decimal)]
+        [InlineData(GenericOutParameterType.Guid)]
+        [InlineData(GenericOutParameterType.ThreeByteStruct)]
+        [InlineData(GenericOutParameterType.TwelveByteStruct)]
+        [InlineData(GenericOutParameterType.String)]
+        [InlineData(GenericOutParameterType.Object)]
+        public void GenericOutParameterDoesNotCorruptAdjacentFields(GenericOutParameterType parameterType)
+        {
+            var proxy = new GenericOutParameterTarget().DuckCast<IGenericOutParameterProxy>();
+
+            switch (parameterType)
+            {
+                case GenericOutParameterType.Boolean:
+                    AssertGenericOutParameter(proxy, true);
+                    break;
+                case GenericOutParameterType.Byte:
+                    AssertGenericOutParameter(proxy, byte.MaxValue);
+                    break;
+                case GenericOutParameterType.SByte:
+                    AssertGenericOutParameter(proxy, sbyte.MinValue);
+                    break;
+                case GenericOutParameterType.Int16:
+                    AssertGenericOutParameter(proxy, short.MinValue);
+                    break;
+                case GenericOutParameterType.UInt16:
+                    AssertGenericOutParameter(proxy, ushort.MaxValue);
+                    break;
+                case GenericOutParameterType.Char:
+                    AssertGenericOutParameter(proxy, '\u1234');
+                    break;
+                case GenericOutParameterType.Int32:
+                    AssertGenericOutParameter(proxy, int.MinValue);
+                    break;
+                case GenericOutParameterType.UInt32:
+                    AssertGenericOutParameter(proxy, uint.MaxValue);
+                    break;
+                case GenericOutParameterType.Single:
+                    AssertGenericOutParameter(proxy, 123.5f);
+                    break;
+                case GenericOutParameterType.Int64:
+                    AssertGenericOutParameter(proxy, long.MinValue);
+                    break;
+                case GenericOutParameterType.UInt64:
+                    AssertGenericOutParameter(proxy, ulong.MaxValue);
+                    break;
+                case GenericOutParameterType.Double:
+                    AssertGenericOutParameter(proxy, 123.5d);
+                    break;
+                case GenericOutParameterType.Decimal:
+                    AssertGenericOutParameter(proxy, 123.5m);
+                    break;
+                case GenericOutParameterType.Guid:
+                    AssertGenericOutParameter(proxy, new Guid("00112233-4455-6677-8899-aabbccddeeff"));
+                    break;
+                case GenericOutParameterType.ThreeByteStruct:
+                    AssertGenericOutParameter(proxy, new ThreeByteStruct(0x12, 0x34, 0x56));
+                    break;
+                case GenericOutParameterType.TwelveByteStruct:
+                    AssertGenericOutParameter(proxy, new TwelveByteStruct(0x0123456789abcdef, 0x12345678));
+                    break;
+                case GenericOutParameterType.String:
+                    AssertGenericOutParameter(proxy, "expected");
+                    break;
+                case GenericOutParameterType.Object:
+                    AssertGenericOutParameter(proxy, new object());
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(parameterType), parameterType, null);
+            }
+        }
+
+        private static void AssertGenericOutParameter<T>(IGenericOutParameterProxy proxy, T initialValue)
+        {
+            var guarded = new GuardedValue<T>
+            {
+                Before = BeforeSentinel,
+                Value = initialValue,
+                After = AfterSentinel,
+            };
+
+            proxy.GetDefault<T>(out guarded.Value);
+
+            Assert.Equal(BeforeSentinel, guarded.Before);
+            Assert.Equal(default(T), guarded.Value);
+            Assert.Equal(AfterSentinel, guarded.After);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct GuardedValue<T>
+        {
+            public byte Before;
+            public T Value;
+            public byte After;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private readonly struct ThreeByteStruct
+        {
+            private readonly byte _first;
+            private readonly byte _second;
+            private readonly byte _third;
+
+            public ThreeByteStruct(byte first, byte second, byte third)
+            {
+                _first = first;
+                _second = second;
+                _third = third;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private readonly struct TwelveByteStruct
+        {
+            private readonly long _first;
+            private readonly int _second;
+
+            public TwelveByteStruct(long first, int second)
+            {
+                _first = first;
+                _second = second;
+            }
+        }
+
+        private class GenericOutParameterTarget
+        {
+            public void GetDefault<T>(out T output) => output = default;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Use typed `ldobj`/`stobj` access for generic parameters and concrete value types when DuckTyping adapts `ref` and `out` parameters.
- Keep `ldind.ref`/`stind.ref` for parameters known to be reference types.
- Add sentinel-based regressions for 18 generic value/reference types and for every legal enum underlying type.
- Update the expected generated DuckTyping assembly counts for the additional proxies.

## Reason for change

DuckTyping used `ldind.ref` and `stind.ref` while adapting by-ref parameters. Those instructions operate on native-sized references rather than on the actual value type.

For generic `T`, small value types could overwrite adjacent memory and larger value types could produce invalid IL. Concrete enums were also vulnerable: DuckTyping permits an enum proxy parameter to map to a target parameter with the same underlying primitive type, so a proxy `ref ByteEnum` mapped to target `ref byte` still reached the reference-sized load/store path.

The concrete byte-enum reproduction changed an adjacent sentinel from `0x1122334455667788` to `0x1100000000000000` for both `ref` and `out`.

## Implementation details

The generated IL now uses `ldobj`/`stobj` whenever the parameter element is a value type or a generic parameter. The type token makes the runtime use the exact type and size, covering primitives, enums, structs, nullable value types, and closed generic value types without manual size calculations.

Known reference types continue to use `ldind.ref`/`stind.ref`.

## Test coverage

- The new concrete enum regression failed before the follow-up fix with an adjacent-memory sentinel mismatch.
- All 19 `GenericOutParameterTests` cases pass on .NET 8.
- Full DuckTyping suite on .NET 8: 10,950 passed, 5 skipped, 0 failed.
- CI is running for commit `2b6bf5746e43cdb9142af6b6a171e2cb195ee7f1`.

## Other details

<!-- Fixes #{issue} -->
