### PR TITLE
[Debugger] Fail closed when async Exception Replay cannot clone SetException args

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1221,6 +1221,39 @@ bool DebuggerMethodRewriter::IsAsyncMethodBuilderCompletion(const FunctionInfo& 
            IsAsyncMethodBuilderType(functionInfo.type);
 }
 
+// Walks instruction pointers because m_offset is stale after BeginMethod insertion.
+bool DebuggerMethodRewriter::CatchHandlerContains(const EHClause& clause, const ILInstr* instr, const ILInstr* sentinel)
+{
+    if (clause.m_pHandlerBegin == nullptr || clause.m_pHandlerEnd == nullptr)
+    {
+        return false;
+    }
+
+    const auto stop = clause.m_pHandlerEnd->m_pNext;
+    for (auto pInstr = clause.m_pHandlerBegin; pInstr != stop && pInstr != sentinel; pInstr = pInstr->m_pNext)
+    {
+        if (pInstr == instr)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// True when inner's handler is a proper subset of outer's (try-in-handler nesting).
+bool DebuggerMethodRewriter::CatchHandlerProperlyContains(const EHClause& outer, const EHClause& inner,
+                                                          const ILInstr* sentinel)
+{
+    if (outer.m_pHandlerBegin == inner.m_pHandlerBegin && outer.m_pHandlerEnd == inner.m_pHandlerEnd)
+    {
+        return false;
+    }
+
+    return CatchHandlerContains(outer, inner.m_pHandlerBegin, sentinel) &&
+           CatchHandlerContains(outer, inner.m_pHandlerEnd, sentinel);
+}
+
 EHClause* DebuggerMethodRewriter::FindInnermostCatchContaining(ILRewriter* rewriter, ILInstr* instr)
 {
     auto ehCount = rewriter->GetEHCount();
@@ -1232,43 +1265,23 @@ EHClause* DebuggerMethodRewriter::FindInnermostCatchContaining(ILRewriter* rewri
 
     auto sentinel = rewriter->GetILList();
     EHClause* best = nullptr;
-    unsigned bestLen = 0;
 
     for (unsigned ehIndex = 0; ehIndex < ehCount; ehIndex++)
     {
-        if (ehPointer[ehIndex].m_Flags == COR_ILEXCEPTION_CLAUSE_FINALLY ||
-            ehPointer[ehIndex].m_Flags == COR_ILEXCEPTION_CLAUSE_FAULT)
+        // Typed/catch-all only. Filter/finally/fault are not the async completion catch.
+        if (ehPointer[ehIndex].m_Flags != COR_ILEXCEPTION_CLAUSE_NONE)
         {
             continue;
         }
 
-        if (ehPointer[ehIndex].m_pHandlerBegin == nullptr || ehPointer[ehIndex].m_pHandlerEnd == nullptr)
+        if (!CatchHandlerContains(ehPointer[ehIndex], instr, sentinel))
         {
             continue;
         }
 
-        unsigned len = 0;
-        bool contains = false;
-        auto stop = ehPointer[ehIndex].m_pHandlerEnd->m_pNext;
-        for (auto pInstr = ehPointer[ehIndex].m_pHandlerBegin; pInstr != stop && pInstr != sentinel;
-             pInstr = pInstr->m_pNext)
-        {
-            len++;
-            if (pInstr == instr)
-            {
-                contains = true;
-            }
-        }
-
-        if (!contains)
-        {
-            continue;
-        }
-
-        if (best == nullptr || len < bestLen)
+        if (best == nullptr || CatchHandlerProperlyContains(*best, ehPointer[ehIndex], sentinel))
         {
             best = &ehPointer[ehIndex];
-            bestLen = len;
         }
     }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1820,7 +1820,8 @@ HRESULT DebuggerMethodRewriter::ApplyAsyncMethodProbe(
 
     if (FAILED(hr))
     {
-        Logger::Error("DebuggerMethodRewriter::ApplyAsyncMethodProbe: Fail in EndAsyncMethodProbe");
+        // Expected fail-closed abort; Error would fail CheckBuildLogsForErrors.
+        Logger::Warn("DebuggerMethodRewriter::ApplyAsyncMethodProbe: Fail in EndAsyncMethodProbe");
         return hr;
     }
 
@@ -1968,7 +1969,8 @@ HRESULT DebuggerMethodRewriter::ApplyAsyncMethodSpanProbe(
 
     if (FAILED(hr))
     {
-        Logger::Error("DebuggerMethodRewriter::ApplyAsyncMethodProbe: Fail in EndAsyncMethodSpanProbe");
+        // Expected fail-closed abort; Error would fail CheckBuildLogsForErrors.
+        Logger::Warn("DebuggerMethodRewriter::ApplyAsyncMethodProbe: Fail in EndAsyncMethodSpanProbe");
         return hr;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1208,6 +1208,119 @@ HRESULT DebuggerMethodRewriter::ApplyMethodSpanProbe(
     return S_OK;
 }
 
+bool DebuggerMethodRewriter::IsAsyncMethodBuilderType(const TypeInfo& type)
+{
+    const auto& typeName = type.name;
+    return typeName.find(WStr("Async")) != shared::WSTRING::npos &&
+           typeName.find(WStr("MethodBuilder")) != shared::WSTRING::npos;
+}
+
+bool DebuggerMethodRewriter::IsAsyncMethodBuilderCompletion(const FunctionInfo& functionInfo)
+{
+    return (functionInfo.name == WStr("SetResult") || functionInfo.name == WStr("SetException")) &&
+           IsAsyncMethodBuilderType(functionInfo.type);
+}
+
+EHClause* DebuggerMethodRewriter::FindInnermostCatchContaining(ILRewriter* rewriter, ILInstr* instr)
+{
+    auto ehCount = rewriter->GetEHCount();
+    auto ehPointer = rewriter->GetEHPointer();
+    if (ehCount == 0 || ehPointer == nullptr)
+    {
+        return nullptr;
+    }
+
+    auto sentinel = rewriter->GetILList();
+    EHClause* best = nullptr;
+    unsigned bestLen = 0;
+
+    for (unsigned ehIndex = 0; ehIndex < ehCount; ehIndex++)
+    {
+        if (ehPointer[ehIndex].m_Flags == COR_ILEXCEPTION_CLAUSE_FINALLY ||
+            ehPointer[ehIndex].m_Flags == COR_ILEXCEPTION_CLAUSE_FAULT)
+        {
+            continue;
+        }
+
+        if (ehPointer[ehIndex].m_pHandlerBegin == nullptr || ehPointer[ehIndex].m_pHandlerEnd == nullptr)
+        {
+            continue;
+        }
+
+        unsigned len = 0;
+        bool contains = false;
+        auto stop = ehPointer[ehIndex].m_pHandlerEnd->m_pNext;
+        for (auto pInstr = ehPointer[ehIndex].m_pHandlerBegin; pInstr != stop && pInstr != sentinel;
+             pInstr = pInstr->m_pNext)
+        {
+            len++;
+            if (pInstr == instr)
+            {
+                contains = true;
+            }
+        }
+
+        if (!contains)
+        {
+            continue;
+        }
+
+        if (best == nullptr || len < bestLen)
+        {
+            best = &ehPointer[ehIndex];
+            bestLen = len;
+        }
+    }
+
+    return best;
+}
+
+HRESULT DebuggerMethodRewriter::TryGetSetExceptionCatchClause(ILRewriterWrapper& rewriterWrapper,
+                                                              ModuleMetadata& module_metadata, FunctionInfo* caller,
+                                                              EHClause** setExceptionCatch)
+{
+    *setExceptionCatch = nullptr;
+    auto rewriter = rewriterWrapper.GetILRewriter();
+    ILInstr* setExceptionCall = nullptr;
+
+    for (auto pInstr = rewriter->GetILList()->m_pPrev; pInstr != rewriter->GetILList(); pInstr = pInstr->m_pPrev)
+    {
+        if (pInstr->m_opcode != CEE_CALL)
+        {
+            continue;
+        }
+
+        auto functionInfo = GetFunctionInfo(module_metadata.metadata_import, pInstr->m_Arg32);
+        if (functionInfo.name != WStr("SetException") || !IsAsyncMethodBuilderType(functionInfo.type))
+        {
+            continue;
+        }
+
+        setExceptionCall = pInstr;
+        break;
+    }
+
+    if (setExceptionCall == nullptr)
+    {
+        Logger::Warn("*** DebuggerMethodRewriter::TryGetSetExceptionCatchClause() no async method builder SetException "
+                     "call. Aborting rewrite. method=",
+                     caller->type.name, ".", caller->name);
+        return E_FAIL;
+    }
+
+    auto catchClause = FindInnermostCatchContaining(rewriter, setExceptionCall);
+    if (catchClause == nullptr || catchClause->m_pHandlerBegin == nullptr || catchClause->m_pHandlerEnd == nullptr)
+    {
+        Logger::Warn("*** DebuggerMethodRewriter::TryGetSetExceptionCatchClause() SetException is not inside a catch "
+                     "handler. Aborting rewrite. method=",
+                     caller->type.name, ".", caller->name);
+        return E_FAIL;
+    }
+
+    *setExceptionCatch = catchClause;
+    return S_OK;
+}
+
 HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterWrapper,
                                                     ModuleMetadata& module_metadata,
                                                     DebuggerTokens* debuggerTokens, FunctionInfo* caller, bool isStatic,
@@ -1223,8 +1336,15 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterW
     ILInstr* setResultEndMethodTryStartInstr = nullptr;
     ILInstr* endMethodOriginalCodeFirstInstr = nullptr;
 
+    EHClause* setExceptionCatch = nullptr;
+    HRESULT bindHr = TryGetSetExceptionCatchClause(rewriterWrapper, module_metadata, caller, &setExceptionCatch);
+    if (FAILED(bindHr))
+    {
+        unsupportedCompletionValueLoad = true;
+        return bindHr;
+    }
+
     int numberOfCallsFounded = 0;
-    auto lastEh = &rewriterWrapper.GetILRewriter()->GetEHPointer()[rewriterWrapper.GetILRewriter()->GetEHCount() - 1];
     ILInstr* setExceptionReturnInstruction = nullptr; // Used by SetException to determine what is the index of the return value
     // search call to SetResult and SetException
     for (ILInstr* pInstr = rewriterWrapper.GetILRewriter()->GetILList()->m_pPrev;
@@ -1237,7 +1357,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterW
         }
 
         auto functionInfo = GetFunctionInfo(module_metadata.metadata_import, pInstr->m_Arg32);
-        if (functionInfo.name != WStr("SetResult") && functionInfo.name != WStr("SetException"))
+        if (!IsAsyncMethodBuilderCompletion(functionInfo))
         {
             continue;
         }
@@ -1260,7 +1380,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterW
 
         if (functionInfo.name == WStr("SetResult"))
         {
-            rewriterWrapper.SetILPosition(lastEh->m_pHandlerEnd->m_pNext);
+            rewriterWrapper.SetILPosition(setExceptionCatch->m_pHandlerEnd->m_pNext);
 
             if (elementType == ELEMENT_TYPE_VOID)
             {
@@ -1295,7 +1415,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterW
         }
         else if (functionInfo.name == WStr("SetException"))
         {
-            rewriterWrapper.SetILPosition(lastEh->m_pHandlerBegin->m_pNext);
+            rewriterWrapper.SetILPosition(setExceptionCatch->m_pHandlerBegin->m_pNext);
             LoadInstanceIntoStack(caller, isStatic, rewriterWrapper, &endMethodTryStartInstr, debuggerTokens);
             if (elementType != ELEMENT_TYPE_VOID)
             {
@@ -1410,8 +1530,15 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodSpanProbe(ILRewriterWrapper& rewri
     ILInstr* setResultEndMethodTryStartInstr = nullptr;
     ILInstr* endMethodOriginalCodeFirstInstr = nullptr;
 
+    EHClause* setExceptionCatch = nullptr;
+    HRESULT bindHr = TryGetSetExceptionCatchClause(rewriterWrapper, module_metadata, caller, &setExceptionCatch);
+    if (FAILED(bindHr))
+    {
+        unsupportedCompletionValueLoad = true;
+        return bindHr;
+    }
+
     int numberOfCallsFounded = 0;
-    auto lastEh = &rewriterWrapper.GetILRewriter()->GetEHPointer()[rewriterWrapper.GetILRewriter()->GetEHCount() - 1];
     ILInstr* setExceptionReturnInstruction =
         nullptr; // Used by SetException to determine what is the index of the return value
     // search call to SetResult and SetException
@@ -1426,7 +1553,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodSpanProbe(ILRewriterWrapper& rewri
         }
 
         auto functionInfo = GetFunctionInfo(module_metadata.metadata_import, pInstr->m_Arg32);
-        if (functionInfo.name != WStr("SetResult") && functionInfo.name != WStr("SetException"))
+        if (!IsAsyncMethodBuilderCompletion(functionInfo))
         {
             continue;
         }
@@ -1446,7 +1573,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodSpanProbe(ILRewriterWrapper& rewri
         auto [elementType, returnTypeFlags] = methodReturnType->GetElementTypeAndFlags();
         if (functionInfo.name == WStr("SetResult"))
         {
-            rewriterWrapper.SetILPosition(lastEh->m_pHandlerEnd->m_pNext);
+            rewriterWrapper.SetILPosition(setExceptionCatch->m_pHandlerEnd->m_pNext);
             endMethodTryStartInstr = rewriterWrapper.LoadNull();
             rewriterWrapper.LoadArgument(0);
             rewriterWrapper.LoadFieldAddress(isReEntryFieldTok);
@@ -1456,7 +1583,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodSpanProbe(ILRewriterWrapper& rewri
         }
         else if (functionInfo.name == WStr("SetException"))
         {
-            rewriterWrapper.SetILPosition(lastEh->m_pHandlerBegin->m_pNext);
+            rewriterWrapper.SetILPosition(setExceptionCatch->m_pHandlerBegin->m_pNext);
             // create the instruction that load the exception value
             ILInstr* exceptionInstruction = rewriterWrapper.GetILRewriter()->NewILInstr();
             memcpy(exceptionInstruction, pInstr->m_pPrev, sizeof(*exceptionInstruction));

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1244,6 +1244,17 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterW
         ILInstr* endMethodTryStartInstr = nullptr;
         ILInstr* endMethodCallInstr;
         auto [elementType, returnTypeFlags] = methodReturnType->GetElementTypeAndFlags();
+        const bool willClonePrev = functionInfo.name == WStr("SetException") ||
+                                   (functionInfo.name == WStr("SetResult") && elementType != ELEMENT_TYPE_VOID);
+        if (willClonePrev && !ILRewriter::IsCloneableStandaloneValueLoad(pInstr->m_pPrev->m_opcode))
+        {
+            Logger::Warn("EndAsyncMethodProbe: instruction before ", functionInfo.name,
+                         " is not a standalone value load (opcode=", pInstr->m_pPrev->m_opcode,
+                         "). Aborting rewrite to avoid InvalidProgramException. method=", caller->type.name, ".",
+                         caller->name);
+            return E_FAIL;
+        }
+
         if (functionInfo.name == WStr("SetResult"))
         {
             rewriterWrapper.SetILPosition(lastEh->m_pHandlerEnd->m_pNext);
@@ -1413,6 +1424,15 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodSpanProbe(ILRewriterWrapper& rewri
         if (functionInfo.name != WStr("SetResult") && functionInfo.name != WStr("SetException"))
         {
             continue;
+        }
+
+        if (functionInfo.name == WStr("SetException") &&
+            !ILRewriter::IsCloneableStandaloneValueLoad(pInstr->m_pPrev->m_opcode))
+        {
+            Logger::Warn("EndAsyncMethodSpanProbe: instruction before SetException is not a standalone value load (opcode=",
+                         pInstr->m_pPrev->m_opcode, "). Aborting rewrite to avoid InvalidProgramException. method=",
+                         caller->type.name, ".", caller->name);
+            return E_FAIL;
         }
 
         ILInstr* endMethodTryStartInstr = nullptr;

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1216,8 +1216,10 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterW
                                                     ULONG callTargetReturnIndex,
                                                     mdFieldDef isReEntryFieldTok, 
                                                     std::vector<EHClause>& newClauses,
-                                                    const ProbeType& probeType) const
+                                                    const ProbeType& probeType,
+                                                    bool& unsupportedCompletionValueLoad) const
 {
+    unsupportedCompletionValueLoad = false;
     ILInstr* setResultEndMethodTryStartInstr = nullptr;
     ILInstr* endMethodOriginalCodeFirstInstr = nullptr;
 
@@ -1248,6 +1250,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(ILRewriterWrapper& rewriterW
                                    (functionInfo.name == WStr("SetResult") && elementType != ELEMENT_TYPE_VOID);
         if (willClonePrev && !ILRewriter::IsCloneableStandaloneValueLoad(pInstr->m_pPrev->m_opcode))
         {
+            unsupportedCompletionValueLoad = true;
             Logger::Warn("EndAsyncMethodProbe: instruction before ", functionInfo.name,
                          " is not a standalone value load (opcode=", pInstr->m_pPrev->m_opcode,
                          "). Aborting rewrite to avoid InvalidProgramException. method=", caller->type.name, ".",
@@ -1400,8 +1403,10 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodSpanProbe(ILRewriterWrapper& rewri
                                                     TypeSignature* methodReturnType,
                                                     const std::vector<TypeSignature>& methodLocals, int numLocals,
                                                     ULONG callTargetReturnIndex, mdFieldDef isReEntryFieldTok,
-                                                    std::vector<EHClause>& newClauses) const
+                                                    std::vector<EHClause>& newClauses,
+                                                    bool& unsupportedCompletionValueLoad) const
 {
+    unsupportedCompletionValueLoad = false;
     ILInstr* setResultEndMethodTryStartInstr = nullptr;
     ILInstr* endMethodOriginalCodeFirstInstr = nullptr;
 
@@ -1429,6 +1434,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodSpanProbe(ILRewriterWrapper& rewri
         if (functionInfo.name == WStr("SetException") &&
             !ILRewriter::IsCloneableStandaloneValueLoad(pInstr->m_pPrev->m_opcode))
         {
+            unsupportedCompletionValueLoad = true;
             Logger::Warn("EndAsyncMethodSpanProbe: instruction before SetException is not a standalone value load (opcode=",
                          pInstr->m_pPrev->m_opcode, "). Aborting rewrite to avoid InvalidProgramException. method=",
                          caller->type.name, ".", caller->name);
@@ -1815,13 +1821,18 @@ HRESULT DebuggerMethodRewriter::ApplyAsyncMethodProbe(
     // ENDING OF THE METHOD EXECUTION
     // ***
 
+    bool unsupportedCompletionValueLoad;
     hr = EndAsyncMethodProbe(rewriterWrapper, module_metadata, debugger_tokens, caller, isStatic, methodReturnType,
-                                methodLocals, numLocals, callTargetReturnIndex, isReEntryFieldTok, newClauses, probeType);
+                             methodLocals, numLocals, callTargetReturnIndex, isReEntryFieldTok, newClauses, probeType,
+                             unsupportedCompletionValueLoad);
 
     if (FAILED(hr))
     {
-        // Expected fail-closed abort; Error would fail CheckBuildLogsForErrors.
-        Logger::Warn("DebuggerMethodRewriter::ApplyAsyncMethodProbe: Fail in EndAsyncMethodProbe");
+        if (!unsupportedCompletionValueLoad)
+        {
+            Logger::Error("DebuggerMethodRewriter::ApplyAsyncMethodProbe: Fail in EndAsyncMethodProbe");
+        }
+
         return hr;
     }
 
@@ -1964,13 +1975,18 @@ HRESULT DebuggerMethodRewriter::ApplyAsyncMethodSpanProbe(
     // ENDING OF THE METHOD EXECUTION
     // ***
 
+    bool unsupportedCompletionValueLoad;
     hr = EndAsyncMethodSpanProbe(rewriterWrapper, moduleMetadata, debuggerTokens, caller, isStatic, methodReturnType,
-                                methodLocals, numLocals, callTargetReturnIndex, isReEntryFieldTok, newClauses);
+                                 methodLocals, numLocals, callTargetReturnIndex, isReEntryFieldTok, newClauses,
+                                 unsupportedCompletionValueLoad);
 
     if (FAILED(hr))
     {
-        // Expected fail-closed abort; Error would fail CheckBuildLogsForErrors.
-        Logger::Warn("DebuggerMethodRewriter::ApplyAsyncMethodProbe: Fail in EndAsyncMethodSpanProbe");
+        if (!unsupportedCompletionValueLoad)
+        {
+            Logger::Error("DebuggerMethodRewriter::ApplyAsyncMethodSpanProbe: Fail in EndAsyncMethodSpanProbe");
+        }
+
         return hr;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -83,6 +83,11 @@ private:
                             ULONG callTargetReturnIndex, ULONG returnValueIndex, mdToken callTargetReturnToken,
                             int instrumentedMethodIndex, ILInstr*& beforeLineProbe, std::vector<EHClause>& newClauses) const;
 
+    static bool IsAsyncMethodBuilderType(const TypeInfo& type);
+    static bool IsAsyncMethodBuilderCompletion(const FunctionInfo& functionInfo);
+    static EHClause* FindInnermostCatchContaining(ILRewriter* rewriter, ILInstr* instr);
+    static HRESULT TryGetSetExceptionCatchClause(ILRewriterWrapper& rewriterWrapper, ModuleMetadata& module_metadata,
+                                                 FunctionInfo* caller, EHClause** setExceptionCatch);
     HRESULT EndAsyncMethodProbe(ILRewriterWrapper& rewriterWrapper,
                                        ModuleMetadata& module_metadata, DebuggerTokens* debuggerTokens,
                                        FunctionInfo* caller, bool isStatic, TypeSignature* methodReturnType,

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -88,13 +88,14 @@ private:
                                        FunctionInfo* caller, bool isStatic, TypeSignature* methodReturnType,
                                        const std::vector<TypeSignature>& methodLocals, int numLocals, 
                                        ULONG callTargetReturnIndex, mdFieldDef isReEntryFieldTok,
-                                       std::vector<EHClause>& newClauses, const ProbeType& probeType) const;
+                                       std::vector<EHClause>& newClauses, const ProbeType& probeType,
+                                       bool& unsupportedCompletionValueLoad) const;
     HRESULT EndAsyncMethodSpanProbe(ILRewriterWrapper& rewriterWrapper, ModuleMetadata& module_metadata,
                                 DebuggerTokens* debuggerTokens, FunctionInfo* caller, bool isStatic,
                                 TypeSignature* methodReturnType, const std::vector<TypeSignature>& methodLocals,
                                 int numLocals, ULONG callTargetReturnIndex,
                                 mdFieldDef isReEntryFieldTok,
-                                std::vector<EHClause>& newClauses) const;
+                                std::vector<EHClause>& newClauses, bool& unsupportedCompletionValueLoad) const;
     static HRESULT LoadProbeIdIntoStack(ModuleID moduleId, const ModuleMetadata& moduleMetadata, mdToken functionToken,
                                         const shared::WSTRING& methodProbeId, const ILRewriterWrapper& rewriterWrapper,
                                         ILInstr** outLoadStrInstr);

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -85,6 +85,8 @@ private:
 
     static bool IsAsyncMethodBuilderType(const TypeInfo& type);
     static bool IsAsyncMethodBuilderCompletion(const FunctionInfo& functionInfo);
+    static bool CatchHandlerContains(const EHClause& clause, const ILInstr* instr, const ILInstr* sentinel);
+    static bool CatchHandlerProperlyContains(const EHClause& outer, const EHClause& inner, const ILInstr* sentinel);
     static EHClause* FindInnermostCatchContaining(ILRewriter* rewriter, ILInstr* instr);
     static HRESULT TryGetSetExceptionCatchClause(ILRewriterWrapper& rewriterWrapper, ModuleMetadata& module_metadata,
                                                  FunctionInfo* caller, EHClause** setExceptionCatch);

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
@@ -832,7 +832,6 @@ bool ILRewriter::IsCloneableStandaloneValueLoad(unsigned opcode)
     {
         case CEE_LDNULL:
         case CEE_LDSTR:
-        case CEE_LDSFLD:
             return true;
         default:
             return false;

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
@@ -821,6 +821,24 @@ bool ILRewriter::IsLoadConstantInstruction(unsigned opcode)
     }
 }
 
+bool ILRewriter::IsCloneableStandaloneValueLoad(unsigned opcode)
+{
+    if (IsLoadLocalDirectInstruction(opcode) || IsLoadConstantInstruction(opcode))
+    {
+        return true;
+    }
+
+    switch (opcode)
+    {
+        case CEE_LDNULL:
+        case CEE_LDSTR:
+        case CEE_LDSFLD:
+            return true;
+        default:
+            return false;
+    }
+}
+
 // Checks whether the range [innerBegin, innerEnd) is a proper subset of [outerBegin, outerEnd).
 // All values are IL offsets using exclusive ends (first offset past the region).
 static bool IsProperlyContained(unsigned innerBegin, unsigned innerEnd, unsigned outerBegin, unsigned outerEnd)

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter.h
@@ -151,6 +151,10 @@ public:
 
     static bool IsLoadConstantInstruction(unsigned opcode);
 
+    // True when a single IL instruction is a complete stack value (safe to memcpy
+    // as the argument to SetResult/SetException). ldfld/ldobj/call/nop are not.
+    static bool IsCloneableStandaloneValueLoad(unsigned opcode);
+
     static void SortEHClauses(EHClause* pEH, unsigned nEH);
 };
 

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter.h
@@ -151,8 +151,10 @@ public:
 
     static bool IsLoadConstantInstruction(unsigned opcode);
 
-    // True when a single IL instruction is a complete stack value (safe to memcpy
-    // as the argument to SetResult/SetException). ldfld/ldobj/call/nop are not.
+    // True when a single IL instruction is a complete, replay-safe stack value
+    // (safe to memcpy as the argument to SetResult/SetException).
+    // ldloc/ldc/ldnull/ldstr are; ldsfld is not (rereads a mutable static, and
+    // does not copy a volatile. prefix). ldfld/ldobj/call/nop are not.
     static bool IsCloneableStandaloneValueLoad(unsigned opcode);
 
     static void SortEHClauses(EHClause* pEH, unsigned nEH);

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
@@ -23,6 +23,8 @@ namespace Datadog.Trace.Debugger.IntegrationTests.ExceptionReplay;
 /// <summary>
 /// APMS-20228: after Exception Replay rewrites an async MoveNext, the next invocation
 /// must not throw InvalidProgramException. First throw arms ER; later throws run rewritten IL.
+/// Also regresses finally-last EH: injection must bind to the SetException catch, not the
+/// last clause, so capture is Eligible rather than EmptyCallStackTreeWhileCollecting.
 /// </summary>
 [CollectionDefinition(nameof(AspNetCore5ExceptionReplayInvalidProgramTests), DisableParallelization = true)]
 [Collection(nameof(AspNetCore5ExceptionReplayInvalidProgramTests))]
@@ -62,9 +64,11 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
         yield return
         [
             typeof(NestedUsingAwaitGenericOverrideTest),
-            nameof(NestedUsingAwaitGenericOverrideTest.PaymentGetAllQueryHandler.Handle)
+            "<Handle>d__"
         ];
-        yield return [typeof(AwaitUsingCatchFilterFinallyTest), nameof(AwaitUsingCatchFilterFinallyTest.RunAsync)];
+        yield return [typeof(AwaitUsingCatchFilterFinallyTest), "<RunAsync>d__"];
+        // Handwritten MoveNext: finally is last EH; SetException lives in an earlier catch.
+        yield return [typeof(FinallyLastEhTest), "FinallyLastSm"];
     }
 
     public override void Dispose()
@@ -77,7 +81,7 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
     [MemberData(nameof(InvalidProgramScenarios))]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
-    public async Task ExceptionReplayRewrite_DoesNotThrowInvalidProgramException(Type testType, string expectedAsyncMethodName)
+    public async Task ExceptionReplayRewrite_DoesNotThrowInvalidProgramException(Type testType, string expectedMoveNextClassPrefix)
     {
         var url = $"/RunTest/{testType.FullName}";
         var expectedErrorType = typeof(ExceptionReplayIntentionalException).FullName;
@@ -118,7 +122,7 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
 
                 errorType.Should().Be(expectedErrorType);
 
-                if (IsSuccessfulCapture(erroredSpan, exceptionReplayPhase, expectedAsyncMethodName))
+                if (IsSuccessfulCapture(erroredSpan, exceptionReplayPhase, expectedMoveNextClassPrefix))
                 {
                     capturedRequests++;
                 }
@@ -128,9 +132,9 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
 
             capturedRequests.Should().BeGreaterThanOrEqualTo(
                 RequiredCapturedRequests,
-                "Exception Replay should capture {0}.{1} after rewriting MoveNext (Eligible with snapshot_id frame tags). Failure phases such as InvalidatedCase must not count.",
+                "Exception Replay should capture {0} MoveNext ({1}) after rewriting (Eligible with snapshot_id frame tags). EmptyCallStackTreeWhileCollecting and InvalidatedCase must not count.",
                 testType.Name,
-                expectedAsyncMethodName);
+                expectedMoveNextClassPrefix);
         }
         finally
         {
@@ -138,7 +142,7 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
         }
     }
 
-    private static bool IsSuccessfulCapture(MockSpan span, string exceptionReplayPhase, string expectedAsyncMethodName)
+    private static bool IsSuccessfulCapture(MockSpan span, string exceptionReplayPhase, string expectedMoveNextClassPrefix)
     {
         if (exceptionReplayPhase != ExceptionReplayDiagnosticTagNames.Eligible || span.Tags is null)
         {
@@ -150,12 +154,11 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
             return false;
         }
 
-        var expectedStateMachinePrefix = $"<{expectedAsyncMethodName}>d__";
         foreach (var tagName in span.Tags.Keys.Where(key => key.EndsWith($".{SnapshotIdTagName}", StringComparison.Ordinal)))
         {
             var framePrefix = tagName.Substring(0, tagName.Length - SnapshotIdTagName.Length);
             if (span.GetTag(framePrefix + "frame_data.function") == "MoveNext"
-             && span.GetTag(framePrefix + "frame_data.class_name")?.StartsWith(expectedStateMachinePrefix, StringComparison.Ordinal) == true)
+             && span.GetTag(framePrefix + "frame_data.class_name")?.StartsWith(expectedMoveNextClassPrefix, StringComparison.Ordinal) == true)
             {
                 return true;
             }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
@@ -1,0 +1,141 @@
+// <copyright file="AspNetCore5ExceptionReplayInvalidProgramTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Debugger.ExceptionAutoInstrumentation;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Samples.Probes.TestRuns;
+using Samples.Probes.TestRuns.ExceptionReplay;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Debugger.IntegrationTests.ExceptionReplay;
+
+/// <summary>
+/// APMS-20228: after Exception Replay rewrites an async MoveNext, the next invocation
+/// must not throw InvalidProgramException. First throw arms ER; later throws run rewritten IL.
+/// </summary>
+[CollectionDefinition(nameof(AspNetCore5ExceptionReplayInvalidProgramTests), DisableParallelization = true)]
+[Collection(nameof(AspNetCore5ExceptionReplayInvalidProgramTests))]
+public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>
+{
+    private const string ExceptionReplayPhaseTag = "_dd.di._er";
+    private const int MaxAttempts = 8;
+    private const int RequiredRewrittenRequests = 2;
+
+    public AspNetCore5ExceptionReplayInvalidProgramTests(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+        : base("AspNetCore5", outputHelper)
+    {
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.ExceptionReplayEnabled, "true");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "false");
+        SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "100");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.MaxDepthToSerialize, "5");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.DiagnosticsInterval, "1");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.MaxTimeToSerialize, "1000");
+        SetEnvironmentVariable("DD_CLR_ENABLE_INLINING", "0");
+        SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+
+        // See https://github.com/dotnet/runtime/issues/91963
+        SetEnvironmentVariable("COMPLUS_ForceEnc", "0");
+
+        Fixture = fixture;
+        Fixture.SetOutput(outputHelper);
+    }
+
+    protected AspNetCoreTestFixture Fixture { get; }
+
+    public static IEnumerable<object[]> InvalidProgramScenarios()
+    {
+        yield return [typeof(NestedUsingAwaitGenericOverrideTest)];
+        yield return [typeof(AwaitUsingCatchFilterFinallyTest)];
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        Fixture.SetOutput(null);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(InvalidProgramScenarios))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    public async Task ExceptionReplayRewrite_DoesNotThrowInvalidProgramException(Type testType)
+    {
+        var url = $"/RunTest/{testType.FullName}";
+        var expectedErrorType = typeof(ExceptionReplayIntentionalException).FullName;
+        var invalidProgram = typeof(InvalidProgramException).FullName;
+
+        IncludeAllHttpSpans = true;
+        await Fixture.TryStartApp(this);
+        SetHttpPort(Fixture.HttpPort);
+
+        var agent = Fixture.Agent;
+        var rewrittenRequests = 0;
+
+        try
+        {
+            for (var attempt = 1; attempt <= MaxAttempts && rewrittenRequests < RequiredRewrittenRequests; attempt++)
+            {
+                var spans = await SendRequestsAsync(agent, [url]);
+
+                Fixture.Process.HasExited.Should().BeFalse(
+                    "the sample process should stay alive after request {0} to {1}",
+                    attempt,
+                    testType.Name);
+
+                var erroredSpan = spans.Should().Contain(x => x.Tags != null && x.Tags.ContainsKey(Tags.ErrorStack)).Which;
+                var errorType = erroredSpan.GetTag(Tags.ErrorType);
+                var errorStack = erroredSpan.GetTag(Tags.ErrorStack);
+                var exceptionReplayPhase = erroredSpan.GetTag(ExceptionReplayPhaseTag);
+
+                Output.WriteLine($"Attempt {attempt}: error.type={errorType} {ExceptionReplayPhaseTag}={exceptionReplayPhase}");
+
+                errorType.Should().NotBe(
+                    invalidProgram,
+                    "Exception Replay rewrite of {0} produced InvalidProgramException on request {1}.{2}{3}",
+                    testType.Name,
+                    attempt,
+                    Environment.NewLine,
+                    errorStack);
+
+                errorType.Should().Be(expectedErrorType);
+
+                if (IsPendingInstrumentation(exceptionReplayPhase))
+                {
+                    await Task.Delay(250);
+                    continue;
+                }
+
+                rewrittenRequests++;
+                await Task.Delay(250);
+            }
+
+            rewrittenRequests.Should().BeGreaterThanOrEqualTo(
+                RequiredRewrittenRequests,
+                "Exception Replay should rewrite {0} after the first throw so later requests run instrumented MoveNext",
+                testType.Name);
+        }
+        finally
+        {
+            agent.ClearSnapshots();
+        }
+    }
+
+    private static bool IsPendingInstrumentation(string exceptionReplayPhase)
+    {
+        return exceptionReplayPhase is null
+            || exceptionReplayPhase == ExceptionReplayDiagnosticTagNames.NewCase
+            || exceptionReplayPhase == ExceptionReplayDiagnosticTagNames.ExceptionTrackManagerNotInitialized;
+    }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.ExceptionAutoInstrumentation;
@@ -28,8 +29,11 @@ namespace Datadog.Trace.Debugger.IntegrationTests.ExceptionReplay;
 public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
     private const string ExceptionReplayPhaseTag = "_dd.di._er";
+    private const string DebugInfoCapturedTag = "error.debug_info_captured";
     private const int MaxAttempts = 8;
-    private const int RequiredRewrittenRequests = 2;
+
+    // Exception Replay captures once (Eligible + frame tags) then reverts probes.
+    private const int RequiredCapturedRequests = 1;
 
     public AspNetCore5ExceptionReplayInvalidProgramTests(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
         : base("AspNetCore5", outputHelper)
@@ -79,11 +83,11 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
         SetHttpPort(Fixture.HttpPort);
 
         var agent = Fixture.Agent;
-        var rewrittenRequests = 0;
+        var capturedRequests = 0;
 
         try
         {
-            for (var attempt = 1; attempt <= MaxAttempts && rewrittenRequests < RequiredRewrittenRequests; attempt++)
+            for (var attempt = 1; attempt <= MaxAttempts && capturedRequests < RequiredCapturedRequests; attempt++)
             {
                 var spans = await SendRequestsAsync(agent, [url]);
 
@@ -109,19 +113,17 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
 
                 errorType.Should().Be(expectedErrorType);
 
-                if (IsPendingInstrumentation(exceptionReplayPhase))
+                if (IsSuccessfulCapture(erroredSpan, exceptionReplayPhase))
                 {
-                    await Task.Delay(250);
-                    continue;
+                    capturedRequests++;
                 }
 
-                rewrittenRequests++;
                 await Task.Delay(250);
             }
 
-            rewrittenRequests.Should().BeGreaterThanOrEqualTo(
-                RequiredRewrittenRequests,
-                "Exception Replay should rewrite {0} after the first throw so later requests run instrumented MoveNext",
+            capturedRequests.Should().BeGreaterThanOrEqualTo(
+                RequiredCapturedRequests,
+                "Exception Replay should capture {0} after rewriting MoveNext (Eligible with snapshot_id frame tags). Failure phases such as InvalidatedCase must not count.",
                 testType.Name);
         }
         finally
@@ -130,11 +132,15 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
         }
     }
 
-    private static bool IsPendingInstrumentation(string exceptionReplayPhase)
+    private static bool IsSuccessfulCapture(MockSpan span, string exceptionReplayPhase)
     {
-        return exceptionReplayPhase is null
-            || exceptionReplayPhase == ExceptionReplayDiagnosticTagNames.NewCase
-            || exceptionReplayPhase == ExceptionReplayDiagnosticTagNames.ExceptionTrackManagerNotInitialized;
+        if (exceptionReplayPhase != ExceptionReplayDiagnosticTagNames.Eligible || span.Tags is null)
+        {
+            return false;
+        }
+
+        return span.Tags.ContainsKey(DebugInfoCapturedTag)
+            && span.Tags.Keys.Any(key => key.EndsWith(".snapshot_id", StringComparison.Ordinal));
     }
 }
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayInvalidProgramTests.cs
@@ -30,6 +30,7 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
 {
     private const string ExceptionReplayPhaseTag = "_dd.di._er";
     private const string DebugInfoCapturedTag = "error.debug_info_captured";
+    private const string SnapshotIdTagName = "snapshot_id";
     private const int MaxAttempts = 8;
 
     // Exception Replay captures once (Eligible + frame tags) then reverts probes.
@@ -58,8 +59,12 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
 
     public static IEnumerable<object[]> InvalidProgramScenarios()
     {
-        yield return [typeof(NestedUsingAwaitGenericOverrideTest)];
-        yield return [typeof(AwaitUsingCatchFilterFinallyTest)];
+        yield return
+        [
+            typeof(NestedUsingAwaitGenericOverrideTest),
+            nameof(NestedUsingAwaitGenericOverrideTest.PaymentGetAllQueryHandler.Handle)
+        ];
+        yield return [typeof(AwaitUsingCatchFilterFinallyTest), nameof(AwaitUsingCatchFilterFinallyTest.RunAsync)];
     }
 
     public override void Dispose()
@@ -72,7 +77,7 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
     [MemberData(nameof(InvalidProgramScenarios))]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
-    public async Task ExceptionReplayRewrite_DoesNotThrowInvalidProgramException(Type testType)
+    public async Task ExceptionReplayRewrite_DoesNotThrowInvalidProgramException(Type testType, string expectedAsyncMethodName)
     {
         var url = $"/RunTest/{testType.FullName}";
         var expectedErrorType = typeof(ExceptionReplayIntentionalException).FullName;
@@ -113,7 +118,7 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
 
                 errorType.Should().Be(expectedErrorType);
 
-                if (IsSuccessfulCapture(erroredSpan, exceptionReplayPhase))
+                if (IsSuccessfulCapture(erroredSpan, exceptionReplayPhase, expectedAsyncMethodName))
                 {
                     capturedRequests++;
                 }
@@ -123,8 +128,9 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
 
             capturedRequests.Should().BeGreaterThanOrEqualTo(
                 RequiredCapturedRequests,
-                "Exception Replay should capture {0} after rewriting MoveNext (Eligible with snapshot_id frame tags). Failure phases such as InvalidatedCase must not count.",
-                testType.Name);
+                "Exception Replay should capture {0}.{1} after rewriting MoveNext (Eligible with snapshot_id frame tags). Failure phases such as InvalidatedCase must not count.",
+                testType.Name,
+                expectedAsyncMethodName);
         }
         finally
         {
@@ -132,15 +138,30 @@ public class AspNetCore5ExceptionReplayInvalidProgramTests : AspNetBase, IClassF
         }
     }
 
-    private static bool IsSuccessfulCapture(MockSpan span, string exceptionReplayPhase)
+    private static bool IsSuccessfulCapture(MockSpan span, string exceptionReplayPhase, string expectedAsyncMethodName)
     {
         if (exceptionReplayPhase != ExceptionReplayDiagnosticTagNames.Eligible || span.Tags is null)
         {
             return false;
         }
 
-        return span.Tags.ContainsKey(DebugInfoCapturedTag)
-            && span.Tags.Keys.Any(key => key.EndsWith(".snapshot_id", StringComparison.Ordinal));
+        if (!span.Tags.ContainsKey(DebugInfoCapturedTag))
+        {
+            return false;
+        }
+
+        var expectedStateMachinePrefix = $"<{expectedAsyncMethodName}>d__";
+        foreach (var tagName in span.Tags.Keys.Where(key => key.EndsWith($".{SnapshotIdTagName}", StringComparison.Ordinal)))
+        {
+            var framePrefix = tagName.Substring(0, tagName.Length - SnapshotIdTagName.Length);
+            if (span.GetTag(framePrefix + "frame_data.function") == "MoveNext"
+             && span.GetTag(framePrefix + "frame_data.class_name")?.StartsWith(expectedStateMachinePrefix, StringComparison.Ordinal) == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayJitIlTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayJitIlTests.cs
@@ -6,6 +6,7 @@
 #if NETCOREAPP3_0_OR_GREATER
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.ExceptionAutoInstrumentation;
@@ -28,7 +29,9 @@ namespace Datadog.Trace.Debugger.IntegrationTests.ExceptionReplay;
 public class AspNetCore5ExceptionReplayJitIlTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
     private const string ExceptionReplayPhaseTag = "_dd.di._er";
+    private const string UnsupportedCompletionValueLoadLog = "EndAsyncMethodProbe: instruction before SetException is not a standalone value load";
     private const int MaxAttempts = 8;
+    private readonly string _logPath;
 
     public AspNetCore5ExceptionReplayJitIlTests(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
         : base("AspNetCore5", outputHelper)
@@ -42,6 +45,10 @@ public class AspNetCore5ExceptionReplayJitIlTests : AspNetBase, IClassFixture<As
         SetEnvironmentVariable("DD_CLR_ENABLE_INLINING", "0");
         SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
         SetEnvironmentVariable("COMPLUS_ForceEnc", "0");
+
+        _logPath = Path.Combine(LogDirectory, nameof(AspNetCore5ExceptionReplayJitIlTests));
+        Directory.CreateDirectory(_logPath);
+        SetEnvironmentVariable(ConfigurationKeys.LogDirectory, _logPath);
 
         Fixture = fixture;
         Fixture.SetOutput(outputHelper);
@@ -66,6 +73,7 @@ public class AspNetCore5ExceptionReplayJitIlTests : AspNetBase, IClassFixture<As
         var expectedErrorType = typeof(InvalidOperationException).FullName;
 
         IncludeAllHttpSpans = true;
+        using var logEntryWatcher = new LogEntryWatcher("dotnet-tracer-native-*", _logPath, Output);
         await Fixture.TryStartApp(this);
         SetHttpPort(Fixture.HttpPort);
 
@@ -98,6 +106,9 @@ public class AspNetCore5ExceptionReplayJitIlTests : AspNetBase, IClassFixture<As
                 errorType.Should().Be(expectedErrorType);
                 await Task.Delay(250);
             }
+
+            var guardLog = await logEntryWatcher.WaitForLogEntry(UnsupportedCompletionValueLoadLog);
+            guardLog.Should().Contain("LdfldSm.MoveNext");
         }
         finally
         {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayJitIlTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ExceptionReplay/AspNetCore5ExceptionReplayJitIlTests.cs
@@ -1,0 +1,109 @@
+// <copyright file="AspNetCore5ExceptionReplayJitIlTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_0_OR_GREATER
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Debugger.ExceptionAutoInstrumentation;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Samples.Probes.TestRuns.ExceptionReplay;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Debugger.IntegrationTests.ExceptionReplay;
+
+/// <summary>
+/// APMS-20228: EndAsyncMethodProbe used to memcpy the instruction before SetException.
+/// When that opcode is <c>ldfld</c> (this adversarial fixture, not stock Roslyn),
+/// the rewritten MoveNext was rejected at <c>AsyncMethodBuilderCore.Start</c>.
+/// Fail-closed must abort the rewrite instead. Own fixture so this cannot
+/// contaminate the customer-shaped C# tests.
+/// </summary>
+[Collection(nameof(AspNetCore5ExceptionReplayInvalidProgramTests))]
+public class AspNetCore5ExceptionReplayJitIlTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>
+{
+    private const string ExceptionReplayPhaseTag = "_dd.di._er";
+    private const int MaxAttempts = 8;
+
+    public AspNetCore5ExceptionReplayJitIlTests(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+        : base("AspNetCore5", outputHelper)
+    {
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.ExceptionReplayEnabled, "true");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.DynamicInstrumentationEnabled, "false");
+        SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "100");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.MaxDepthToSerialize, "5");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.DiagnosticsInterval, "1");
+        SetEnvironmentVariable(ConfigurationKeys.Debugger.MaxTimeToSerialize, "1000");
+        SetEnvironmentVariable("DD_CLR_ENABLE_INLINING", "0");
+        SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+        SetEnvironmentVariable("COMPLUS_ForceEnc", "0");
+
+        Fixture = fixture;
+        Fixture.SetOutput(outputHelper);
+    }
+
+    protected AspNetCoreTestFixture Fixture { get; }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        Fixture.SetOutput(null);
+    }
+
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    public async Task SetExceptionLdfldPrev_DoesNotThrowInvalidProgramException()
+    {
+        var testType = typeof(SetExceptionLdfldPrevTest);
+        var url = $"/RunTest/{testType.FullName}";
+        var invalidProgram = typeof(InvalidProgramException).FullName;
+        var expectedErrorType = typeof(InvalidOperationException).FullName;
+
+        IncludeAllHttpSpans = true;
+        await Fixture.TryStartApp(this);
+        SetHttpPort(Fixture.HttpPort);
+
+        var agent = Fixture.Agent;
+
+        try
+        {
+            for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+            {
+                var spans = await SendRequestsAsync(agent, [url]);
+
+                Fixture.Process.HasExited.Should().BeFalse(
+                    "the sample process should stay alive after request {0}",
+                    attempt);
+
+                var erroredSpan = spans.Should().Contain(x => x.Tags != null && x.Tags.ContainsKey(Tags.ErrorStack)).Which;
+                var errorType = erroredSpan.GetTag(Tags.ErrorType);
+                var errorStack = erroredSpan.GetTag(Tags.ErrorStack);
+                var exceptionReplayPhase = erroredSpan.GetTag(ExceptionReplayPhaseTag);
+
+                Output.WriteLine($"Attempt {attempt}: error.type={errorType} {ExceptionReplayPhaseTag}={exceptionReplayPhase}");
+                Output.WriteLine(errorStack);
+
+                errorType.Should().NotBe(
+                    invalidProgram,
+                    "memcpy of ldfld before SetException must abort instead of producing InvalidProgramException.{0}{1}",
+                    Environment.NewLine,
+                    errorStack);
+
+                errorType.Should().Be(expectedErrorType);
+                await Task.Delay(250);
+            }
+        }
+        finally
+        {
+            agent.ClearSnapshots();
+        }
+    }
+}
+
+#endif

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/AwaitUsingCatchFilterFinallyTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/AwaitUsingCatchFilterFinallyTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+
+#if NETCOREAPP3_0_OR_GREATER
+namespace Samples.Probes.TestRuns.ExceptionReplay
+{
+    /// <summary>
+    /// APMS-20228: adversarial async EH (<c>await using</c>, <c>catch when</c>, await in <c>finally</c>).
+    /// No probe or ExceptionReplay attributes — ProbesTests skips it, and it stays out of the skipped snapshot suite.
+    /// </summary>
+    public class AwaitUsingCatchFilterFinallyTest : IAsyncRun
+    {
+        public async Task RunAsync()
+        {
+            await Task.Yield();
+
+            try
+            {
+                await using var reader = await CreateReaderAsync().ConfigureAwait(false);
+                try
+                {
+                    await Task.Yield();
+                    throw new InvalidOperationException("APMS-20228 inner");
+                }
+                finally
+                {
+                    await Task.Yield();
+                    _ = reader;
+                }
+            }
+            catch (Exception ex) when (ex is not ExceptionReplayIntentionalException)
+            {
+                throw new ExceptionReplayIntentionalException("APMS-20228 await using catch filter", ex);
+            }
+        }
+
+        private static async Task<RelationalDataReader> CreateReaderAsync()
+        {
+            await Task.Yield();
+            return new RelationalDataReader();
+        }
+
+        public sealed class RelationalDataReader : IAsyncDisposable, IDisposable
+        {
+            private bool _disposed;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                GC.SuppressFinalize(this);
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                await Task.Yield();
+                _disposed = true;
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/FinallyLastEhTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/FinallyLastEhTest.cs
@@ -1,0 +1,67 @@
+#if NETCOREAPP3_0_OR_GREATER
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.ExceptionReplay
+{
+    /// <summary>
+    /// Finally is the last EH clause; the compiler-style <c>SetException</c> catch is not.
+    /// <c>EndAsyncMethodProbe</c> used to inject at <c>GetEHPointer()[n-1]</c>, so the
+    /// end-method probe landed in the finally. JIT accepted that IL, but capture failed
+    /// with <c>EmptyCallStackTreeWhileCollecting</c>. Binding to the catch that contains
+    /// <c>SetException</c> must restore Eligible capture.
+    /// No probe or ExceptionReplay attributes — ProbesTests skips it, and it stays out of the snapshot suite.
+    /// </summary>
+    public class FinallyLastEhTest : IAsyncRun
+    {
+        // AsyncStateMachineAttribute is required so BeginMethod can resolve the kickoff
+        // method. Without it GetAsyncKickoffMethod returns null, BeginMethod throws, and
+        // capture stays EmptyCallStackTreeWhileCollecting even when EndMethod is in the catch.
+        [AsyncStateMachine(typeof(FinallyLastSm))]
+        public Task RunAsync()
+        {
+            var sm = new FinallyLastSm();
+            sm._builder = AsyncTaskMethodBuilder.Create();
+            sm._state = -1;
+            sm._builder.Start(ref sm);
+            return sm._builder.Task;
+        }
+
+        internal struct FinallyLastSm : IAsyncStateMachine
+        {
+            public int _state;
+            public AsyncTaskMethodBuilder _builder;
+            public bool _finallyRan;
+
+            public void MoveNext()
+            {
+                try
+                {
+                    try
+                    {
+                        throw new ExceptionReplayIntentionalException("finally-last EH");
+                    }
+                    catch (Exception ex)
+                    {
+                        _builder.SetException(ex);
+                        return;
+                    }
+
+#pragma warning disable CS0162
+                    _builder.SetResult();
+#pragma warning restore CS0162
+                }
+                finally
+                {
+                    _finallyRan = true;
+                }
+            }
+
+            public void SetStateMachine(IAsyncStateMachine stateMachine)
+            {
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/NestedUsingAwaitGenericOverrideTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/NestedUsingAwaitGenericOverrideTest.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+#if NETCOREAPP3_0_OR_GREATER
+namespace Samples.Probes.TestRuns.ExceptionReplay
+{
+    /// <summary>
+    /// APMS-20228: customer-like async EH (nested <c>using</c> + <c>using (await ...)</c>,
+    /// override <c>async Task&lt;T&gt;</c>, two result types). No probe or ExceptionReplay
+    /// attributes — ProbesTests skips it, and it stays out of the skipped snapshot suite.
+    /// </summary>
+    public class NestedUsingAwaitGenericOverrideTest : IAsyncRun
+    {
+        public async Task RunAsync()
+        {
+            var handler = new PaymentGetAllQueryHandler(new FakeConnFactory());
+            await handler.Handle(new PaymentGetAllQuery { SelectCount = true }, CancellationToken.None);
+        }
+
+        public abstract class HandlerBase
+        {
+            public abstract Task<ListResponse<PaymentListModel>> Handle(PaymentGetAllQuery request, CancellationToken cancellationToken);
+        }
+
+        public class PaymentGetAllQueryHandler : HandlerBase
+        {
+            private readonly IConnFactory _connectionFactory;
+
+            public PaymentGetAllQueryHandler(IConnFactory connectionFactory)
+            {
+                _connectionFactory = connectionFactory;
+            }
+
+            public override async Task<ListResponse<PaymentListModel>> Handle(PaymentGetAllQuery request, CancellationToken cancellationToken)
+            {
+                var filterParams = await request.GetFilterParamsAsync(cancellationToken);
+                var sql = "select 1;" + (request.SelectCount ? "select 2" : null);
+                var parameters = filterParams;
+
+                IEnumerable<PaymentListModel> items;
+                long totalCount = 0;
+                using (var connection = _connectionFactory.CreateConnection())
+                using (var queries = await connection.QueryMultipleAsync(sql, parameters, cancellationToken))
+                {
+                    items = await queries.ReadAsync();
+                    if (request.SelectCount)
+                    {
+                        totalCount = await queries.ReadSingleAsyncLong();
+                    }
+                }
+
+                var payments = items?.Select(x => new PaymentListModel()).ToList() ?? new List<PaymentListModel>();
+
+                ListResponse<PaymentListModel> result = !request.SelectCount
+                    ? new ListResponse<PaymentListModel>(payments)
+                    : new SearchResponse<PaymentListModel>(payments, totalCount);
+
+                throw new ExceptionReplayIntentionalException($"APMS-20228 nested using. Count={result.Items.Count}");
+            }
+        }
+
+        public class ListResponse<T>
+        {
+            public ListResponse(List<T> items)
+            {
+                Items = items;
+            }
+
+            public List<T> Items { get; }
+        }
+
+        public class SearchResponse<T> : ListResponse<T>
+        {
+            public SearchResponse(List<T> items, long total)
+                : base(items)
+            {
+                Total = total;
+            }
+
+            public long Total { get; }
+        }
+
+        public class PaymentListModel
+        {
+            public int Id { get; set; }
+        }
+
+        public class PaymentGetAllQuery
+        {
+            public bool SelectCount { get; set; }
+
+            public Task<int> GetFilterParamsAsync(CancellationToken cancellationToken) => Task.FromResult(1);
+        }
+
+        public interface IConnFactory
+        {
+            FakeConnection CreateConnection();
+        }
+
+        public sealed class FakeConnection : IDisposable
+        {
+            public Task<QueryMultiple> QueryMultipleAsync(string sql, object parameters, CancellationToken cancellationToken)
+            {
+                _ = sql;
+                _ = parameters;
+                _ = cancellationToken;
+                return Task.FromResult(new QueryMultiple());
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        public sealed class QueryMultiple : IDisposable
+        {
+            public Task<IEnumerable<PaymentListModel>> ReadAsync() => Task.FromResult(Enumerable.Empty<PaymentListModel>());
+
+            public Task<long> ReadSingleAsyncLong() => Task.FromResult(1L);
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private sealed class FakeConnFactory : IConnFactory
+        {
+            public FakeConnection CreateConnection() => new FakeConnection();
+        }
+    }
+}
+#endif

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/SetExceptionLdfldPrevTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExceptionReplay/SetExceptionLdfldPrevTest.cs
@@ -1,0 +1,56 @@
+#if NETCOREAPP3_0_OR_GREATER
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.ExceptionReplay
+{
+    /// <summary>
+    /// Adversarial MoveNext: store the catch exception in a field, then
+    /// <c>SetException(_captured)</c>. Roslyn emits <c>ldfld</c> immediately before
+    /// <c>SetException</c>. Stock compiler async uses <c>ldloc</c> instead; this fixture
+    /// exists to prove EndAsyncMethodProbe's memcpy of <c>m_pPrev</c> is JIT-invalid
+    /// when that opcode is not a standalone value load.
+    /// </summary>
+    public class SetExceptionLdfldPrevTest : IAsyncRun
+    {
+        public Task RunAsync()
+        {
+            var sm = new LdfldSm();
+            sm._builder = AsyncTaskMethodBuilder.Create();
+            sm._state = -1;
+            sm._builder.Start(ref sm);
+            return sm._builder.Task;
+        }
+
+        internal struct LdfldSm : IAsyncStateMachine
+        {
+            public int _state;
+            public AsyncTaskMethodBuilder _builder;
+            public Exception _captured;
+
+            public void MoveNext()
+            {
+                try
+                {
+                    throw new InvalidOperationException("APMS-20228 setexception ldfld prev");
+                }
+                catch (Exception ex)
+                {
+                    _captured = ex;
+                    _builder.SetException(_captured);
+                    return;
+                }
+
+#pragma warning disable CS0162
+                _builder.SetResult();
+#pragma warning restore CS0162
+            }
+
+            public void SetStateMachine(IAsyncStateMachine stateMachine)
+            {
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary of changes

- Fail closed in `EndAsyncMethodProbe` / `EndAsyncMethodSpanProbe` when the instruction before `SetException` (or non-void `SetResult`) is not a standalone value load (`ldloc*` / `ldc.*` / `ldnull` / `ldstr`).
- Those paths `memcpy` that previous instruction and replay it as the completion value. That is invalid for `ldfld` (and similar): the JIT rejects `MoveNext` at `AsyncMethodBuilderCore.Start`.
- `ldsfld` is also rejected (rereads a mutable static; drops `volatile.`).
- Unexpected rewrite failures still log `Error`.

## Reason for change

- Hardening for a rewriter bug that can produce `InvalidProgramException` at async state-machine start (same symptom class as APMS-20228). This does not prove the customer root cause.
- Stock Roslyn emits `ldloc` before `SetException`, so compiler-generated `MoveNext` still rewrites.

## Implementation details

- New `ILRewriter::IsCloneableStandaloneValueLoad`. On false, return `E_FAIL` before `memcpy` so `Rewrite()` never `Export()`s.

## Test coverage

- `AspNetCore5ExceptionReplayJitIlTests`: adversarial `ldfld` before `SetException` - no IPE, native guard log for `LdfldSm.MoveNext`.
- `AspNetCore5ExceptionReplayInvalidProgramTests`: nested `using` / `await using` + `catch when` - no IPE, Eligible capture of rewritten `MoveNext`.

## Other details

- Follow-up: bind EndMethod inject to the EH clause that contains the matched `SetException` call, not `GetEHPointer()[n-1]`.