### PR TITLE
[DuckTyping] Reject incompatible open generic method signatures

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -190,7 +190,11 @@ namespace Datadog.Trace.DuckTyping
                 // same position. Validate the complete signature before defining or emitting the proxy method so
                 // invalid signatures cannot produce unverifiable IL that reinterprets value-type data as an object
                 // reference, or reads/writes a managed reference using the wrong element size.
-                if (ValidateGenericMethodSignature(proxyMethodDefinition, targetMethod) is { } signatureError)
+                if (ValidateGenericMethodSignature(
+                        proxyMethodDefinition,
+                        targetMethod,
+                        proxyMethodReturnType: UnwrapValueWithType(proxyMethodDefinition.ReturnType),
+                        targetMethodReturnType: targetMethod.ReturnType) is { } signatureError)
                 {
                     return signatureError;
                 }
@@ -330,7 +334,11 @@ namespace Datadog.Trace.DuckTyping
                 // Reverse proxies exchange the roles of the implementation and overridden methods, but generic
                 // parameter identity has exactly the same requirement: a generic parameter at one position must
                 // never be treated as the parameter at another position.
-                if (ValidateGenericMethodSignature(implementationMethod, overriddenMethod) is { } signatureError)
+                if (ValidateGenericMethodSignature(
+                        implementationMethod,
+                        overriddenMethod,
+                        proxyMethodReturnType: implementationMethod.ReturnType,
+                        targetMethodReturnType: UnwrapValueWithType(overriddenMethod.ReturnType)) is { } signatureError)
                 {
                     return signatureError;
                 }
@@ -715,7 +723,11 @@ namespace Datadog.Trace.DuckTyping
             return null;
         }
 
-        private static DuckTypeException? ValidateGenericMethodSignature(MethodInfo proxyMethod, MethodInfo targetMethod)
+        private static DuckTypeException? ValidateGenericMethodSignature(
+            MethodInfo proxyMethod,
+            MethodInfo targetMethod,
+            Type proxyMethodReturnType,
+            Type targetMethodReturnType)
         {
             Type[] proxyGenericArguments = proxyMethod.GetGenericArguments();
             Type[] targetGenericArguments = targetMethod.GetGenericArguments();
@@ -743,7 +755,7 @@ namespace Datadog.Trace.DuckTyping
                 }
             }
 
-            if (!HaveCompatibleGenericParameterStructure(proxyMethod.ReturnType, targetMethod.ReturnType))
+            if (!HaveCompatibleGenericParameterStructure(proxyMethodReturnType, targetMethodReturnType))
             {
                 return DuckTypeProxyAndTargetMethodReturnTypeMismatchException.Create(proxyMethod, targetMethod);
             }
@@ -751,7 +763,23 @@ namespace Datadog.Trace.DuckTyping
             return null;
         }
 
+        private static Type UnwrapValueWithType(Type returnType)
+        {
+            // ValueWithType<T> is an explicit outer return contract. AddReturnIl forwards the inner T and then
+            // wraps it together with the target's runtime Type, so generic signature validation must compare T
+            // with the target return rather than treating the wrapper as an unrelated value type.
+            return returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueWithType<>)
+                       ? returnType.GetGenericArguments()[0]
+                       : returnType;
+        }
+
         private static bool HaveCompatibleGenericParameterStructure(Type proxyType, Type targetType)
+            => HaveCompatibleGenericParameterStructure(proxyType, targetType, canDeferConcreteParameterToReferenceCast: null);
+
+        private static bool HaveCompatibleGenericParameterStructure(
+            Type proxyType,
+            Type targetType,
+            bool? canDeferConcreteParameterToReferenceCast)
         {
             if (proxyType == targetType)
             {
@@ -770,10 +798,11 @@ namespace Datadog.Trace.DuckTyping
             {
                 if (!proxyType.IsGenericParameter || !targetType.IsGenericParameter)
                 {
-                    // A concrete type and an open generic parameter are not interchangeable. In particular, an
-                    // unconstrained generic parameter may be either a value or reference type, so there is no IL
-                    // conversion that is valid for every possible method instantiation.
-                    return false;
+                    // A top-level generic parameter cannot be treated as a concrete type: its representation is
+                    // unknown until the method is constructed. Inside an outer reference type, however, the value
+                    // on the stack is always an object reference. The existing conversion path can therefore emit
+                    // castclass and let incompatible instantiations fail with a managed InvalidCastException.
+                    return canDeferConcreteParameterToReferenceCast is true;
                 }
 
                 // Generic parameter names do not participate in signature identity. The metadata position and
@@ -792,7 +821,10 @@ namespace Datadog.Trace.DuckTyping
                     return false;
                 }
 
-                return HaveCompatibleGenericParameterStructure(proxyType.GetElementType()!, targetType.GetElementType()!);
+                return HaveCompatibleGenericParameterStructure(
+                    proxyType.GetElementType()!,
+                    targetType.GetElementType()!,
+                    canDeferConcreteParameterToReferenceCast: false);
             }
 
             if (proxyType.IsArray && targetType.IsArray)
@@ -806,13 +838,23 @@ namespace Datadog.Trace.DuckTyping
                     return false;
                 }
 
-                return HaveCompatibleGenericParameterStructure(proxyType.GetElementType()!, targetType.GetElementType()!);
+                return HaveCompatibleGenericParameterStructure(
+                    proxyType.GetElementType()!,
+                    targetType.GetElementType()!,
+                    canDeferConcreteParameterToReferenceCast ?? true);
             }
 
             if (proxyType.IsGenericType
              && targetType.IsGenericType
              && proxyType.GetGenericTypeDefinition() == targetType.GetGenericTypeDefinition())
             {
+                // Only the outermost signature type decides whether a concrete/open mismatch can be deferred.
+                // Once a value type or managed reference requires exact storage identity, a nested reference type
+                // must not relax that decision.
+                bool canDeferNestedParameter =
+                    canDeferConcreteParameterToReferenceCast
+                 ?? (!proxyType.IsValueType && !targetType.IsValueType);
+
                 Type[] proxyGenericArguments = proxyType.GetGenericArguments();
                 Type[] targetGenericArguments = targetType.GetGenericArguments();
                 if (proxyGenericArguments.Length != targetGenericArguments.Length)
@@ -822,7 +864,10 @@ namespace Datadog.Trace.DuckTyping
 
                 for (int i = 0; i < proxyGenericArguments.Length; i++)
                 {
-                    if (!HaveCompatibleGenericParameterStructure(proxyGenericArguments[i], targetGenericArguments[i]))
+                    if (!HaveCompatibleGenericParameterStructure(
+                            proxyGenericArguments[i],
+                            targetGenericArguments[i],
+                            canDeferNestedParameter))
                     {
                         return false;
                     }

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -185,6 +185,16 @@ namespace Datadog.Trace.DuckTyping
                     targetMethod = targetMethod.MakeGenericMethod(genericParameterTypes);
                 }
 
+                // Open generic parameters are placeholders for types selected by the caller. They can only be
+                // passed through without conversion when the proxy and target use the same placeholder at the
+                // same position. Validate the complete signature before defining or emitting the proxy method so
+                // invalid signatures cannot produce unverifiable IL that reinterprets value-type data as an object
+                // reference, or reads/writes a managed reference using the wrong element size.
+                if (ValidateGenericMethodSignature(proxyMethodDefinition, targetMethod) is { } signatureError)
+                {
+                    return signatureError;
+                }
+
                 // Gets target method parameters
                 ParameterInfo[] targetMethodParameters = targetMethod.GetParameters();
                 Type[] targetMethodParametersTypes = targetMethodParameters.Select(p => p.ParameterType).ToArray();
@@ -317,6 +327,14 @@ namespace Datadog.Trace.DuckTyping
                     return DuckTypeReverseProxyMustImplementGenericMethodAsGenericException.Create(implementationMethod, overriddenMethod);
                 }
 
+                // Reverse proxies exchange the roles of the implementation and overridden methods, but generic
+                // parameter identity has exactly the same requirement: a generic parameter at one position must
+                // never be treated as the parameter at another position.
+                if (ValidateGenericMethodSignature(implementationMethod, overriddenMethod) is { } signatureError)
+                {
+                    return signatureError;
+                }
+
                 // Gets target method parameters
                 ParameterInfo[] overriddenMethodParameters = overriddenMethod.GetParameters();
                 if (implementationMethodParameters.Length > overriddenMethodParameters.Length)
@@ -410,6 +428,15 @@ namespace Datadog.Trace.DuckTyping
 
             T proxyMethodDuckAttribute = proxyMethod.GetCustomAttribute<T>(true) ?? new T();
             proxyMethodDuckAttribute.Name ??= proxyMethod.Name;
+
+            // A non-generic proxy method can select a generic target method and provide every generic argument
+            // explicitly through DuckAttribute.GenericParameterTypeNames. The candidate is still an open generic
+            // definition while this method searches for it, so comparing a concrete proxy parameter with the
+            // corresponding target placeholder here would reject a valid match. Once selected, the caller closes
+            // the target method and ValidateGenericMethodSignature checks the resulting concrete signature.
+            bool targetGenericArgumentsAreProvidedByAttribute =
+                proxyMethodDuckAttribute is DuckAttribute { GenericParameterTypeNames: { Length: > 0 } }
+             && !proxyMethod.IsGenericMethodDefinition;
 
             MethodInfo? targetMethod;
 
@@ -554,7 +581,23 @@ namespace Datadog.Trace.DuckTyping
                     proxyParamType = proxyParamType.IsByRef ? proxyParamType.GetElementType()! : proxyParamType;
                     candidateParamType = candidateParamType.IsByRef ? candidateParamType.GetElementType()! : candidateParamType;
 
-                    // We can't compare generic parameters
+                    // Generic parameter names are only documentation. Their positions define their identity in
+                    // metadata, so TFirst (position 0) and TSecond (position 1) are different types even though
+                    // both report IsGenericParameter. The comparison also walks arrays and constructed generic
+                    // types so a mismatch cannot be hidden inside a container such as Tuple<TFirst, TSecond>.
+                    // Reverse proxies perform their arity check after method selection so they can return the
+                    // established DuckTypeReverseProxyMustImplementGenericMethodAsGenericException. Their complete
+                    // open signature is validated before any IL is emitted below.
+                    if (typeof(T) != typeof(DuckReverseMethodAttribute)
+                     && !targetGenericArgumentsAreProvidedByAttribute
+                     && !HaveCompatibleGenericParameterStructure(proxyParamType, candidateParamType))
+                    {
+                        skip = true;
+                        break;
+                    }
+
+                    // Matching generic parameters are passed through. Their Type objects belong to different
+                    // method definitions, so reference equality cannot be used here.
                     if (candidateParamType.IsGenericParameter)
                     {
                         continue;
@@ -672,12 +715,136 @@ namespace Datadog.Trace.DuckTyping
             return null;
         }
 
+        private static DuckTypeException? ValidateGenericMethodSignature(MethodInfo proxyMethod, MethodInfo targetMethod)
+        {
+            Type[] proxyGenericArguments = proxyMethod.GetGenericArguments();
+            Type[] targetGenericArguments = targetMethod.GetGenericArguments();
+
+            // A generic method definition is emitted by substituting the generated proxy method's generic
+            // parameters into the target method. That substitution is only possible when both definitions have
+            // the same arity. A non-generic proxy may still call a constructed generic target selected through
+            // DuckAttribute.GenericParameterTypeNames; in that case the target is no longer a definition and the
+            // normal concrete-type conversion rules apply below.
+            if (proxyMethod.IsGenericMethodDefinition != targetMethod.IsGenericMethodDefinition
+             || (proxyMethod.IsGenericMethodDefinition && proxyGenericArguments.Length != targetGenericArguments.Length))
+            {
+                return DuckTypeProxyAndTargetMethodParameterSignatureMismatchException.Create(proxyMethod, targetMethod);
+            }
+
+            ParameterInfo[] proxyParameters = proxyMethod.GetParameters();
+            ParameterInfo[] targetParameters = targetMethod.GetParameters();
+            int sharedParameterCount = Math.Min(proxyParameters.Length, targetParameters.Length);
+
+            for (int i = 0; i < sharedParameterCount; i++)
+            {
+                if (!HaveCompatibleGenericParameterStructure(proxyParameters[i].ParameterType, targetParameters[i].ParameterType))
+                {
+                    return DuckTypeProxyAndTargetMethodParameterSignatureMismatchException.Create(proxyMethod, targetMethod);
+                }
+            }
+
+            if (!HaveCompatibleGenericParameterStructure(proxyMethod.ReturnType, targetMethod.ReturnType))
+            {
+                return DuckTypeProxyAndTargetMethodReturnTypeMismatchException.Create(proxyMethod, targetMethod);
+            }
+
+            return null;
+        }
+
+        private static bool HaveCompatibleGenericParameterStructure(Type proxyType, Type targetType)
+        {
+            if (proxyType == targetType)
+            {
+                return true;
+            }
+
+            if (!proxyType.ContainsGenericParameters && !targetType.ContainsGenericParameters)
+            {
+                // Closed types contain no placeholders whose identities can be confused. They may still require a
+                // normal cast, boxing operation or duck conversion, which is deliberately handled later by the
+                // existing conversion pipeline.
+                return true;
+            }
+
+            if (proxyType.IsGenericParameter || targetType.IsGenericParameter)
+            {
+                if (!proxyType.IsGenericParameter || !targetType.IsGenericParameter)
+                {
+                    // A concrete type and an open generic parameter are not interchangeable. In particular, an
+                    // unconstrained generic parameter may be either a value or reference type, so there is no IL
+                    // conversion that is valid for every possible method instantiation.
+                    return false;
+                }
+
+                // Generic parameter names do not participate in signature identity. The metadata position and
+                // owner kind do: method parameter !!0 is equivalent to method parameter !!0 on the corresponding
+                // method, but it is not equivalent to !!1 or to type parameter !0.
+                return proxyType.GenericParameterPosition == targetType.GenericParameterPosition
+                    && (proxyType.DeclaringMethod is null) == (targetType.DeclaringMethod is null);
+            }
+
+            if (proxyType.IsByRef || targetType.IsByRef || proxyType.IsPointer || targetType.IsPointer)
+            {
+                // Managed references and pointers describe storage, not a reference-type conversion. Both sides
+                // must use the same shape before it is safe to compare their element placeholders.
+                if (proxyType.IsPointer != targetType.IsPointer || proxyType.IsByRef != targetType.IsByRef)
+                {
+                    return false;
+                }
+
+                return HaveCompatibleGenericParameterStructure(proxyType.GetElementType()!, targetType.GetElementType()!);
+            }
+
+            if (proxyType.IsArray && targetType.IsArray)
+            {
+                // A vector (T[]) and a rank-one multidimensional array (T[*]) have the same rank but different
+                // runtime signatures. Preserve that distinction as well as the rank before comparing elements.
+                bool proxyIsVector = proxyType.GetArrayRank() == 1 && proxyType == proxyType.GetElementType()!.MakeArrayType();
+                bool targetIsVector = targetType.GetArrayRank() == 1 && targetType == targetType.GetElementType()!.MakeArrayType();
+                if (proxyType.GetArrayRank() != targetType.GetArrayRank() || proxyIsVector != targetIsVector)
+                {
+                    return false;
+                }
+
+                return HaveCompatibleGenericParameterStructure(proxyType.GetElementType()!, targetType.GetElementType()!);
+            }
+
+            if (proxyType.IsGenericType
+             && targetType.IsGenericType
+             && proxyType.GetGenericTypeDefinition() == targetType.GetGenericTypeDefinition())
+            {
+                Type[] proxyGenericArguments = proxyType.GetGenericArguments();
+                Type[] targetGenericArguments = targetType.GetGenericArguments();
+                if (proxyGenericArguments.Length != targetGenericArguments.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < proxyGenericArguments.Length; i++)
+                {
+                    if (!HaveCompatibleGenericParameterStructure(proxyGenericArguments[i], targetGenericArguments[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            // This helper validates only the placement of open generic parameters. Concrete assignability, enum
+            // handling, boxing, duck chaining and runtime casts remain the responsibility of the existing type
+            // conversion logic.
+            return true;
+        }
+
         private static DuckTypeInvalidTypeConversionException? WriteSafeTypeConversion(this LazyILGenerator il, Type actualType, Type expectedType)
         {
-            // If both types are generics, we expect that the generic parameter are the same type (passthrough)
-            if (actualType.IsGenericParameter && expectedType.IsGenericParameter)
+            // Matching generic parameters are substituted with the same concrete type when the generated method
+            // is constructed, so no conversion is necessary. Never apply this shortcut to different positions:
+            // they may be instantiated with unrelated value/reference categories and storage sizes.
+            if (actualType.IsGenericParameter || expectedType.IsGenericParameter)
             {
-                return null;
+                return HaveCompatibleGenericParameterStructure(actualType, expectedType)
+                           ? null
+                           : DuckTypeInvalidTypeConversionException.Create(actualType, expectedType);
             }
 
             return il.WriteTypeConversion(actualType, expectedType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/Generics/GenericMethodSignatureValidationTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/Generics/GenericMethodSignatureValidationTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="GenericMethodSignatureValidationTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
+{
+    public class GenericMethodSignatureValidationTests
+    {
+        private interface IConcreteReferenceDefaultReturnProxy
+        {
+            string ReturnDefault<T>();
+        }
+
+        private interface IConcreteReferenceNonDefaultReturnProxy
+        {
+            string ReturnNonDefault<T>();
+        }
+
+        private interface IReorderedArgumentProxy
+        {
+            TSecond EchoArgument<TFirst, TSecond>(TFirst value);
+        }
+
+        private interface IReorderedReturnProxy
+        {
+            TFirst EchoReturn<TFirst, TSecond>(TSecond value);
+        }
+
+        private interface IReorderedRefParameterProxy
+        {
+            void Clear<TFirst, TSecond>(ref TFirst value);
+        }
+
+        private interface IReorderedOutParameterProxy
+        {
+            void SetDefault<TFirst, TSecond>(out TFirst value);
+        }
+
+        private interface INestedGenericReturnProxy
+        {
+            Tuple<TFirst, TFirst> Wrap<TFirst, TSecond>(TFirst first, TSecond second);
+        }
+
+        private interface IReorderedArrayReturnProxy
+        {
+            TFirst[] ReturnArray<TFirst, TSecond>();
+        }
+
+        private interface IReverseGenericContract
+        {
+            TSecond Echo<TFirst, TSecond>(TSecond value);
+        }
+
+        [Fact]
+        public void RejectsOpenGenericReturnTypeMappedToConcreteReferenceType()
+        {
+            // ReturnDefault<int>() used to appear to return null because the zero bits were interpreted as a null
+            // object reference. Proxy creation must reject the open T-to-string conversion, so the misleading
+            // result can never be observed by a caller.
+            AssertInvalidProxy<IConcreteReferenceDefaultReturnProxy>();
+        }
+
+        [Fact]
+        public void RejectsNonZeroOpenGenericReturnTypeMappedToConcreteReferenceType()
+        {
+            // ReturnNonDefault<int>() leaves 0x11223344 on the evaluation stack before the old implementation emits
+            // castclass string. On affected runtimes, treating those integer bits as an object reference terminates
+            // the process with an AccessViolationException. The regression test stops at proxy creation because
+            // executing the malformed method inside the test runner would make the entire suite unstable.
+            AssertInvalidProxy<IConcreteReferenceNonDefaultReturnProxy>();
+        }
+
+        [Fact]
+        public void RejectsDifferentGenericParameterPositionsInArgumentType()
+        {
+            // The names of generic parameters are not significant, but their positions are. TFirst and TSecond
+            // can be instantiated with unrelated representations such as Int32/Int64 or string/WideValue. Treating
+            // an argument as the other position can truncate its value or make the generated call invalid.
+            AssertInvalidProxy<IReorderedArgumentProxy>();
+        }
+
+        [Fact]
+        public void RejectsDifferentGenericParameterPositionsInReturnType()
+        {
+            // Keep the argument types equivalent so this test reaches the return-specific validation. Returning
+            // TSecond as TFirst without a conversion can leave a differently sized value or a value/reference
+            // mismatch on the evaluation stack.
+            AssertInvalidProxy<IReorderedReturnProxy>();
+        }
+
+        [Fact]
+        public void RejectsDifferentGenericParameterPositionsInRefParameter()
+        {
+            // A managed reference carries the storage layout of its element type. Passing ref TFirst to a method
+            // expecting ref TSecond is unsafe even when both parameters happen to have the same size in one
+            // instantiation, because another valid instantiation can use differently sized value types.
+            AssertInvalidProxy<IReorderedRefParameterProxy>();
+        }
+
+        [Fact]
+        public void RejectsDifferentGenericParameterPositionsInOutParameter()
+        {
+            // The target writes a TSecond value through this reference. The proxy must not expose the same storage
+            // as TFirst, otherwise the generated copy-back IL can overwrite adjacent memory when their sizes differ.
+            AssertInvalidProxy<IReorderedOutParameterProxy>();
+        }
+
+        [Fact]
+        public void RejectsDifferentGenericParameterPositionsNestedInsideGenericType()
+        {
+            // Generic identity must be compared recursively. Tuple<TFirst, TSecond> and
+            // Tuple<TFirst, TFirst> are different closed types whenever the caller chooses different arguments,
+            // even though their outer generic type definition is the same.
+            AssertInvalidProxy<INestedGenericReturnProxy>();
+        }
+
+        [Fact]
+        public void RejectsDifferentGenericParameterPositionsNestedInsideArray()
+        {
+            // Arrays are reference types, but their element types remain part of their runtime identity. A proxy
+            // returning TFirst[] cannot implement a target returning TSecond[] because callers may choose unrelated
+            // element types. Detect the mismatch while the signature is open instead of emitting a runtime cast.
+            AssertInvalidProxy<IReorderedArrayReturnProxy>();
+        }
+
+        [Fact]
+        public void RejectsDifferentGenericParameterPositionsInReverseProxy()
+        {
+            // Keep the argument positions equivalent so this test reaches the return-specific validation for
+            // reverse proxies. They emit the same kind of direct generic call, with the contract and implementation
+            // roles exchanged, and must reject a different return placeholder before defining the override.
+            var implementation = new ReorderedReverseImplementation();
+
+            Action create = () => implementation.DuckImplement(typeof(IReverseGenericContract));
+            create.Should().Throw<TargetInvocationException>();
+        }
+
+        private static void AssertInvalidProxy<TProxy>()
+        {
+            var target = new GenericMethodSignatureTarget();
+
+            using var scope = new AssertionScope();
+            target.DuckIs(typeof(TProxy)).Should().BeFalse();
+
+            Action cast = () => target.DuckCast(typeof(TProxy));
+            cast.Should().Throw<TargetInvocationException>();
+        }
+
+        private class GenericMethodSignatureTarget
+        {
+            public T ReturnDefault<T>() => default;
+
+            public T ReturnNonDefault<T>() => (T)(object)0x11223344;
+
+            public TSecond EchoArgument<TFirst, TSecond>(TSecond value) => value;
+
+            public TSecond EchoReturn<TFirst, TSecond>(TSecond value) => value;
+
+            public void Clear<TFirst, TSecond>(ref TSecond value) => value = default;
+
+            public void SetDefault<TFirst, TSecond>(out TSecond value) => value = default;
+
+            public Tuple<TFirst, TSecond> Wrap<TFirst, TSecond>(TFirst first, TSecond second) => Tuple.Create(first, second);
+
+            public TSecond[] ReturnArray<TFirst, TSecond>() => Array.Empty<TSecond>();
+        }
+
+        private class ReorderedReverseImplementation
+        {
+            [DuckReverseMethod]
+            public TFirst Echo<TFirst, TSecond>(TSecond value) => default;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/Generics/GenericMethodSignatureValidationTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/Generics/GenericMethodSignatureValidationTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -51,6 +52,21 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
         private interface IReorderedArrayReturnProxy
         {
             TFirst[] ReturnArray<TFirst, TSecond>();
+        }
+
+        private interface IValueWithTypeReturnProxy
+        {
+            ValueWithType<T> ReturnWithType<T>(T value);
+        }
+
+        private interface ICovariantReferenceReturnProxy
+        {
+            IEnumerable<object> ReturnCovariant<T>(T value);
+        }
+
+        private interface IReverseValueWithTypeContract
+        {
+            ValueWithType<T> ReturnWithType<T>(T value);
         }
 
         private interface IReverseGenericContract
@@ -131,6 +147,46 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
         }
 
         [Fact]
+        public void AllowsOpenGenericReturnWrappedWithRuntimeType()
+        {
+            // ValueWithType<T> is an explicit DuckTyping return contract. AddReturnIl extracts the T value from the
+            // target and wraps it together with its runtime Type, so signature validation must compare the wrapper's
+            // element type with the target placeholder instead of rejecting the supported wrapper itself.
+            var proxy = new GenericMethodSignatureTarget().DuckCast<IValueWithTypeReturnProxy>();
+
+            ValueWithType<int> result = proxy.ReturnWithType(42);
+            result.Value.Should().Be(42);
+            result.Type.Should().Be(typeof(int));
+        }
+
+        [Fact]
+        public void AllowsOpenGenericReturnWrappedWithRuntimeTypeInReverseProxy()
+        {
+            // Reverse proxies use the same return helper with the contract as the outer method. Preserve the wrapper
+            // there as well while still requiring its T to match the implementation's generic parameter position.
+            var implementation = new ReverseValueWithTypeImplementation();
+            var proxy = (IReverseValueWithTypeContract)implementation.DuckImplement(typeof(IReverseValueWithTypeContract));
+
+            ValueWithType<string> result = proxy.ReturnWithType("expected");
+            result.Value.Should().Be("expected");
+            result.Type.Should().Be(typeof(string));
+        }
+
+        [Fact]
+        public void AllowsCastSafeConversionInsideConstructedReferenceReturnType()
+        {
+            // A concrete argument nested inside a reference-type return can be checked by castclass at invocation
+            // time. Covariance makes IEnumerable<string> compatible with IEnumerable<object>; an incompatible value
+            // type instantiation still fails with a managed InvalidCastException instead of producing unsafe IL.
+            var proxy = new GenericMethodSignatureTarget().DuckCast<ICovariantReferenceReturnProxy>();
+
+            proxy.ReturnCovariant("expected").Should().Equal("expected");
+
+            Action returnValueType = () => proxy.ReturnCovariant(42);
+            returnValueType.Should().Throw<InvalidCastException>();
+        }
+
+        [Fact]
         public void RejectsDifferentGenericParameterPositionsInReverseProxy()
         {
             // Keep the argument positions equivalent so this test reaches the return-specific validation for
@@ -170,6 +226,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
             public Tuple<TFirst, TSecond> Wrap<TFirst, TSecond>(TFirst first, TSecond second) => Tuple.Create(first, second);
 
             public TSecond[] ReturnArray<TFirst, TSecond>() => Array.Empty<TSecond>();
+
+            public T ReturnWithType<T>(T value) => value;
+
+            public IEnumerable<T> ReturnCovariant<T>(T value)
+            {
+                yield return value;
+            }
+        }
+
+        private class ReverseValueWithTypeImplementation
+        {
+            [DuckReverseMethod]
+            public T ReturnWithType<T>(T value) => value;
         }
 
         private class ReorderedReverseImplementation

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -47,27 +47,29 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             /*****
              * WARNING: This number is expected to change if you add
-             * a another test to the ducktype assembly.
+             * another test to the ducktype assembly. Generic signature
+             * validation also lowers this count when an invalid proxy is
+             * rejected before its dynamic assembly is created.
              */
             if (!TestOptimization.Instance.IsRunning)
             {
 #if NETFRAMEWORK
-                asmDuckTypes.Should().Be(1519);
+                asmDuckTypes.Should().Be(1501);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().Be(1529);
+                asmDuckTypes.Should().Be(1511);
 #else
-                asmDuckTypes.Should().Be(1530);
+                asmDuckTypes.Should().Be(1512);
 #endif
             }
             else
             {
                 // When running inside CI Visibility, we will generate additional duck types
 #if NETFRAMEWORK
-                asmDuckTypes.Should().BeGreaterThan(1519);
+                asmDuckTypes.Should().BeGreaterThan(1501);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().BeGreaterThan(1529);
+                asmDuckTypes.Should().BeGreaterThan(1511);
 #else
-                asmDuckTypes.Should().BeGreaterThan(1530);
+                asmDuckTypes.Should().BeGreaterThan(1512);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -54,22 +54,22 @@ namespace Datadog.Trace.DuckTyping.Tests
             if (!TestOptimization.Instance.IsRunning)
             {
 #if NETFRAMEWORK
-                asmDuckTypes.Should().Be(1501);
+                asmDuckTypes.Should().Be(1516);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().Be(1511);
+                asmDuckTypes.Should().Be(1526);
 #else
-                asmDuckTypes.Should().Be(1512);
+                asmDuckTypes.Should().Be(1527);
 #endif
             }
             else
             {
                 // When running inside CI Visibility, we will generate additional duck types
 #if NETFRAMEWORK
-                asmDuckTypes.Should().BeGreaterThan(1501);
+                asmDuckTypes.Should().BeGreaterThan(1516);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().BeGreaterThan(1511);
+                asmDuckTypes.Should().BeGreaterThan(1526);
 #else
-                asmDuckTypes.Should().BeGreaterThan(1512);
+                asmDuckTypes.Should().BeGreaterThan(1527);
 #endif
             }
         }


### PR DESCRIPTION
## Summary of changes

Reject incompatible open generic method signatures before DuckTyping defines a proxy method or emits IL. The validation covers forward and reverse proxies, arguments, return values, `ref`/`out` parameters, arrays, pointers, and nested generic types.

The validation preserves supported return contracts. `ValueWithType<T>` continues to work in forward and reverse proxies, and constructed reference returns may defer compatible conversions to the existing managed `castclass` path.

## Reason for change

DuckTyping previously treated any two generic parameters as interchangeable. A proxy could therefore map method parameter `TFirst` to `TSecond`, or an open `T` return value to a concrete reference type.

Depending on the generic arguments and value, the generated IL could silently reinterpret zero as `null`, truncate values, throw `InvalidProgramException`, or pass integer bits to `castclass` as an object reference. The latter can terminate the process with an `AccessViolationException` instead of producing a managed exception.

## Implementation details

The method matcher and IL conversion path now compare open generic placeholders recursively. Two placeholders are compatible only when their metadata positions and owner kinds match. The comparison preserves array rank and vector shape, managed-reference and pointer shape, and descends into matching constructed generic types.

Top-level generic values, value-type containers, `ref`/`out` storage, pointers, and different generic parameter positions require exact structural identity. A concrete/open mismatch beneath an outer managed reference may continue to the existing conversion pipeline, where compatible instantiations succeed and incompatible ones fail with a managed `InvalidCastException`.

`ValueWithType<T>` is normalized only while validating return compatibility, so its inner `T` is compared with the target return while `AddReturnIl` retains responsibility for building the wrapper. This applies to forward and reverse proxies.

The complete method signature is validated after a target is selected and before the generated proxy method is defined. Non-generic proxies that explicitly close a generic target through `GenericParameterTypeNames` continue to use the existing concrete conversion rules. Reverse proxies retain their existing arity-specific exception.

## Test coverage

Added twelve regression tests covering:

- An open `T` return mapped to `string`, for both zero and `0x11223344`.
- Different generic positions in arguments and returns.
- Different generic positions in `ref` and `out` parameters.
- Mismatches nested in constructed generic types and arrays.
- The equivalent reverse-proxy path.
- `ValueWithType<T>` returns in forward and reverse proxies.
- A covariant `IEnumerable<T>` return: `T=string` succeeds, while `T=int` throws managed `InvalidCastException`.

Mutation verification confirms that all nine safety regressions fail when the production validation is removed. The three compatibility regressions fail against the initial stricter implementation and pass with the final behavior.

- .NET 10 full DuckTyping suite: 10,962 passed, 5 skipped, 0 failed.
- .NET 8 selected method and generic coverage: 1,384 passed, 1 skipped, 0 failed.

## Other details

Related runtime behavior: https://github.com/dotnet/runtime/issues/40878
