### PR TITLE
chore(ci): bump llm-validation-platform to v0.1.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - project: 'ddoghq/llm-validation-platform'
-    ref: d59e4af6d6666092f65740b9a4d1bf3651a64321   # v0.1.2 (immutable SHA; a tag could be retargeted)
+    ref: c331696647a78672101002ba48ccebbd41b0fae8   # v0.1.3 (immutable SHA; a tag could be retargeted)
     file: '/ci/llm-validation.gitlab-ci.yml'
   # MIGRATION TOUCHPOINT (GitHub org / GitLab group split):
   # GitLab does not expand top-level `variables:` inside `include:` keywords,
@@ -45,7 +45,7 @@ variables:
 "llm validation":
   variables:
     LLMVAL_PLATFORM_PROJECT: "ddoghq/llm-validation-platform"
-    LLMVAL_PLATFORM_REF: "d59e4af6d6666092f65740b9a4d1bf3651a64321"   # v0.1.2 (must match include ref above)
+    LLMVAL_PLATFORM_REF: "c331696647a78672101002ba48ccebbd41b0fae8"   # v0.1.3 (must match include ref above)
 
 build-windows-ci-image:
   stage: build


### PR DESCRIPTION
## Summary of changes
Bump the pinned `llm-validation-platform` ref `d59e4af` (v0.1.2) → `c331696` (v0.1.3), in both the `include: ref:` and `LLMVAL_PLATFORM_REF` (kept identical, as the pinning policy requires).

## Reason for change
v0.1.3 pins the CI runner image by digest instead of the moving `:newest` tag, which drifted on 2025-09-09 and broke the gate's runtime node install. dd-trace-dotnet rides the platform's image default, so this bump picks up the fix before a monitored-file PR would have tripped the failure here.

## Implementation details

## Test coverage

## Other details

