### PR TITLE
feat(ci_visibility): dynamic atr retries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Datadog .NET Tracer (`dd-trace-dotnet`) Release Notes
 
 
+## Unreleased
+
+### Features
+
+- CI Visibility: Adds `DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED` to enable dynamic Auto Test Retries budgets based on test duration, instead of the flat per-test retry limit. Optionally configure the five duration-based budgets with `DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS` (five comma-separated integers in `[1, 20]`), corresponding to the Early Flake Detection duration buckets.
+
+
 
 
 

--- a/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
@@ -26,35 +26,6 @@ namespace Datadog.Trace.Ci.Configuration
 
         private static readonly IDatadogLogger SettingsLog = DatadogLogging.GetLoggerFor<TestOptimizationSettings>();
 
-        internal static int[]? ParseDynamicAtrBuckets(string? rawBuckets)
-        {
-            if (StringUtil.IsNullOrEmpty(rawBuckets))
-            {
-                return null;
-            }
-
-            var parts = rawBuckets!.Split(',');
-            if (parts.Length != RetryBucketCount)
-            {
-                SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
-                return null;
-            }
-
-            var buckets = new int[RetryBucketCount];
-            for (var i = 0; i < RetryBucketCount; i++)
-            {
-                if (!int.TryParse(parts[i].Trim(), out var value) || value < 1 || value > MaxRetriesPerBucket)
-                {
-                    SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
-                    return null;
-                }
-
-                buckets[i] = value;
-            }
-
-            return buckets;
-        }
-
         private TracerSettings? _tracerSettings;
 
         public TestOptimizationSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
@@ -324,6 +295,35 @@ namespace Datadog.Trace.Ci.Configuration
         /// Gets the tracer settings
         /// </summary>
         public TracerSettings TracerSettings => LazyInitializer.EnsureInitialized(ref _tracerSettings, () => InitializeTracerSettings())!;
+
+        internal static int[]? ParseDynamicAtrBuckets(string? rawBuckets)
+        {
+            if (StringUtil.IsNullOrEmpty(rawBuckets))
+            {
+                return null;
+            }
+
+            var parts = rawBuckets!.Split(',');
+            if (parts.Length != RetryBucketCount)
+            {
+                SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
+                return null;
+            }
+
+            var buckets = new int[RetryBucketCount];
+            for (var i = 0; i < RetryBucketCount; i++)
+            {
+                if (!int.TryParse(parts[i].Trim(), out var value) || value < 1 || value > MaxRetriesPerBucket)
+                {
+                    SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
+                    return null;
+                }
+
+                buckets[i] = value;
+            }
+
+            return buckets;
+        }
 
         public static TestOptimizationSettings FromDefaultSources()
         {

--- a/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
@@ -26,6 +26,35 @@ namespace Datadog.Trace.Ci.Configuration
 
         private static readonly IDatadogLogger SettingsLog = DatadogLogging.GetLoggerFor<TestOptimizationSettings>();
 
+        internal static int[]? ParseDynamicAtrBuckets(string? rawBuckets)
+        {
+            if (StringUtil.IsNullOrEmpty(rawBuckets))
+            {
+                return null;
+            }
+
+            var parts = rawBuckets!.Split(',');
+            if (parts.Length != RetryBucketCount)
+            {
+                SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
+                return null;
+            }
+
+            var buckets = new int[RetryBucketCount];
+            for (var i = 0; i < RetryBucketCount; i++)
+            {
+                if (!int.TryParse(parts[i].Trim(), out var value) || value < 1 || value > MaxRetriesPerBucket)
+                {
+                    SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
+                    return null;
+                }
+
+                buckets[i] = value;
+            }
+
+            return buckets;
+        }
+
         private TracerSettings? _tracerSettings;
 
         public TestOptimizationSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
@@ -346,35 +375,6 @@ namespace Datadog.Trace.Ci.Configuration
             Agentless = enabled;
             ApiKey = apiKey;
             AgentlessUrl = agentlessUrl;
-        }
-
-        internal static int[]? ParseDynamicAtrBuckets(string? rawBuckets)
-        {
-            if (StringUtil.IsNullOrEmpty(rawBuckets))
-            {
-                return null;
-            }
-
-            var parts = rawBuckets!.Split(',');
-            if (parts.Length != RetryBucketCount)
-            {
-                SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
-                return null;
-            }
-
-            var buckets = new int[RetryBucketCount];
-            for (var i = 0; i < RetryBucketCount; i++)
-            {
-                if (!int.TryParse(parts[i].Trim(), out var value) || value < 1 || value > MaxRetriesPerBucket)
-                {
-                    SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
-                    return null;
-                }
-
-                buckets[i] = value;
-            }
-
-            return buckets;
         }
 
         internal void SetCodeCoverageMode(string? coverageMode)

--- a/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
@@ -111,6 +112,10 @@ namespace Datadog.Trace.Ci.Configuration
 
             // Flaky retry
             FlakyRetryEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.FlakyRetryEnabled).AsBool();
+
+            // Dynamic ATR (duration-based retry budgets)
+            DynamicAtrEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.DynamicAtrEnabled).AsBool(false);
+            DynamicAtrBuckets = ParseDynamicAtrBuckets(config.WithKeys(ConfigurationKeys.CIVisibility.DynamicAtrBuckets).AsString());
 
             // Maximum number of retry attempts for a single test case.
             FlakyRetryCount = config.WithKeys(ConfigurationKeys.CIVisibility.FlakyRetryCount).AsInt32(defaultValue: 5, validator: val => val >= 1) ?? 5;
@@ -247,6 +252,16 @@ namespace Datadog.Trace.Ci.Configuration
         public bool? FlakyRetryEnabled { get; private set; }
 
         /// <summary>
+        /// Gets a value indicating whether dynamic, duration-based ATR retry budgets are enabled.
+        /// </summary>
+        public bool DynamicAtrEnabled { get; private set; }
+
+        /// <summary>
+        /// Gets the custom dynamic ATR retry buckets (five ints), or null to use EFD retry settings.
+        /// </summary>
+        public int[]? DynamicAtrBuckets { get; private set; }
+
+        /// <summary>
         /// Gets a value indicating the maximum number of retry attempts for a single test case.
         /// </summary>
         public int FlakyRetryCount { get; private set; }
@@ -326,6 +341,40 @@ namespace Datadog.Trace.Ci.Configuration
             Agentless = enabled;
             ApiKey = apiKey;
             AgentlessUrl = agentlessUrl;
+        }
+
+        private static readonly IDatadogLogger SettingsLog = DatadogLogging.GetLoggerFor<TestOptimizationSettings>();
+
+        private const int RetryBucketCount = 5;
+        private const int MaxRetriesPerBucket = 20;
+
+        internal static int[]? ParseDynamicAtrBuckets(string? rawBuckets)
+        {
+            if (StringUtil.IsNullOrEmpty(rawBuckets))
+            {
+                return null;
+            }
+
+            var parts = rawBuckets!.Split(',');
+            if (parts.Length != RetryBucketCount)
+            {
+                SettingsLog.Warning<string, int>("Invalid {EnvVar} value {Value}; expected {Count} comma-separated integers in [1, {Max}].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets, RetryBucketCount);
+                return null;
+            }
+
+            var buckets = new int[RetryBucketCount];
+            for (var i = 0; i < RetryBucketCount; i++)
+            {
+                if (!int.TryParse(parts[i].Trim(), out var value) || value < 1 || value > MaxRetriesPerBucket)
+                {
+                    SettingsLog.Warning<string, int>("Invalid {EnvVar} value {Value}; expected {Count} comma-separated integers in [1, {Max}].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets, RetryBucketCount);
+                    return null;
+                }
+
+                buckets[i] = value;
+            }
+
+            return buckets;
         }
 
         internal void SetCodeCoverageMode(string? coverageMode)

--- a/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/TestOptimizationSettings.cs
@@ -21,6 +21,11 @@ namespace Datadog.Trace.Ci.Configuration
 {
     internal sealed class TestOptimizationSettings
     {
+        private const int RetryBucketCount = 5;
+        private const int MaxRetriesPerBucket = 20;
+
+        private static readonly IDatadogLogger SettingsLog = DatadogLogging.GetLoggerFor<TestOptimizationSettings>();
+
         private TracerSettings? _tracerSettings;
 
         public TestOptimizationSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
@@ -343,11 +348,6 @@ namespace Datadog.Trace.Ci.Configuration
             AgentlessUrl = agentlessUrl;
         }
 
-        private static readonly IDatadogLogger SettingsLog = DatadogLogging.GetLoggerFor<TestOptimizationSettings>();
-
-        private const int RetryBucketCount = 5;
-        private const int MaxRetriesPerBucket = 20;
-
         internal static int[]? ParseDynamicAtrBuckets(string? rawBuckets)
         {
             if (StringUtil.IsNullOrEmpty(rawBuckets))
@@ -358,7 +358,7 @@ namespace Datadog.Trace.Ci.Configuration
             var parts = rawBuckets!.Split(',');
             if (parts.Length != RetryBucketCount)
             {
-                SettingsLog.Warning<string, int>("Invalid {EnvVar} value {Value}; expected {Count} comma-separated integers in [1, {Max}].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets, RetryBucketCount);
+                SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
                 return null;
             }
 
@@ -367,7 +367,7 @@ namespace Datadog.Trace.Ci.Configuration
             {
                 if (!int.TryParse(parts[i].Trim(), out var value) || value < 1 || value > MaxRetriesPerBucket)
                 {
-                    SettingsLog.Warning<string, int>("Invalid {EnvVar} value {Value}; expected {Count} comma-separated integers in [1, {Max}].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets, RetryBucketCount);
+                    SettingsLog.Warning<string, string>("Invalid {EnvVar} value {Value}; expected five comma-separated integers in [1, 20].", ConfigurationKeys.CIVisibility.DynamicAtrBuckets, rawBuckets);
                     return null;
                 }
 

--- a/tracer/src/Datadog.Trace/Ci/ITestOptimizationFlakyRetryFeature.cs
+++ b/tracer/src/Datadog.Trace/Ci/ITestOptimizationFlakyRetryFeature.cs
@@ -8,6 +8,10 @@ namespace Datadog.Trace.Ci;
 
 internal interface ITestOptimizationFlakyRetryFeature : ITestOptimizationFeature
 {
+    bool BackendEnabled { get; }
+
+    bool DynamicAtrEnabled { get; }
+
     int FlakyRetryCount { get; }
 
     int TotalFlakyRetryCount { get; }

--- a/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.GetSettingsAsync.cs
+++ b/tracer/src/Datadog.Trace/Ci/Net/TestOptimizationClient.GetSettingsAsync.cs
@@ -270,6 +270,50 @@ internal sealed partial class TestOptimizationClient
             ThirtySeconds = thirtySeconds;
             FiveMinutes = fiveMinutes;
         }
+
+        /// <summary>
+        /// Returns the EFD retry-bucket index for an initial test duration.
+        /// </summary>
+        public int RetryBucketIndexForDuration(double initialAttemptSeconds)
+        {
+            if (initialAttemptSeconds <= 5)
+            {
+                return 0;
+            }
+
+            if (initialAttemptSeconds <= 10)
+            {
+                return 1;
+            }
+
+            if (initialAttemptSeconds <= 30)
+            {
+                return 2;
+            }
+
+            if (initialAttemptSeconds <= 300)
+            {
+                return 3;
+            }
+
+            return 4;
+        }
+
+        /// <summary>
+        /// Returns the configured retry budget for an initial test duration.
+        /// </summary>
+        public int RetriesForDuration(double initialAttemptSeconds)
+        {
+            var retries = RetryBucketIndexForDuration(initialAttemptSeconds) switch
+            {
+                0 => FiveSeconds ?? 0,
+                1 => TenSeconds ?? 0,
+                2 => ThirtySeconds ?? 0,
+                3 => FiveMinutes ?? 0,
+                _ => 0,
+            };
+            return retries;
+        }
     }
 
     public readonly struct TestManagementSettingsResponse

--- a/tracer/src/Datadog.Trace/Ci/TestOptimization.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimization.cs
@@ -18,6 +18,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
 using TaskExtensions = Datadog.Trace.ExtensionMethods.TaskExtensions;
 
@@ -625,6 +626,7 @@ internal sealed class TestOptimization : ITestOptimization
                 }
 
                 FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings);
+                RecordDynamicAtrTelemetry(settings);
                 DynamicInstrumentationFeature = TestOptimizationDynamicInstrumentationFeature.Create(settings, remoteSettings);
                 KnownTestsFeature = TestOptimizationKnownTestsFeature.Create(settings, remoteSettings, client);
                 EarlyFlakeDetectionFeature = TestOptimizationEarlyFlakeDetectionFeature.Create(settings, remoteSettings, KnownTestsFeature);
@@ -677,11 +679,23 @@ internal sealed class TestOptimization : ITestOptimization
         using var cd = CodeDurationRef.Create();
         var remoteSettings = TestOptimizationClient.CreateSettingsResponseFromTestOptimizationSettings(settings, tracerManagement);
         FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings);
+        RecordDynamicAtrTelemetry(settings);
         DynamicInstrumentationFeature = TestOptimizationDynamicInstrumentationFeature.Create(settings, remoteSettings);
         KnownTestsFeature = TestOptimizationKnownTestsFeature.Create(settings, remoteSettings, client);
         EarlyFlakeDetectionFeature = TestOptimizationEarlyFlakeDetectionFeature.Create(settings, remoteSettings, KnownTestsFeature);
         ImpactedTestsDetectionFeature = TestOptimizationImpactedTestsDetectionFeature.Create(settings, remoteSettings, environmentValues);
         SkippableFeature = TestOptimizationSkippableFeature.Create(settings, remoteSettings, client, this);
         TestManagementFeature = TestOptimizationTestManagementFeature.Create(settings, remoteSettings, client);
+    }
+
+    private static void RecordDynamicAtrTelemetry(TestOptimizationSettings settings)
+    {
+        if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
+        {
+            var hasCustomBuckets = settings.DynamicAtrBuckets is not null
+                ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True
+                : MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False;
+            TelemetryFactory.Metrics.RecordCountCIVisibilityDynamicAtrRetries(hasCustomBuckets);
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/TestOptimization.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimization.cs
@@ -626,7 +626,7 @@ internal sealed class TestOptimization : ITestOptimization
                 }
 
                 FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings);
-                RecordDynamicAtrTelemetry(settings);
+                RecordDynamicAtrTelemetry(settings, FlakyRetryFeature);
                 DynamicInstrumentationFeature = TestOptimizationDynamicInstrumentationFeature.Create(settings, remoteSettings);
                 KnownTestsFeature = TestOptimizationKnownTestsFeature.Create(settings, remoteSettings, client);
                 EarlyFlakeDetectionFeature = TestOptimizationEarlyFlakeDetectionFeature.Create(settings, remoteSettings, KnownTestsFeature);
@@ -679,7 +679,7 @@ internal sealed class TestOptimization : ITestOptimization
         using var cd = CodeDurationRef.Create();
         var remoteSettings = TestOptimizationClient.CreateSettingsResponseFromTestOptimizationSettings(settings, tracerManagement);
         FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings);
-        RecordDynamicAtrTelemetry(settings);
+        RecordDynamicAtrTelemetry(settings, FlakyRetryFeature);
         DynamicInstrumentationFeature = TestOptimizationDynamicInstrumentationFeature.Create(settings, remoteSettings);
         KnownTestsFeature = TestOptimizationKnownTestsFeature.Create(settings, remoteSettings, client);
         EarlyFlakeDetectionFeature = TestOptimizationEarlyFlakeDetectionFeature.Create(settings, remoteSettings, KnownTestsFeature);
@@ -688,9 +688,9 @@ internal sealed class TestOptimization : ITestOptimization
         TestManagementFeature = TestOptimizationTestManagementFeature.Create(settings, remoteSettings, client);
     }
 
-    private static void RecordDynamicAtrTelemetry(TestOptimizationSettings settings)
+    internal static void RecordDynamicAtrTelemetry(TestOptimizationSettings settings, ITestOptimizationFlakyRetryFeature? flakyRetryFeature)
     {
-        if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
+        if (flakyRetryFeature?.DynamicAtrEnabled == true)
         {
             var hasCustomBuckets = settings.DynamicAtrBuckets is not null
                 ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True

--- a/tracer/src/Datadog.Trace/Ci/TestOptimization.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimization.cs
@@ -625,7 +625,7 @@ internal sealed class TestOptimization : ITestOptimization
                     remoteSettings = await client.GetSettingsAsync(skipFrameworkInfo: true).ConfigureAwait(false);
                 }
 
-                FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings);
+                FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings, isRemoteSettingsResponse: true);
                 RecordDynamicAtrTelemetry(settings, FlakyRetryFeature);
                 DynamicInstrumentationFeature = TestOptimizationDynamicInstrumentationFeature.Create(settings, remoteSettings);
                 KnownTestsFeature = TestOptimizationKnownTestsFeature.Create(settings, remoteSettings, client);
@@ -678,7 +678,7 @@ internal sealed class TestOptimization : ITestOptimization
     {
         using var cd = CodeDurationRef.Create();
         var remoteSettings = TestOptimizationClient.CreateSettingsResponseFromTestOptimizationSettings(settings, tracerManagement);
-        FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings);
+        FlakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, remoteSettings, isRemoteSettingsResponse: false);
         RecordDynamicAtrTelemetry(settings, FlakyRetryFeature);
         DynamicInstrumentationFeature = TestOptimizationDynamicInstrumentationFeature.Create(settings, remoteSettings);
         KnownTestsFeature = TestOptimizationKnownTestsFeature.Create(settings, remoteSettings, client);

--- a/tracer/src/Datadog.Trace/Ci/TestOptimizationFlakyRetryFeature.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimizationFlakyRetryFeature.cs
@@ -25,13 +25,19 @@ internal sealed class TestOptimizationFlakyRetryFeature : ITestOptimizationFlaky
             settings.SetFlakyRetryEnabled(clientSettingsResponse.FlakyTestRetries.Value);
         }
 
+        BackendEnabled = clientSettingsResponse.FlakyTestRetries == true;
         Enabled = settings.FlakyRetryEnabled == true;
+        DynamicAtrEnabled = settings.DynamicAtrEnabled && BackendEnabled && Enabled;
         FlakyRetryCount = settings.FlakyRetryCount;
         TotalFlakyRetryCount = settings.TotalFlakyRetryCount;
         Log.Information("{V}", Enabled ? "TestOptimizationFlakyRetryFeature: Flaky retries is enabled." : "TestOptimizationFlakyRetryFeature: Flaky retries is disabled.");
     }
 
     public bool Enabled { get; }
+
+    public bool BackendEnabled { get; }
+
+    public bool DynamicAtrEnabled { get; }
 
     public int FlakyRetryCount { get; }
 

--- a/tracer/src/Datadog.Trace/Ci/TestOptimizationFlakyRetryFeature.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestOptimizationFlakyRetryFeature.cs
@@ -17,7 +17,7 @@ internal sealed class TestOptimizationFlakyRetryFeature : ITestOptimizationFlaky
 
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TestOptimizationFlakyRetryFeature));
 
-    private TestOptimizationFlakyRetryFeature(TestOptimizationSettings settings, TestOptimizationClient.SettingsResponse clientSettingsResponse)
+    private TestOptimizationFlakyRetryFeature(TestOptimizationSettings settings, TestOptimizationClient.SettingsResponse clientSettingsResponse, bool isRemoteSettingsResponse)
     {
         if (!settings.FlakyRetryEnabled.HasValue && clientSettingsResponse.FlakyTestRetries.HasValue)
         {
@@ -25,7 +25,7 @@ internal sealed class TestOptimizationFlakyRetryFeature : ITestOptimizationFlaky
             settings.SetFlakyRetryEnabled(clientSettingsResponse.FlakyTestRetries.Value);
         }
 
-        BackendEnabled = clientSettingsResponse.FlakyTestRetries == true;
+        BackendEnabled = isRemoteSettingsResponse && clientSettingsResponse.FlakyTestRetries == true;
         Enabled = settings.FlakyRetryEnabled == true;
         DynamicAtrEnabled = settings.DynamicAtrEnabled && BackendEnabled && Enabled;
         FlakyRetryCount = settings.FlakyRetryCount;
@@ -43,6 +43,6 @@ internal sealed class TestOptimizationFlakyRetryFeature : ITestOptimizationFlaky
 
     public int TotalFlakyRetryCount { get; }
 
-    public static ITestOptimizationFlakyRetryFeature Create(TestOptimizationSettings settings, TestOptimizationClient.SettingsResponse clientSettingsResponse)
-        => new TestOptimizationFlakyRetryFeature(settings, clientSettingsResponse);
+    public static ITestOptimizationFlakyRetryFeature Create(TestOptimizationSettings settings, TestOptimizationClient.SettingsResponse clientSettingsResponse, bool isRemoteSettingsResponse)
+        => new TestOptimizationFlakyRetryFeature(settings, clientSettingsResponse, isRemoteSettingsResponse);
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -335,6 +335,35 @@ internal static class Common
         skippableFeature.RecordTestSkipCoverageBackfill(skippableTest, moduleName);
     }
 
+    /// <summary>
+    /// Computes the number of ATR retry executions for a test based on its initial duration.
+    /// When dynamic ATR is enabled, the retry budget is driven by duration buckets
+    /// (5s/10s/30s/5m/>5m) instead of the flat <c>FlakyRetryCount</c> limit.
+    /// </summary>
+    /// <param name="duration">Duration of the initial test attempt.</param>
+    /// <returns>Number of retry executions (not counting the initial attempt).</returns>
+    internal static int GetDynamicAtrRetryCountForDuration(TimeSpan duration)
+    {
+        var testOptimization = TestOptimization.Instance;
+        var settings = testOptimization.Settings;
+        var seconds = duration.TotalSeconds;
+
+        int retries;
+        if (settings.DynamicAtrBuckets is { } customBuckets)
+        {
+            var efdSettings = testOptimization.EarlyFlakeDetectionFeature?.EarlyFlakeDetectionSettings.SlowTestRetries ?? default;
+            var index = efdSettings.RetryBucketIndexForDuration(seconds);
+            retries = index < customBuckets.Length ? customBuckets[index] : 0;
+        }
+        else
+        {
+            var slowRetriesSettings = testOptimization.EarlyFlakeDetectionFeature?.EarlyFlakeDetectionSettings.SlowTestRetries ?? default;
+            retries = slowRetriesSettings.RetriesForDuration(seconds);
+        }
+
+        return Math.Max(1, retries);
+    }
+
     internal static int GetNumberOfExecutionsForDuration(TimeSpan duration)
     {
         var earlyFlakeDetectionFeature = TestOptimization.Instance.EarlyFlakeDetectionFeature;
@@ -343,27 +372,11 @@ internal static class Common
             return 1;
         }
 
-        int numberOfExecutions;
         var slowRetriesSettings = earlyFlakeDetectionFeature?.EarlyFlakeDetectionSettings.SlowTestRetries ?? default;
-        if (slowRetriesSettings.FiveSeconds.HasValue && duration.TotalSeconds < 5)
+        var numberOfExecutions = slowRetriesSettings.RetriesForDuration(duration.TotalSeconds);
+        if (numberOfExecutions > 0)
         {
-            numberOfExecutions = slowRetriesSettings.FiveSeconds.Value;
-            Log.Information<int>("Common: EFD: Number of executions has been set to {Value} for this test that runs under 5 seconds.", numberOfExecutions);
-        }
-        else if (slowRetriesSettings.TenSeconds.HasValue && duration.TotalSeconds < 10)
-        {
-            numberOfExecutions = slowRetriesSettings.TenSeconds.Value;
-            Log.Information<int>("Common: EFD: Number of executions has been set to {Value} for this test that runs under 10 seconds.", numberOfExecutions);
-        }
-        else if (slowRetriesSettings.ThirtySeconds.HasValue && duration.TotalSeconds < 30)
-        {
-            numberOfExecutions = slowRetriesSettings.ThirtySeconds.Value;
-            Log.Information<int>("Common: EFD: Number of executions has been set to {Value} for this test that runs under 30 seconds.", numberOfExecutions);
-        }
-        else if (slowRetriesSettings.FiveMinutes.HasValue && duration.TotalMinutes < 5)
-        {
-            numberOfExecutions = slowRetriesSettings.FiveMinutes.Value;
-            Log.Information<int>("Common: EFD: Number of executions has been set to {Value} for this test that runs under 5 minutes.", numberOfExecutions);
+            Log.Information<int>("Common: EFD: Number of executions has been set to {Value} for this test that runs under {Duration} seconds.", numberOfExecutions, (int)duration.TotalSeconds);
         }
         else
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
@@ -280,7 +280,9 @@ public sealed class TestMethodAttributeExecuteAsyncIntegration
 
                 // Flaky retry is enabled and the test failed
                 Interlocked.CompareExchange(ref _totalRetries, testOptimization.FlakyRetryFeature?.TotalFlakyRetryCount ?? TestOptimizationFlakyRetryFeature.TotalFlakyRetryCountDefault, -1);
-                var remainingRetries = testOptimization.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault;
+                var remainingRetries = testOptimization.Settings.DynamicAtrEnabled
+                    ? Common.GetDynamicAtrRetryCountForDuration(duration)
+                    : (testOptimization.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault);
                 if (remainingRetries > 0)
                 {
                     var retryState = new RetryState

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
@@ -280,7 +280,7 @@ public sealed class TestMethodAttributeExecuteAsyncIntegration
 
                 // Flaky retry is enabled and the test failed
                 Interlocked.CompareExchange(ref _totalRetries, testOptimization.FlakyRetryFeature?.TotalFlakyRetryCount ?? TestOptimizationFlakyRetryFeature.TotalFlakyRetryCountDefault, -1);
-                var remainingRetries = testOptimization.Settings.DynamicAtrEnabled
+                var remainingRetries = testOptimization.FlakyRetryFeature?.DynamicAtrEnabled == true
                     ? Common.GetDynamicAtrRetryCountForDuration(duration)
                     : (testOptimization.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault);
                 if (remainingRetries > 0)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/DynamicFlakyRetryBehavior.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/DynamicFlakyRetryBehavior.cs
@@ -1,0 +1,29 @@
+// <copyright file="DynamicFlakyRetryBehavior.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.Ci;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit;
+
+internal readonly struct DynamicFlakyRetryBehavior : IRetryBehavior
+{
+    public DynamicFlakyRetryBehavior(ITestOptimization testOptimization, int remainingRetries)
+    {
+        // Share the same _totalRetries counter as FlakyRetryBehavior so that
+        // pre-close budget checks in TestOptimizationTestCommand see the same value.
+        RemainingRetries = remainingRetries;
+        FlakyRetryBehavior.EnsureTotalRetriesInitialized(testOptimization);
+    }
+
+    public int RemainingRetries { get; }
+
+    public string RetryMode => "DynamicFlakyRetry";
+
+    public bool ShouldRetry(ITestResult result)
+        => result.ResultState.Status == TestStatus.Failed && FlakyRetryBehavior.DecrementTotalRetries() > 0;
+
+    public ITestResult ResultChanges(ITestResult result) => result;
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/FlakyRetryBehavior.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/FlakyRetryBehavior.cs
@@ -16,7 +16,7 @@ internal readonly struct FlakyRetryBehavior : IRetryBehavior
     public FlakyRetryBehavior(ITestOptimization testOptimization)
     {
         RemainingRetries = testOptimization.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault;
-        Interlocked.CompareExchange(ref _totalRetries, testOptimization.FlakyRetryFeature?.TotalFlakyRetryCount ?? TestOptimizationFlakyRetryFeature.TotalFlakyRetryCountDefault, -1);
+        EnsureTotalRetriesInitialized(testOptimization);
     }
 
     public int RemainingRetries { get; }
@@ -27,6 +27,22 @@ internal readonly struct FlakyRetryBehavior : IRetryBehavior
         => result.ResultState.Status == TestStatus.Failed && Interlocked.Decrement(ref _totalRetries) > 0;
 
     public ITestResult ResultChanges(ITestResult result) => result;
+
+    /// <summary>
+    /// Ensures the session-level total retry budget is initialized.
+    /// Shared with <see cref="DynamicFlakyRetryBehavior"/> so both paths use the same counter.
+    /// </summary>
+    internal static void EnsureTotalRetriesInitialized(ITestOptimization testOptimization)
+    {
+        Interlocked.CompareExchange(ref _totalRetries, testOptimization.FlakyRetryFeature?.TotalFlakyRetryCount ?? TestOptimizationFlakyRetryFeature.TotalFlakyRetryCountDefault, -1);
+    }
+
+    /// <summary>
+    /// Atomically decrements the session-level total retry budget.
+    /// Shared with <see cref="DynamicFlakyRetryBehavior"/>.
+    /// </summary>
+    internal static int DecrementTotalRetries()
+        => Interlocked.Decrement(ref _totalRetries);
 
     /// <summary>
     /// Read-only snapshot of remaining ATR budget for pre-close checks.

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/TestOptimizationTestCommand.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/TestOptimizationTestCommand.cs
@@ -106,7 +106,7 @@ internal sealed class TestOptimizationTestCommand
                 Common.Log.Debug("TestOptimizationTestCommand: Exception instrumentation was set or timed out.");
             }
 
-            if (testOptimization.Settings.DynamicAtrEnabled)
+            if (testOptimization.FlakyRetryFeature?.DynamicAtrEnabled == true)
             {
                 var dynamicRetries = Common.GetDynamicAtrRetryCountForDuration(duration);
                 result = DoRetries(new DynamicFlakyRetryBehavior(testOptimization, dynamicRetries), context, result);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/TestOptimizationTestCommand.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/TestOptimizationTestCommand.cs
@@ -106,7 +106,15 @@ internal sealed class TestOptimizationTestCommand
                 Common.Log.Debug("TestOptimizationTestCommand: Exception instrumentation was set or timed out.");
             }
 
-            result = DoRetries(new FlakyRetryBehavior(testOptimization), context, result);
+            if (testOptimization.Settings.DynamicAtrEnabled)
+            {
+                var dynamicRetries = Common.GetDynamicAtrRetryCountForDuration(duration);
+                result = DoRetries(new DynamicFlakyRetryBehavior(testOptimization, dynamicRetries), context, result);
+            }
+            else
+            {
+                result = DoRetries(new FlakyRetryBehavior(testOptimization), context, result);
+            }
         }
         else if (atfWillRetry)
         {
@@ -168,7 +176,7 @@ internal sealed class TestOptimizationTestCommand
     private static TestRetryMode GetRetryMode(in RetryState retryState)
     {
         return retryState.BehaviorType == typeof(EarlyFlakeDetectionRetryBehavior) ? TestRetryMode.EarlyFlakeDetection
-             : retryState.BehaviorType == typeof(FlakyRetryBehavior) ? TestRetryMode.AutomaticTestRetry
+             : retryState.BehaviorType == typeof(FlakyRetryBehavior) || retryState.BehaviorType == typeof(DynamicFlakyRetryBehavior) ? TestRetryMode.AutomaticTestRetry
              : retryState.BehaviorType == typeof(AttemptToFixRetryBehavior) ? TestRetryMode.AttemptToFix
              : TestRetryMode.None;
     }
@@ -265,7 +273,7 @@ internal sealed class TestOptimizationTestCommand
             }
 
             // Determine if this is the final execution
-            var isAtrBehavior = retryState.BehaviorType == typeof(FlakyRetryBehavior);
+            var isAtrBehavior = retryState.BehaviorType == typeof(FlakyRetryBehavior) || retryState.BehaviorType == typeof(DynamicFlakyRetryBehavior);
             var isAtrEarlyExit = isAtrBehavior &&
                                  resultStatus == TestStatus.Passed &&
                                  !retryState.IsLastRetry;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -300,7 +300,7 @@ internal static class XUnitIntegration
         {
             var hasRemainingExecutions = testCaseMetadata.IsRetry
                                              ? testCaseMetadata.CountDownExecutionNumber > 0
-                                             : TestOptimization.Instance.Settings.DynamicAtrEnabled ||
+                                             : TestOptimization.Instance.FlakyRetryFeature?.DynamicAtrEnabled == true ||
                                                (TestOptimization.Instance.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault) > 0;
             retryDecision = hasRemainingExecutions
                                 ? XUnitRetryCoordinator.GetOrCreateRetryExecutionDecision(
@@ -408,7 +408,7 @@ internal static class XUnitIntegration
     {
         testCaseMetadata.TotalExecutions = testCaseMetadata.SelectedRetryMode switch
         {
-            TestRetryMode.AutomaticTestRetry => testOptimization.Settings.DynamicAtrEnabled
+            TestRetryMode.AutomaticTestRetry => testOptimization.FlakyRetryFeature?.DynamicAtrEnabled == true
                 ? Common.GetDynamicAtrRetryCountForDuration(initialDuration) + 1
                 : (testOptimization.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault) + 1,
             TestRetryMode.AttemptToFix => testOptimization.TestManagementFeature?.TestManagementAttemptToFixRetryCount ?? TestOptimizationTestManagementFeature.TestManagementAttemptToFixRetryCountDefault,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -300,7 +300,8 @@ internal static class XUnitIntegration
         {
             var hasRemainingExecutions = testCaseMetadata.IsRetry
                                              ? testCaseMetadata.CountDownExecutionNumber > 0
-                                             : (TestOptimization.Instance.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault) > 0;
+                                             : TestOptimization.Instance.Settings.DynamicAtrEnabled ||
+                                               (TestOptimization.Instance.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault) > 0;
             retryDecision = hasRemainingExecutions
                                 ? XUnitRetryCoordinator.GetOrCreateRetryExecutionDecision(
                                     testCaseMetadata,
@@ -403,13 +404,15 @@ internal static class XUnitIntegration
         return TestRetryMode.None;
     }
 
-    internal static void InitializeTotalExecutions(ITestOptimization testOptimization, TestCaseMetadata testCaseMetadata, Func<int> getEarlyFlakeDetectionExecutions)
+    internal static void InitializeTotalExecutions(ITestOptimization testOptimization, TestCaseMetadata testCaseMetadata, TimeSpan initialDuration)
     {
         testCaseMetadata.TotalExecutions = testCaseMetadata.SelectedRetryMode switch
         {
-            TestRetryMode.AutomaticTestRetry => (testOptimization.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault) + 1,
+            TestRetryMode.AutomaticTestRetry => testOptimization.Settings.DynamicAtrEnabled
+                ? Common.GetDynamicAtrRetryCountForDuration(initialDuration) + 1
+                : (testOptimization.FlakyRetryFeature?.FlakyRetryCount ?? TestOptimizationFlakyRetryFeature.FlakyRetryCountDefault) + 1,
             TestRetryMode.AttemptToFix => testOptimization.TestManagementFeature?.TestManagementAttemptToFixRetryCount ?? TestOptimizationTestManagementFeature.TestManagementAttemptToFixRetryCountDefault,
-            _ => getEarlyFlakeDetectionExecutions()
+            _ => Common.GetNumberOfExecutionsForDuration(initialDuration)
         };
 
         testCaseMetadata.CountDownExecutionNumber = testCaseMetadata.TotalExecutions - 1;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitRetryCoordinator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitRetryCoordinator.cs
@@ -57,7 +57,7 @@ internal static class XUnitRetryCoordinator
                     XUnitIntegration.InitializeTotalExecutions(
                         testOptimization,
                         testCaseMetadata,
-                        () => Common.GetNumberOfExecutionsForDuration(TimeSpan.FromSeconds((double)runSummary.Time)));
+                        TimeSpan.FromSeconds((double)runSummary.Time));
                 }
 
                 if (testCaseMetadata.CountDownExecutionNumber > 0)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
@@ -189,7 +189,7 @@ public static class XUnitTestRunnerRunAsyncIntegration
                 // If it's the first execution then let's calculate the total executions
                 if (isFirstExecution)
                 {
-                    XUnitIntegration.InitializeTotalExecutions(testOptimization, testCaseMetadata, () => Common.GetNumberOfExecutionsForDuration(TraceClock.Instance.UtcNow - testRunnerState.StartTime));
+                    XUnitIntegration.InitializeTotalExecutions(testOptimization, testCaseMetadata, TraceClock.Instance.UtcNow - testRunnerState.StartTime);
                 }
 
                 if (testCaseMetadata.CountDownExecutionNumber > 0)

--- a/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
+++ b/tracer/src/Datadog.Trace/Configuration/supported-configurations.yaml
@@ -451,6 +451,22 @@ supportedConfigurations:
     product: CIVisibility
     const_name: CodeCoverageSnkFile
     documentation: Configuration key for re-signing assemblies after the Code Coverage modification.
+  DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS:
+  - implementation: A
+    scope: managed
+    type: string
+    default: null
+    product: CIVisibility
+    const_name: DynamicAtrBuckets
+    documentation: Configuration key for overriding the five duration-based Auto Test Retries budgets with five comma-separated integers in [1, 20].
+  DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED:
+  - implementation: A
+    scope: managed
+    type: boolean
+    default: 'false'
+    product: CIVisibility
+    const_name: DynamicAtrEnabled
+    documentation: Configuration key for enabling dynamic, duration-based Auto Test Retries budgets instead of the flat per-test retry limit.
   DD_CIVISIBILITY_DI_ENABLED:
   - implementation: A
     scope: managed

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
@@ -85,6 +85,16 @@ internal static partial class ConfigurationKeys
         public const string DynamicInstrumentationEnabled = "DD_CIVISIBILITY_DI_ENABLED";
 
         /// <summary>
+        /// Configuration key for overriding the five duration-based Auto Test Retries budgets with five comma-separated integers in [1, 20].
+        /// </summary>
+        public const string DynamicAtrBuckets = "DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS";
+
+        /// <summary>
+        /// Configuration key for enabling dynamic, duration-based Auto Test Retries budgets instead of the flat per-test retry limit.
+        /// </summary>
+        public const string DynamicAtrEnabled = "DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED";
+
+        /// <summary>
         /// Configuration key for enabling or disabling the early flake detection feature in CI Visibility
         /// </summary>
         public const string EarlyFlakeDetectionEnabled = "DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3191;
+    private const int CountCIVisibilityLength = 3193;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -3245,6 +3245,9 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // dynamic_atr_retries.enabled, index = 3191
+            new(new[] { "has_custom_buckets:true" }),
+            new(null),
         };
 
     /// <summary>
@@ -3253,7 +3256,7 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, 2, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3456,6 +3459,12 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 3180 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+        var index = 3191 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 35;
+    public const int Length = 36;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -57,6 +57,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "test_management_tests.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "test_management_tests.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "dynamic_atr_retries.enabled",
             _ => null!,
         };
 
@@ -114,6 +115,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -78,4 +78,6 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
@@ -85,6 +85,16 @@ internal static partial class ConfigurationKeys
         public const string DynamicInstrumentationEnabled = "DD_CIVISIBILITY_DI_ENABLED";
 
         /// <summary>
+        /// Configuration key for overriding the five duration-based Auto Test Retries budgets with five comma-separated integers in [1, 20].
+        /// </summary>
+        public const string DynamicAtrBuckets = "DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS";
+
+        /// <summary>
+        /// Configuration key for enabling dynamic, duration-based Auto Test Retries budgets instead of the flat per-test retry limit.
+        /// </summary>
+        public const string DynamicAtrEnabled = "DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED";
+
+        /// <summary>
         /// Configuration key for enabling or disabling the early flake detection feature in CI Visibility
         /// </summary>
         public const string EarlyFlakeDetectionEnabled = "DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3191;
+    private const int CountCIVisibilityLength = 3193;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -3245,6 +3245,9 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // dynamic_atr_retries.enabled, index = 3191
+            new(new[] { "has_custom_buckets:true" }),
+            new(null),
         };
 
     /// <summary>
@@ -3253,7 +3256,7 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, 2, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3456,6 +3459,12 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 3180 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+        var index = 3191 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 35;
+    public const int Length = 36;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -57,6 +57,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "test_management_tests.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "test_management_tests.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "dynamic_atr_retries.enabled",
             _ => null!,
         };
 
@@ -114,6 +115,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -78,4 +78,6 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
@@ -85,6 +85,16 @@ internal static partial class ConfigurationKeys
         public const string DynamicInstrumentationEnabled = "DD_CIVISIBILITY_DI_ENABLED";
 
         /// <summary>
+        /// Configuration key for overriding the five duration-based Auto Test Retries budgets with five comma-separated integers in [1, 20].
+        /// </summary>
+        public const string DynamicAtrBuckets = "DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS";
+
+        /// <summary>
+        /// Configuration key for enabling dynamic, duration-based Auto Test Retries budgets instead of the flat per-test retry limit.
+        /// </summary>
+        public const string DynamicAtrEnabled = "DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED";
+
+        /// <summary>
         /// Configuration key for enabling or disabling the early flake detection feature in CI Visibility
         /// </summary>
         public const string EarlyFlakeDetectionEnabled = "DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3191;
+    private const int CountCIVisibilityLength = 3193;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -3245,6 +3245,9 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // dynamic_atr_retries.enabled, index = 3191
+            new(new[] { "has_custom_buckets:true" }),
+            new(null),
         };
 
     /// <summary>
@@ -3253,7 +3256,7 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, 2, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3456,6 +3459,12 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 3180 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+        var index = 3191 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 35;
+    public const int Length = 36;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -57,6 +57,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "test_management_tests.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "test_management_tests.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "dynamic_atr_retries.enabled",
             _ => null!,
         };
 
@@ -114,6 +115,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -78,4 +78,6 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/ConfigurationKeysGenerator/ConfigurationKeys.CIVisibility.g.cs
@@ -85,6 +85,16 @@ internal static partial class ConfigurationKeys
         public const string DynamicInstrumentationEnabled = "DD_CIVISIBILITY_DI_ENABLED";
 
         /// <summary>
+        /// Configuration key for overriding the five duration-based Auto Test Retries budgets with five comma-separated integers in [1, 20].
+        /// </summary>
+        public const string DynamicAtrBuckets = "DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS";
+
+        /// <summary>
+        /// Configuration key for enabling dynamic, duration-based Auto Test Retries budgets instead of the flat per-test retry limit.
+        /// </summary>
+        public const string DynamicAtrEnabled = "DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED";
+
+        /// <summary>
         /// Configuration key for enabling or disabling the early flake detection feature in CI Visibility
         /// </summary>
         public const string EarlyFlakeDetectionEnabled = "DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED";

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal sealed partial class CiVisibilityMetricsTelemetryCollector
 {
-    private const int CountCIVisibilityLength = 3191;
+    private const int CountCIVisibilityLength = 3193;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> values.
@@ -3245,6 +3245,9 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
             new(new[] { "error_type:status_code_4xx_response", "status_code:404" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:408" }),
             new(new[] { "error_type:status_code_4xx_response", "status_code:429" }),
+            // dynamic_atr_retries.enabled, index = 3191
+            new(new[] { "has_custom_buckets:true" }),
+            new(null),
         };
 
     /// <summary>
@@ -3253,7 +3256,7 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountCIVisibilityEntryCounts { get; }
-        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, };
+        = new int[]{ 40, 2700, 64, 10, 10, 4, 1, 4, 22, 2, 18, 144, 2, 11, 2, 11, 2, 11, 64, 2, 11, 1, 1, 4, 4, 4, 1, 1, 2, 11, 2, 11, 1, 2, 11, 2, };
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
@@ -3456,6 +3459,12 @@ internal sealed partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 3180 + (int)tag;
+        Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
+    }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+        var index = 3191 + (int)tag;
         Interlocked.Add(ref _buffer.CountCIVisibility[index], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountCIVisibilityExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountCIVisibilityExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.CountCIVisibility" /> metric.
     /// </summary>
-    public const int Length = 35;
+    public const int Length = 36;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -57,6 +57,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "impacted_tests_detection.is_modified",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "test_management_tests.request",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "test_management_tests.request_errors",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "dynamic_atr_retries.enabled",
             _ => null!,
         };
 
@@ -114,6 +115,7 @@ internal static partial class CountCIVisibilityExtensions
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.ImpactedTestsIsModified => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequest => "civisibility",
             Datadog.Trace.Telemetry.Metrics.CountCIVisibility.TestManagementTestsRequestErrors => "civisibility",
+            Datadog.Trace.Telemetry.Metrics.CountCIVisibility.DynamicAtrRetries => "civisibility",
             _ => null,
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -78,4 +78,6 @@ internal partial interface IMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequest(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityRequestCompressed tag, int increment = 1);
 
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1);
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1);
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class MetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_CountCIVisibility.g.cs
@@ -151,4 +151,8 @@ internal sealed partial class NullMetricsTelemetryCollector
     public void RecordCountCIVisibilityTestManagementTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
     }
+
+    public void RecordCountCIVisibilityDynamicAtrRetries(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets tag, int increment = 1)
+    {
+    }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/CountCIVisibility.cs
@@ -268,4 +268,10 @@ internal enum CountCIVisibility
     /// </summary>
     [TelemetryMetric<MetricTags.CIVisibilityErrorType>("test_management_tests.request_errors", isCommon: true, NS.CIVisibility)]
     TestManagementTestsRequestErrors,
+
+    /// <summary>
+    /// The number of sessions that have dynamic, duration-based ATR retries enabled.
+    /// Tagged with has_custom_buckets true/false.
+    /// </summary>
+    [TelemetryMetric<MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets>("dynamic_atr_retries.enabled", isCommon: true, NS.CIVisibility)] DynamicAtrRetries,
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -809,6 +809,12 @@ internal static class MetricTags
         [Description("test_management_enabled:false")] Disabled,
     }
 
+    public enum CIVisibilityDynamicAtrRetriesHasCustomBuckets
+    {
+        [Description("has_custom_buckets:true")] True,
+        [Description("")] False,
+    }
+
     public enum CIVisibilityRequestCompressed
     {
         [Description("")] Uncompressed,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2RetriesTests.cs
@@ -46,6 +46,26 @@ public class MsTestV2RetriesTests : TestingFrameworkRetriesTests
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "TestIntegrations")]
     [Trait("Category", "FlakyRetries")]
+    public override Task<List<MockCIVisibilityTest>> DynamicFlakyRetries(string packageVersion)
+    {
+        return base.DynamicFlakyRetries(packageVersion);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.MSTest2Retries), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
+    public override Task DynamicFlakyRetriesHonorSessionCap(string packageVersion)
+    {
+        return base.DynamicFlakyRetriesHonorSessionCap(packageVersion);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.MSTest2Retries), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
     [Flaky("Under investigation", 5)]
     public override Task FlakyRetriesWithExceptionReplay(string packageVersion)
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitRetriesTests.cs
@@ -46,6 +46,26 @@ public class NUnitRetriesTests : TestingFrameworkRetriesTests
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "TestIntegrations")]
     [Trait("Category", "FlakyRetries")]
+    public override Task<List<MockCIVisibilityTest>> DynamicFlakyRetries(string packageVersion)
+    {
+        return base.DynamicFlakyRetries(packageVersion);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.NUnitRetries), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
+    public override Task DynamicFlakyRetriesHonorSessionCap(string packageVersion)
+    {
+        return base.DynamicFlakyRetriesHonorSessionCap(packageVersion);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.NUnitRetries), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
     [Flaky("Under investigation", 5)]
     public override Task FlakyRetriesWithExceptionReplay(string packageVersion)
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/TestingFrameworkRetriesTests.cs
@@ -44,11 +44,32 @@ public abstract class TestingFrameworkRetriesTests : TestingFrameworkEvpTest
     public virtual Task<List<MockCIVisibilityTest>> FlakyRetries(string packageVersion)
         => FlakyRetriesWithArguments(packageVersion, arguments: null);
 
+    public virtual Task<List<MockCIVisibilityTest>> DynamicFlakyRetries(string packageVersion)
+    {
+        SetEnvironmentVariable(ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "1");
+        SetEnvironmentVariable(ConfigurationKeys.CIVisibility.DynamicAtrBuckets, "5,1,1,1,1");
+        return FlakyRetriesWithArguments(packageVersion, arguments: null, retryCount: 1, expectedRetryCount: 5, expectedLastRetryCount: 1);
+    }
+
+    public virtual async Task DynamicFlakyRetriesHonorSessionCap(string packageVersion)
+    {
+        SetEnvironmentVariable(ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "1");
+        SetEnvironmentVariable(ConfigurationKeys.CIVisibility.DynamicAtrBuckets, "5,1,1,1,1");
+        var tests = await FlakyRetriesWithArguments(packageVersion, arguments: null, retryCount: 1, totalRetryCount: 2, assertRetryCounts: false);
+        var sessionTests = tests.Where(t => t.Resource is AlwaysFails or TrueAtLastRetry or TrueAtThirdRetry or AlwaysPasses).ToList();
+        sessionTests.Select(t => t.Resource).Should().Contain([AlwaysFails, AlwaysPasses, TrueAtLastRetry, TrueAtThirdRetry]);
+
+        var retryCountForSession = sessionTests.Count - 4;
+        retryCountForSession.Should().BeGreaterThanOrEqualTo(0).And.BeLessThanOrEqualTo(2);
+    }
+
     public virtual Task FlakyRetriesWithExceptionReplay(string packageVersion)
         => FlakyRetriesWithExceptionReplayCore(packageVersion);
 
-    protected async Task<List<MockCIVisibilityTest>> FlakyRetriesWithArguments(string packageVersion, string arguments)
+    protected async Task<List<MockCIVisibilityTest>> FlakyRetriesWithArguments(string packageVersion, string arguments, int retryCount = 5, int? expectedRetryCount = null, int? expectedLastRetryCount = null, int? totalRetryCount = null, bool assertRetryCounts = true)
     {
+        expectedRetryCount ??= retryCount;
+        expectedLastRetryCount ??= expectedRetryCount;
         EnvironmentHelper.EnableDefaultTransport();
         var tests = new List<MockCIVisibilityTest>();
         var testSuites = new List<MockCIVisibilityTestSuite>();
@@ -66,9 +87,12 @@ public abstract class TestingFrameworkRetriesTests : TestingFrameworkEvpTest
         Output.WriteLine("RunId: {0}", runId);
         try
         {
-            var retryCount = 5;
             SetEnvironmentVariable(ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "1");
             SetEnvironmentVariable(ConfigurationKeys.CIVisibility.FlakyRetryCount, retryCount.ToString());
+            if (totalRetryCount.HasValue)
+            {
+                SetEnvironmentVariable(ConfigurationKeys.CIVisibility.TotalFlakyRetryCount, totalRetryCount.Value.ToString());
+            }
 
             using var agent = EnvironmentHelper.GetMockAgent();
             agent.EventPlatformProxyPayloadReceived += (sender, e) =>
@@ -118,25 +142,28 @@ public abstract class TestingFrameworkRetriesTests : TestingFrameworkEvpTest
 
             testSuites.Should().HaveCount(ExpectedTestSuiteCount);
 
-            // AlwaysFails => 1 + 5 retries
-            var alwaysFailsTests = tests.Where(t => t.Resource == AlwaysFails).ToList();
-            alwaysFailsTests.Should().HaveCount(1 + retryCount);
-            alwaysFailsTests.Should().OnlyContain(t => t.Meta[TestTags.Status] == TestTags.StatusFail);
+            if (assertRetryCounts)
+            {
+                // AlwaysFails uses the configured retry budget.
+                var alwaysFailsTests = tests.Where(t => t.Resource == AlwaysFails).ToList();
+                alwaysFailsTests.Should().HaveCount(1 + expectedRetryCount.Value);
+                alwaysFailsTests.Should().OnlyContain(t => t.Meta[TestTags.Status] == TestTags.StatusFail);
 
-            // AlwaysPasses => 1
-            var alwaysPassesTests = tests.Where(t => t.Resource == AlwaysPasses).ToList();
-            alwaysPassesTests.Should().HaveCount(1);
-            alwaysPassesTests.Should().OnlyContain(t => t.Meta[TestTags.Status] == TestTags.StatusPass);
+                // AlwaysPasses => 1
+                var alwaysPassesTests = tests.Where(t => t.Resource == AlwaysPasses).ToList();
+                alwaysPassesTests.Should().HaveCount(1);
+                alwaysPassesTests.Should().OnlyContain(t => t.Meta[TestTags.Status] == TestTags.StatusPass);
 
-            // TrueAtLastRetry => 1 + 5 retries
-            var trueAtLastRetryTests = tests.Where(t => t.Resource == TrueAtLastRetry).ToList();
-            trueAtLastRetryTests.Should().HaveCount(1 + retryCount);
-            trueAtLastRetryTests.Should().Contain(t => t.Meta[TestTags.Status] == TestTags.StatusPass);
+                // TrueAtLastRetry stops after the first successful retry.
+                var trueAtLastRetryTests = tests.Where(t => t.Resource == TrueAtLastRetry).ToList();
+                trueAtLastRetryTests.Should().HaveCount(1 + expectedLastRetryCount.Value);
+                trueAtLastRetryTests.Should().Contain(t => t.Meta[TestTags.Status] == TestTags.StatusPass);
 
-            // TrueAtThirdRetry => 1 + 3 retries
-            var trueAtThirdRetryTests = tests.Where(t => t.Resource == TrueAtThirdRetry).ToList();
-            trueAtThirdRetryTests.Should().HaveCount(1 + 3);
-            trueAtThirdRetryTests.Should().Contain(t => t.Meta[TestTags.Status] == TestTags.StatusPass);
+                // TrueAtThirdRetry => 1 + 3 retries
+                var trueAtThirdRetryTests = tests.Where(t => t.Resource == TrueAtThirdRetry).ToList();
+                trueAtThirdRetryTests.Should().HaveCount(1 + 3);
+                trueAtThirdRetryTests.Should().Contain(t => t.Meta[TestTags.Status] == TestTags.StatusPass);
+            }
         }
         catch
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTests.cs
@@ -46,6 +46,26 @@ public class XUnitRetriesTests : TestingFrameworkRetriesTests
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "TestIntegrations")]
     [Trait("Category", "FlakyRetries")]
+    public override Task<List<MockCIVisibilityTest>> DynamicFlakyRetries(string packageVersion)
+    {
+        return base.DynamicFlakyRetries(packageVersion);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.XUnitRetries), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
+    public override Task DynamicFlakyRetriesHonorSessionCap(string packageVersion)
+    {
+        return base.DynamicFlakyRetriesHonorSessionCap(packageVersion);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.XUnitRetries), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
     [Flaky("Under investigation", 5)]
     public override Task FlakyRetriesWithExceptionReplay(string packageVersion)
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTestsV3.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitRetriesTestsV3.cs
@@ -42,6 +42,26 @@ public class XUnitRetriesTestsV3 : TestingFrameworkRetriesTests
         return base.FlakyRetries(packageVersion);
     }
 
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.XUnitRetriesV3), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
+    public override Task<List<MockCIVisibilityTest>> DynamicFlakyRetries(string packageVersion)
+    {
+        return base.DynamicFlakyRetries(packageVersion);
+    }
+
+    [SkippableTheory]
+    [MemberData(nameof(PackageVersions.XUnitRetriesV3), MemberType = typeof(PackageVersions))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "TestIntegrations")]
+    [Trait("Category", "FlakyRetries")]
+    public override Task DynamicFlakyRetriesHonorSessionCap(string packageVersion)
+    {
+        return base.DynamicFlakyRetriesHonorSessionCap(packageVersion);
+    }
+
     [SkippableTheory(Skip = "Exception Replay coverage for xunit.v3 requires further investigation.")]
     [MemberData(nameof(PackageVersions.XUnitRetriesV3), MemberType = typeof(PackageVersions))]
     [Trait("Category", "EndToEnd")]

--- a/tracer/test/Datadog.Trace.Tests/Ci/DynamicAtrRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/DynamicAtrRetriesTests.cs
@@ -1,0 +1,269 @@
+// <copyright file="DynamicAtrRetriesTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Ci;
+using Datadog.Trace.Ci.Configuration;
+using Datadog.Trace.Ci.Coverage.Backfill;
+using Datadog.Trace.Ci.Net;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Ci;
+
+[Collection(nameof(TracerInstanceTestCollection))]
+[EnvironmentVariablesCleaner(
+    ConfigurationKeys.CIVisibility.DynamicAtrEnabled,
+    ConfigurationKeys.CIVisibility.DynamicAtrBuckets)]
+public class DynamicAtrRetriesTests : SettingsTestsBase
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("false", false)]
+    [InlineData("true", true)]
+    [InlineData("1", true)]
+    public void DynamicAtrEnablementParsing(string? enabled, bool expected)
+    {
+        var envVars = new List<(string Key, string Value)>();
+        if (enabled is not null)
+        {
+            envVars.Add((ConfigurationKeys.CIVisibility.DynamicAtrEnabled, enabled));
+        }
+
+        var settings = CreateSettings(envVars.ToArray());
+        settings.DynamicAtrEnabled.Should().Be(expected);
+    }
+
+    public static IEnumerable<object[]> DynamicAtrBucketsTestData => new List<object[]>
+    {
+        new object[] { null, null },
+        new object[] { "", null },
+        new object[] { "10,4,1,1,1", new[] { 10, 4, 1, 1, 1 } },
+        new object[] { "10,4,1", null },             // wrong count
+        new object[] { "10,4,0,1,1", null },         // value < 1
+        new object[] { "21,4,1,1,1", null },        // value > 20
+        new object[] { "invalid", null },            // non-integer
+        new object[] { "a,b,c,d,e", null },          // all non-integer
+    };
+
+    [Theory]
+    [MemberData(nameof(DynamicAtrBucketsTestData))]
+    public void DynamicAtrBucketsParsing(string? buckets, int[]? expected)
+    {
+        var envVars = new List<(string Key, string Value)>();
+        if (buckets is not null)
+        {
+            envVars.Add((ConfigurationKeys.CIVisibility.DynamicAtrBuckets, buckets));
+        }
+
+        var settings = CreateSettings(envVars.ToArray());
+        if (expected is null)
+        {
+            settings.DynamicAtrBuckets.Should().BeNull();
+        }
+        else
+        {
+            settings.DynamicAtrBuckets.Should().Equal(expected);
+        }
+    }
+
+    [Fact]
+    public void SlowTestRetries_RetryBucketIndexForDuration()
+    {
+        var slowRetries = new TestOptimizationClient.SlowTestRetriesSettingsResponse(10, 5, 3, 1);
+        slowRetries.RetryBucketIndexForDuration(1).Should().Be(0);
+        slowRetries.RetryBucketIndexForDuration(5).Should().Be(0);
+        slowRetries.RetryBucketIndexForDuration(6).Should().Be(1);
+        slowRetries.RetryBucketIndexForDuration(10).Should().Be(1);
+        slowRetries.RetryBucketIndexForDuration(11).Should().Be(2);
+        slowRetries.RetryBucketIndexForDuration(30).Should().Be(2);
+        slowRetries.RetryBucketIndexForDuration(31).Should().Be(3);
+        slowRetries.RetryBucketIndexForDuration(300).Should().Be(3);
+        slowRetries.RetryBucketIndexForDuration(301).Should().Be(4);
+    }
+
+    [Fact]
+    public void SlowTestRetries_RetriesForDuration_UsesEfdSettings()
+    {
+        var slowRetries = new TestOptimizationClient.SlowTestRetriesSettingsResponse(10, 5, 3, 1);
+        slowRetries.RetriesForDuration(1).Should().Be(10);    // 5s bucket
+        slowRetries.RetriesForDuration(6).Should().Be(5);     // 10s bucket
+        slowRetries.RetriesForDuration(11).Should().Be(3);    // 30s bucket
+        slowRetries.RetriesForDuration(31).Should().Be(1);    // 5m bucket
+        slowRetries.RetriesForDuration(301).Should().Be(0);   // >5m bucket
+    }
+
+    [Fact]
+    public void SlowTestRetries_RetriesForDuration_NullFieldsDefaultToZero()
+    {
+        var slowRetries = new TestOptimizationClient.SlowTestRetriesSettingsResponse();
+        slowRetries.RetriesForDuration(1).Should().Be(0);
+        slowRetries.RetriesForDuration(301).Should().Be(0);
+    }
+
+    [Fact]
+    public void ParseDynamicAtrBuckets_ValidInput_ReturnsBuckets()
+    {
+        TestOptimizationSettings.ParseDynamicAtrBuckets("10,4,1,1,1")
+            .Should().Equal(new[] { 10, 4, 1, 1, 1 });
+    }
+
+    [Fact]
+    public void ParseDynamicAtrBuckets_NullOrEmpty_ReturnsNull()
+    {
+        TestOptimizationSettings.ParseDynamicAtrBuckets(null).Should().BeNull();
+        TestOptimizationSettings.ParseDynamicAtrBuckets("").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDynamicAtrBuckets_WrongCount_ReturnsNull()
+    {
+        TestOptimizationSettings.ParseDynamicAtrBuckets("10,4,1").Should().BeNull();
+        TestOptimizationSettings.ParseDynamicAtrBuckets("10,4,1,1,1,1").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDynamicAtrBuckets_ValueOutOfRange_ReturnsNull()
+    {
+        TestOptimizationSettings.ParseDynamicAtrBuckets("0,4,1,1,1").Should().BeNull();
+        TestOptimizationSettings.ParseDynamicAtrBuckets("21,4,1,1,1").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDynamicAtrBuckets_NonInteger_ReturnsNull()
+    {
+        TestOptimizationSettings.ParseDynamicAtrBuckets("a,b,c,d,e").Should().BeNull();
+        TestOptimizationSettings.ParseDynamicAtrBuckets("10,4,1,1,x").Should().BeNull();
+    }
+
+    [Fact]
+    public void DynamicAtrEnabled_DoesNotAffectFlakyRetryCount()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryCount, "5"));
+        settings.DynamicAtrEnabled.Should().BeTrue();
+        settings.FlakyRetryCount.Should().Be(5);
+    }
+
+    [Fact]
+    public void DynamicAtrBuckets_OnlyTakesEffectWhenEnabled()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "false"),
+            (ConfigurationKeys.CIVisibility.DynamicAtrBuckets, "3,1,1,1,1"));
+        settings.DynamicAtrEnabled.Should().BeFalse();
+        settings.DynamicAtrBuckets.Should().Equal(new[] { 3, 1, 1, 1, 1 });
+    }
+
+    [Fact]
+    public void Telemetry_DynamicAtrRetriesMetric_HasCustomBucketsTrue()
+    {
+        var mockCollector = new Mock<IMetricsTelemetryCollector>();
+        var original = TelemetryFactory.SetMetricsForTesting(mockCollector.Object);
+        try
+        {
+            var settings = CreateSettings(
+                (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+                (ConfigurationKeys.CIVisibility.DynamicAtrBuckets, "3,1,1,1,1"),
+                (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
+
+            // Simulate the telemetry call that TestOptimization would make
+            if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
+            {
+                var hasCustomBuckets = settings.DynamicAtrBuckets is not null
+                    ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True
+                    : MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False;
+                TelemetryFactory.Metrics.RecordCountCIVisibilityDynamicAtrRetries(hasCustomBuckets);
+            }
+
+            mockCollector.Verify(
+                c => c.RecordCountCIVisibilityDynamicAtrRetries(
+                    MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True,
+                    It.IsAny<int>()),
+                Times.Once);
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(original);
+        }
+    }
+
+    [Fact]
+    public void Telemetry_DynamicAtrRetriesMetric_HasCustomBucketsFalse()
+    {
+        var mockCollector = new Mock<IMetricsTelemetryCollector>();
+        var original = TelemetryFactory.SetMetricsForTesting(mockCollector.Object);
+        try
+        {
+            var settings = CreateSettings(
+                (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+                (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
+
+            // No custom buckets set
+            if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
+            {
+                var hasCustomBuckets = settings.DynamicAtrBuckets is not null
+                    ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True
+                    : MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False;
+                TelemetryFactory.Metrics.RecordCountCIVisibilityDynamicAtrRetries(hasCustomBuckets);
+            }
+
+            mockCollector.Verify(
+                c => c.RecordCountCIVisibilityDynamicAtrRetries(
+                    MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False,
+                    It.IsAny<int>()),
+                Times.Once);
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(original);
+        }
+    }
+
+    [Fact]
+    public void Telemetry_DynamicAtrDisabled_DoesNotRecordMetric()
+    {
+        var mockCollector = new Mock<IMetricsTelemetryCollector>();
+        var original = TelemetryFactory.SetMetricsForTesting(mockCollector.Object);
+        try
+        {
+            var settings = CreateSettings(
+                (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "false"),
+                (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
+
+            if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
+            {
+                var hasCustomBuckets = settings.DynamicAtrBuckets is not null
+                    ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True
+                    : MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False;
+                TelemetryFactory.Metrics.RecordCountCIVisibilityDynamicAtrRetries(hasCustomBuckets);
+            }
+
+            mockCollector.Verify(
+                c => c.RecordCountCIVisibilityDynamicAtrRetries(
+                    It.IsAny<MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets>(),
+                    It.IsAny<int>()),
+                Times.Never);
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(original);
+        }
+    }
+
+    private static TestOptimizationSettings CreateSettings(params (string Key, string Value)[] values)
+    {
+        CoverageBackfillCapability.ResetCommandLineCacheForTests();
+        return new TestOptimizationSettings(CreateConfigurationSource(values), NullConfigurationTelemetry.Instance);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Ci/DynamicAtrRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/DynamicAtrRetriesTests.cs
@@ -9,6 +9,8 @@ using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Ci.Coverage.Backfill;
 using Datadog.Trace.Ci.Net;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.TestHelpers;
@@ -23,7 +25,9 @@ namespace Datadog.Trace.Tests.Ci;
 [Collection(nameof(TracerInstanceTestCollection))]
 [EnvironmentVariablesCleaner(
     ConfigurationKeys.CIVisibility.DynamicAtrEnabled,
-    ConfigurationKeys.CIVisibility.DynamicAtrBuckets)]
+    ConfigurationKeys.CIVisibility.DynamicAtrBuckets,
+    ConfigurationKeys.CIVisibility.FlakyRetryEnabled,
+    ConfigurationKeys.CIVisibility.FlakyRetryCount)]
 public class DynamicAtrRetriesTests : SettingsTestsBase
 {
     [Theory]
@@ -177,14 +181,9 @@ public class DynamicAtrRetriesTests : SettingsTestsBase
                 (ConfigurationKeys.CIVisibility.DynamicAtrBuckets, "3,1,1,1,1"),
                 (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
 
-            // Simulate the telemetry call that TestOptimization would make
-            if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
-            {
-                var hasCustomBuckets = settings.DynamicAtrBuckets is not null
-                    ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True
-                    : MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False;
-                TelemetryFactory.Metrics.RecordCountCIVisibilityDynamicAtrRetries(hasCustomBuckets);
-            }
+            var flakyRetryFeature = CreateFlakyRetryFeature(settings, backendEnabled: true);
+
+            TestOptimization.RecordDynamicAtrTelemetry(settings, flakyRetryFeature);
 
             mockCollector.Verify(
                 c => c.RecordCountCIVisibilityDynamicAtrRetries(
@@ -209,14 +208,9 @@ public class DynamicAtrRetriesTests : SettingsTestsBase
                 (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
                 (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
 
-            // No custom buckets set
-            if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
-            {
-                var hasCustomBuckets = settings.DynamicAtrBuckets is not null
-                    ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True
-                    : MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False;
-                TelemetryFactory.Metrics.RecordCountCIVisibilityDynamicAtrRetries(hasCustomBuckets);
-            }
+            var flakyRetryFeature = CreateFlakyRetryFeature(settings, backendEnabled: true);
+
+            TestOptimization.RecordDynamicAtrTelemetry(settings, flakyRetryFeature);
 
             mockCollector.Verify(
                 c => c.RecordCountCIVisibilityDynamicAtrRetries(
@@ -240,14 +234,9 @@ public class DynamicAtrRetriesTests : SettingsTestsBase
             var settings = CreateSettings(
                 (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "false"),
                 (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
+            var flakyRetryFeature = CreateFlakyRetryFeature(settings, backendEnabled: true);
 
-            if (settings.DynamicAtrEnabled && settings.FlakyRetryEnabled == true)
-            {
-                var hasCustomBuckets = settings.DynamicAtrBuckets is not null
-                    ? MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.True
-                    : MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets.False;
-                TelemetryFactory.Metrics.RecordCountCIVisibilityDynamicAtrRetries(hasCustomBuckets);
-            }
+            TestOptimization.RecordDynamicAtrTelemetry(settings, flakyRetryFeature);
 
             mockCollector.Verify(
                 c => c.RecordCountCIVisibilityDynamicAtrRetries(
@@ -259,6 +248,85 @@ public class DynamicAtrRetriesTests : SettingsTestsBase
         {
             TelemetryFactory.SetMetricsForTesting(original);
         }
+    }
+
+    [Fact]
+    public void DynamicAtrRequiresBackendAtrDespiteLocalFlatAtrOverride()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryCount, "5"));
+
+        var flakyRetryFeature = CreateFlakyRetryFeature(settings, backendEnabled: false);
+
+        flakyRetryFeature.Enabled.Should().BeTrue();
+        flakyRetryFeature.BackendEnabled.Should().BeFalse();
+        flakyRetryFeature.DynamicAtrEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void XUnit_UsesFlatRetryBudgetWhenBackendAtrIsDisabled()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryCount, "5"));
+        var flakyRetryFeature = CreateFlakyRetryFeature(settings, backendEnabled: false);
+        var testOptimization = new Mock<ITestOptimization>();
+        testOptimization.SetupGet(x => x.Settings).Returns(settings);
+        testOptimization.SetupGet(x => x.FlakyRetryFeature).Returns(flakyRetryFeature);
+        var metadata = new TestCaseMetadata("case", totalExecution: 1, countDownExecutionNumber: 0)
+        {
+            SelectedRetryMode = TestRetryMode.AutomaticTestRetry,
+        };
+
+        XUnitIntegration.InitializeTotalExecutions(testOptimization.Object, metadata, TimeSpan.FromSeconds(1));
+
+        metadata.TotalExecutions.Should().Be(6);
+    }
+
+    [Fact]
+    public void Telemetry_BackendAtrDisabled_DoesNotRecordDynamicAtrMetric()
+    {
+        var mockCollector = new Mock<IMetricsTelemetryCollector>();
+        var original = TelemetryFactory.SetMetricsForTesting(mockCollector.Object);
+        try
+        {
+            var settings = CreateSettings(
+                (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+                (ConfigurationKeys.CIVisibility.DynamicAtrBuckets, "3,1,1,1,1"),
+                (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
+            var flakyRetryFeature = CreateFlakyRetryFeature(settings, backendEnabled: false);
+
+            TestOptimization.RecordDynamicAtrTelemetry(settings, flakyRetryFeature);
+
+            mockCollector.Verify(
+                c => c.RecordCountCIVisibilityDynamicAtrRetries(
+                    It.IsAny<MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets>(),
+                    It.IsAny<int>()),
+                Times.Never);
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(original);
+        }
+    }
+
+    private static ITestOptimizationFlakyRetryFeature CreateFlakyRetryFeature(TestOptimizationSettings settings, bool backendEnabled)
+    {
+        return TestOptimizationFlakyRetryFeature.Create(
+            settings,
+            new TestOptimizationClient.SettingsResponse(
+                codeCoverage: false,
+                testsSkipping: false,
+                requireGit: false,
+                impactedTestsEnabled: false,
+                flakyTestRetries: backendEnabled,
+                earlyFlakeDetection: new TestOptimizationClient.EarlyFlakeDetectionSettingsResponse(),
+                knownTestsEnabled: false,
+                testManagement: new TestOptimizationClient.TestManagementSettingsResponse(),
+                dynamicInstrumentationEnabled: false));
     }
 
     private static TestOptimizationSettings CreateSettings(params (string Key, string Value)[] values)

--- a/tracer/test/Datadog.Trace.Tests/Ci/DynamicAtrRetriesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Ci/DynamicAtrRetriesTests.cs
@@ -251,6 +251,56 @@ public class DynamicAtrRetriesTests : SettingsTestsBase
     }
 
     [Fact]
+    public void SkippedSettingsRequestWithLocalFlatAtrDoesNotEnableDynamicAtr()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.CIVisibility.CodeCoverage, "false"),
+            (ConfigurationKeys.CIVisibility.TestsSkippingEnabled, "false"),
+            (ConfigurationKeys.CIVisibility.EarlyFlakeDetectionEnabled, "false"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryCount, "5"),
+            (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.DynamicInstrumentationEnabled, "false"),
+            (ConfigurationKeys.CIVisibility.ImpactedTestsDetectionEnabled, "false"),
+            (ConfigurationKeys.CIVisibility.TestManagementEnabled, "false"));
+        var locallySynthesizedResponse = TestOptimizationClient.CreateSettingsResponseFromTestOptimizationSettings(settings, tracerManagement: null);
+        var flakyRetryFeature = TestOptimizationFlakyRetryFeature.Create(settings, locallySynthesizedResponse, isRemoteSettingsResponse: false);
+        var testOptimization = new Mock<ITestOptimization>();
+        testOptimization.SetupGet(x => x.Settings).Returns(settings);
+        testOptimization.SetupGet(x => x.FlakyRetryFeature).Returns(flakyRetryFeature);
+        var metadata = new TestCaseMetadata("case", totalExecution: 1, countDownExecutionNumber: 0)
+        {
+            SelectedRetryMode = TestRetryMode.AutomaticTestRetry,
+        };
+
+        locallySynthesizedResponse.FlakyTestRetries.Should().BeTrue();
+        flakyRetryFeature.Enabled.Should().BeTrue();
+        flakyRetryFeature.BackendEnabled.Should().BeFalse();
+        flakyRetryFeature.DynamicAtrEnabled.Should().BeFalse();
+
+        XUnitIntegration.InitializeTotalExecutions(testOptimization.Object, metadata, TimeSpan.FromSeconds(1));
+
+        metadata.TotalExecutions.Should().Be(6);
+
+        var mockCollector = new Mock<IMetricsTelemetryCollector>();
+        var original = TelemetryFactory.SetMetricsForTesting(mockCollector.Object);
+        try
+        {
+            TestOptimization.RecordDynamicAtrTelemetry(settings, flakyRetryFeature);
+
+            mockCollector.Verify(
+                c => c.RecordCountCIVisibilityDynamicAtrRetries(
+                    It.IsAny<MetricTags.CIVisibilityDynamicAtrRetriesHasCustomBuckets>(),
+                    It.IsAny<int>()),
+                Times.Never);
+        }
+        finally
+        {
+            TelemetryFactory.SetMetricsForTesting(original);
+        }
+    }
+
+    [Fact]
     public void DynamicAtrRequiresBackendAtrDespiteLocalFlatAtrOverride()
     {
         var settings = CreateSettings(
@@ -263,6 +313,48 @@ public class DynamicAtrRetriesTests : SettingsTestsBase
         flakyRetryFeature.Enabled.Should().BeTrue();
         flakyRetryFeature.BackendEnabled.Should().BeFalse();
         flakyRetryFeature.DynamicAtrEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void XUnit_DynamicAtrFallbackSchedulesOneRetryForDurationsOverFiveMinutes()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.CIVisibility.DynamicAtrEnabled, "true"),
+            (ConfigurationKeys.CIVisibility.FlakyRetryEnabled, "true"));
+        var flakyRetryFeature = CreateFlakyRetryFeature(settings, backendEnabled: true);
+        var earlyFlakeDetectionFeature = new Mock<ITestOptimizationEarlyFlakeDetectionFeature>();
+        earlyFlakeDetectionFeature.SetupGet(x => x.EarlyFlakeDetectionSettings).Returns(
+            new TestOptimizationClient.EarlyFlakeDetectionSettingsResponse(
+                enabled: false,
+                slowTestRetries: new TestOptimizationClient.SlowTestRetriesSettingsResponse(),
+                faultySessionThreshold: 0));
+        var testOptimization = new Mock<ITestOptimization>();
+        testOptimization.SetupGet(x => x.Settings).Returns(settings);
+        testOptimization.SetupGet(x => x.FlakyRetryFeature).Returns(flakyRetryFeature);
+        testOptimization.SetupGet(x => x.EarlyFlakeDetectionFeature).Returns(earlyFlakeDetectionFeature.Object);
+        var metadata = new TestCaseMetadata("case", totalExecution: 1, countDownExecutionNumber: 0)
+        {
+            SelectedRetryMode = TestRetryMode.AutomaticTestRetry,
+        };
+        var originalTestOptimization = TestOptimization.Instance;
+        try
+        {
+            TestOptimization.Instance = testOptimization.Object;
+
+            XUnitIntegration.InitializeTotalExecutions(testOptimization.Object, metadata, TimeSpan.FromSeconds(301));
+
+            metadata.TotalExecutions.Should().Be(2);
+            var remainingRetries = 1;
+            XUnitIntegration.GetRetryExecutionDecision(metadata, hasFailures: true, hasNotRun: false, ref remainingRetries)
+                            .Should().Be(XUnitRetryExecutionDecision.Retry);
+            remainingRetries.Should().Be(0);
+            XUnitIntegration.GetRetryExecutionDecision(metadata, hasFailures: true, hasNotRun: false, ref remainingRetries)
+                            .Should().Be(XUnitRetryExecutionDecision.RetryBudgetExhausted);
+        }
+        finally
+        {
+            TestOptimization.Instance = originalTestOptimization;
+        }
     }
 
     [Fact]
@@ -326,7 +418,8 @@ public class DynamicAtrRetriesTests : SettingsTestsBase
                 earlyFlakeDetection: new TestOptimizationClient.EarlyFlakeDetectionSettingsResponse(),
                 knownTestsEnabled: false,
                 testManagement: new TestOptimizationClient.TestManagementSettingsResponse(),
-                dynamicInstrumentationEnabled: false));
+                dynamicInstrumentationEnabled: false),
+            isRemoteSettingsResponse: true);
     }
 
     private static TestOptimizationSettings CreateSettings(params (string Key, string Value)[] values)


### PR DESCRIPTION
## Summary of changes

Add dynamic Auto Test Retries (ATR) budgets based on test duration, instead of the flat per-test retry limit. When enabled, the number of retries allowed for a test is determined by the duration of its initial attempt, using the same duration buckets as Early Flake Detection (5s / 10s / 30s / 5m / >5m).

Two new env vars control the behavior:
- DD_CIVISIBILITY_DYNAMIC_ATR_ENABLED — enables duration-based ATR budgets. When unset/false, ATR stays on its existing flat-limit path.
- DD_CIVISIBILITY_DYNAMIC_ATR_BUCKETS — optionally overrides the five duration-based retry budgets with five positive comma-separated integers in [1, 20]. When unset/empty, the EFD retry settings from the backend are used.

The new handler classifies each test once (by its initial-attempt duration) and caches the resulting max-retries count for the lifetime of that test. The duration bucket index is computed via shared helpers on the EFD settings type, so bucket boundaries stay consistent with EFD (the existing EFD retry handler is refactored to use them too).

Telemetry: records a `dynamic_atr_retries.enabled` count metric with a `has_custom_buckets` tag when dynamic ATR is enabled.

Feature parity with dd-trace-py PR #20028.