### PR TITLE
[Feature Flags] Add agentless EVP fallback transport

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -929,6 +929,7 @@
       <type fullname="System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs" />
       <type fullname="System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute" />
       <type fullname="System.Runtime.InteropServices.ComVisibleAttribute" />
+      <type fullname="System.Runtime.InteropServices.ExternalException" />
       <type fullname="System.Runtime.InteropServices.GCHandle" />
       <type fullname="System.Runtime.InteropServices.GCHandleType" />
       <type fullname="System.Runtime.InteropServices.InAttribute" />

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -30,7 +30,8 @@ internal sealed record AgentConfiguration
         List<string>? peerTags = null,
         int obfuscationVersion = 0,
         AgentTraceFilterConfig? traceFilterConfig = null,
-        List<string>? featureFlags = null)
+        List<string>? featureFlags = null,
+        bool eventPlatformProxySupportsEvpOriginHeaders = false)
     {
         ConfigurationEndpoint = configurationEndpoint;
         DebuggerEndpoint = debuggerEndpoint;
@@ -51,6 +52,7 @@ internal sealed record AgentConfiguration
         ObfuscationVersion = obfuscationVersion;
         TraceFilterConfig = traceFilterConfig ?? AgentTraceFilterConfig.Empty;
         FeatureFlags = featureFlags;
+        EventPlatformProxySupportsEvpOriginHeaders = eventPlatformProxySupportsEvpOriginHeaders;
     }
 
     public string? ConfigurationEndpoint { get; }
@@ -82,6 +84,8 @@ internal sealed record AgentConfiguration
     public string? DataStreamsMonitoringEndpoint { get; }
 
     public string? EventPlatformProxyEndpoint { get; }
+
+    public bool EventPlatformProxySupportsEvpOriginHeaders { get; }
 
     public string? TelemetryProxyEndpoint { get; }
 

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -35,6 +35,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
         private const string SupportedDataStreamsEndpoint = "v0.1/pipeline_stats";
         private const string SupportedEventPlatformProxyEndpointV2 = "evp_proxy/v2";
         private const string SupportedEventPlatformProxyEndpointV4 = "evp_proxy/v4";
+        private const string EvpOriginHeader = "DD-EVP-ORIGIN";
+        private const string EvpOriginVersionHeader = "DD-EVP-ORIGIN-VERSION";
         private const string SupportedTelemetryProxyEndpoint = "telemetry/proxy";
         private const string SupportedTracerFlareEndpoint = "tracer_flare/v1";
 
@@ -373,6 +375,10 @@ namespace Datadog.Trace.Agent.DiscoveryService
             }
 
             var discoveredEndpoints = (jObject["endpoints"] as JArray)?.Values<string>().ToArray();
+            var evpProxyAllowedHeaders = (jObject["evp_proxy_allowed_headers"] as JArray)?.Values<string>().ToArray();
+            var eventPlatformProxySupportsEvpOriginHeaders =
+                evpProxyAllowedHeaders?.Any(header => string.Equals(header?.Trim(), EvpOriginHeader, StringComparison.OrdinalIgnoreCase)) == true
+             && evpProxyAllowedHeaders.Any(header => string.Equals(header?.Trim(), EvpOriginVersionHeader, StringComparison.OrdinalIgnoreCase));
             string? configurationEndpoint = null;
             string? debuggerEndpoint = null;
             string? debuggerV2Endpoint = null;
@@ -463,7 +469,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 peerTags: peerTags!,
                 obfuscationVersion: obfuscationVersion,
                 traceFilterConfig: traceFilterConfig,
-                featureFlags: featureFlags!);
+                featureFlags: featureFlags!,
+                eventPlatformProxySupportsEvpOriginHeaders: eventPlatformProxySupportsEvpOriginHeaders);
 
             // Save the hash, whether the details we care about changed or not
             _configurationHash = HexString.ToHexString(sha256.Hash);

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
@@ -17,16 +17,20 @@ namespace Datadog.Trace.Agent.Transports
     {
         private readonly KeyValuePair<string, string>[] _defaultHeaders;
         private readonly Uri _baseEndpoint;
+        private readonly bool _allowAutoRedirect;
         private WebProxy _proxy;
         private NetworkCredential _credential;
         private TimeSpan? _timeout;
 
-        public ApiWebRequestFactory(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders, TimeSpan? timeout = null)
+        public ApiWebRequestFactory(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders, TimeSpan? timeout = null, bool allowAutoRedirect = true)
         {
             _baseEndpoint = baseEndpoint;
             _defaultHeaders = defaultHeaders;
             _timeout = timeout;
+            _allowAutoRedirect = allowAutoRedirect;
         }
+
+        internal bool AllowAutoRedirect => _allowAutoRedirect;
 
         public string Info(Uri endpoint)
         {
@@ -38,6 +42,7 @@ namespace Datadog.Trace.Agent.Transports
         public IApiRequest Create(Uri endpoint)
         {
             var request = WebRequest.CreateHttp(endpoint);
+            request.AllowAutoRedirect = _allowAutoRedirect;
             if (_proxy is not null)
             {
                 request.Proxy = _proxy;

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
@@ -22,9 +22,9 @@ namespace Datadog.Trace.Agent.Transports
         private readonly HttpMessageHandler _handler;
         private readonly Uri _baseEndpoint;
 
-        public HttpClientRequestFactory(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders, HttpMessageHandler handler = null, TimeSpan? timeout = null)
+        public HttpClientRequestFactory(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders, HttpMessageHandler handler = null, TimeSpan? timeout = null, bool allowAutoRedirect = true)
         {
-            _handler = handler ?? new HttpClientHandler();
+            _handler = handler ?? new HttpClientHandler { AllowAutoRedirect = allowAutoRedirect };
             _client = new HttpClient(_handler);
             _baseEndpoint = baseEndpoint;
             if (timeout.HasValue)
@@ -40,6 +40,8 @@ namespace Datadog.Trace.Agent.Transports
             // Disable keep-alive
             _client.DefaultRequestHeaders.ConnectionClose = true;
         }
+
+        internal bool AllowAutoRedirect => _handler is not HttpClientHandler handler || handler.AllowAutoRedirect;
 
         public Uri GetEndpoint(string relativePath) => relativePath is null ? _baseEndpoint : UriHelpers.Combine(_baseEndpoint, relativePath);
 

--- a/tracer/src/Datadog.Trace/FeatureFlags/Agentless/AgentlessEndpoint.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Agentless/AgentlessEndpoint.cs
@@ -78,28 +78,12 @@ internal sealed class AgentlessEndpoint
         var configured = baseUrl?.Trim();
         if (StringUtil.IsNullOrEmpty(configured))
         {
-            var trimmedSite = site?.Trim();
-            if (StringUtil.IsNullOrEmpty(trimmedSite))
+            if (!TryNormalizeSite(site, out var normalizedSite, out error))
             {
-                error = "No Datadog site is configured";
                 return false;
             }
 
-            // The site is concatenated into a host, so every character that can change what a URL means
-            // has to be rejected before that happens. "@" is the dangerous one: it would make the rest of
-            // the value the real host, and the API key would be sent there. "/", "?" and "#" would start a
-            // path, query or fragment, and ":" a port or a scheme. Uri.TryCreate accepts several of these,
-            // so it cannot be relied on to catch them. The other tracers reject the same set.
-            foreach (var character in trimmedSite)
-            {
-                if (char.IsWhiteSpace(character) || character is '/' or '?' or '#' or '@' or ':')
-                {
-                    error = "The configured Datadog site is not valid";
-                    return false;
-                }
-            }
-
-            var managedHost = ManagedHostPrefix + trimmedSite.ToLowerInvariant();
+            var managedHost = ManagedHostPrefix + normalizedSite;
 
             if (!Uri.TryCreate($"https://{managedHost}{DefaultPath}", UriKind.Absolute, out var managedUri))
             {
@@ -141,6 +125,81 @@ internal sealed class AgentlessEndpoint
         }
 
         endpoint = new AgentlessEndpoint(custom, isManaged: false);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates and normalizes a Datadog site before it is appended to a managed hostname.
+    /// Configuration and event delivery use this same method so credentials cannot be routed by
+    /// two subtly different parsers.
+    /// </summary>
+    internal static bool TryNormalizeSite(string? site, out string normalizedSite, out string? error)
+    {
+        normalizedSite = string.Empty;
+        error = null;
+
+        var trimmedSite = site?.Trim();
+        if (StringUtil.IsNullOrEmpty(trimmedSite))
+        {
+            error = "No Datadog site is configured";
+            return false;
+        }
+
+        // The complete managed host must remain below the DNS limit once either the configuration
+        // or event-intake prefix is applied.
+        if (trimmedSite.Length > 230)
+        {
+            error = "The configured Datadog site is not valid";
+            return false;
+        }
+
+        var labelLength = 0;
+        var previousWasHyphen = false;
+        foreach (var character in trimmedSite)
+        {
+            if (character == '.')
+            {
+                if (labelLength == 0 || previousWasHyphen)
+                {
+                    error = "The configured Datadog site is not valid";
+                    return false;
+                }
+
+                labelLength = 0;
+                previousWasHyphen = false;
+                continue;
+            }
+
+            if (character is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or >= '0' and <= '9')
+            {
+                labelLength++;
+                previousWasHyphen = false;
+            }
+            else if (character == '-' && labelLength > 0)
+            {
+                labelLength++;
+                previousWasHyphen = true;
+            }
+            else
+            {
+                error = "The configured Datadog site is not valid";
+                return false;
+            }
+
+            if (labelLength > 63)
+            {
+                error = "The configured Datadog site is not valid";
+                return false;
+            }
+        }
+
+        if (labelLength == 0 || previousWasHyphen)
+        {
+            error = "The configured Datadog site is not valid";
+            return false;
+        }
+
+        normalizedSite = trimmedSite.ToLowerInvariant();
         return true;
     }
 

--- a/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpHeaderHelper.cs
@@ -1,0 +1,45 @@
+// <copyright file="FeatureFlagsEvpHeaderHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using Datadog.Trace.HttpOverStreams;
+
+namespace Datadog.Trace.FeatureFlags.Evp;
+
+/// <summary>
+/// Headers used when a Feature Flags event is delivered through a local EVP relay.
+/// </summary>
+internal sealed class FeatureFlagsEvpHeaderHelper : HttpHeaderHelperBase
+{
+    internal const string EvpSubdomainHeader = "X-Datadog-EVP-Subdomain";
+    internal const string EvpSubdomain = "event-platform-intake";
+    internal const string EvpOriginHeader = "DD-EVP-ORIGIN";
+    internal const string EvpOrigin = "dd-trace-dotnet";
+    internal const string EvpOriginVersionHeader = "DD-EVP-ORIGIN-VERSION";
+
+    public static readonly FeatureFlagsEvpHeaderHelper Instance = new();
+
+    private FeatureFlagsEvpHeaderHelper()
+    {
+        DefaultHeaders =
+        [
+            .. AgentHttpHeaderNames.MinimalHeaders,
+            new(EvpSubdomainHeader, EvpSubdomain),
+            new(EvpOriginHeader, EvpOrigin),
+            new(EvpOriginVersionHeader, TracerConstants.ThreePartVersion),
+        ];
+        HttpSerializedDefaultHeaders =
+            $"{AgentHttpHeaderNames.HttpSerializedMinimalHeaders}" +
+            $"{EvpSubdomainHeader}: {EvpSubdomain}{DatadogHttpValues.CrLf}" +
+            $"{EvpOriginHeader}: {EvpOrigin}{DatadogHttpValues.CrLf}" +
+            $"{EvpOriginVersionHeader}: {TracerConstants.ThreePartVersion}{DatadogHttpValues.CrLf}";
+    }
+
+    public override KeyValuePair<string, string>[] DefaultHeaders { get; }
+
+    protected override string HttpSerializedDefaultHeaders { get; }
+}

--- a/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpTransport.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpTransport.cs
@@ -1,0 +1,516 @@
+// <copyright file="FeatureFlagsEvpTransport.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net;
+#if NETCOREAPP
+using System.Net.Http;
+#endif
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags.Agentless;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.FeatureFlags.Evp;
+
+/// <summary>
+/// Selects and sends to a Feature Flags EVP route without changing the product payload.
+/// </summary>
+internal sealed class FeatureFlagsEvpTransport : IDisposable
+{
+    internal const string ExposureIntakePath = "api/v2/exposures";
+    internal const string FlagEvaluationIntakePath = "api/v2/flagevaluation";
+    internal const int PayloadSizeLimitBytes = 5 * 1024 * 1024;
+    internal const string EventPlatformProxyV4 = "evp_proxy/v4";
+    internal const string EventPlatformProxyV2 = "evp_proxy/v2";
+
+    private static readonly TimeSpan InitialDiscoveryWait = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan RouteRecoveryCooldown = TimeSpan.FromSeconds(30);
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(FeatureFlagsEvpTransport));
+
+    private readonly FeatureFlagsSource _source;
+    private readonly IApiRequestFactory? _directRequestFactory;
+    private readonly IDiscoveryService _discoveryService;
+    private readonly Action<AgentConfiguration> _discoveryCallback;
+    private readonly Action<string>? _warningSink;
+    private readonly IDisposable? _settingsSubscription;
+    private readonly TimeSpan _initialDiscoveryWait;
+    private readonly TimeSpan _routeRecoveryCooldown;
+    private readonly Func<DateTimeOffset> _utcNow;
+    private readonly TaskCompletionSource<bool> _initialDiscovery = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly bool _discoverySubscribed;
+
+    private IApiRequestFactory _localRequestFactory;
+    private string? _localProxyEndpoint;
+    private int _directIsSticky;
+    private int _disposed;
+    private int _discoveryKnown;
+    private int _localRecoveryProbeInProgress;
+    private int _unavailableWarningLogged;
+    private long _localUnavailableUntilUtcTicks;
+
+    internal FeatureFlagsEvpTransport(TracerSettings settings, IDiscoveryService discoveryService, Action<string>? warningSink = null)
+    {
+        _source = settings.FeatureFlags.Source;
+        _localRequestFactory = CreateLocalRequestFactory(settings.Manager.InitialExporterSettings);
+        _discoveryService = discoveryService;
+        _discoveryCallback = UpdateAgentConfiguration;
+        _warningSink = warningSink;
+        _initialDiscoveryWait = InitialDiscoveryWait;
+        _routeRecoveryCooldown = RouteRecoveryCooldown;
+        _utcNow = static () => DateTimeOffset.UtcNow;
+
+        if (_source == FeatureFlagsSource.Agentless)
+        {
+            _directRequestFactory = CreateDirectRequestFactory(settings.FeatureFlags, out var invalidSite);
+            if (invalidSite)
+            {
+                WarnInvalidSite();
+            }
+
+            // The shared discovery service owns its own bounded retry/backoff loop. Event flushes
+            // wait for its first result once and then consume later callbacks; they never start an
+            // independent /info request on every flush.
+            _discoveryService.SubscribeToChanges(_discoveryCallback);
+            _discoverySubscribed = true;
+        }
+        else if (_source == FeatureFlagsSource.RemoteConfig)
+        {
+            // Preserve the historical Remote Config transport: fixed EVP v2, no /info discovery,
+            // and no direct credentials.
+            _localProxyEndpoint = EventPlatformProxyV2;
+            Volatile.Write(ref _discoveryKnown, 1);
+            _initialDiscovery.TrySetResult(true);
+        }
+
+        _settingsSubscription = settings.Manager.SubscribeToChanges(changes =>
+        {
+            if (changes.UpdatedExporter is { } exporter)
+            {
+                Interlocked.Exchange(ref _localRequestFactory!, CreateLocalRequestFactory(exporter));
+            }
+        });
+    }
+
+    [TestingOnly]
+    internal FeatureFlagsEvpTransport(
+        FeatureFlagsSource source,
+        IApiRequestFactory localRequestFactory,
+        IApiRequestFactory? directRequestFactory,
+        IDiscoveryService discoveryService,
+        string? initialLocalProxyEndpoint = null,
+        bool initialDiscoveryKnown = true,
+        TimeSpan? initialDiscoveryWait = null,
+        TimeSpan? routeRecoveryCooldown = null,
+        Func<DateTimeOffset>? utcNow = null,
+        Action<string>? warningSink = null)
+    {
+        _source = source;
+        _localRequestFactory = localRequestFactory;
+        _directRequestFactory = source == FeatureFlagsSource.Agentless ? directRequestFactory : null;
+        _discoveryService = discoveryService;
+        _discoveryCallback = UpdateAgentConfiguration;
+        _warningSink = warningSink;
+        _initialDiscoveryWait = initialDiscoveryWait ?? InitialDiscoveryWait;
+        _routeRecoveryCooldown = routeRecoveryCooldown ?? RouteRecoveryCooldown;
+        _utcNow = utcNow ?? (static () => DateTimeOffset.UtcNow);
+
+        if (source == FeatureFlagsSource.RemoteConfig)
+        {
+            _localProxyEndpoint = EventPlatformProxyV2;
+            Volatile.Write(ref _discoveryKnown, 1);
+            _initialDiscovery.TrySetResult(true);
+        }
+        else
+        {
+            _localProxyEndpoint = initialLocalProxyEndpoint;
+            if (initialDiscoveryKnown)
+            {
+                Volatile.Write(ref _discoveryKnown, 1);
+                _initialDiscovery.TrySetResult(true);
+            }
+
+            _discoveryService.SubscribeToChanges(_discoveryCallback);
+            _discoverySubscribed = true;
+        }
+    }
+
+    private enum NetworkFailure
+    {
+        None,
+        DefinitivePreSend,
+        Ambiguous,
+    }
+
+    internal static KeyValuePair<string, string>[] GetDirectHeaders(string apiKey) =>
+    [
+        new(TelemetryConstants.ApiKeyHeader, apiKey),
+        new(FeatureFlagsEvpHeaderHelper.EvpOriginHeader, FeatureFlagsEvpHeaderHelper.EvpOrigin),
+        new(FeatureFlagsEvpHeaderHelper.EvpOriginVersionHeader, TracerConstants.ThreePartVersion),
+    ];
+
+    [SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "Different implementation types are returned for different TFMs")]
+    internal static IApiRequestFactory? CreateDirectRequestFactory(FeatureFlagsSettings settings)
+        => CreateDirectRequestFactory(settings, out _);
+
+    [SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "Different implementation types are returned for different TFMs")]
+    private static IApiRequestFactory? CreateDirectRequestFactory(FeatureFlagsSettings settings, out bool invalidSite)
+    {
+        invalidSite = false;
+        if (string.IsNullOrWhiteSpace(settings.ApiKey))
+        {
+            return null;
+        }
+
+        if (!AgentlessEndpoint.TryNormalizeSite(settings.Site, out var site, out _))
+        {
+            invalidSite = true;
+            return null;
+        }
+
+        var expectedHost = $"event-platform-intake.{site}";
+        if (!Uri.TryCreate($"https://{expectedHost}", UriKind.Absolute, out var endpoint)
+         || endpoint.Scheme != Uri.UriSchemeHttps
+         || !string.Equals(endpoint.IdnHost, expectedHost, StringComparison.Ordinal))
+        {
+            invalidSite = true;
+            return null;
+        }
+
+        var headers = GetDirectHeaders(settings.ApiKey!);
+#if NETCOREAPP
+        // The default HttpClientHandler honours the runtime's HTTPS_PROXY and NO_PROXY settings.
+        // Redirects stay disabled so the API key is sent only to the configured intake host.
+        return new HttpClientRequestFactory(endpoint, headers, timeout: TimeSpan.FromSeconds(5), allowAutoRedirect: false);
+#else
+        // HttpWebRequest uses the platform default proxy and bypass list. Redirects stay disabled
+        // so the API key is sent only to the configured intake host.
+        return new ApiWebRequestFactory(endpoint, headers, timeout: TimeSpan.FromSeconds(5), allowAutoRedirect: false);
+#endif
+    }
+
+    [TestingAndPrivateOnly]
+    internal static IApiRequestFactory CreateLocalRequestFactory(ExporterSettings exporterSettings)
+        => AgentTransportStrategy.Get(
+            exporterSettings,
+            productName: "Feature Flags EVP",
+            tcpTimeout: TimeSpan.FromSeconds(5),
+            httpHeaderHelper: FeatureFlagsEvpHeaderHelper.Instance);
+
+    [TestingAndPrivateOnly]
+    internal static bool IsDefinitivePreSendSocketFailure(SocketException exception)
+        => exception.SocketErrorCode is SocketError.HostNotFound
+                                             or SocketError.TryAgain
+                                             or SocketError.ConnectionRefused
+                                             or SocketError.NetworkUnreachable
+                                             or SocketError.HostUnreachable
+                                             or SocketError.AddressNotAvailable
+        || exception.ErrorCode == 2 // ENOENT for a missing Unix domain socket
+        || exception.ErrorCode == 10061; // WSAECONNREFUSED
+
+    private static NetworkFailure ClassifyNetworkFailure(Exception exception)
+    {
+        var isNetworkFailure = false;
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            switch (current)
+            {
+                case SocketException socketException:
+                    return IsDefinitivePreSendSocketFailure(socketException)
+                               ? NetworkFailure.DefinitivePreSend
+                               : NetworkFailure.Ambiguous;
+                case FileNotFoundException:
+                    return NetworkFailure.DefinitivePreSend;
+                case WebException webException:
+                    switch (webException.Status)
+                    {
+                        case WebExceptionStatus.ConnectFailure:
+                        case WebExceptionStatus.NameResolutionFailure:
+                        case WebExceptionStatus.ProxyNameResolutionFailure:
+                            return NetworkFailure.DefinitivePreSend;
+                        case WebExceptionStatus.ConnectionClosed:
+                        case WebExceptionStatus.KeepAliveFailure:
+                        case WebExceptionStatus.PipelineFailure:
+                        case WebExceptionStatus.ReceiveFailure:
+                        case WebExceptionStatus.RequestCanceled:
+                        case WebExceptionStatus.SendFailure:
+                        case WebExceptionStatus.Timeout:
+                            return NetworkFailure.Ambiguous;
+                    }
+
+                    isNetworkFailure = true;
+                    break;
+#if NETCOREAPP
+                case HttpRequestException:
+#endif
+                case IOException:
+                case OperationCanceledException:
+                case TimeoutException:
+                    isNetworkFailure = true;
+                    break;
+            }
+        }
+
+        return isNetworkFailure ? NetworkFailure.Ambiguous : NetworkFailure.None;
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _initialDiscovery.TrySetResult(false);
+        _settingsSubscription?.Dispose();
+        if (_discoverySubscribed)
+        {
+            _discoveryService.RemoveSubscription(_discoveryCallback);
+        }
+    }
+
+    internal Task SendAsync<T>(T payload, string intakePath, JsonSerializerSettings serializerSettings)
+        => SendAsync(intakePath, request => request.PostAsJsonAsync(payload, MultipartCompression.GZip, serializerSettings));
+
+    internal Task SendCompressedAsync(ArraySegment<byte> payload, string intakePath)
+        => SendAsync(intakePath, request => request.PostAsync(payload, MimeTypes.Json, "gzip"));
+
+    private async Task SendAsync(string intakePath, Func<IApiRequest, Task<IApiResponse>> sendAsync)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
+        if (Volatile.Read(ref _directIsSticky) != 0)
+        {
+            await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        var localProxyEndpoint = Volatile.Read(ref _localProxyEndpoint);
+        if (localProxyEndpoint is not null)
+        {
+            await TrySendLocalAsync(intakePath, localProxyEndpoint, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        if (_source == FeatureFlagsSource.Agentless && Volatile.Read(ref _discoveryKnown) == 0)
+        {
+            var completed = await Task.WhenAny(_initialDiscovery.Task, Task.Delay(_initialDiscoveryWait)).ConfigureAwait(false);
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
+            if (completed != _initialDiscovery.Task && Volatile.Read(ref _discoveryKnown) == 0)
+            {
+                Volatile.Write(ref _discoveryKnown, 1);
+                _initialDiscovery.TrySetResult(false);
+            }
+        }
+
+        localProxyEndpoint = Volatile.Read(ref _localProxyEndpoint);
+        if (localProxyEndpoint is not null)
+        {
+            await TrySendLocalAsync(intakePath, localProxyEndpoint, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        if (_source == FeatureFlagsSource.Agentless && _directRequestFactory is not null)
+        {
+            Interlocked.Exchange(ref _directIsSticky, 1);
+            await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+            return;
+        }
+
+        if (Interlocked.Exchange(ref _unavailableWarningLogged, 1) == 0)
+        {
+            WarnUnavailable();
+        }
+    }
+
+    private void WarnInvalidSite()
+    {
+        const string Message = "Feature Flags direct event delivery is disabled because DD_SITE is not a valid DNS site suffix";
+        if (_warningSink is { } warningSink)
+        {
+            warningSink(Message);
+        }
+        else
+        {
+            Log.Warning("Feature Flags direct event delivery is disabled because DD_SITE is not a valid DNS site suffix");
+        }
+    }
+
+    private void WarnUnavailable()
+    {
+        const string Message = "Feature Flags event delivery is unavailable because no compatible local EVP route or direct intake credentials are available";
+        if (_warningSink is { } warningSink)
+        {
+            warningSink(Message);
+        }
+        else
+        {
+            Log.Warning("Feature Flags event delivery is unavailable because no compatible local EVP route or direct intake credentials are available");
+        }
+    }
+
+    private void UpdateAgentConfiguration(AgentConfiguration configuration)
+    {
+        // Agentless event delivery requires the Agent to preserve the logical producer identity.
+        // Older Agents can advertise EVP while silently dropping these headers, so use direct
+        // intake instead unless /info explicitly advertises both forwarding capabilities.
+        var endpoint = configuration.EventPlatformProxySupportsEvpOriginHeaders
+                           ? configuration.EventPlatformProxyEndpoint switch
+                           {
+                               EventPlatformProxyV4 => EventPlatformProxyV4,
+                               EventPlatformProxyV2 => EventPlatformProxyV2,
+                               _ => null,
+                           }
+                           : null;
+
+        Volatile.Write(ref _localProxyEndpoint, endpoint);
+        if (endpoint is not null)
+        {
+            Interlocked.Exchange(ref _localUnavailableUntilUtcTicks, 0);
+        }
+
+        Volatile.Write(ref _discoveryKnown, 1);
+        _initialDiscovery.TrySetResult(true);
+    }
+
+    private async Task TrySendLocalAsync(string intakePath, string localProxyEndpoint, Func<IApiRequest, Task<IApiResponse>> sendAsync)
+    {
+        var unavailableUntilUtcTicks = Interlocked.Read(ref _localUnavailableUntilUtcTicks);
+        var isRecoveryProbe = unavailableUntilUtcTicks != 0;
+        if (isRecoveryProbe
+         && (_utcNow().UtcTicks < unavailableUntilUtcTicks
+          || Interlocked.CompareExchange(ref _localRecoveryProbeInProgress, 1, 0) != 0))
+        {
+            if (Interlocked.Exchange(ref _unavailableWarningLogged, 1) == 0)
+            {
+                WarnUnavailable();
+            }
+
+            return;
+        }
+
+        try
+        {
+            await SendLocalAsync(intakePath, localProxyEndpoint, sendAsync).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (isRecoveryProbe)
+            {
+                Interlocked.Exchange(ref _localRecoveryProbeInProgress, 0);
+            }
+        }
+    }
+
+    private async Task SendLocalAsync(string intakePath, string localProxyEndpoint, Func<IApiRequest, Task<IApiResponse>> sendAsync)
+    {
+        var localFactory = Volatile.Read(ref _localRequestFactory);
+        var endpoint = localFactory.GetEndpoint($"{localProxyEndpoint}/{intakePath}");
+
+        try
+        {
+            var request = localFactory.Create(endpoint);
+            using var response = await sendAsync(request).ConfigureAwait(false);
+            if (response.StatusCode is >= 200 and < 300)
+            {
+                Interlocked.Exchange(ref _localUnavailableUntilUtcTicks, 0);
+                return;
+            }
+
+            // The Agent contract proves these statuses mean the proxy route did not accept the
+            // payload. An upstream 403 is not safe to replay because it may have been forwarded.
+            if (response.StatusCode is 404 or 405 && LeaveLocalRoute())
+            {
+                await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+                return;
+            }
+
+            Log.Warning<int>("Feature Flags local EVP request failed with HTTP status code {StatusCode}", response.StatusCode);
+        }
+        catch (Exception ex) when (ClassifyNetworkFailure(ex) is NetworkFailure.DefinitivePreSend)
+        {
+            if (LeaveLocalRoute())
+            {
+                await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+            }
+            else
+            {
+                Log.ErrorSkipTelemetry(ex, "Feature Flags local EVP request failed before the payload was sent");
+            }
+        }
+        catch (Exception ex) when (ClassifyNetworkFailure(ex) is NetworkFailure.Ambiguous)
+        {
+            // The local relay may have received this payload. Switch only future payloads so the
+            // current one can never be duplicated across the local and direct routes.
+            LeaveLocalRoute();
+
+            Log.ErrorSkipTelemetry(ex, "Feature Flags local EVP request failed ambiguously; the current event batch will not be replayed");
+        }
+    }
+
+    private bool LeaveLocalRoute()
+    {
+        if (_source != FeatureFlagsSource.Agentless)
+        {
+            return false;
+        }
+
+        if (_directRequestFactory is not null)
+        {
+            Interlocked.Exchange(ref _directIsSticky, 1);
+            return true;
+        }
+
+        var unavailableUntil = _utcNow().Add(_routeRecoveryCooldown).UtcTicks;
+        Interlocked.Exchange(ref _localUnavailableUntilUtcTicks, unavailableUntil);
+        return false;
+    }
+
+    private async Task SendDirectAsync(string intakePath, Func<IApiRequest, Task<IApiResponse>> sendAsync)
+    {
+        var directFactory = _directRequestFactory;
+        if (directFactory is null)
+        {
+            return;
+        }
+
+        var endpoint = directFactory.GetEndpoint(intakePath);
+        try
+        {
+            var request = directFactory.Create(endpoint);
+            using var response = await sendAsync(request).ConfigureAwait(false);
+            if (response.StatusCode is < 200 or >= 300)
+            {
+                Log.Warning<int>("Feature Flags direct EVP request failed with HTTP status code {StatusCode}", response.StatusCode);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Direct intake is terminal: never loop a failed direct request back through the Agent.
+            Log.ErrorSkipTelemetry(ex, "Feature Flags direct EVP request failed");
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpTransport.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Evp/FeatureFlagsEvpTransport.cs
@@ -442,12 +442,23 @@ internal sealed class FeatureFlagsEvpTransport : IDisposable
 
             // The Agent contract proves these statuses mean the proxy route did not accept the
             // payload. An upstream 403 is not safe to replay because it may have been forwarded.
-            if (response.StatusCode is 404 or 405 && LeaveLocalRoute())
+            if (response.StatusCode is 404 or 405)
             {
-                await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+                if (LeaveLocalRoute())
+                {
+                    await SendDirectAsync(intakePath, sendAsync).ConfigureAwait(false);
+                }
+                else
+                {
+                    Log.Warning<int>("Feature Flags local EVP request failed with HTTP status code {StatusCode}", response.StatusCode);
+                }
+
                 return;
             }
 
+            // Other responses may have come from upstream after the Agent accepted the payload.
+            // Never replay this batch, but leave the failed route for future Agentless batches.
+            LeaveLocalRoute();
             Log.Warning<int>("Feature Flags local EVP request failed with HTTP status code {StatusCode}", response.StatusCode);
         }
         catch (Exception ex) when (ClassifyNetworkFailure(ex) is NetworkFailure.DefinitivePreSend)

--- a/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/Exposure/ExposureApi.cs
@@ -7,15 +7,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace.Agent;
-using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags.Evp;
 using Datadog.Trace.FeatureFlags.Exposure.Model;
-using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -28,7 +24,9 @@ internal sealed class ExposureApi : IDisposable
     internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ExposureApi));
 
     private const int DefaultCapacity = 1 << 16; // 65536 elements
-    public const string ExposurePath = "evp_proxy/v2/api/v2/exposures";
+    private static readonly TimeSpan DefaultSendInterval = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(10);
+
     [TestingAndPrivateOnly]
     internal static readonly JsonSerializerSettings SerializerSettings = new()
     {
@@ -39,44 +37,37 @@ internal sealed class ExposureApi : IDisposable
         }
     };
 
-    private readonly TaskCompletionSource<bool> _processExit = new();
-    private readonly TimeSpan _sendInterval = TimeSpan.FromSeconds(10);
+    private readonly TaskCompletionSource<bool> _processExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _lifecycleLock = new();
+    private readonly TimeSpan _sendInterval;
+    private readonly TimeSpan _shutdownTimeout;
     private readonly Queue<ExposureEvent> _exposures = new Queue<ExposureEvent>();
-
     private readonly ExposureCache _exposureCache = new ExposureCache(DefaultCapacity);
-    private IApiRequestFactory _apiRequestFactory;
-    private Dictionary<string, string> _context;
-    private int _started;
+    private readonly FeatureFlagsEvpTransport _transport;
+    private readonly IDisposable _settingsSubscription;
 
-    internal ExposureApi(TracerSettings tracerSettings)
+    private Dictionary<string, string> _context;
+    private Task? _sendLoopTask;
+    private bool _disposed;
+
+    internal ExposureApi(
+        TracerSettings tracerSettings,
+        FeatureFlagsEvpTransport transport,
+        TimeSpan? sendInterval = null,
+        TimeSpan? shutdownTimeout = null)
     {
-        UpdateApi(tracerSettings.Manager.InitialExporterSettings);
+        _transport = transport;
+        _sendInterval = sendInterval ?? DefaultSendInterval;
+        _shutdownTimeout = shutdownTimeout ?? DefaultShutdownTimeout;
         UpdateContext(tracerSettings.Manager.InitialMutableSettings);
 
-        tracerSettings.Manager.SubscribeToChanges(changes =>
+        _settingsSubscription = tracerSettings.Manager.SubscribeToChanges(changes =>
         {
-            if (changes.UpdatedExporter is { } exporter)
-            {
-                UpdateApi(exporter);
-            }
-
             if (changes.UpdatedMutable is { } mutable)
             {
                 UpdateContext(mutable);
             }
         });
-
-        [MemberNotNull(nameof(_apiRequestFactory))]
-        void UpdateApi(ExporterSettings exporterSettings)
-        {
-            Log.Debug("ExposureApi::UpdateApi-> Applying settings");
-            var apiRequestFactory = AgentTransportStrategy.Get(
-                exporterSettings,
-                productName: "FeatureFlags exposure",
-                tcpTimeout: TimeSpan.FromSeconds(5),
-                httpHeaderHelper: EventPlatformHeaderHelper.Instance);
-            Interlocked.Exchange(ref _apiRequestFactory!, apiRequestFactory);
-        }
 
         [MemberNotNull(nameof(_context))]
         void UpdateContext(MutableSettings settings)
@@ -94,17 +85,29 @@ internal sealed class ExposureApi : IDisposable
 
     public void Dispose()
     {
-        _processExit.TrySetResult(true);
-    }
-
-    public void TryToStartSendLoopIfNotStarted()
-    {
-        if (Interlocked.CompareExchange(ref _started, 1, 0) != 0)
+        Task? sendLoopTask;
+        lock (_lifecycleLock)
         {
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _processExit.TrySetResult(true);
+            sendLoopTask = _sendLoopTask;
         }
 
-        _ = Task.Run(SendLoopAsync).ContinueWith(t => { Log.Error(t.Exception, "FeatureFlags Exposure send loop failed"); }, TaskContinuationOptions.OnlyOnFaulted);
+        if (sendLoopTask is not null)
+        {
+            var completed = Task.WhenAny(sendLoopTask, Task.Delay(_shutdownTimeout)).GetAwaiter().GetResult();
+            if (completed != sendLoopTask)
+            {
+                Log.Warning("Could not finish flushing Feature Flags exposures before process end");
+            }
+        }
+
+        _settingsSubscription.Dispose();
     }
 
     private async Task SendLoopAsync()
@@ -112,21 +115,7 @@ internal sealed class ExposureApi : IDisposable
         Log.Debug("ExposureApi::SendLoopAsync -> Enter");
         while (!_processExit.Task.IsCompleted)
         {
-            try
-            {
-                var apiRequestFactory = _apiRequestFactory;
-                var uri = apiRequestFactory.GetEndpoint(ExposurePath);
-                var payload = TryGetPayload();
-                if (payload is not null)
-                {
-                    var request = apiRequestFactory.Create(uri);
-                    using var response = await request.PostAsJsonAsync(payload, MultipartCompression.GZip, SerializerSettings).ConfigureAwait(false);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error while sending Feature Flags exposures to the agent");
-            }
+            await FlushAsync().ConfigureAwait(false);
 
             try
             {
@@ -136,8 +125,27 @@ internal sealed class ExposureApi : IDisposable
             {
                 // We are shutting down, so don't do anything about it
             }
+        }
 
-            Log.Debug("ExposureApi::SendLoopAsync -> Exit");
+        // Dispose signals the loop and then waits for this bounded final flush. This prevents the
+        // common short-lived-process loss mode without allowing shutdown to hang indefinitely.
+        await FlushAsync().ConfigureAwait(false);
+        Log.Debug("ExposureApi::SendLoopAsync -> Exit");
+    }
+
+    private async Task FlushAsync()
+    {
+        try
+        {
+            var payload = TryGetPayload();
+            if (payload is not null)
+            {
+                await _transport.SendAsync(payload, FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error while sending Feature Flags exposures");
         }
     }
 
@@ -161,15 +169,31 @@ internal sealed class ExposureApi : IDisposable
 
     public void SendExposure(in ExposureEvent exposure)
     {
-        if (_exposureCache.Add(exposure))
+        lock (_lifecycleLock)
         {
-            lock (_exposures)
+            if (_disposed)
             {
-                _exposures.Enqueue(exposure);
+                return;
+            }
+
+            if (_exposureCache.Add(exposure))
+            {
+                lock (_exposures)
+                {
+                    _exposures.Enqueue(exposure);
+                }
+            }
+
+            if (_sendLoopTask is null)
+            {
+                _sendLoopTask = Task.Run(SendLoopAsync);
+                _sendLoopTask.ContinueWith(
+                    t => Log.Error(t.Exception, "FeatureFlags Exposure send loop failed"),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted,
+                    TaskScheduler.Default);
             }
         }
-
-        TryToStartSendLoopIfNotStarted();
     }
 
     private sealed class ExposuresRequest(Dictionary<string, string> context, List<ExposureEvent> exposures)

--- a/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsModule.cs
+++ b/tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsModule.cs
@@ -8,7 +8,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags.Evp;
 using Datadog.Trace.FeatureFlags.Exposure;
 using Datadog.Trace.FeatureFlags.Exposure.Model;
 using Datadog.Trace.FeatureFlags.Rcm;
@@ -25,29 +27,31 @@ namespace Datadog.Trace.FeatureFlags
         private readonly IRcmSubscriptionManager _rcmSubscriptionManager;
         private readonly ISubscription _rcmSubscription;
         private readonly FfeProduct _ffeProduct;
+        private readonly FeatureFlagsEvpTransport _evpTransport;
         private readonly ExposureApi _exposureApi;
         private readonly bool _spanEnrichmentEnabled;
 
         private Action? _onNewConfigEventHander;
         private FeatureFlagsEvaluator? _evaluator;
 
-        internal FeatureFlagsModule(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager)
+        internal FeatureFlagsModule(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager, IDiscoveryService? discoveryService = null)
         {
             Log.Debug("FeatureFlagsModule ENABLED");
             _spanEnrichmentEnabled = settings.IsSpanEnrichmentEnabled;
             _rcmSubscriptionManager = rcmSubscriptionManager;
-            _exposureApi = new ExposureApi(settings);
+            _evpTransport = new FeatureFlagsEvpTransport(settings, discoveryService ?? NullDiscoveryService.Instance);
+            _exposureApi = new ExposureApi(settings, _evpTransport);
             _ffeProduct = new FfeProduct(UpdateRemoteConfig);
             _rcmSubscription = new Subscription(_ffeProduct.UpdateFromRcm, RcmProducts.FfeFlags);
             _rcmSubscriptionManager.SubscribeToChanges(_rcmSubscription!);
             _rcmSubscriptionManager.SetCapability(RcmCapabilitiesIndices.FfeFlagConfigurationRules, true);
         }
 
-        public static FeatureFlagsModule? Create(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager)
+        public static FeatureFlagsModule? Create(TracerSettings settings, IRcmSubscriptionManager rcmSubscriptionManager, IDiscoveryService? discoveryService = null)
         {
             if (settings.IsFlaggingProviderEnabled)
             {
-                return new FeatureFlagsModule(settings, rcmSubscriptionManager);
+                return new FeatureFlagsModule(settings, rcmSubscriptionManager, discoveryService);
             }
 
             return null;
@@ -56,6 +60,7 @@ namespace Datadog.Trace.FeatureFlags
         public void Dispose()
         {
             _exposureApi.Dispose();
+            _evpTransport.Dispose();
         }
 
         internal void RegisterOnNewConfigEventHandler(Action? onNewConfig)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -189,7 +189,7 @@ namespace Datadog.Trace
                 }
             }
 
-            featureFlags = FeatureFlagsModule.Create(settings, RcmSubscriptionManager.Instance);
+            featureFlags = FeatureFlagsModule.Create(settings, RcmSubscriptionManager.Instance, discoveryService);
 
             return CreateTracerManagerFrom(
                 settings,

--- a/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestRequestFactory.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestRequestFactory.cs
@@ -15,6 +15,7 @@ internal class TestRequestFactory : IApiRequestFactory
 {
     private readonly Uri _baseEndpoint;
     private readonly Func<Uri, TestApiRequest>[] _requestsToSend;
+    private readonly object _requestsLock = new();
 
     public TestRequestFactory(params Func<Uri, TestApiRequest>[] requestsToSend)
         : this(new Uri("http://localhost"), requestsToSend)
@@ -38,13 +39,16 @@ internal class TestRequestFactory : IApiRequestFactory
 
     public IApiRequest Create(Uri endpoint)
     {
-        var request = (_requestsToSend is null || RequestsSent.Count >= _requestsToSend.Length)
-                          ? new TestApiRequest(endpoint)
-                          : _requestsToSend[RequestsSent.Count](endpoint);
+        lock (_requestsLock)
+        {
+            var request = (_requestsToSend is null || RequestsSent.Count >= _requestsToSend.Length)
+                              ? new TestApiRequest(endpoint)
+                              : _requestsToSend[RequestsSent.Count](endpoint);
 
-        RequestsSent.Add(request);
+            RequestsSent.Add(request);
 
-        return request;
+            return request;
+        }
     }
 
     public void SetProxy(WebProxy proxy, NetworkCredential credential)

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
@@ -29,7 +29,8 @@ internal class DiscoveryServiceMock : IDiscoveryService
         string containerTagsHash = "containerTagsHash",
         bool clientDropP0 = true,
         bool spanMetaStructs = true,
-        bool spanEvents = true)
+        bool spanEvents = true,
+        bool eventPlatformProxySupportsEvpOriginHeaders = true)
         => TriggerChange(
             new AgentConfiguration(
                 configurationEndpoint: configurationEndpoint,
@@ -46,7 +47,8 @@ internal class DiscoveryServiceMock : IDiscoveryService
                 containerTagsHash: containerTagsHash,
                 clientDropP0: clientDropP0,
                 spanMetaStructs: spanMetaStructs,
-                spanEvents: spanEvents));
+                spanEvents: spanEvents,
+                eventPlatformProxySupportsEvpOriginHeaders: eventPlatformProxySupportsEvpOriginHeaders));
 
     public void TriggerChange(AgentConfiguration config)
     {

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -76,7 +76,30 @@ public class DiscoveryServiceTests
         config.StatsEndpoint.Should().NotBeNullOrEmpty();
         config.DataStreamsMonitoringEndpoint.Should().NotBeNullOrEmpty();
         config.EventPlatformProxyEndpoint.Should().Be(evpProxyEndpoint);
+        config.EventPlatformProxySupportsEvpOriginHeaders.Should().BeFalse();
         await ds.DisposeAsync();
+    }
+
+    [Theory]
+    [InlineData("null", false)]
+    [InlineData("[]", false)]
+    [InlineData("[\"DD-EVP-ORIGIN\"]", false)]
+    [InlineData("[\"DD-EVP-ORIGIN-VERSION\"]", false)]
+    [InlineData("[\" dd-evp-origin-version \",\"dd-evp-origin\"]", true)]
+    public async Task ReportsWhetherEvpProxyCanForwardLogicalProducerIdentity(string allowedHeaders, bool expected)
+    {
+        AgentConfiguration config = null;
+        var response = $"{{\"endpoints\":[\"/evp_proxy/v4/\"],\"evp_proxy_allowed_headers\":{allowedHeaders}}}";
+        var factory = new TestRequestFactory(x => new TestApiRequest(x, responseContent: response));
+
+        await using var ds = new DiscoveryService(factory, DisabledServiceRemappingHash, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs, autoStartLoop: false);
+        ds.SubscribeToChanges(x => config = x);
+
+        await ds.RunOneIterationAsync(previousRetryDuration: null);
+
+        config.Should().NotBeNull();
+        config.EventPlatformProxyEndpoint.Should().Be("evp_proxy/v4");
+        config.EventPlatformProxySupportsEvpOriginHeaders.Should().Be(expected);
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/AgentlessEndpointTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/AgentlessEndpointTests.cs
@@ -19,6 +19,7 @@ public class AgentlessEndpointTests
     [Theory]
     [InlineData("datadoghq.com", "https://ufc-server.ff-cdn.datadoghq.com" + DefaultPath)]
     [InlineData("DATADOGHQ.COM", "https://ufc-server.ff-cdn.datadoghq.com" + DefaultPath)] // site is lowercased
+    [InlineData(" datadoghq.com ", "https://ufc-server.ff-cdn.datadoghq.com" + DefaultPath)] // surrounding whitespace is trimmed
     [InlineData("datad0g.com", "https://ufc-server.ff-cdn.datad0g.com" + DefaultPath)] // staging
     [InlineData("ddog-gov.com", "https://ufc-server.ff-cdn.ddog-gov.com" + DefaultPath)] // govcloud
     public void DerivesManagedEndpointFromSite(string site, string expected)
@@ -140,6 +141,11 @@ public class AgentlessEndpointTests
     [InlineData("datadoghq.com/../evil")] // a path escapes the host
     [InlineData("datadoghq.com?x=1")] // a query escapes the host
     [InlineData("datadoghq.com#f")] // a fragment escapes the host
+    [InlineData("datadoghq.com\\attacker.example")] // a backslash can be normalized as a URL separator
+    [InlineData("dátadoghq.com")] // managed endpoints do not implicitly convert Unicode to IDN
+    [InlineData("-datadoghq.com")]
+    [InlineData("datadoghq.com-")]
+    [InlineData("datadoghq..com")]
     public void RejectsMalformedSiteWithoutThrowing(string site)
     {
         AgentlessEndpoint.TryCreate(site, baseUrl: null, out var endpoint, out var error)

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/ExposureApiTests.cs
@@ -1,0 +1,147 @@
+// <copyright file="ExposureApiTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags;
+using Datadog.Trace.FeatureFlags.Evp;
+using Datadog.Trace.FeatureFlags.Exposure;
+using Datadog.Trace.FeatureFlags.Exposure.Model;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using Datadog.Trace.Tests.Agent;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.FeatureFlags;
+
+public class ExposureApiTests
+{
+    [Fact]
+    public async Task DisposeFlushesEventsQueuedWhileAnEarlierBatchIsSending()
+    {
+        var firstSendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var local = new TestRequestFactory(
+            new Uri("http://agent:8126/"),
+            uri => new BlockingApiRequest(uri, firstSendStarted, releaseFirstSend),
+            uri => new RecordingJsonApiRequest(uri));
+        var transport = CreateLocalTransport(local);
+        var api = new ExposureApi(CreateSettings(), transport, TimeSpan.FromHours(1), TimeSpan.FromSeconds(2));
+
+        api.SendExposure(CreateExposure("first"));
+        (await Task.WhenAny(firstSendStarted.Task, Task.Delay(TimeSpan.FromSeconds(1))))
+           .Should().BeSameAs(firstSendStarted.Task);
+
+        api.SendExposure(CreateExposure("second"));
+        var dispose = Task.Run(api.Dispose);
+        releaseFirstSend.TrySetResult(true);
+
+        (await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(3)))).Should().BeSameAs(dispose);
+        await dispose;
+
+        local.RequestsSent.Should().HaveCount(2, "the second exposure is sent by the shutdown flush");
+        var finalRequest = local.RequestsSent[1].Should().BeOfType<RecordingJsonApiRequest>().Subject;
+        finalRequest.Endpoint.AbsolutePath.Should().Be("/evp_proxy/v4/api/v2/exposures");
+        finalRequest.Compression.Should().Be(MultipartCompression.GZip);
+        var payload = JObject.Parse(finalRequest.PayloadJson);
+        payload["context"]!["service"]!.Value<string>().Should().NotBeNullOrEmpty();
+        payload["exposures"]!.Should().ContainSingle();
+        payload["exposures"]![0]!["flag"]!["key"]!.Value<string>().Should().Be("second");
+    }
+
+    [Fact]
+    public async Task DisposeHasABoundedWaitWhenTheNetworkSendDoesNotFinish()
+    {
+        var sendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var local = new TestRequestFactory(
+            new Uri("http://agent:8126/"),
+            uri => new BlockingApiRequest(uri, sendStarted, releaseSend));
+        var transport = CreateLocalTransport(local);
+        var api = new ExposureApi(CreateSettings(), transport, TimeSpan.FromHours(1), TimeSpan.FromMilliseconds(25));
+
+        api.SendExposure(CreateExposure("first"));
+        (await Task.WhenAny(sendStarted.Task, Task.Delay(TimeSpan.FromSeconds(1))))
+           .Should().BeSameAs(sendStarted.Task);
+
+        var stopwatch = Stopwatch.StartNew();
+        api.Dispose();
+        stopwatch.Stop();
+
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(1));
+        releaseSend.TrySetResult(true);
+    }
+
+    [Fact]
+    public async Task SendExposureAfterDisposeIsIgnored()
+    {
+        var local = new TestRequestFactory(new Uri("http://agent:8126/"));
+        var transport = CreateLocalTransport(local);
+        var api = new ExposureApi(CreateSettings(), transport, TimeSpan.FromMilliseconds(1), TimeSpan.FromSeconds(1));
+
+        api.Dispose();
+        api.SendExposure(CreateExposure("after-dispose"));
+        await Task.Delay(TimeSpan.FromMilliseconds(20));
+
+        local.RequestsSent.Should().BeEmpty();
+    }
+
+    private static FeatureFlagsEvpTransport CreateLocalTransport(TestRequestFactory local)
+        => new(
+            FeatureFlagsSource.Agentless,
+            local,
+            directRequestFactory: null,
+            discoveryService: new DiscoveryServiceMock(),
+            initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+    private static ExposureEvent CreateExposure(string flag)
+        => new(
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            new Allocation("allocation"),
+            new Flag(flag),
+            new Variant("variant"),
+            new Subject("subject", new Dictionary<string, object?>()));
+
+    private static TracerSettings CreateSettings()
+        => new(new NameValueConfigurationSource(new NameValueCollection()));
+
+    private sealed class BlockingApiRequest(
+        Uri endpoint,
+        TaskCompletionSource<bool> sendStarted,
+        TaskCompletionSource<bool> releaseSend) : TestApiRequest(endpoint)
+    {
+        public override async Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
+        {
+            sendStarted.TrySetResult(true);
+            await releaseSend.Task.ConfigureAwait(false);
+            return await base.PostAsJsonAsync(payload, compression, settings).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class RecordingJsonApiRequest(Uri endpoint) : TestApiRequest(endpoint)
+    {
+        public string PayloadJson { get; private set; } = string.Empty;
+
+        public MultipartCompression Compression { get; private set; }
+
+        public override Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
+        {
+            PayloadJson = JsonConvert.SerializeObject(payload, settings);
+            Compression = compression;
+            return base.PostAsJsonAsync(payload, compression, settings);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvpTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvpTransportTests.cs
@@ -329,20 +329,49 @@ public class FeatureFlagsEvpTransportTests
     [InlineData(429)]
     [InlineData(500)]
     [InlineData(503)]
-    public async Task PotentiallyForwardedOrRetryableHttpFailureDoesNotFallback(int statusCode)
+    public async Task PotentiallyForwardedOrRetryableHttpFailureChangesOnlyFutureBatchesToDirect(int statusCode)
     {
         var local = CreateFactory(
             "http://agent:8126/",
-            uri => new TestApiRequest(uri, statusCode),
-            uri => new TestApiRequest(uri));
+            uri => new TestApiRequest(uri, statusCode));
         var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
         using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
 
         await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
         await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
 
-        local.RequestsSent.Should().HaveCount(2);
-        direct.RequestsSent.Should().BeEmpty("the SDK must not replay a batch that the relay may have accepted");
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().ContainSingle("the failed batch is not replayed, but the next batch uses direct intake");
+    }
+
+    [Theory]
+    [InlineData(403)]
+    [InlineData(429)]
+    [InlineData(500)]
+    [InlineData(503)]
+    public async Task PotentiallyForwardedOrRetryableHttpFailureWithoutDirectCredentialsEntersCooldown(int statusCode)
+    {
+        var now = new DateTimeOffset(2026, 9, 12, 0, 0, 0, TimeSpan.Zero);
+        var local = CreateFactory(
+            "http://agent:8126/",
+            uri => new TestApiRequest(uri, statusCode),
+            uri => new TestApiRequest(uri));
+        using var transport = CreateTransport(
+            local,
+            direct: null,
+            initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4,
+            routeRecoveryCooldown: TimeSpan.FromMinutes(1),
+            utcNow: () => now);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle("the failed route remains unavailable during cooldown");
+
+        now = now.AddMinutes(1);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().HaveCount(2, "one post-cooldown local probe restores delivery");
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvpTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsEvpTransportTests.cs
@@ -1,0 +1,649 @@
+// <copyright file="FeatureFlagsEvpTransportTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.FeatureFlags;
+using Datadog.Trace.FeatureFlags.Evp;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using Datadog.Trace.Tests.Agent;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.FeatureFlags;
+
+public class FeatureFlagsEvpTransportTests
+{
+    private static readonly JsonSerializerSettings SerializerSettings = new();
+
+    public static IEnumerable<object[]> AmbiguousFailures()
+    {
+        yield return [new IOException("broken pipe")];
+        yield return [new TimeoutException("timeout")];
+        yield return [new TaskCanceledException("HTTP timeout")];
+        yield return [new SocketException((int)SocketError.ConnectionReset)];
+        yield return [new WebException("send failed", WebExceptionStatus.SendFailure)];
+    }
+
+    public static IEnumerable<object[]> DefinitivePreSendFailures()
+    {
+        yield return [new SocketException((int)SocketError.HostNotFound)];
+        yield return [new SocketException((int)SocketError.TryAgain)];
+        yield return [new SocketException((int)SocketError.ConnectionRefused)];
+        yield return [new SocketException((int)SocketError.NetworkUnreachable)];
+        yield return [new SocketException((int)SocketError.HostUnreachable)];
+        yield return [new SocketException((int)SocketError.AddressNotAvailable)];
+        yield return [new SocketException(10061)]; // Windows WSAECONNREFUSED
+        yield return [new FileNotFoundException("missing Unix domain socket")];
+        yield return [new WebException("refused", WebExceptionStatus.ConnectFailure)];
+    }
+
+    [Theory]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV4, FeatureFlagsEvpTransport.ExposureIntakePath)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV4, FeatureFlagsEvpTransport.FlagEvaluationIntakePath)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV2, FeatureFlagsEvpTransport.ExposureIntakePath)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV2, FeatureFlagsEvpTransport.FlagEvaluationIntakePath)]
+    public async Task DiscoverySelectsAdvertisedLocalRoute(string proxyEndpoint, string intakePath)
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery);
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: proxyEndpoint);
+        await transport.SendAsync(new object(), intakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle()
+             .Which.Endpoint.AbsolutePath.Should().Be($"/{proxyEndpoint}/{intakePath}");
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AgentlessLocalSelectionRequiresIdentityHeaderForwarding(bool supportsBothIdentityHeaders)
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery);
+
+        discovery.TriggerChange(
+            eventPlatformProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4,
+            eventPlatformProxySupportsEvpOriginHeaders: supportsBothIdentityHeaders);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        if (supportsBothIdentityHeaders)
+        {
+            local.RequestsSent.Should().ContainSingle();
+            direct.RequestsSent.Should().BeEmpty();
+        }
+        else
+        {
+            local.RequestsSent.Should().BeEmpty("the Agent cannot preserve the logical SDK identity");
+            direct.RequestsSent.Should().ContainSingle();
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentInitialSendsShareOneDiscoverySubscription()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery, initialDiscoveryKnown: false);
+
+        var exposure = transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        var evaluation = transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        discovery.Callbacks.Should().ContainSingle("the transport consumes the tracer's shared /info discovery stream");
+        discovery.TriggerChange(eventPlatformProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+        await Task.WhenAll(exposure, evaluation);
+
+        local.RequestsSent.Should().HaveCount(2);
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DirectRouteIsStickyAfterDiscoveryReportsNoCompatibleProxy()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery);
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: "v0.4/traces");
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().BeEmpty();
+        direct.RequestsSent.Select(r => r.Endpoint.AbsolutePath).Should().Equal(
+            $"/{FeatureFlagsEvpTransport.ExposureIntakePath}",
+            $"/{FeatureFlagsEvpTransport.FlagEvaluationIntakePath}");
+    }
+
+    [Fact]
+    public async Task InitialDiscoveryTimeoutSelectsDirectAndStaysDirect()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(
+            local,
+            direct,
+            initialDiscoveryKnown: false,
+            initialDiscoveryWait: TimeSpan.FromMilliseconds(10));
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().BeEmpty();
+        direct.RequestsSent.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task UnavailableRouteWarnsOnceAndRecoversWhenAgentAppears()
+    {
+        var warnings = new List<string>();
+        var local = CreateFactory("http://agent:8126/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct: null, discovery, warningSink: warnings.Add);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        warnings.Should().ContainSingle();
+        local.RequestsSent.Should().BeEmpty();
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task FailedLocalRouteWithoutDirectCredentialsRecoversAfterCooldown()
+    {
+        var now = new DateTimeOffset(2026, 9, 12, 0, 0, 0, TimeSpan.Zero);
+        var warnings = new List<string>();
+        var local = CreateFactory(
+            "http://agent:8126/",
+            uri => new ThrowingApiRequest(uri, new IOException("ambiguous reset")),
+            uri => new TestApiRequest(uri));
+        using var transport = CreateTransport(
+            local,
+            direct: null,
+            initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4,
+            routeRecoveryCooldown: TimeSpan.FromMinutes(1),
+            utcNow: () => now,
+            warningSink: warnings.Add);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle("flushes must not probe a failed route during cooldown");
+        warnings.Should().ContainSingle();
+
+        now = now.AddMinutes(1);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().HaveCount(3, "one post-cooldown probe restores normal local delivery");
+    }
+
+    [Fact]
+    public async Task ConcurrentFlushesShareOnePostCooldownRecoveryProbe()
+    {
+        var now = new DateTimeOffset(2026, 9, 12, 0, 0, 0, TimeSpan.Zero);
+        var probeStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProbe = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var local = CreateFactory(
+            "http://agent:8126/",
+            uri => new ThrowingApiRequest(uri, new IOException("ambiguous reset")),
+            uri => new BlockingApiRequest(uri, probeStarted, releaseProbe));
+        using var transport = CreateTransport(
+            local,
+            direct: null,
+            initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4,
+            routeRecoveryCooldown: TimeSpan.FromMinutes(1),
+            utcNow: () => now);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        now = now.AddMinutes(1);
+
+        var probe = transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        (await Task.WhenAny(probeStarted.Task, Task.Delay(TimeSpan.FromSeconds(1))))
+           .Should().BeSameAs(probeStarted.Task);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+        local.RequestsSent.Should().HaveCount(2, "a concurrent flush must not start a second recovery probe");
+
+        releaseProbe.TrySetResult(true);
+        await probe;
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().HaveCount(3, "a successful probe restores normal local delivery");
+    }
+
+    [Theory]
+    [InlineData(404)]
+    [InlineData(405)]
+    public async Task UnsupportedLocalRouteWithoutDirectCredentialsEntersCooldown(int statusCode)
+    {
+        var now = new DateTimeOffset(2026, 9, 12, 0, 0, 0, TimeSpan.Zero);
+        var local = CreateFactory(
+            "http://agent:8126/",
+            uri => new TestApiRequest(uri, statusCode),
+            uri => new TestApiRequest(uri));
+        using var transport = CreateTransport(
+            local,
+            direct: null,
+            initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4,
+            routeRecoveryCooldown: TimeSpan.FromMinutes(1),
+            utcNow: () => now);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+
+        now = now.AddMinutes(1);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task RemoteConfigurationAlwaysUsesHistoricalV2WithoutDiscoveryOrDirectCredentials()
+    {
+        var local = CreateFactory(
+            "http://agent:8126/",
+            uri => new TestApiRequest(uri, statusCode: 404),
+            uri => new ThrowingApiRequest(uri, new SocketException((int)SocketError.ConnectionRefused)),
+            uri => new TestApiRequest(uri));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        using var transport = new FeatureFlagsEvpTransport(FeatureFlagsSource.RemoteConfig, local, direct, discovery);
+
+        discovery.Callbacks.Should().BeEmpty("Remote Config must not change its historical transport contract");
+        discovery.TriggerChange(eventPlatformProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().HaveCount(3);
+        local.RequestsSent.Should().OnlyContain(
+            request => request.Endpoint.AbsolutePath == $"/{FeatureFlagsEvpTransport.EventPlatformProxyV2}/{FeatureFlagsEvpTransport.ExposureIntakePath}");
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoteConfigurationProductionConstructionDoesNotSubscribeToDiscovery()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "remote_config"),
+            (ConfigurationKeys.ApiKey, "must-not-be-used"));
+        var discovery = new DiscoveryServiceMock();
+
+        using var transport = new FeatureFlagsEvpTransport(settings, discovery);
+
+        discovery.Callbacks.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(404)]
+    [InlineData(405)]
+    public async Task UnsupportedLocalRouteReplaysCurrentBatchDirectAndStaysDirect(int statusCode)
+    {
+        var local = CreateFactory("http://agent:8126/", uri => new TestApiRequest(uri, statusCode));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().HaveCount(2, "the safe-to-replay batch and later batches use direct intake");
+    }
+
+    [Theory]
+    [InlineData(403)]
+    [InlineData(429)]
+    [InlineData(500)]
+    [InlineData(503)]
+    public async Task PotentiallyForwardedOrRetryableHttpFailureDoesNotFallback(int statusCode)
+    {
+        var local = CreateFactory(
+            "http://agent:8126/",
+            uri => new TestApiRequest(uri, statusCode),
+            uri => new TestApiRequest(uri));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().HaveCount(2);
+        direct.RequestsSent.Should().BeEmpty("the SDK must not replay a batch that the relay may have accepted");
+    }
+
+    [Theory]
+    [MemberData(nameof(DefinitivePreSendFailures))]
+    public async Task DefinitivePreSendFailureReplaysCurrentBatchDirectAndStaysDirect(Exception failure)
+    {
+        var local = CreateFactory("http://agent:8126/", uri => new ThrowingApiRequest(uri, failure));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [MemberData(nameof(AmbiguousFailures))]
+    public async Task AmbiguousLocalFailureChangesOnlyFutureBatchesToDirect(Exception failure)
+    {
+        var local = CreateFactory("http://agent:8126/", uri => new ThrowingApiRequest(uri, failure));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        using var transport = CreateTransport(local, direct, initialLocalProxyEndpoint: FeatureFlagsEvpTransport.EventPlatformProxyV4);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        direct.RequestsSent.Should().BeEmpty("an ambiguously failed batch may already have reached the relay");
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        local.RequestsSent.Should().ContainSingle();
+        direct.RequestsSent.Should().ContainSingle("only a later batch is safe to send direct");
+    }
+
+    [Fact]
+    public async Task DirectFailureNeverLoopsBackToAgent()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory(
+            "https://event-platform-intake.datadoghq.com/",
+            uri => new ThrowingApiRequest(uri, new IOException("direct reset")));
+        using var transport = CreateTransport(local, direct);
+
+        await transport.SendAsync(new object(), FeatureFlagsEvpTransport.FlagEvaluationIntakePath, SerializerSettings);
+
+        direct.RequestsSent.Should().ContainSingle();
+        local.RequestsSent.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV4, false)]
+    [InlineData(FeatureFlagsEvpTransport.EventPlatformProxyV2, false)]
+    [InlineData(null, true)]
+    public async Task CompressedPayloadUsesTheSelectedRoute(string? proxyEndpoint, bool usesDirect)
+    {
+        var local = CreateFactory("http://agent:8126/", uri => new RecordingCompressedApiRequest(uri));
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/", uri => new RecordingCompressedApiRequest(uri));
+        var discovery = new DiscoveryServiceMock();
+        using var transport = CreateTransport(local, direct, discovery);
+
+        discovery.TriggerChange(eventPlatformProxyEndpoint: proxyEndpoint ?? "v0.4/traces");
+        var payload = new byte[] { 1, 2, 3 };
+        await transport.SendCompressedAsync(new ArraySegment<byte>(payload), FeatureFlagsEvpTransport.FlagEvaluationIntakePath);
+
+        var selectedFactory = usesDirect ? direct : local;
+        var request = selectedFactory.RequestsSent.Should().ContainSingle().Which.Should().BeOfType<RecordingCompressedApiRequest>().Subject;
+        request.Endpoint.AbsolutePath.Should().Be(
+            usesDirect
+                ? $"/{FeatureFlagsEvpTransport.FlagEvaluationIntakePath}"
+                : $"/{proxyEndpoint}/{FeatureFlagsEvpTransport.FlagEvaluationIntakePath}");
+        request.Payload.Should().Equal(payload);
+        request.ContentType.Should().Be(MimeTypes.Json);
+        request.ContentEncoding.Should().Be("gzip");
+    }
+
+    [Fact]
+    public void DirectAndLocalHeadersHaveExactIdentityAndCredentialIsolation()
+    {
+        var directHeaders = FeatureFlagsEvpTransport.GetDirectHeaders("test-api-key").ToDictionary(x => x.Key, x => x.Value);
+        var localHeaders = FeatureFlagsEvpHeaderHelper.Instance.DefaultHeaders.ToDictionary(x => x.Key, x => x.Value);
+
+        directHeaders.Should().HaveCount(3);
+        directHeaders.Should().Contain(TelemetryConstants.ApiKeyHeader, "test-api-key");
+        directHeaders.Should().Contain(FeatureFlagsEvpHeaderHelper.EvpOriginHeader, FeatureFlagsEvpHeaderHelper.EvpOrigin);
+        directHeaders.Should().Contain(FeatureFlagsEvpHeaderHelper.EvpOriginVersionHeader, TracerConstants.ThreePartVersion);
+        directHeaders.Should().NotContainKey(FeatureFlagsEvpHeaderHelper.EvpSubdomainHeader);
+
+        localHeaders.Should().Contain(FeatureFlagsEvpHeaderHelper.EvpSubdomainHeader, FeatureFlagsEvpHeaderHelper.EvpSubdomain);
+        localHeaders.Should().Contain(FeatureFlagsEvpHeaderHelper.EvpOriginHeader, FeatureFlagsEvpHeaderHelper.EvpOrigin);
+        localHeaders.Should().Contain(FeatureFlagsEvpHeaderHelper.EvpOriginVersionHeader, TracerConstants.ThreePartVersion);
+        localHeaders.Should().NotContainKey(TelemetryConstants.ApiKeyHeader);
+    }
+
+    [Theory]
+    [InlineData("http://agent:8126/base/path/", "http://agent:8126/base/path/evp_proxy/v4/api/v2/exposures")]
+    [InlineData("https://agent:8126/base/path/", "https://agent:8126/base/path/evp_proxy/v4/api/v2/exposures")]
+    public void LocalHttpFactoryPreservesSchemeAndBasePath(string agentUrl, string expectedEndpoint)
+    {
+        var settings = CreateSettings((ConfigurationKeys.AgentUri, agentUrl));
+
+        var factory = FeatureFlagsEvpTransport.CreateLocalRequestFactory(settings.Manager.InitialExporterSettings);
+
+        factory.GetEndpoint($"{FeatureFlagsEvpTransport.EventPlatformProxyV4}/{FeatureFlagsEvpTransport.ExposureIntakePath}")
+               .Should().Be(new Uri(expectedEndpoint));
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Fact]
+    public void LocalUnixDomainSocketFactoryBuildsEvpRouteOnStreamEndpoint()
+    {
+        var settings = CreateSettings((ConfigurationKeys.AgentUri, "unix:///tmp/dd-apm-test.socket"));
+
+        var factory = FeatureFlagsEvpTransport.CreateLocalRequestFactory(settings.Manager.InitialExporterSettings);
+
+        factory.GetEndpoint($"{FeatureFlagsEvpTransport.EventPlatformProxyV4}/{FeatureFlagsEvpTransport.ExposureIntakePath}")
+               .Should().Be(new Uri("http://localhost/evp_proxy/v4/api/v2/exposures"));
+    }
+#endif
+
+    [Fact]
+    public void LocalNamedPipeFactoryBuildsEvpRouteOnStreamEndpoint()
+    {
+        var settings = CreateSettings((ConfigurationKeys.TracesPipeName, "dd-apm-test-pipe"));
+
+        var factory = FeatureFlagsEvpTransport.CreateLocalRequestFactory(settings.Manager.InitialExporterSettings);
+
+        factory.GetEndpoint($"{FeatureFlagsEvpTransport.EventPlatformProxyV2}/{FeatureFlagsEvpTransport.FlagEvaluationIntakePath}")
+               .Should().Be(new Uri("http://localhost/evp_proxy/v2/api/v2/flagevaluation"));
+    }
+
+    [Theory]
+    [InlineData("datadoghq.eu", "https://event-platform-intake.datadoghq.eu/")]
+    [InlineData(" DATADOGHQ.COM ", "https://event-platform-intake.datadoghq.com/")]
+    public void DirectFactoryUsesNormalizedHttpsIntakeAndDisablesRedirects(string site, string expectedBase)
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "agentless"),
+            (ConfigurationKeys.ApiKey, "test-api-key"),
+            (ConfigurationKeys.Site, site));
+
+        var factory = FeatureFlagsEvpTransport.CreateDirectRequestFactory(settings.FeatureFlags);
+
+        factory.Should().NotBeNull();
+        factory!.GetEndpoint(FeatureFlagsEvpTransport.ExposureIntakePath)
+                .Should().Be(new Uri(expectedBase + FeatureFlagsEvpTransport.ExposureIntakePath));
+        factory.GetEndpoint(FeatureFlagsEvpTransport.FlagEvaluationIntakePath)
+               .Should().Be(new Uri(expectedBase + FeatureFlagsEvpTransport.FlagEvaluationIntakePath));
+#if NETCOREAPP3_1_OR_GREATER
+        factory.Should().BeOfType<HttpClientRequestFactory>()
+               .Which.AllowAutoRedirect.Should().BeFalse("DD-API-KEY must never follow an intake redirect");
+#else
+        factory.Should().BeOfType<ApiWebRequestFactory>()
+               .Which.AllowAutoRedirect.Should().BeFalse("DD-API-KEY must never follow an intake redirect");
+#endif
+    }
+
+    [Fact]
+    public void DirectFactoryUsesDefaultSiteWhenDdSiteIsUnset()
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "agentless"),
+            (ConfigurationKeys.ApiKey, "test-api-key"));
+
+        var factory = FeatureFlagsEvpTransport.CreateDirectRequestFactory(settings.FeatureFlags);
+
+        factory.Should().NotBeNull();
+        factory!.GetEndpoint(FeatureFlagsEvpTransport.ExposureIntakePath)
+                .Should().Be(new Uri("https://event-platform-intake.datadoghq.com/api/v2/exposures"));
+    }
+
+    [Theory]
+    [InlineData("datadoghq.com@attacker.example")]
+    [InlineData("https://attacker.example")]
+    [InlineData("datadoghq.com/path")]
+    [InlineData("datadoghq.com?redirect=attacker.example")]
+    [InlineData("datadoghq.com#attacker.example")]
+    [InlineData("datadoghq.com:443")]
+    [InlineData("datadoghq.com\\attacker.example")]
+    [InlineData("data doghq.com")]
+    [InlineData("-datadoghq.com")]
+    [InlineData("datadoghq.com-")]
+    [InlineData("datadoghq..com")]
+    [InlineData("dátadoghq.com")]
+    public void DirectFactoryRejectsSiteThatIsNotAnAsciiDnsSuffix(string site)
+    {
+        var settings = CreateSettings(
+            (ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "agentless"),
+            (ConfigurationKeys.ApiKey, "test-api-key"),
+            (ConfigurationKeys.Site, site));
+
+        FeatureFlagsEvpTransport.CreateDirectRequestFactory(settings.FeatureFlags).Should().BeNull();
+    }
+
+    [Fact]
+    public void InvalidSiteWarningIsGenericAndEmittedOnce()
+    {
+        const string Site = "secret@attacker.example";
+        const string ApiKey = "secret-api-key";
+        var warnings = new List<string>();
+        var settings = CreateSettings(
+            (ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "agentless"),
+            (ConfigurationKeys.ApiKey, ApiKey),
+            (ConfigurationKeys.Site, Site));
+
+        using var transport = new FeatureFlagsEvpTransport(settings, new DiscoveryServiceMock(), warnings.Add);
+
+        warnings.Should().ContainSingle();
+        warnings[0].Should().NotContain(Site).And.NotContain(ApiKey);
+    }
+
+    [Fact]
+    public async Task DisposeUnsubscribesAndUnblocksInitialDiscoveryWait()
+    {
+        var local = CreateFactory("http://agent:8126/");
+        var direct = CreateFactory("https://event-platform-intake.datadoghq.com/");
+        var discovery = new DiscoveryServiceMock();
+        var transport = CreateTransport(
+            local,
+            direct,
+            discovery,
+            initialDiscoveryKnown: false,
+            initialDiscoveryWait: TimeSpan.FromMinutes(1));
+
+        var send = transport.SendAsync(new object(), FeatureFlagsEvpTransport.ExposureIntakePath, SerializerSettings);
+        discovery.Callbacks.Should().ContainSingle();
+
+        transport.Dispose();
+
+        discovery.Callbacks.Should().BeEmpty();
+        (await Task.WhenAny(send, Task.Delay(TimeSpan.FromSeconds(1)))).Should().BeSameAs(send);
+        await send;
+        local.RequestsSent.Should().BeEmpty();
+        direct.RequestsSent.Should().BeEmpty();
+    }
+
+    private static FeatureFlagsEvpTransport CreateTransport(
+        TestRequestFactory local,
+        TestRequestFactory? direct,
+        DiscoveryServiceMock? discovery = null,
+        string? initialLocalProxyEndpoint = null,
+        bool initialDiscoveryKnown = true,
+        TimeSpan? initialDiscoveryWait = null,
+        TimeSpan? routeRecoveryCooldown = null,
+        Func<DateTimeOffset>? utcNow = null,
+        Action<string>? warningSink = null)
+        => new(
+            FeatureFlagsSource.Agentless,
+            local,
+            direct,
+            discovery ?? new DiscoveryServiceMock(),
+            initialLocalProxyEndpoint,
+            initialDiscoveryKnown,
+            initialDiscoveryWait,
+            routeRecoveryCooldown,
+            utcNow,
+            warningSink);
+
+    private static TestRequestFactory CreateFactory(string baseEndpoint, params Func<Uri, TestApiRequest>[] requests)
+        => new(new Uri(baseEndpoint), requests);
+
+    private static TracerSettings CreateSettings(params (string Key, string Value)[] values)
+    {
+        var source = new NameValueCollection();
+        foreach (var (key, value) in values)
+        {
+            source[key] = value;
+        }
+
+        return new TracerSettings(new NameValueConfigurationSource(source));
+    }
+
+    private sealed class ThrowingApiRequest(Uri endpoint, Exception exception) : TestApiRequest(endpoint)
+    {
+        public override Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
+            => Task.FromException<IApiResponse>(exception);
+    }
+
+    private sealed class BlockingApiRequest(
+        Uri endpoint,
+        TaskCompletionSource<bool> sendStarted,
+        TaskCompletionSource<bool> releaseSend) : TestApiRequest(endpoint)
+    {
+        public override async Task<IApiResponse> PostAsJsonAsync<T>(T payload, MultipartCompression compression, JsonSerializerSettings settings)
+        {
+            sendStarted.TrySetResult(true);
+            await releaseSend.Task.ConfigureAwait(false);
+            return await base.PostAsJsonAsync(payload, compression, settings).ConfigureAwait(false);
+        }
+    }
+
+    private sealed class RecordingCompressedApiRequest(Uri endpoint) : TestApiRequest(endpoint)
+    {
+        public byte[] Payload { get; private set; } = [];
+
+        public string ContentEncoding { get; private set; } = string.Empty;
+
+        public override Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
+        {
+            Payload = bytes.ToArray();
+            ContentEncoding = contentEncoding;
+            return base.PostAsync(bytes, contentType, contentEncoding);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsModuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsModuleTests.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.FeatureFlags.Rcm.Model;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Tests.Agent;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
@@ -23,6 +24,28 @@ namespace Datadog.Trace.Tests.FeatureFlags;
 
 public class FeatureFlagsModuleTests
 {
+    [Fact]
+    public void AgentlessModuleUsesSharedDiscoveryForEventDelivery()
+    {
+        var rcmManager = new MockRcmSubscriptionManager();
+        var discovery = new DiscoveryServiceMock();
+        var collection = new NameValueCollection
+        {
+            { ConfigurationKeys.FeatureFlags.FlaggingProviderEnabled, "true" },
+            { ConfigurationKeys.FeatureFlags.FeatureFlagsConfigurationSource, "agentless" },
+            { ConfigurationKeys.ApiKey, "test-api-key" },
+            { ConfigurationKeys.Site, "datadoghq.com" },
+        };
+        var settings = new TracerSettings(new NameValueConfigurationSource(collection));
+
+        using (new FeatureFlagsModule(settings, rcmManager, discovery))
+        {
+            discovery.Callbacks.Should().ContainSingle();
+        }
+
+        discovery.Callbacks.Should().BeEmpty();
+    }
+
     [Fact]
     public void UpdateRemoteConfig_WithEmptyList_InvokesCallbackAndReturnsProviderNotReady()
     {


### PR DESCRIPTION
## Reason for change / Motivation

We are shipping an Agentless, CDN-delivered Feature Flags configuration mode to simplify customer deployments. The core telemetry produced by the SDK still needs a safe network path off the process: prefer an available Agent or serverless proxy, then fall back to Datadog's direct EVP intake when Agentless credentials are available.

Without this change, .NET can receive Agentless configuration but exposure events still use the historical Agent-only EVP client and are lost when no Agent or `serverless-init` is present. This implements the .NET transport portion of [FFLSDK-189](https://linear.app/datadoghq/issue/FFLSDK-189/net-evp-fallback-for-exposures-and-flag-evaluations).

## Summary of changes / Changes

The diagram shows exposure delivery in this PR; flag-evaluation emission remains separate. CDN configuration polling is independent of this event path.

```mermaid
flowchart TD
    E["Exposure batch"] --> M{"Configuration mode"}
    M -->|Remote Config| RC["Historical Agent-only EVP v2<br/>No discovery or direct fallback"]
    M -->|Agentless| I["Shared /info discovery<br/>Initial wait bounded to 5 seconds"]
    I -->|"Both origin headers forwarded<br/>Prefer advertised v4, then v2"| L["Local Agent or serverless-init<br/>EVP subdomain header; no API key"]
    I -->|"No compatible route or discovery timeout"| C{"Valid API key and site?"}
    L -->|"Local request fails"| C
    C -->|Yes| D["Direct HTTPS EVP intake<br/>API key; redirects disabled<br/>Sticky: never return to local"]
    C -->|No| U["Unavailable<br/>No batch retained for later replay"]
    U -.->|"New discovery callback"| I
    U -.->|"After a local failure only:<br/>one concurrent probe after 30 seconds"| L
```

Both routes send `DD-EVP-ORIGIN: dd-trace-dotnet` and `DD-EVP-ORIGIN-VERSION`. On local failure, direct replay of the **current batch** is allowed only for `404`/`405` or a proven pre-send failure. Ambiguous timeouts/resets and other HTTP errors (including `403`, `429`, and `5xx`) switch **future batches only**; they never replay the current batch.

- Adds one Feature Flags EVP route state machine shared by exposure delivery and the future flag-evaluation writer.
- Selects an advertised local EVP v4 route before v2, but only when `/info` confirms that the Agent forwards both `DD-EVP-ORIGIN` identity headers.
- Falls back only in Agentless mode to the canonical direct HTTPS paths, with the API key restricted to direct intake and the EVP subdomain header restricted to the local relay.
- Sends exact logical producer identity (`dd-trace-dotnet` and the tracer version) on both routes.
- Shares strict `DD_SITE` normalization between Agentless configuration and direct event delivery and disables automatic redirects for credential-bearing direct requests.
- Keeps direct routing sticky, bounds unavailable-route recovery, and limits same-batch replay to local `404`/`405` or definitive pre-send failures. Ambiguous failures and `403`/`429`/`5xx` responses are never replayed; future batches switch to direct when credentials exist, otherwise the route enters bounded unavailable recovery.
- Flushes queued exposures during shutdown with a bounded wait and blocks post-dispose enqueue races.

## Implementation details / Decisions

- Remote Config deliberately retains its historical fixed EVP v2 client. It does not subscribe to discovery, acquire direct credentials, or enter the Agentless cooldown state.
- Agentless local selection consumes the tracer's shared discovery stream instead of creating a second `/info` loop. Recovery after a failed route permits one concurrent post-cooldown route probe; a discovery callback can restore the route sooner.
- Direct intake is terminal for the process lifetime. A direct failure never loops back to the Agent.
- This PR wires exposures. It exposes the same compressed send path and route state for the flag-evaluation work tracked in [#9139](https://github.com/DataDog/dd-trace-dotnet/pull/9139), but does not absorb that payload, aggregation, or privacy work.
- The small backwards-compatible redirect opt-out in the generic HTTP factories is sufficient for this direct sender. The broader API-key redirect guard in [#9064](https://github.com/DataDog/dd-trace-dotnet/pull/9064) can subsume that hook later; this PR does not depend on it.
- The branch contains signed commits directly on `master` and has no unmerged PR ancestry.
- Provider-lifecycle foundation [#9044](https://github.com/DataDog/dd-trace-dotnet/pull/9044) merged on September 14 and is now included through master. The conflict resolution preserves its lazy exposure creation, deferred/idempotent activation and cleanup while injecting shared discovery into the EVP transport.

## Test coverage / Validation

Merged master `773007d736d6eda017b333b9d61aa5ebef6fb73f`; exact candidate `7eba07853048a9d2e61f506051dca6984287c3e1`.

- `dotnet test tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj -f net10.0 --filter 'FullyQualifiedName~FeatureFlags|FullyQualifiedName~Agent.DiscoveryServiceTests' --verbosity minimal` — 658 passed, 0 failed, 0 skipped.
- `dotnet format whitespace tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj --no-restore --verify-no-changes --include tracer/src/Datadog.Trace/FeatureFlags/FeatureFlagsModule.cs tracer/src/Datadog.Trace/TracerManagerFactory.cs tracer/test/Datadog.Trace.Tests/FeatureFlags/FeatureFlagsModuleTests.cs --verbosity minimal` — passed.
- `git diff --check` — passed. The new merge commit is GitHub verified: `verified=true`, `reason=valid`.
- Added a production-factory regression proving shared discovery, no Remote Config subscription in Agentless mode, deferred/idempotent source activation, and subscription/source disposal.
- Existing transport tests cover local/direct paths and headers, credential isolation, redirects, site validation, v4/v2 preference and capabilities, no-replay cases, shared discovery, sticky direct, bounded recovery and shutdown.

### End-to-end gate

Earlier exact-artifact runs failed before transport was exercised: the old candidate did not start Agentless UFC polling because #9044 was missing. That foundation is now merged; the former external blocker is resolved.

Neither direct nor serverless-init system tests have been rerun on this combined candidate. Rebuild this exact SHA and validate both routes next; passing unit tests is not backend-intake proof. Broader framework builds and current CI are not claimed from older heads.

No `system-tests` or dogfooding files are changed by this PR.

