### PR TITLE
[DuckTyping] Validate target ToString methods before emitting IL

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -515,35 +515,56 @@ namespace Datadog.Trace.DuckTyping
             il.Emit(OpCodes.Ldflda, instanceField);
             il.Emit(OpCodes.Ret);
 
-            var toStringTargetType = targetType.GetMethod(nameof(IDuckType.ToString), Type.EmptyTypes);
-            if (toStringTargetType is not null)
+            // A target can hide Object.ToString with a public parameterless method whose return type is
+            // unrelated to string, or with a static method. Method lookup by name and parameter types alone
+            // accepts those methods because the return type is not part of a CLR method signature. Calling such
+            // a method from the string-returning proxy method leaves an incompatible value on the evaluation
+            // stack and can make the JIT consume an integer as an object reference.
+            //
+            // Restrict the lookup to instance methods and validate the return type before emitting any IL. If
+            // the most-derived candidate has hidden the virtual ToString slot with an incompatible signature,
+            // calling Object.ToString is the correct fallback: normal virtual dispatch still reaches any valid
+            // override inherited by the target.
+            var toStringTargetMethod = targetType.GetMethod(
+                nameof(IDuckType.ToString),
+                BindingFlags.Public | BindingFlags.Instance,
+                binder: null,
+                Type.EmptyTypes,
+                modifiers: null);
+            if (toStringTargetMethod?.ReturnType != typeof(string))
             {
-                MethodBuilder toStringMethod = proxyTypeBuilder.DefineMethod(nameof(IDuckType.ToString), toStringTargetType.Attributes, typeof(string), Type.EmptyTypes);
-                il = toStringMethod.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_0);
-                if (instanceType.IsValueType)
-                {
-                    il.Emit(OpCodes.Ldflda, instanceField);
-                    il.Emit(OpCodes.Constrained, targetType);
-                    il.EmitCall(OpCodes.Callvirt, toStringTargetType, null);
-                }
-                else
-                {
-                    il.Emit(OpCodes.Ldfld, instanceField);
-                    il.Emit(OpCodes.Dup);
-                    var lblTrue = il.DefineLabel();
-                    il.Emit(OpCodes.Brtrue_S, lblTrue);
-
-                    il.Emit(OpCodes.Pop);
-                    il.Emit(OpCodes.Ldnull);
-                    il.Emit(OpCodes.Ret);
-
-                    il.MarkLabel(lblTrue);
-                    il.EmitCall(OpCodes.Callvirt, toStringTargetType, null);
-                }
-
-                il.Emit(OpCodes.Ret);
+                toStringTargetMethod = typeof(object).GetMethod(nameof(IDuckType.ToString), Type.EmptyTypes)!;
             }
+
+            MethodBuilder toStringMethod = proxyTypeBuilder.DefineMethod(
+                nameof(IDuckType.ToString),
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig,
+                typeof(string),
+                Type.EmptyTypes);
+            il = toStringMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            if (instanceType.IsValueType)
+            {
+                il.Emit(OpCodes.Ldflda, instanceField);
+                il.Emit(OpCodes.Constrained, targetType);
+                il.EmitCall(OpCodes.Callvirt, toStringTargetMethod, null);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldfld, instanceField);
+                il.Emit(OpCodes.Dup);
+                var lblTrue = il.DefineLabel();
+                il.Emit(OpCodes.Brtrue_S, lblTrue);
+
+                il.Emit(OpCodes.Pop);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ret);
+
+                il.MarkLabel(lblTrue);
+                il.EmitCall(OpCodes.Callvirt, toStringTargetMethod, null);
+            }
+
+            il.Emit(OpCodes.Ret);
 
             return instanceField;
         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/DuckToStringByPassTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/DuckToStringByPassTests.cs
@@ -72,12 +72,62 @@ namespace Datadog.Trace.DuckTyping.Tests
             proxy.ToString().Should().Be(instance.ToString());
         }
 
+        [Fact]
+        public void ToStringIgnoresHiddenMethodWithNonStringReturnType()
+        {
+            var instance = new TargetWithHiddenNonStringToString();
+
+            var proxy = instance.DuckCast<IEmptyProxy>();
+
+            ((IDuckType)proxy).ToString().Should().Be("ToString from the base target.");
+        }
+
+        [Fact]
+        public void ToStringIgnoresHiddenStaticMethod()
+        {
+            var instance = new TargetWithHiddenStaticToString();
+
+            var proxy = instance.DuckCast<IEmptyProxy>();
+
+            ((IDuckType)proxy).ToString().Should().Be("ToString from the base target.");
+        }
+
+        [Fact]
+        public void ToStringUsesHiddenInstanceMethodWithStringReturnType()
+        {
+            var instance = new TargetWithHiddenStringToString();
+
+            var proxy = instance.DuckCast<IEmptyProxy>();
+
+            ((IDuckType)proxy).ToString().Should().Be("ToString from the hidden target method.");
+        }
+
         public class TargetClass
         {
             public override string ToString()
             {
                 return "ToString from Target instance.";
             }
+        }
+
+        public class TargetBaseClass
+        {
+            public override string ToString() => "ToString from the base target.";
+        }
+
+        public class TargetWithHiddenNonStringToString : TargetBaseClass
+        {
+            public new virtual int ToString() => 0;
+        }
+
+        public class TargetWithHiddenStaticToString : TargetBaseClass
+        {
+            public static new string ToString() => "ToString from the hidden static target method.";
+        }
+
+        public class TargetWithHiddenStringToString : TargetBaseClass
+        {
+            public new string ToString() => "ToString from the hidden target method.";
         }
 
         public interface IEmptyProxy


### PR DESCRIPTION
## Summary of changes

Validates the target selected for the generated `IDuckType.ToString()` implementation and emits virtual proxy methods with attributes that remain valid when the proxy base seals `ToString()`.

## Reason for change

A target can hide `object.ToString()` with a public parameterless method that is static, returns a non-string value, returns by reference, or is an open generic method. Emitting a string-returning body around an incompatible or open method can produce invalid IL: the reproduced failures include `BadImageFormatException` and a value interpreted as an object reference.

Reflection lookup by name and parameter types can also throw `AmbiguousMatchException` when generic and non-generic parameterless overloads coexist.

Always overriding the inherited proxy `ToString()` is invalid when a class proxy seals that method: the generated type fails to load because a final method cannot be overridden.

## Implementation details

The target lookup considers only public instance members named `ToString`. It selects the closed, parameterless, non-generic candidate declared by the most-derived type and requires an exact `string` return. Incompatible, ambiguous, and open signatures fall back to `object.ToString()`; virtual dispatch still reaches any valid inherited override. The fallback `MethodInfo` is cached with the other DuckTyping reflection metadata.

The generated method normally overrides `ToString()`. When the proxy base seals that method, it uses a new virtual slot instead. Direct calls retain the sealed proxy implementation, while `IDuckType.ToString()` remains mapped to the target implementation.

## Test coverage

- Empty and `ToString`-declaring interface, class, and abstract class proxies
- A class proxy with a sealed `ToString()`, including direct and `IDuckType` dispatch
- Default, overridden, inherited, and hidden target implementations
- Hidden instance methods returning `int` or `ref string`
- Hidden static methods
- Open generic `ToString<T>()`
- Coexisting generic and non-generic parameterless overloads
- Value-type targets using `int` and enum values
- Full DuckTyping suite on .NET 8: 10,971 passed, 5 skipped
- `DuckToStringByPassTests` on .NET Core 3.0: 15 passed

## Other details
