### PR TITLE
[DuckTyping] Reject incompatible managed references and pointers

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/ILHelpersExtensions.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/ILHelpersExtensions.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.DuckTyping
     internal static class ILHelpersExtensions
     {
         private static readonly List<DynamicMethod> DynamicMethods = new();
+        private static readonly PropertyInfo? IsFunctionPointerProperty = typeof(Type).GetProperty("IsFunctionPointer", BindingFlags.Instance | BindingFlags.Public);
 
         internal static DynamicMethod GetDynamicMethodForIndex(int index)
         {
@@ -275,6 +276,16 @@ namespace Datadog.Trace.DuckTyping
                 return null;
             }
 
+            // Managed references, unmanaged pointers and function pointers are special evaluation-stack
+            // categories. They are not object references, even though reflection reports them as non-value
+            // types, and castclass, box or an omitted conversion cannot change one special category into
+            // another. Their exact reflected types must match before IL emission; otherwise the generated body
+            // can be unverifiable or make the runtime consume an address using the wrong calling convention.
+            if (RequiresExactTypeMatch(actualUnderlyingType) || RequiresExactTypeMatch(expectedUnderlyingType))
+            {
+                return DuckTypeInvalidTypeConversionException.Create(actualType, expectedType);
+            }
+
             if (actualUnderlyingType.IsValueType)
             {
                 if (expectedUnderlyingType.IsValueType)
@@ -365,6 +376,16 @@ namespace Datadog.Trace.DuckTyping
                 return null;
             }
 
+            // Managed references, unmanaged pointers and function pointers are special evaluation-stack
+            // categories. They are not object references, even though reflection reports them as non-value
+            // types, and castclass, box or an omitted conversion cannot change one special category into
+            // another. Their exact reflected types must match before IL emission; otherwise the generated body
+            // can be unverifiable or make the runtime consume an address using the wrong calling convention.
+            if (RequiresExactTypeMatch(actualUnderlyingType) || RequiresExactTypeMatch(expectedUnderlyingType))
+            {
+                return DuckTypeInvalidTypeConversionException.Create(actualType, expectedType);
+            }
+
             if (actualUnderlyingType.IsValueType)
             {
                 if (expectedUnderlyingType.IsValueType)
@@ -389,6 +410,25 @@ namespace Datadog.Trace.DuckTyping
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns whether a reflected type represents an evaluation-stack category that cannot participate in
+        /// the boxing and reference conversions supported by <see cref="WriteTypeConversion"/>.
+        /// </summary>
+        /// <param name="type">Type to inspect.</param>
+        /// <returns><c>true</c> when only an exact type match can be emitted safely.</returns>
+        private static bool RequiresExactTypeMatch(Type type)
+        {
+            if (type.IsByRef || type.IsPointer)
+            {
+                return true;
+            }
+
+            // Type.IsFunctionPointer is not part of every reference assembly targeted by the tracer. The
+            // running runtime can still expose function-pointer metadata for an inspected assembly, so query
+            // the property when it is available instead of silently treating the type as an object reference.
+            return IsFunctionPointerProperty?.GetValue(type, index: null) is true;
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -54,22 +54,22 @@ namespace Datadog.Trace.DuckTyping.Tests
             if (!TestOptimization.Instance.IsRunning)
             {
 #if NETFRAMEWORK
-                asmDuckTypes.Should().Be(1516);
+                asmDuckTypes.Should().Be(1518);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().Be(1526);
+                asmDuckTypes.Should().Be(1528);
 #else
-                asmDuckTypes.Should().Be(1527);
+                asmDuckTypes.Should().Be(1529);
 #endif
             }
             else
             {
                 // When running inside CI Visibility, we will generate additional duck types
 #if NETFRAMEWORK
-                asmDuckTypes.Should().BeGreaterThan(1516);
+                asmDuckTypes.Should().BeGreaterThan(1518);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().BeGreaterThan(1526);
+                asmDuckTypes.Should().BeGreaterThan(1528);
 #else
-                asmDuckTypes.Should().BeGreaterThan(1527);
+                asmDuckTypes.Should().BeGreaterThan(1529);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/SpecialTypeMethodTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/SpecialTypeMethodTests.cs
@@ -1,0 +1,130 @@
+// <copyright file="SpecialTypeMethodTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+
+namespace Datadog.Trace.DuckTyping.Tests.Methods;
+
+public unsafe class SpecialTypeMethodTests
+{
+    [Fact]
+    public void ExactManagedReferenceReturnCanBeInvoked()
+    {
+        var target = new ManagedReferenceTarget();
+        var proxy = target.DuckCast<IExactManagedReferenceProxy>();
+
+        ref var value = ref proxy.GetReference();
+        value = 42;
+
+        target.Value.Should().Be(42);
+    }
+
+    [Theory]
+    [InlineData(typeof(IIncompatibleManagedReferenceProxy))]
+    [InlineData(typeof(IManagedReferenceAsObjectProxy))]
+    public void IncompatibleManagedReferenceReturnIsRejected(Type proxyType)
+    {
+        var target = new ManagedReferenceTarget();
+
+        DuckType.CanCreate(proxyType, target).Should().BeFalse();
+        target.DuckIs(proxyType).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ExactPointerReturnCanBeInvoked()
+    {
+        var proxy = new PointerTarget().DuckCast<IExactPointerProxy>();
+
+        ((nint)proxy.GetPointer()).Should().Be(new nint(0x1234));
+    }
+
+    [Theory]
+    [InlineData(typeof(IIncompatiblePointerProxy))]
+    [InlineData(typeof(IPointerAsObjectProxy))]
+    public void IncompatiblePointerReturnIsRejected(Type proxyType)
+    {
+        var target = new PointerTarget();
+
+        DuckType.CanCreate(proxyType, target).Should().BeFalse();
+        target.DuckIs(proxyType).Should().BeFalse();
+    }
+
+#if NET5_0_OR_GREATER
+    [Fact]
+    public void FunctionPointerReturnedAsObjectIsRejected()
+    {
+        var target = new FunctionPointerTarget();
+
+        DuckType.CanCreate<IFunctionPointerAsObjectProxy>(target).Should().BeFalse();
+        target.DuckIs<IFunctionPointerAsObjectProxy>().Should().BeFalse();
+    }
+#endif
+
+    private interface IExactManagedReferenceProxy
+    {
+        ref int GetReference();
+    }
+
+    private interface IIncompatibleManagedReferenceProxy
+    {
+        ref long GetReference();
+    }
+
+    private interface IManagedReferenceAsObjectProxy
+    {
+        object GetReference();
+    }
+
+    private interface IExactPointerProxy
+    {
+        long* GetPointer();
+    }
+
+    private interface IIncompatiblePointerProxy
+    {
+        int* GetPointer();
+    }
+
+    private interface IPointerAsObjectProxy
+    {
+        object GetPointer();
+    }
+
+#if NET5_0_OR_GREATER
+    private interface IFunctionPointerAsObjectProxy
+    {
+        object GetFunctionPointer();
+    }
+#endif
+
+    private class ManagedReferenceTarget
+    {
+        private int _value = 21;
+
+        public int Value => _value;
+
+        public ref int GetReference() => ref _value;
+    }
+
+    private class PointerTarget
+    {
+        public long* GetPointer() => (long*)0x1234;
+    }
+
+#if NET5_0_OR_GREATER
+    private class FunctionPointerTarget
+    {
+        public delegate*<void> GetFunctionPointer() => &Empty;
+
+        private static void Empty()
+        {
+        }
+    }
+#endif
+}

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/SpecialTypeMethodTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/SpecialTypeMethodTests.cs
@@ -41,7 +41,7 @@ public unsafe class SpecialTypeMethodTests
     {
         var proxy = new PointerTarget().DuckCast<IExactPointerProxy>();
 
-        ((nint)proxy.GetPointer()).Should().Be(new nint(0x1234));
+        ((nint)proxy.GetPointer()).Should().Be((nint)0x1234);
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/SpecialTypeMethodTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/SpecialTypeMethodTests.cs
@@ -55,7 +55,10 @@ public unsafe class SpecialTypeMethodTests
         target.DuckIs(proxyType).Should().BeFalse();
     }
 
-#if NET5_0_OR_GREATER
+    // .NET 5 through .NET 7 reflection represents a function-pointer signature as IntPtr, so boxing the
+    // reflected value is valid there. Starting with .NET 8, reflection preserves the function-pointer type
+    // and DuckTyping must reject any attempt to treat that evaluation-stack value as an object reference.
+#if NET8_0_OR_GREATER
     [Fact]
     public void FunctionPointerReturnedAsObjectIsRejected()
     {
@@ -96,7 +99,7 @@ public unsafe class SpecialTypeMethodTests
         object GetPointer();
     }
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private interface IFunctionPointerAsObjectProxy
     {
         object GetFunctionPointer();
@@ -117,7 +120,7 @@ public unsafe class SpecialTypeMethodTests
         public long* GetPointer() => (long*)0x1234;
     }
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private class FunctionPointerTarget
     {
         public delegate*<void> GetFunctionPointer() => &Empty;


### PR DESCRIPTION
## Summary of changes

Requires exact type identity when DuckTyping handles managed references, unmanaged pointers, or function pointers.

## Reason for change

Reflection reports these types as non-value types, but they are special CLR evaluation-stack categories rather than object references. The previous conversion path could emit `castclass`, omit a required conversion, or return an address under an incompatible signature. Depending on the shape, invocation produced invalid IL, fake object references, or a native process crash.

## Implementation details

Both the emitting and dry-run conversion paths now reject a mismatch whenever either side is a managed reference, pointer, or function pointer. Exact matches remain unchanged. Function-pointer detection discovers the runtime-only property once and caches an open delegate, so subsequent checks avoid reflection and boxed Boolean results while the code continues to build against the tracer's older reference assemblies.

## Test coverage

- Exact `ref int` return, including mutation through the returned reference
- Rejection of `ref int` as `ref long` and as `object`
- Exact `long*` return
- Rejection of `long*` as `int*` and as `object`
- Rejection of a function pointer returned as `object` on .NET 8 and later, where reflection preserves function-pointer types
- Full DuckTyping suite on .NET 5: 10,968 passed, 5 skipped
- Full DuckTyping suite on .NET 6: 10,968 passed, 5 skipped
- Full DuckTyping suite on .NET 8: 10,969 passed, 5 skipped

## Other details
