### PR TITLE
[DuckTyping] Reject invalid conversions for ref-like types

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -772,6 +772,7 @@
       <type fullname="System.IO.File" />
       <type fullname="System.IO.FileAccess" />
       <type fullname="System.IO.FileInfo" />
+      <type fullname="System.IO.FileLoadException" />
       <type fullname="System.IO.FileMode" />
       <type fullname="System.IO.FileNotFoundException" />
       <type fullname="System.IO.FileOptions" />
@@ -844,6 +845,7 @@
       <type fullname="System.Reflection.ConstructorInfo" />
       <type fullname="System.Reflection.CustomAttributeData" />
       <type fullname="System.Reflection.CustomAttributeExtensions" />
+      <type fullname="System.Reflection.CustomAttributeFormatException" />
       <type fullname="System.Reflection.CustomAttributeNamedArgument" />
       <type fullname="System.Reflection.CustomAttributeTypedArgument" />
       <type fullname="System.Reflection.DefaultMemberAttribute" />

--- a/tracer/src/Datadog.Trace/DuckTyping/ILHelpersExtensions.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/ILHelpersExtensions.cs
@@ -275,6 +275,16 @@ namespace Datadog.Trace.DuckTyping
                 return null;
             }
 
+            // Ref-like structs may live only in managed stack locations. The CLR explicitly forbids boxing
+            // them, storing them in object references, or unboxing an object into them. Reflection still
+            // reports them as value types, so allowing the normal value/reference conversion branches below
+            // would emit box, isinst or unbox.any instructions that are invalid for types such as Span<T>.
+            // Exact matches have already returned above and remain valid pass-through signatures.
+            if (IsByRefLike(actualUnderlyingType) || IsByRefLike(expectedUnderlyingType))
+            {
+                return DuckTypeInvalidTypeConversionException.Create(actualType, expectedType);
+            }
+
             if (actualUnderlyingType.IsValueType)
             {
                 if (expectedUnderlyingType.IsValueType)
@@ -365,6 +375,16 @@ namespace Datadog.Trace.DuckTyping
                 return null;
             }
 
+            // Ref-like structs may live only in managed stack locations. The CLR explicitly forbids boxing
+            // them, storing them in object references, or unboxing an object into them. Reflection still
+            // reports them as value types, so allowing the normal value/reference conversion branches below
+            // would emit box, isinst or unbox.any instructions that are invalid for types such as Span<T>.
+            // Exact matches have already returned above and remain valid pass-through signatures.
+            if (IsByRefLike(actualUnderlyingType) || IsByRefLike(expectedUnderlyingType))
+            {
+                return DuckTypeInvalidTypeConversionException.Create(actualType, expectedType);
+            }
+
             if (actualUnderlyingType.IsValueType)
             {
                 if (expectedUnderlyingType.IsValueType)
@@ -389,6 +409,23 @@ namespace Datadog.Trace.DuckTyping
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Returns whether a type carries the runtime marker that restricts it to managed stack locations.
+        /// </summary>
+        /// <param name="type">Type to inspect.</param>
+        /// <returns><c>true</c> for a ref-like value type; otherwise, <c>false</c>.</returns>
+        private static bool IsByRefLike(Type type)
+        {
+            // Type.IsByRefLike is unavailable in some reference assemblies targeted by the tracer. Inspecting
+            // CustomAttributeData avoids constructing arbitrary attributes while providing the same answer on
+            // runtimes that encode ref-like types with IsByRefLikeAttribute.
+            return type.GetCustomAttributesData()
+                       .Any(attribute => string.Equals(
+                                attribute.AttributeType.FullName,
+                                "System.Runtime.CompilerServices.IsByRefLikeAttribute",
+                                StringComparison.Ordinal));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/DuckTyping/ILHelpersExtensions.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/ILHelpersExtensions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -20,6 +21,7 @@ namespace Datadog.Trace.DuckTyping
     internal static class ILHelpersExtensions
     {
         private static readonly List<DynamicMethod> DynamicMethods = new();
+        private static readonly Func<Type, bool>? RuntimeIsByRefLike = CreateRuntimeIsByRefLikeGetter();
 
         internal static DynamicMethod GetDynamicMethodForIndex(int index)
         {
@@ -418,14 +420,62 @@ namespace Datadog.Trace.DuckTyping
         /// <returns><c>true</c> for a ref-like value type; otherwise, <c>false</c>.</returns>
         private static bool IsByRefLike(Type type)
         {
-            // Type.IsByRefLike is unavailable in some reference assemblies targeted by the tracer. Inspecting
-            // CustomAttributeData avoids constructing arbitrary attributes while providing the same answer on
-            // runtimes that encode ref-like types with IsByRefLikeAttribute.
-            return type.GetCustomAttributesData()
-                       .Any(attribute => string.Equals(
-                                attribute.AttributeType.FullName,
-                                "System.Runtime.CompilerServices.IsByRefLikeAttribute",
-                                StringComparison.Ordinal));
+            // A managed reference is represented by a wrapper Type whose IsValueType and custom attributes
+            // describe the wrapper, not the value stored at the referenced location. Inspect the element so
+            // ref Span<T> cannot fall through to a castclass instruction for a managed pointer.
+            if (type.IsByRef)
+            {
+                type = type.GetElementType()!;
+            }
+
+            // Only value types can be ref-like. This inexpensive guard also keeps ordinary customer reference
+            // conversions away from custom-attribute inspection, where an unrelated attribute whose assembly
+            // cannot be loaded could otherwise make proxy validation fail.
+            if (!type.IsValueType)
+            {
+                return false;
+            }
+
+            // Newer runtimes expose the flag directly and answer without enumerating custom attributes. The
+            // tracer also targets reference assemblies that do not contain Type.IsByRefLike, so the getter is
+            // discovered once rather than referenced statically.
+            if (RuntimeIsByRefLike is not null)
+            {
+                return RuntimeIsByRefLike(type);
+            }
+
+            // Older runtimes encode the restriction with IsByRefLikeAttribute. CustomAttributeData avoids
+            // constructing customer attributes. If metadata for an attribute cannot be resolved, conservatively
+            // reject the non-exact value-type conversion instead of risking invalid IL.
+            try
+            {
+                return type.GetCustomAttributesData()
+                           .Any(attribute => string.Equals(
+                                    attribute.AttributeType.FullName,
+                                    "System.Runtime.CompilerServices.IsByRefLikeAttribute",
+                                    StringComparison.Ordinal));
+            }
+            catch (Exception ex) when (IsAttributeInspectionException(ex))
+            {
+                return true;
+            }
+        }
+
+        private static bool IsAttributeInspectionException(Exception exception)
+            => exception is TypeLoadException
+                    or FileNotFoundException
+                    or FileLoadException
+                    or CustomAttributeFormatException
+                    or BadImageFormatException;
+
+        /// <summary>
+        /// Creates an open delegate for <c>Type.IsByRefLike</c> when the running CLR exposes it.
+        /// </summary>
+        /// <returns>The cached property getter, or <c>null</c> on older runtimes.</returns>
+        private static Func<Type, bool>? CreateRuntimeIsByRefLikeGetter()
+        {
+            MethodInfo? getter = typeof(Type).GetProperty("IsByRefLike", BindingFlags.Instance | BindingFlags.Public)?.GetMethod;
+            return getter is null ? null : (Func<Type, bool>)getter.CreateDelegate(typeof(Func<Type, bool>));
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 #elif NETCOREAPP2_1
                 asmDuckTypes.Should().Be(1526);
 #else
-                asmDuckTypes.Should().Be(1527);
+                asmDuckTypes.Should().Be(1528);
 #endif
             }
             else
@@ -69,7 +69,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 #elif NETCOREAPP2_1
                 asmDuckTypes.Should().BeGreaterThan(1526);
 #else
-                asmDuckTypes.Should().BeGreaterThan(1527);
+                asmDuckTypes.Should().BeGreaterThan(1528);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -57,6 +57,8 @@ namespace Datadog.Trace.DuckTyping.Tests
                 asmDuckTypes.Should().Be(1516);
 #elif NETCOREAPP2_1
                 asmDuckTypes.Should().Be(1526);
+#elif NETCOREAPP3_0
+                asmDuckTypes.Should().Be(1527);
 #else
                 asmDuckTypes.Should().Be(1528);
 #endif
@@ -68,6 +70,8 @@ namespace Datadog.Trace.DuckTyping.Tests
                 asmDuckTypes.Should().BeGreaterThan(1516);
 #elif NETCOREAPP2_1
                 asmDuckTypes.Should().BeGreaterThan(1526);
+#elif NETCOREAPP3_0
+                asmDuckTypes.Should().BeGreaterThan(1527);
 #else
                 asmDuckTypes.Should().BeGreaterThan(1528);
 #endif

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ByRefLikeTypeTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ByRefLikeTypeTests.cs
@@ -62,6 +62,16 @@ public class ByRefLikeTypeTests
         target.DuckIs<ISpanParameterProxy>().Should().BeFalse();
     }
 
+    [Fact]
+    public void ByRefLikeTypeInsideManagedReferenceCannotBeConverted()
+    {
+        var byRefSpan = typeof(Span<int>).MakeByRefType();
+        var byRefObject = typeof(object).MakeByRefType();
+
+        ILHelpersExtensions.CheckTypeConversion(byRefSpan, byRefObject).Should().NotBeNull();
+        ILHelpersExtensions.CheckTypeConversion(byRefObject, byRefSpan).Should().NotBeNull();
+    }
+
     private interface IExactSpanReturnProxy
     {
         Span<int> GetSpan();

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ByRefLikeTypeTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ByRefLikeTypeTests.cs
@@ -6,6 +6,7 @@
 #if NETCOREAPP3_1_OR_GREATER
 
 using System;
+using System.Reflection;
 using FluentAssertions;
 using Xunit;
 
@@ -33,6 +34,7 @@ public class ByRefLikeTypeTests
 
         DuckType.CanCreate<ISpanReturnAsObjectProxy>(target).Should().BeFalse();
         target.DuckIs<ISpanReturnAsObjectProxy>().Should().BeFalse();
+        AssertInvalidConversion<ISpanReturnAsObjectProxy>(target);
     }
 
     [Fact]
@@ -42,6 +44,7 @@ public class ByRefLikeTypeTests
 
         DuckType.CanCreate<ISpanPropertyAsObjectProxy>(target).Should().BeFalse();
         target.DuckIs<ISpanPropertyAsObjectProxy>().Should().BeFalse();
+        AssertInvalidConversion<ISpanPropertyAsObjectProxy>(target);
     }
 
     [Fact]
@@ -51,6 +54,7 @@ public class ByRefLikeTypeTests
 
         DuckType.CanCreate<IObjectParameterProxy>(target).Should().BeFalse();
         target.DuckIs<IObjectParameterProxy>().Should().BeFalse();
+        AssertInvalidConversion<IObjectParameterProxy>(target);
     }
 
     [Fact]
@@ -60,6 +64,7 @@ public class ByRefLikeTypeTests
 
         DuckType.CanCreate<ISpanParameterProxy>(target).Should().BeFalse();
         target.DuckIs<ISpanParameterProxy>().Should().BeFalse();
+        AssertInvalidConversion<ISpanParameterProxy>(target);
     }
 
     [Fact]
@@ -70,6 +75,17 @@ public class ByRefLikeTypeTests
 
         ILHelpersExtensions.CheckTypeConversion(byRefSpan, byRefObject).Should().NotBeNull();
         ILHelpersExtensions.CheckTypeConversion(byRefObject, byRefSpan).Should().NotBeNull();
+    }
+
+    private static void AssertInvalidConversion<TProxy>(object target)
+    {
+        Action genericCast = () => target.DuckCast<TProxy>();
+        genericCast.Should().ThrowExactly<DuckTypeInvalidTypeConversionException>();
+
+        Action nonGenericCast = () => target.DuckCast(typeof(TProxy));
+        nonGenericCast.Should()
+                      .Throw<TargetInvocationException>()
+                      .WithInnerExceptionExactly<DuckTypeInvalidTypeConversionException>();
     }
 
     private interface IExactSpanReturnProxy

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ByRefLikeTypeTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ByRefLikeTypeTests.cs
@@ -1,0 +1,113 @@
+// <copyright file="ByRefLikeTypeTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_1_OR_GREATER
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests.Methods;
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+
+public class ByRefLikeTypeTests
+{
+    [Fact]
+    public void ExactByRefLikeReturnCanBeInvoked()
+    {
+        var target = new ByRefLikeTarget();
+        var proxy = target.DuckCast<IExactSpanReturnProxy>();
+
+        proxy.GetSpan()[0] = 42;
+
+        target.FirstValue.Should().Be(42);
+    }
+
+    [Fact]
+    public void ByRefLikeReturnAsObjectIsRejected()
+    {
+        var target = new ByRefLikeTarget();
+
+        DuckType.CanCreate<ISpanReturnAsObjectProxy>(target).Should().BeFalse();
+        target.DuckIs<ISpanReturnAsObjectProxy>().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ByRefLikePropertyAsObjectIsRejected()
+    {
+        var target = new ByRefLikeTarget();
+
+        DuckType.CanCreate<ISpanPropertyAsObjectProxy>(target).Should().BeFalse();
+        target.DuckIs<ISpanPropertyAsObjectProxy>().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ObjectParameterCannotBeConvertedToByRefLikeType()
+    {
+        var target = new ByRefLikeTarget();
+
+        DuckType.CanCreate<IObjectParameterProxy>(target).Should().BeFalse();
+        target.DuckIs<IObjectParameterProxy>().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ByRefLikeParameterCannotBeBoxedAsObject()
+    {
+        var target = new ObjectParameterTarget();
+
+        DuckType.CanCreate<ISpanParameterProxy>(target).Should().BeFalse();
+        target.DuckIs<ISpanParameterProxy>().Should().BeFalse();
+    }
+
+    private interface IExactSpanReturnProxy
+    {
+        Span<int> GetSpan();
+    }
+
+    private interface ISpanReturnAsObjectProxy
+    {
+        object GetSpan();
+    }
+
+    private interface ISpanPropertyAsObjectProxy
+    {
+        object Values { get; }
+    }
+
+    private interface IObjectParameterProxy
+    {
+        void Accept(object value);
+    }
+
+    private interface ISpanParameterProxy
+    {
+        void Accept(Span<int> value);
+    }
+
+    private class ByRefLikeTarget
+    {
+        private readonly int[] _values = [21];
+
+        public int FirstValue => _values[0];
+
+        public Span<int> Values => _values;
+
+        public Span<int> GetSpan() => _values;
+
+        public void Accept(Span<int> value)
+        {
+        }
+    }
+
+    private class ObjectParameterTarget
+    {
+        public void Accept(object value)
+        {
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes

Rejects DuckTyping conversions that would box, unbox, cast, or expose a ref-like value such as `Span<T>` through an incompatible managed reference.

## Reason for change

Ref-like structs can live only in managed stack locations. The generic value-type conversion path previously treated them like ordinary structs and could emit `box`, `isinst`, or `unbox.any` instructions that the CLR forbids. A managed-reference wrapper such as `Span<T>&` could also bypass the check and reach a `castclass` instruction for a managed pointer.

## Implementation details

Both the emitting and dry-run conversion paths reject every non-exact conversion involving a ref-like element. Detection unwraps managed references, exits immediately for ordinary reference types, and uses a cached delegate to `Type.IsByRefLike` when the runtime exposes it. Older runtimes fall back to attribute metadata without constructing attributes; unresolved metadata conservatively rejects the conversion.

Exact ref-like signatures continue to pass through unchanged. Rejections follow the existing DuckTyping exception contract: generic `DuckCast<T>()` throws `DuckTypeInvalidTypeConversionException` directly, while the non-generic `DuckCast(Type)` path retains its established `TargetInvocationException` wrapper with the DuckTyping exception as its inner exception.

## Test coverage

- Exact `Span<int>` return and mutation through the returned span
- Rejection of `Span<int>` method and property returns as `object`
- Rejection of conversions in both directions between `Span<int>&` and `object&`
- Rejection of `object` to `Span<int>` parameter conversion
- Rejection of boxing a `Span<int>` parameter as `object`
- Exception contract verification for generic and non-generic proxy creation
- Full DuckTyping suite on .NET 8: 10,968 passed, 5 skipped
- Full DuckTyping suite compiled for `netcoreapp3.0`: 10,962 passed, 5 skipped

## Other details
