### PR TITLE
[DuckTyping] Preserve constraints on generated generic methods

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -153,7 +153,6 @@ namespace Datadog.Trace.DuckTyping
 
                 // Gets the proxy method definition generic arguments
                 Type[] proxyMethodDefinitionGenericArguments = proxyMethodDefinition.GetGenericArguments();
-                string[] proxyMethodDefinitionGenericArgumentsNames = proxyMethodDefinitionGenericArguments.Select(a => a.Name).ToArray();
 
                 // Checks if the target method is a generic method while the proxy method is non generic (checks if the Duck attribute contains the generic parameters)
                 Type[] targetMethodGenericArguments = targetMethod.GetGenericArguments();
@@ -208,7 +207,13 @@ namespace Datadog.Trace.DuckTyping
 
                 // Create the proxy method implementation
                 MethodBuilder? proxyMethod = proxyTypeBuilder?.DefineMethod(proxyMethodDefinition.Name, proxyMethodAttributes, proxyMethodDefinition.ReturnType, proxyMethodDefinitionParametersTypes);
-                LazyILGenerator il = MethodIlHelper.InitialiseProxyMethod(proxyMethod, proxyMethodDefinitionParameters, proxyMethodDefinitionGenericArgumentsNames, targetMethod, instanceField);
+                LazyILGenerator il = MethodIlHelper.InitialiseProxyMethod(
+                    proxyMethod,
+                    proxyMethodDefinitionParameters,
+                    proxyMethodDefinitionGenericArguments,
+                    targetMethod,
+                    instanceField,
+                    out Type[] proxyMethodGenericArguments);
 
                 // Load all the arguments / parameters
                 if (MethodIlHelper.AddIlToLoadArguments(
@@ -233,7 +238,7 @@ namespace Datadog.Trace.DuckTyping
                 {
                     // If the instance is public we can emit directly without any dynamic method
 
-                    targetMethod = MethodIlHelper.AddIlForDirectMethodCall(il, targetMethod, proxyMethodDefinitionGenericArguments);
+                    targetMethod = MethodIlHelper.AddIlForDirectMethodCall(il, targetMethod, proxyMethodGenericArguments);
                 }
                 else
                 {
@@ -322,7 +327,6 @@ namespace Datadog.Trace.DuckTyping
                 // Gets the proxy method definition generic arguments
                 Type[] overriddenMethodGenericArguments = overriddenMethod.GetGenericArguments();
                 Type[] implementationDefinitionGenericArguments = implementationMethod.GetGenericArguments();
-                string[] implementationDefinitionGenericArgumentsNames = implementationDefinitionGenericArguments.Select(a => a.Name).ToArray();
 
                 // Reverse duck typing doesn't support providing a non-generic implementation for a generic method
                 if (overriddenMethodGenericArguments.Length > 0
@@ -359,7 +363,13 @@ namespace Datadog.Trace.DuckTyping
 
                 // Create the proxy method implementation
                 MethodBuilder? proxyMethod = proxyTypeBuilder?.DefineMethod(overriddenMethod.Name, proxyMethodAttributes, overriddenMethod.ReturnType, overriddenMethodParametersTypes);
-                LazyILGenerator il = MethodIlHelper.InitialiseProxyMethod(proxyMethod, overriddenMethodParameters, implementationDefinitionGenericArgumentsNames, implementationMethod, instanceField);
+                LazyILGenerator il = MethodIlHelper.InitialiseProxyMethod(
+                    proxyMethod,
+                    overriddenMethodParameters,
+                    overriddenMethodGenericArguments,
+                    implementationMethod,
+                    instanceField,
+                    out Type[] proxyMethodGenericArguments);
 
                 // Load all the arguments / parameters
                 if (MethodIlHelper.AddIlToLoadArguments(
@@ -382,7 +392,7 @@ namespace Datadog.Trace.DuckTyping
                 // We know we have direct access to the target method because we defined it in our proxy
 
                 // If the instance is public we can emit directly without any dynamic method
-                implementationMethod = MethodIlHelper.AddIlForDirectMethodCall(il, implementationMethod, overriddenMethodGenericArguments);
+                implementationMethod = MethodIlHelper.AddIlForDirectMethodCall(il, implementationMethod, proxyMethodGenericArguments);
 
                 // We check if we have output or ref parameters to set in the proxy method
                 if (outputAndRefParameters is not null)
@@ -916,19 +926,34 @@ namespace Datadog.Trace.DuckTyping
             internal static LazyILGenerator InitialiseProxyMethod(
                 MethodBuilder? proxyMethod,
                 ParameterInfo[] proxyMethodDefinitionParameters,
-                string[] proxyMethodDefinitionGenericArgumentsNames,
+                Type[] proxyMethodDefinitionGenericArguments,
                 MethodInfo targetMethod,
-                FieldInfo? instanceField)
+                FieldInfo? instanceField,
+                out Type[] proxyMethodGenericArguments)
             {
                 if (proxyMethod is null)
                 {
+                    // Dry runs do not define a MethodBuilder, but the remaining validation still needs the
+                    // definition parameters to construct and check the target generic method.
+                    proxyMethodGenericArguments = proxyMethodDefinitionGenericArguments;
                     return new LazyILGenerator(null);
                 }
 
                 ParameterBuilder[] proxyMethodParametersBuilders = new ParameterBuilder[proxyMethodDefinitionParameters.Length];
-                if (proxyMethodDefinitionGenericArgumentsNames.Length > 0)
+                if (proxyMethodDefinitionGenericArguments.Length > 0)
                 {
-                    _ = proxyMethod.DefineGenericParameters(proxyMethodDefinitionGenericArgumentsNames);
+                    // DefineGenericParameters creates new placeholders owned by the emitted proxy method. Names
+                    // alone are insufficient: without the source attributes and type constraints the CLR must
+                    // treat every placeholder as unconstrained, and a call to a constrained target method then
+                    // fails verification even when the original proxy contract declared the same constraints.
+                    GenericTypeParameterBuilder[] genericParameterBuilders =
+                        proxyMethod.DefineGenericParameters(proxyMethodDefinitionGenericArguments.Select(argument => argument.Name).ToArray());
+                    CopyGenericParameterConstraints(proxyMethodDefinitionGenericArguments, genericParameterBuilders);
+                    proxyMethodGenericArguments = genericParameterBuilders;
+                }
+                else
+                {
+                    proxyMethodGenericArguments = Type.EmptyTypes;
                 }
 
                 // Define the proxy method implementation parameters for optional parameters with default values
@@ -957,6 +982,98 @@ namespace Datadog.Trace.DuckTyping
                 }
 
                 return il;
+            }
+
+            /// <summary>
+            /// Copies the generic parameter contract from a proxy definition to the parameters owned by the
+            /// emitted method.
+            /// </summary>
+            /// <param name="definitionArguments">Generic parameters from the proxy method definition.</param>
+            /// <param name="emittedArguments">Generic parameter builders owned by the emitted proxy method.</param>
+            private static void CopyGenericParameterConstraints(
+                Type[] definitionArguments,
+                GenericTypeParameterBuilder[] emittedArguments)
+            {
+                for (int i = 0; i < definitionArguments.Length; i++)
+                {
+                    Type definitionArgument = definitionArguments[i];
+                    GenericTypeParameterBuilder emittedArgument = emittedArguments[i];
+                    emittedArgument.SetGenericParameterAttributes(definitionArgument.GenericParameterAttributes);
+
+                    Type? baseTypeConstraint = null;
+                    List<Type>? interfaceConstraints = null;
+                    foreach (Type constraint in definitionArgument.GetGenericParameterConstraints())
+                    {
+                        Type emittedConstraint = ReplaceMethodGenericParameters(
+                            constraint,
+                            definitionArguments,
+                            emittedArguments);
+
+                        if (emittedConstraint.IsInterface)
+                        {
+                            interfaceConstraints ??= new List<Type>();
+                            interfaceConstraints.Add(emittedConstraint);
+                        }
+                        else
+                        {
+                            // CLR metadata permits one class constraint. A constraint that references another
+                            // method generic parameter also belongs in this slot, even though reflection does
+                            // not report that placeholder as a class.
+                            baseTypeConstraint = emittedConstraint;
+                        }
+                    }
+
+                    if (baseTypeConstraint is not null)
+                    {
+                        emittedArgument.SetBaseTypeConstraint(baseTypeConstraint);
+                    }
+
+                    if (interfaceConstraints is not null)
+                    {
+                        emittedArgument.SetInterfaceConstraints(interfaceConstraints.ToArray());
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Rebuilds a constraint so any method generic placeholders are owned by the emitted proxy method.
+            /// Type-level generic parameters remain unchanged because the generated proxy type already owns them.
+            /// </summary>
+            /// <param name="type">Constraint type to rebuild.</param>
+            /// <param name="definitionArguments">Parameters owned by the source method definition.</param>
+            /// <param name="emittedArguments">Parameters owned by the emitted proxy method.</param>
+            /// <returns>The constraint expressed in terms of the emitted method parameters.</returns>
+            private static Type ReplaceMethodGenericParameters(
+                Type type,
+                Type[] definitionArguments,
+                GenericTypeParameterBuilder[] emittedArguments)
+            {
+                if (type.IsGenericParameter && type.DeclaringMethod is not null)
+                {
+                    int position = type.GenericParameterPosition;
+                    if (position < definitionArguments.Length && type == definitionArguments[position])
+                    {
+                        return emittedArguments[position];
+                    }
+
+                    return type;
+                }
+
+                if (!type.IsGenericType)
+                {
+                    return type;
+                }
+
+                Type[] genericArguments = type.GetGenericArguments();
+                for (int i = 0; i < genericArguments.Length; i++)
+                {
+                    genericArguments[i] = ReplaceMethodGenericParameters(
+                        genericArguments[i],
+                        definitionArguments,
+                        emittedArguments);
+                }
+
+                return type.GetGenericTypeDefinition().MakeGenericType(genericArguments);
             }
 
             internal static DuckTypeException? AddIlToLoadArguments(
@@ -1157,12 +1274,14 @@ namespace Datadog.Trace.DuckTyping
             internal static MethodInfo AddIlForDirectMethodCall(
                 LazyILGenerator il,
                 MethodInfo targetMethod,
-                Type[] proxyMethodDefinitionGenericArguments)
+                Type[] proxyMethodGenericArguments)
             {
-                // Create generic method call
-                if (proxyMethodDefinitionGenericArguments.Length > 0)
+                // Construct the target with parameters owned by the emitted method. Reusing the generic
+                // parameters from the source MethodInfo loses the relationship between the emitted method's
+                // constraints and the call operand, which can make an otherwise valid body unverifiable.
+                if (proxyMethodGenericArguments.Length > 0)
                 {
-                    targetMethod = targetMethod.MakeGenericMethod(proxyMethodDefinitionGenericArguments);
+                    targetMethod = targetMethod.MakeGenericMethod(proxyMethodGenericArguments);
                 }
 
                 // Method call

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -54,22 +54,22 @@ namespace Datadog.Trace.DuckTyping.Tests
             if (!TestOptimization.Instance.IsRunning)
             {
 #if NETFRAMEWORK
-                asmDuckTypes.Should().Be(1516);
+                asmDuckTypes.Should().Be(1518);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().Be(1526);
+                asmDuckTypes.Should().Be(1528);
 #else
-                asmDuckTypes.Should().Be(1527);
+                asmDuckTypes.Should().Be(1529);
 #endif
             }
             else
             {
                 // When running inside CI Visibility, we will generate additional duck types
 #if NETFRAMEWORK
-                asmDuckTypes.Should().BeGreaterThan(1516);
+                asmDuckTypes.Should().BeGreaterThan(1518);
 #elif NETCOREAPP2_1
-                asmDuckTypes.Should().BeGreaterThan(1526);
+                asmDuckTypes.Should().BeGreaterThan(1528);
 #else
-                asmDuckTypes.Should().BeGreaterThan(1527);
+                asmDuckTypes.Should().BeGreaterThan(1529);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericMethodConstraintTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/GenericMethodConstraintTests.cs
@@ -1,0 +1,191 @@
+// <copyright file="GenericMethodConstraintTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests.Methods;
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+
+public class GenericMethodConstraintTests
+{
+    [Fact]
+    public void MatchingGenericMethodConstraintsCanBeInvoked()
+    {
+        var proxy = new MatchingConstraintTarget().DuckCast<IMatchingConstraintProxy>();
+
+        proxy.Struct<int>().Should().Be(nameof(Int32));
+        proxy.Reference<string>().Should().Be(nameof(String));
+        proxy.Create<ConstraintImplementation>().Should().BeOfType<ConstraintImplementation>();
+        proxy.Base<ConstraintImplementation>().Should().Be(nameof(ConstraintImplementation));
+        proxy.Interface<ConstraintImplementation>().Should().Be(nameof(ConstraintImplementation));
+        proxy.Multiple<ConstraintImplementation>().Should().Be(nameof(ConstraintImplementation));
+        proxy.Related<ConstraintBase, ConstraintImplementation>().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GeneratedMethodPreservesConstraintMetadata()
+    {
+        var proxy = new MatchingConstraintTarget().DuckCast<IMatchingConstraintProxy>();
+        var generatedType = proxy.GetType();
+
+        AssertConstraintsMatch(
+            typeof(IMatchingConstraintProxy).GetMethod(nameof(IMatchingConstraintProxy.Struct)),
+            generatedType.GetMethod(nameof(IMatchingConstraintProxy.Struct)));
+        AssertConstraintsMatch(
+            typeof(IMatchingConstraintProxy).GetMethod(nameof(IMatchingConstraintProxy.Reference)),
+            generatedType.GetMethod(nameof(IMatchingConstraintProxy.Reference)));
+        AssertConstraintsMatch(
+            typeof(IMatchingConstraintProxy).GetMethod(nameof(IMatchingConstraintProxy.Create)),
+            generatedType.GetMethod(nameof(IMatchingConstraintProxy.Create)));
+        AssertConstraintsMatch(
+            typeof(IMatchingConstraintProxy).GetMethod(nameof(IMatchingConstraintProxy.Base)),
+            generatedType.GetMethod(nameof(IMatchingConstraintProxy.Base)));
+        AssertConstraintsMatch(
+            typeof(IMatchingConstraintProxy).GetMethod(nameof(IMatchingConstraintProxy.Interface)),
+            generatedType.GetMethod(nameof(IMatchingConstraintProxy.Interface)));
+        AssertConstraintsMatch(
+            typeof(IMatchingConstraintProxy).GetMethod(nameof(IMatchingConstraintProxy.Multiple)),
+            generatedType.GetMethod(nameof(IMatchingConstraintProxy.Multiple)));
+
+        var relatedArguments = generatedType
+                              .GetMethod(nameof(IMatchingConstraintProxy.Related))
+                              .GetGenericArguments();
+        relatedArguments[1].GetGenericParameterConstraints().Should().ContainSingle()
+                           .Which.Should().BeSameAs(relatedArguments[0]);
+    }
+
+    [Fact]
+    public void ReverseProxyPreservesGenericMethodConstraints()
+    {
+        var implementation = new ReverseConstraintImplementation();
+        var proxy = (IReverseConstraintContract)implementation.DuckImplement(typeof(IReverseConstraintContract));
+
+        proxy.Struct<int>().Should().Be(nameof(Int32));
+
+        var genericArgument = proxy.GetType()
+                                   .GetMethod(nameof(IReverseConstraintContract.Struct))
+                                   .GetGenericArguments()[0];
+        genericArgument.GenericParameterAttributes.Should().Be(
+            GenericParameterAttributes.NotNullableValueTypeConstraint |
+            GenericParameterAttributes.DefaultConstructorConstraint);
+    }
+
+    [Fact]
+    public void WeakerProxyConstraintsAreRejected()
+    {
+        var target = new ValueTypeConstraintTarget();
+
+        DuckType.CanCreate<IUnconstrainedProxy>(target).Should().BeFalse();
+        target.DuckIs<IUnconstrainedProxy>().Should().BeFalse();
+    }
+
+    private static void AssertConstraintsMatch(MethodInfo definitionMethod, MethodInfo generatedMethod)
+    {
+        var definitionArgument = definitionMethod.GetGenericArguments()[0];
+        var generatedArgument = generatedMethod.GetGenericArguments()[0];
+
+        generatedArgument.GenericParameterAttributes.Should().Be(definitionArgument.GenericParameterAttributes);
+        generatedArgument.GetGenericParameterConstraints()
+                         .Should()
+                         .BeEquivalentTo(definitionArgument.GetGenericParameterConstraints());
+    }
+
+    private interface IMatchingConstraintProxy
+    {
+        string Struct<T>()
+            where T : struct;
+
+        string Reference<T>()
+            where T : class;
+
+        T Create<T>()
+            where T : class, new();
+
+        string Base<T>()
+            where T : ConstraintBase;
+
+        string Interface<T>()
+            where T : IConstraintMarker;
+
+        string Multiple<T>()
+            where T : ConstraintBase, IConstraintMarker, new();
+
+        bool Related<TBase, TDerived>()
+            where TDerived : TBase;
+    }
+
+    private interface IReverseConstraintContract
+    {
+        string Struct<T>()
+            where T : struct;
+    }
+
+    private interface IUnconstrainedProxy
+    {
+        string Describe<T>();
+    }
+
+    private class MatchingConstraintTarget
+    {
+        public string Struct<T>()
+            where T : struct
+            => typeof(T).Name;
+
+        public string Reference<T>()
+            where T : class
+            => typeof(T).Name;
+
+        public T Create<T>()
+            where T : class, new()
+            => new();
+
+        public string Base<T>()
+            where T : ConstraintBase
+            => typeof(T).Name;
+
+        public string Interface<T>()
+            where T : IConstraintMarker
+            => typeof(T).Name;
+
+        public string Multiple<T>()
+            where T : ConstraintBase, IConstraintMarker, new()
+            => typeof(T).Name;
+
+        public bool Related<TBase, TDerived>()
+            where TDerived : TBase
+            => typeof(TBase).IsAssignableFrom(typeof(TDerived));
+    }
+
+    private class ReverseConstraintImplementation
+    {
+        [DuckReverseMethod]
+        public string Struct<T>()
+            where T : struct
+            => typeof(T).Name;
+    }
+
+    private class ValueTypeConstraintTarget
+    {
+        public string Describe<T>()
+            where T : struct
+            => typeof(T).Name;
+    }
+
+    private class ConstraintBase
+    {
+    }
+
+    private interface IConstraintMarker
+    {
+    }
+
+    private class ConstraintImplementation : ConstraintBase, IConstraintMarker
+    {
+    }
+}


### PR DESCRIPTION
## Summary of changes

Preserves generic method constraints on emitted forward and reverse DuckTyping proxy methods.

## Reason for change

`DefineGenericParameters()` creates new parameters owned by the generated method. The previous implementation copied only their names, so a proxy contract such as `where T : struct` became unconstrained. Calling a target with the original constraint then failed CLR verification with `VerificationException`, even when the proxy and target signatures matched.

## Implementation details

The generated parameters now copy their `GenericParameterAttributes`, class constraint, interface constraints, and constraints that refer to another method generic parameter. Nested generic and array constraint types are rebuilt with the generated parameters. The substitution reuses closed or otherwise unchanged types, avoiding unnecessary `MakeGenericType()` calls. Generic parameter names are copied with a single explicit allocation instead of a LINQ pipeline. Direct target calls are constructed with the generated parameters so the call operand and method body share the same constraint metadata. The same logic is used for forward and reverse proxies.

## Test coverage

- Matching `struct`, `class`, and `new()` constraints
- Base-class, interface, and combined constraints
- Constraints that reference another method generic parameter, including a nested array type
- Reflected metadata on generated methods
- Constrained reverse proxy invocation
- Rejection of a proxy weaker than the target constraint
- Mutation check against master reproduced `VerificationException` in forward and reverse proxies
- Full DuckTyping suite on .NET 8: 10,966 passed, 5 skipped

## Other details
